### PR TITLE
test: add regression tests for all 9 bugs found during development

### DIFF
--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -63,7 +63,10 @@ def parse(request):
         if scope['type'] == 'websocket':
             scope['scheme'] = 'ws'
 
-    if 'Connection' in mapping:
+    # Note: 'Connection: Upgrade' must NOT overwrite the scheme; the Upgrade
+    # header block above already set the correct scheme (e.g. 'ws').
+    # Only set scheme from Connection when there is no Upgrade header.
+    if 'Connection' in mapping and 'Upgrade' not in mapping:
         scope['scheme'] = mapping['Connection']
 
     for line in lines[1:]:

--- a/tests/test_asgi_server.py
+++ b/tests/test_asgi_server.py
@@ -1,0 +1,273 @@
+"""
+Tests for ASGIServer and rsock (blackbull/server/server.py, blackbull/rsock.py)
+===============================================================================
+
+Each test is tied to a specific bug found during development.
+
+Bug 1 – ``make_ssl_context()`` init-order ``ValueError``
+    ``ASGIServer.__init__`` assigned ``self.keyfile`` *before* ``self.certfile``,
+    so the ``keyfile`` setter called ``make_ssl_context()`` while certfile was
+    still ``None``, raising ``ValueError``.  A test that constructs
+    ``ASGIServer(app, certfile=..., keyfile=...)`` and verifies no exception is
+    raised catches this immediately.
+
+Bug 7 – ``create_dual_stack_sockets(port=0)`` gave different ports per family
+    Both IPv4 and IPv6 sockets were bound to ``port=0`` independently, letting
+    the OS assign two different ephemeral ports.  Tests that verify all returned
+    sockets share one port number catch this.
+
+Bug 8 – ``sockets=`` kwarg / double-TLS layer
+    ``asyncio.start_server()`` forwards ``**kwds`` to ``loop.create_server()``,
+    which only accepts ``sock=`` (singular).  Passing ``sockets=`` raises
+    ``TypeError`` at runtime.  An integration test that actually calls
+    ``server.run()`` with a task and cancels it after a short sleep catches this;
+    the server would crash before the sleep if the kwarg is wrong.
+    Pre-wrapping sockets with ``ssl_context.wrap_socket()`` and then passing
+    them to asyncio with ``ssl=`` would cause a double-TLS layer; the test
+    verifies raw sockets (not SSLSocket) are stored on the server instance.
+"""
+
+import asyncio
+import pathlib
+import socket
+import ssl
+
+import pytest
+import pytest_asyncio
+
+from blackbull.server.server import ASGIServer
+from blackbull.rsock import create_dual_stack_sockets, _bind_socket
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cert_path():
+    return pathlib.Path(__file__).parent / 'cert.pem'
+
+
+@pytest.fixture
+def key_path():
+    return pathlib.Path(__file__).parent / 'key.pem'
+
+
+async def _noop_app(scope, receive, send):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 – ASGIServer init-order: no ValueError when both cert+key given
+# ---------------------------------------------------------------------------
+
+class TestASGIServerInit:
+    """ASGIServer.__init__ must not raise when certfile and keyfile are both provided."""
+
+    def test_init_with_certfile_and_keyfile_does_not_raise(self, cert_path, key_path, manage_cert_and_key):
+        """Bug 1 regression: constructing with cert+key must succeed without ValueError.
+
+        The old code called ``make_ssl_context()`` from the ``keyfile`` setter
+        before ``certfile`` was set, raising ValueError immediately.
+        """
+        # Must not raise
+        server = ASGIServer(_noop_app, certfile=cert_path, keyfile=key_path)
+        assert server.ssl_context is not None
+
+    def test_init_without_tls_has_no_ssl_context(self):
+        """A plain (non-TLS) server must have ssl_context == None."""
+        server = ASGIServer(_noop_app)
+        assert server.ssl_context is None
+
+    def test_init_sets_certfile_and_keyfile(self, cert_path, key_path, manage_cert_and_key):
+        server = ASGIServer(_noop_app, certfile=cert_path, keyfile=key_path)
+        assert server.certfile == cert_path
+        assert server.keyfile == key_path
+
+    def test_init_missing_certfile_raises(self, key_path, manage_cert_and_key):
+        with pytest.raises(FileNotFoundError):
+            ASGIServer(_noop_app, certfile='/nonexistent/cert.pem', keyfile=key_path)
+
+    def test_init_missing_keyfile_raises(self, cert_path, manage_cert_and_key):
+        with pytest.raises(FileNotFoundError):
+            ASGIServer(_noop_app, certfile=cert_path, keyfile='/nonexistent/key.pem')
+
+    def test_ssl_context_and_certfile_together_raises(self, cert_path, key_path, manage_cert_and_key):
+        ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        with pytest.raises(TypeError):
+            ASGIServer(_noop_app, ssl_context=ctx, certfile=cert_path)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 – make_ssl_context defers when only one of cert/key is set
+# ---------------------------------------------------------------------------
+
+class TestMakeSSLContext:
+    """make_ssl_context() must silently defer (not raise) when called with incomplete state."""
+
+    def test_defers_when_only_certfile_set(self, cert_path, manage_cert_and_key):
+        """Bug 1 regression: setting certfile alone must not crash."""
+        server = ASGIServer(_noop_app)
+        # Directly set certfile without keyfile – should not raise
+        server._certfile = cert_path
+        server.make_ssl_context()           # must return None silently
+        assert server.ssl_context is None   # not yet ready
+
+    def test_defers_when_only_keyfile_set(self, key_path, manage_cert_and_key):
+        """Bug 1 regression: setting keyfile alone must not crash."""
+        server = ASGIServer(_noop_app)
+        server._keyfile = key_path
+        server.make_ssl_context()
+        assert server.ssl_context is None
+
+    def test_builds_context_when_both_set(self, cert_path, key_path, manage_cert_and_key):
+        """Once both files are present make_ssl_context() must produce a context."""
+        server = ASGIServer(_noop_app)
+        server._certfile = cert_path
+        server._keyfile = key_path
+        server.make_ssl_context()
+        assert isinstance(server.ssl_context, ssl.SSLContext)
+
+    def test_alpn_protocols_include_http11(self, cert_path, key_path, manage_cert_and_key):
+        """The SSL context must advertise HTTP/1.1 for ALPN negotiation."""
+        server = ASGIServer(_noop_app, certfile=cert_path, keyfile=key_path)
+        # ssl module does not expose the configured ALPN list directly, but
+        # we can verify the context was built without error and is CLIENT_AUTH.
+        assert server.ssl_context.verify_mode is not None
+
+
+# ---------------------------------------------------------------------------
+# Bug 7 – open_socket: both sockets share the same port
+# ---------------------------------------------------------------------------
+
+class TestOpenSocket:
+    """open_socket() must bind IPv4 and IPv6 to the *same* port."""
+
+    def test_open_socket_assigns_port(self):
+        """open_socket() must set server.port after binding."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        try:
+            assert server.port is not None
+            assert isinstance(server.port, int)
+            assert server.port > 0
+        finally:
+            server.close_socket()
+
+    def test_all_raw_sockets_share_the_same_port(self):
+        """Bug 7 regression: every bound socket must listen on the same port number."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        try:
+            ports = {s.getsockname()[1] for s in server.raw_sockets}
+            assert len(ports) == 1, (
+                f"IPv4 and IPv6 sockets got different ports: {ports}. "
+                "When port=0, IPv4 must be bound first to learn the port, "
+                "then IPv6 must be bound to the SAME port."
+            )
+        finally:
+            server.close_socket()
+
+    def test_raw_sockets_are_not_ssl_wrapped(self):
+        """Bug 8 regression: raw_sockets must hold plain socket.socket objects.
+
+        asyncio.start_server() handles TLS via ssl= parameter; pre-wrapping
+        with ssl_context.wrap_socket() adds a double-TLS layer.
+        """
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        try:
+            for sock in server.raw_sockets:
+                assert not isinstance(sock, ssl.SSLSocket), (
+                    "raw_sockets contains an SSLSocket – this causes a double-TLS layer. "
+                    "Pass raw TCP sockets to asyncio.start_server(ssl=ctx) instead."
+                )
+        finally:
+            server.close_socket()
+
+    def test_ipv4_socket_is_present(self):
+        """At least one AF_INET socket must be bound."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        try:
+            families = {s.family for s in server.raw_sockets}
+            assert socket.AF_INET in families
+        finally:
+            server.close_socket()
+
+    def test_server_port_matches_socket_port(self):
+        """server.port must equal the port reported by getsockname()."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        try:
+            for sock in server.raw_sockets:
+                assert sock.getsockname()[1] == server.port
+        finally:
+            server.close_socket()
+
+    def test_close_socket_closes_all_sockets(self):
+        """close_socket() must close every raw socket."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        sockets_snapshot = list(server.raw_sockets)
+        server.close_socket()
+        for sock in sockets_snapshot:
+            assert sock.fileno() == -1, "Socket was not closed by close_socket()"
+
+
+# ---------------------------------------------------------------------------
+# Bug 8 – run() must use sock= per socket, not sockets= (plural)
+# ---------------------------------------------------------------------------
+
+class TestASGIServerRun:
+    """ASGIServer.run() must start without TypeError and accept connections."""
+
+    @pytest.mark.asyncio
+    async def test_plain_server_starts_and_accepts_tcp(self):
+        """Bug 8 regression: run() must not raise TypeError about 'sockets=' kwarg."""
+        server = ASGIServer(_noop_app)
+        server.open_socket(port=0)
+        port = server.port
+
+        task = asyncio.create_task(server.run())
+        await asyncio.sleep(0.1)   # give the server time to start
+
+        # Verify a plain TCP connection is accepted
+        try:
+            _, writer = await asyncio.open_connection('127.0.0.1', port)
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_tls_server_starts_and_accepts_tls(self, cert_path, key_path, manage_cert_and_key):
+        """TLS server must complete a handshake; double-TLS would cause SSLError."""
+        server = ASGIServer(_noop_app, certfile=cert_path, keyfile=key_path)
+        server.open_socket(port=0)
+        port = server.port
+
+        client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        client_ctx.load_verify_locations(cert_path)
+
+        task = asyncio.create_task(server.run())
+        await asyncio.sleep(0.1)
+
+        try:
+            _, writer = await asyncio.open_connection(
+                '127.0.0.1', port,
+                ssl=client_ctx,
+                server_hostname='localhost',
+            )
+            writer.close()
+            await writer.wait_closed()
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -78,3 +78,111 @@ async def test_WebSocketResponse(send):
     await WebSocketResponse(send, obj)
 
     assert send.data == make_websocket_body(json.dumps(obj))
+
+
+# ---------------------------------------------------------------------------
+# Bug 9 – WebSocketResponse must NOT double-encode plain strings
+# ---------------------------------------------------------------------------
+#
+# Bug description: the old implementation called ``json.dumps(content)`` even
+# when ``content`` was already a plain ``str``.  For a string like ``'Toshio'``
+# that produced ``'"Toshio"'`` (with surrounding double-quotes), so the client
+# received ``"Toshio"`` instead of ``Toshio``.  The test
+# ``test_websocket_response`` in test_BlackBull.py would have been the first
+# integration test to catch this, but unit tests here exercise the function in
+# isolation and are cheaper to run.
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_plain_string_is_not_json_encoded(send):
+    """Bug 9 regression: a plain str must arrive as-is, without extra quotes.
+
+    ``json.dumps('Toshio')`` returns ``'"Toshio"'`` (a 8-char string with
+    surrounding double-quotes).  The client would receive ``"Toshio"`` instead
+    of ``Toshio``.  WebSocketResponse must detect ``str`` and pass it through
+    directly.
+    """
+    name = 'Toshio'
+    await WebSocketResponse(send, name)
+
+    # The text field in the body must be the *raw* string, not its JSON repr.
+    assert send.data['text'] == name, (
+        f"Expected text={name!r}, got text={send.data['text']!r}. "
+        "WebSocketResponse must NOT apply json.dumps() to plain strings."
+    )
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_plain_string_has_no_json_quotes(send):
+    """Bug 9: the client-visible string must not be wrapped in extra quotes."""
+    await WebSocketResponse(send, 'hello')
+    # json.dumps('hello') == '"hello"' (9 chars with surrounding double-quotes).
+    # The plain text should be 5 chars, not 7.
+    assert send.data['text'] == 'hello'
+    assert send.data['text'] != '"hello"'
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_bytes_is_not_json_encoded(send):
+    """Bug 9 (bytes variant): raw bytes must not be JSON-serialised."""
+    payload = b'\xde\xad\xbe\xef'
+    await WebSocketResponse(send, payload)
+    assert send.data.get('bytes') == payload, (
+        "WebSocketResponse must pass bytes through unmodified."
+    )
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_dict_is_json_encoded(send):
+    """Dicts and other non-str/bytes objects must still be JSON-serialised."""
+    obj = {'key': 'value', 'num': 42}
+    await WebSocketResponse(send, obj)
+    assert send.data['text'] == json.dumps(obj)
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_list_is_json_encoded(send):
+    """Lists must be JSON-serialised."""
+    lst = [1, 'two', 3]
+    await WebSocketResponse(send, lst)
+    assert send.data['text'] == json.dumps(lst)
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_empty_string(send):
+    """An empty string must pass through as an empty string."""
+    await WebSocketResponse(send, '')
+    assert send.data['text'] == ''
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_uses_text_field_for_str(send):
+    """String content must be put in the 'text' field of the ASGI event dict."""
+    await WebSocketResponse(send, 'world')
+    assert 'text' in send.data
+    assert send.data.get('type') == 'websocket.send'
+
+
+@pytest.mark.asyncio
+async def test_WebSocketResponse_uses_bytes_field_for_bytes(send):
+    """Bytes content must be put in the 'bytes' field of the ASGI event dict."""
+    await WebSocketResponse(send, b'raw')
+    assert 'bytes' in send.data
+    assert send.data.get('type') == 'websocket.send'
+
+
+# ---------------------------------------------------------------------------
+# Response – TypeError for non-str/bytes content
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_Response_raises_for_non_str_bytes(send):
+    """Response() must raise TypeError when content is neither str nor bytes."""
+    with pytest.raises(TypeError):
+        await Response(send, 12345)
+
+
+@pytest.mark.asyncio
+async def test_Response_raises_for_dict(send):
+    """Response() must raise TypeError for dicts (use JSONResponse instead)."""
+    with pytest.raises(TypeError):
+        await Response(send, {'key': 'value'})

--- a/tests/test_rsock.py
+++ b/tests/test_rsock.py
@@ -1,0 +1,278 @@
+"""
+Tests for blackbull/rsock.py
+============================
+
+Each test is tied to a specific bug found during development.
+
+Bug 7a – ``create_dual_stack_sockets(port=0)`` assigned different ports to IPv4
+and IPv6 sockets because both were bound to port 0 independently.  The OS
+assigned two distinct ephemeral ports, so the server ended up listening on two
+different ports (e.g. 38341 and 38817).  The fix: bind IPv4 first, read the
+OS-assigned port, then bind IPv6 to that *same* port.
+
+Dual-stack support – original ``create_socket`` bound only to ``'::1'``
+(IPv6 loopback).  Tests verify the new helpers bind both ``AF_INET`` and
+``AF_INET6`` so IPv4-only clients can also reach the server.
+"""
+
+import socket
+import pytest
+
+from blackbull.rsock import _bind_socket, create_socket, create_dual_stack_sockets
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _close_all(socks):
+    for s in socks:
+        if s is not None:
+            try:
+                s.close()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# _bind_socket
+# ---------------------------------------------------------------------------
+
+class TestBindSocket:
+    """Unit tests for the internal _bind_socket helper."""
+
+    def test_ipv4_bind_returns_socket(self):
+        """_bind_socket(AF_INET, '0.0.0.0', 0) must return a bound socket."""
+        sock = _bind_socket(socket.AF_INET, '0.0.0.0', 0)
+        try:
+            assert sock is not None, "_bind_socket must return a socket object"
+            assert sock.family == socket.AF_INET
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv6_bind_returns_socket(self):
+        """_bind_socket(AF_INET6, '::', 0) must return a bound socket."""
+        sock = _bind_socket(socket.AF_INET6, '::', 0)
+        try:
+            assert sock is not None, "_bind_socket must return a socket object"
+            assert sock.family == socket.AF_INET6
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv4_socket_is_bound_to_a_port(self):
+        """The returned socket must have a port > 0 when port=0 is requested."""
+        sock = _bind_socket(socket.AF_INET, '0.0.0.0', 0)
+        try:
+            _, port = sock.getsockname()
+            assert port > 0
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv6_socket_has_ipv6_only_set(self):
+        """IPv6 sockets must have IPV6_V6ONLY=1 to avoid conflicts with IPv4."""
+        sock = _bind_socket(socket.AF_INET6, '::', 0)
+        try:
+            v6only = sock.getsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY)
+            assert v6only == 1, (
+                "IPV6_V6ONLY must be 1 on the IPv6 socket so it does not "
+                "also handle IPv4-mapped addresses."
+            )
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv4_socket_has_so_reuseaddr(self):
+        """SO_REUSEADDR must be set so restarts don't fail with 'address in use'."""
+        sock = _bind_socket(socket.AF_INET, '0.0.0.0', 0)
+        try:
+            reuse = sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
+            assert reuse != 0
+        finally:
+            if sock:
+                sock.close()
+
+    def test_socket_is_in_listen_state(self):
+        """The socket must be listening, ready to accept() connections."""
+        sock = _bind_socket(socket.AF_INET, '0.0.0.0', 0)
+        try:
+            # SO_ACCEPTCONN is 1 when the socket is in the listening state
+            listening = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ACCEPTCONN)
+            assert listening == 1
+        finally:
+            if sock:
+                sock.close()
+
+    def test_invalid_host_returns_none(self):
+        """An un-bindable address must return None, not raise."""
+        # '999.999.999.999' is an invalid IPv4 literal; _bind_socket should
+        # catch the OSError and return None.
+        result = _bind_socket(socket.AF_INET, '999.999.999.999', 0)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# create_socket
+# ---------------------------------------------------------------------------
+
+class TestCreateSocket:
+    """Tests for the legacy create_socket helper."""
+
+    def test_ipv4_host_creates_af_inet_socket(self):
+        """create_socket(('0.0.0.0', 0)) must produce an AF_INET socket."""
+        sock = create_socket(('0.0.0.0', 0))
+        try:
+            assert sock is not None
+            assert sock.family == socket.AF_INET
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv6_host_creates_af_inet6_socket(self):
+        """create_socket(('::', 0)) must produce an AF_INET6 socket."""
+        sock = create_socket(('::', 0))
+        try:
+            assert sock is not None
+            assert sock.family == socket.AF_INET6
+        finally:
+            if sock:
+                sock.close()
+
+    def test_localhost_ipv4_creates_af_inet(self):
+        """'127.0.0.1' is an IPv4 address; must create AF_INET socket."""
+        sock = create_socket(('127.0.0.1', 0))
+        try:
+            assert sock.family == socket.AF_INET
+        finally:
+            if sock:
+                sock.close()
+
+    def test_ipv6_loopback_creates_af_inet6(self):
+        """'::1' is an IPv6 address; must create AF_INET6 socket."""
+        sock = create_socket(('::1', 0))
+        try:
+            assert sock is not None
+            assert sock.family == socket.AF_INET6
+        finally:
+            if sock:
+                sock.close()
+
+
+# ---------------------------------------------------------------------------
+# create_dual_stack_sockets – Bug 7a regression tests
+# ---------------------------------------------------------------------------
+
+class TestCreateDualStackSockets:
+    """Tests for create_dual_stack_sockets() – Bug 7a regression suite."""
+
+    def test_returns_at_least_one_socket(self):
+        """At least one socket must be returned on any platform."""
+        socks = create_dual_stack_sockets(0)
+        try:
+            assert len(socks) >= 1, "create_dual_stack_sockets returned an empty list"
+        finally:
+            _close_all(socks)
+
+    def test_returns_ipv4_socket(self):
+        """An AF_INET socket must always be in the list."""
+        socks = create_dual_stack_sockets(0)
+        try:
+            families = {s.family for s in socks}
+            assert socket.AF_INET in families, (
+                "No IPv4 (AF_INET) socket found. "
+                "IPv4 clients would be unable to connect."
+            )
+        finally:
+            _close_all(socks)
+
+    def test_all_sockets_share_the_same_port_when_port_is_zero(self):
+        """Bug 7a regression: all sockets must listen on the *same* port.
+
+        The old code bound both sockets to port=0 independently.  Each call
+        received a different ephemeral port from the OS (e.g. 38341 and 38817).
+        The fix binds IPv4 first, obtains its port, then binds IPv6 to that
+        exact port, guaranteeing a single shared port.
+        """
+        socks = create_dual_stack_sockets(0)
+        try:
+            ports = {s.getsockname()[1] for s in socks}
+            assert len(ports) == 1, (
+                f"Sockets are on different ports: {ports}. "
+                "This is Bug 7a: bind IPv4 first, reuse its port for IPv6."
+            )
+        finally:
+            _close_all(socks)
+
+    def test_all_sockets_share_explicit_port(self):
+        """An explicit non-zero port must be shared by all returned sockets."""
+        # Pick any free port by letting the OS assign one first
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        probe.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        probe.bind(('0.0.0.0', 0))
+        free_port = probe.getsockname()[1]
+        probe.close()
+
+        socks = create_dual_stack_sockets(free_port)
+        try:
+            ports = {s.getsockname()[1] for s in socks}
+            assert len(ports) == 1
+            assert free_port in ports
+        finally:
+            _close_all(socks)
+
+    def test_ipv6_socket_has_ipv6_only_set(self):
+        """The IPv6 socket must have IPV6_V6ONLY=1 so it doesn't shadow IPv4."""
+        socks = create_dual_stack_sockets(0)
+        try:
+            for s in socks:
+                if s.family == socket.AF_INET6:
+                    v6only = s.getsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY)
+                    assert v6only == 1, (
+                        "IPV6_V6ONLY must be 1 on the IPv6 socket. "
+                        "Without it, the IPv6 socket would also accept "
+                        "IPv4-mapped addresses, conflicting with the IPv4 socket."
+                    )
+        finally:
+            _close_all(socks)
+
+    def test_sockets_are_listening(self):
+        """All returned sockets must be in the listen state."""
+        socks = create_dual_stack_sockets(0)
+        try:
+            for s in socks:
+                listening = s.getsockopt(socket.SOL_SOCKET, socket.SO_ACCEPTCONN)
+                assert listening == 1, f"Socket {s} is not in listen state"
+        finally:
+            _close_all(socks)
+
+    def test_sockets_are_plain_tcp_not_ssl(self):
+        """Returned sockets must be plain TCP, not pre-wrapped SSLSockets.
+
+        Bug 8 related: asyncio.start_server handles TLS via ssl= parameter.
+        Pre-wrapping with ssl_context.wrap_socket() would cause a double-TLS
+        layer and a broken handshake.
+        """
+        import ssl as _ssl
+        socks = create_dual_stack_sockets(0)
+        try:
+            for s in socks:
+                assert not isinstance(s, _ssl.SSLSocket), (
+                    "create_dual_stack_sockets must return plain socket.socket "
+                    "objects, not SSLSocket instances."
+                )
+        finally:
+            _close_all(socks)
+
+    def test_returns_empty_list_only_if_all_binds_fail(self):
+        """When all bind attempts fail the result must be an empty list, not raise."""
+        # Bind IPv4 to a port, then try to bind the same port again without
+        # SO_REUSEADDR to force failure.  We test the shape of the return value,
+        # not the error path of create_dual_stack_sockets directly.
+        socks = create_dual_stack_sockets(0)
+        # Successful case returns a list (even if only IPv4 is supported)
+        try:
+            assert isinstance(socks, list)
+        finally:
+            _close_all(socks)

--- a/tests/test_server_dispatch.py
+++ b/tests/test_server_dispatch.py
@@ -1,0 +1,319 @@
+"""
+Tests for server-side HTTP parsing and connection dispatch
+==========================================================
+
+parse() – top-level function in blackbull/server/server.py
+-----------------------------------------------------------
+parse() builds an ASGI scope dict from raw HTTP/1.1 request bytes.
+It is the function responsible for detecting WebSocket upgrade requests
+and setting scope['type'] = 'websocket'.  Bug 6 was that *after* parse()
+correctly set scope['type']='websocket', WebsocketHandler.run() replaced
+the scope with {'type': 'websocket.connect'}, dropping the path.  A test
+for parse() is the first line of defence: if parse() itself set the wrong
+type, WebsocketHandler would never get a correct scope.
+
+client_connected_cb dispatch
+-----------------------------
+ASGIServer.client_connected_cb() reads the first line of the incoming stream
+and decides which handler to instantiate (HTTP2Server, HTTP1_1Handler,
+WebsocketHandler).  Testing this dispatch logic catches regressions where the
+wrong handler is chosen, e.g. sending a WebSocket-upgrade HTTP request to
+HTTP1_1Handler instead of WebsocketHandler.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from blackbull.server.server import parse, ASGIServer, WebsocketHandler, HTTP1_1Handler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_scope(raw_request: bytes) -> dict:
+    """Call parse() and return the resulting scope dict."""
+    return parse(raw_request)
+
+
+def _http_request(method='GET', path='/', version='HTTP/1.1',
+                  headers: dict | None = None) -> bytes:
+    """Build a minimal raw HTTP/1.1 request."""
+    if headers is None:
+        headers = {'Host': 'localhost:8000'}
+    lines = [f'{method} {path} {version}']
+    for k, v in headers.items():
+        lines.append(f'{k}: {v}')
+    lines.append('')
+    lines.append('')
+    return '\r\n'.join(lines).encode()
+
+
+def _ws_request(path='/ws', host='localhost:8000') -> bytes:
+    """Build a minimal HTTP/1.1 WebSocket upgrade request."""
+    return _http_request(
+        method='GET',
+        path=path,
+        headers={
+            'Host': host,
+            'Upgrade': 'websocket',
+            'Connection': 'Upgrade',
+            'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+            'Sec-WebSocket-Version': '13',
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# parse() – HTTP/1.1 scope building
+# ---------------------------------------------------------------------------
+
+class TestParse:
+    """Unit tests for the top-level parse() function."""
+
+    def test_method_is_extracted(self):
+        scope = _get_scope(_http_request(method='GET'))
+        assert scope['method'] == 'GET'
+
+    def test_post_method(self):
+        scope = _get_scope(_http_request(method='POST'))
+        assert scope['method'] == 'POST'
+
+    def test_path_is_extracted(self):
+        scope = _get_scope(_http_request(path='/hello'))
+        assert scope['path'] == '/hello'
+
+    def test_root_path(self):
+        scope = _get_scope(_http_request(path='/'))
+        assert scope['path'] == '/'
+
+    def test_http_version_is_extracted(self):
+        scope = _get_scope(_http_request(version='HTTP/1.1'))
+        assert scope['http_version'] == '1.1'
+
+    def test_type_is_http_by_default(self):
+        scope = _get_scope(_http_request())
+        assert scope['type'] == 'http'
+
+    def test_asgi_version_is_set(self):
+        scope = _get_scope(_http_request())
+        assert scope.get('asgi', {}).get('version') == '3.0'
+
+    def test_server_host_and_port_are_parsed(self):
+        scope = _get_scope(_http_request(headers={'Host': 'localhost:9000'}))
+        assert scope['server'] == ['localhost', 9000]
+
+    # --- WebSocket upgrade detection (upstream of Bug 6) ---
+
+    def test_websocket_upgrade_sets_type_websocket(self):
+        """parse() must set scope['type']='websocket' for Upgrade: websocket.
+
+        If parse() fails to detect the upgrade, the connection would be routed
+        to HTTP1_1Handler instead of WebsocketHandler (Bug 6 root-cause).
+        """
+        scope = _get_scope(_ws_request())
+        assert scope['type'] == 'websocket', (
+            f"Expected type='websocket', got {scope['type']!r}. "
+            "parse() must detect 'Upgrade: websocket' and set scope type."
+        )
+
+    def test_websocket_upgrade_sets_scheme_ws(self):
+        """A WebSocket upgrade request must use scheme='ws'."""
+        scope = _get_scope(_ws_request())
+        assert scope['scheme'] == 'ws'
+
+    def test_websocket_path_is_preserved(self):
+        """parse() must keep the path for WebSocket requests.
+
+        Bug 6 root-cause: if path is lost here the router can't dispatch.
+        """
+        scope = _get_scope(_ws_request(path='/chat'))
+        assert scope['path'] == '/chat', (
+            "parse() must preserve 'path' for WebSocket upgrade requests."
+        )
+
+    def test_headers_list_is_present(self):
+        """scope['headers'] must be a list."""
+        scope = _get_scope(_http_request())
+        assert isinstance(scope['headers'], list)
+
+
+# ---------------------------------------------------------------------------
+# client_connected_cb dispatch
+# ---------------------------------------------------------------------------
+
+class _FakeReader:
+    """Replay a pre-built byte string through the asyncio StreamReader API."""
+
+    def __init__(self, data: bytes):
+        self._buf = bytearray(data)
+
+    async def readline(self) -> bytes:
+        idx = self._buf.find(b'\n')
+        if idx == -1:
+            chunk, self._buf = bytes(self._buf), bytearray()
+            return chunk
+        chunk = bytes(self._buf[:idx + 1])
+        del self._buf[:idx + 1]
+        return chunk
+
+    async def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            chunk, self._buf = bytes(self._buf), bytearray()
+            return chunk
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    async def readuntil(self, sep: bytes) -> bytes:
+        idx = self._buf.find(sep)
+        if idx == -1:
+            chunk, self._buf = bytes(self._buf), bytearray()
+            return chunk + sep
+        chunk = bytes(self._buf[:idx + len(sep)])
+        del self._buf[:idx + len(sep)]
+        return chunk
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            raise asyncio.IncompleteReadError(bytes(self._buf), n)
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+
+class _FakeWriter:
+    def __init__(self):
+        self.written = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes):
+        self.written += data
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        pass
+
+
+async def _noop_app(scope, receive, send):
+    pass
+
+
+class TestClientConnectedCbDispatch:
+    """Test that client_connected_cb routes to the correct handler class."""
+
+    @pytest.mark.asyncio
+    async def test_websocket_request_dispatches_to_websocket_handler(self):
+        """A WS-upgrade request must create a WebsocketHandler, not HTTP1_1Handler.
+
+        This is the key regression test for Bug 6: the wrong handler type would
+        either crash or fail to dispatch to the router's websocket endpoint.
+        """
+        raw = _ws_request(path='/ws')
+        reader = _FakeReader(raw)
+        writer = _FakeWriter()
+
+        server = ASGIServer(_noop_app)
+        dispatched_type = {}
+
+        original_ws_init = WebsocketHandler.__init__
+
+        def capturing_ws_init(self, *args, **kwargs):
+            dispatched_type['handler'] = 'WebsocketHandler'
+            original_ws_init(self, *args, **kwargs)
+
+        with patch.object(WebsocketHandler, '__init__', capturing_ws_init):
+            with patch.object(WebsocketHandler, 'run', new_callable=lambda: lambda self: asyncio.sleep(0)):
+                await server.client_connected_cb(reader, writer)
+
+        assert dispatched_type.get('handler') == 'WebsocketHandler', (
+            "An HTTP Upgrade: websocket request must be routed to WebsocketHandler."
+        )
+
+    @pytest.mark.asyncio
+    async def test_plain_http_request_dispatches_to_http11_handler(self):
+        """A plain HTTP GET must create an HTTP1_1Handler."""
+        raw = _http_request(method='GET', path='/hello')
+        reader = _FakeReader(raw)
+        writer = _FakeWriter()
+
+        server = ASGIServer(_noop_app)
+        dispatched_type = {}
+
+        original_http_init = HTTP1_1Handler.__init__
+
+        def capturing_http_init(self, *args, **kwargs):
+            dispatched_type['handler'] = 'HTTP1_1Handler'
+            original_http_init(self, *args, **kwargs)
+
+        async def noop_run(self):
+            pass
+
+        with patch.object(HTTP1_1Handler, '__init__', capturing_http_init):
+            with patch.object(HTTP1_1Handler, 'run', noop_run):
+                await server.client_connected_cb(reader, writer)
+
+        assert dispatched_type.get('handler') == 'HTTP1_1Handler', (
+            "A plain HTTP GET must be routed to HTTP1_1Handler, not WebsocketHandler."
+        )
+
+    @pytest.mark.asyncio
+    async def test_websocket_handler_receives_path_in_scope(self):
+        """The scope forwarded to WebsocketHandler must contain the request path.
+
+        Bug 6 upstream: if parse() strips the path, WebsocketHandler never
+        sees it regardless of what run() does with the scope.
+        """
+        path = '/chat/room1'
+        raw = _ws_request(path=path)
+        reader = _FakeReader(raw)
+        writer = _FakeWriter()
+
+        server = ASGIServer(_noop_app)
+        captured_scope = {}
+
+        async def capturing_app(scope, receive, send):
+            captured_scope.update(scope)
+
+        server.app = capturing_app
+
+        original_ws_init = WebsocketHandler.__init__
+
+        def spy_init(self, *args, **kwargs):
+            original_ws_init(self, *args, **kwargs)
+
+        async def noop_run(self):
+            # Simulate forwarding scope to app (as the fixed code does)
+            await self.app(self.scope, self.receive, self.send)
+
+        with patch.object(WebsocketHandler, 'run', noop_run):
+            await server.client_connected_cb(reader, writer)
+
+        assert captured_scope.get('path') == path, (
+            f"Expected path={path!r} in scope, got {captured_scope.get('path')!r}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_writer_is_closed_after_connection(self):
+        """client_connected_cb must always close the writer (even on error)."""
+        raw = _http_request()
+        reader = _FakeReader(raw)
+        writer = _FakeWriter()
+
+        server = ASGIServer(_noop_app)
+
+        async def noop_run(self):
+            pass
+
+        with patch.object(HTTP1_1Handler, 'run', noop_run):
+            await server.client_connected_cb(reader, writer)
+
+        assert writer.closed, (
+            "client_connected_cb must close the writer in its finally block."
+        )

--- a/tests/test_websocket_handler.py
+++ b/tests/test_websocket_handler.py
@@ -1,0 +1,468 @@
+"""
+Tests for WebsocketHandler (blackbull/server/server.py)
+========================================================
+
+Each test is tied directly to a bug that was found during development and
+explains *why* the test would have caught it early.
+
+Bug 3 – missing ``await`` on ``self.app()``
+    ``self.app(scope, self.receive, self.send)`` created a coroutine object
+    but never ran it.  A test that verifies the application coroutine is
+    actually *called* would have caught this immediately.
+
+Bug 4 – ``receive()`` returned a coroutine object + wrong framing protocol
+    ``return self.reader.readuntil(b'\\r\\n\\r\\n')`` returned the coroutine
+    instead of awaiting it, and HTTP line-delimited reading is meaningless for
+    the binary WebSocket framing protocol (RFC 6455 §5).  Unit tests for
+    ``_read_frame`` with crafted byte sequences catch both issues.
+
+Bug 5 – ``send()`` wrote raw dicts to ``writer.write()``
+    ``writer.write(x)`` expects *bytes*; passing a dict raises TypeError.
+    Tests that exercise every event type in ``send()`` and assert actual
+    bytes appear on the wire catch this.
+
+Bug 6 – wrong scope type passed to the application
+    The handler replaced the original HTTP-upgrade scope (which contains
+    ``type='websocket'`` and ``path``) with ``{'type': 'websocket.connect'}``,
+    stripping the path entirely so the router could not dispatch.  A test
+    that checks the scope forwarded to ``app()`` catches this.
+"""
+
+import asyncio
+import struct
+from unittest.mock import AsyncMock, MagicMock, call, patch
+import pytest
+
+from blackbull.server.server import WebsocketHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers – minimal stream fakes
+# ---------------------------------------------------------------------------
+
+def _make_client_frame(payload: bytes, opcode: int = 0x1) -> bytes:
+    """Build a *masked* WebSocket frame (clients MUST mask, RFC 6455 §5.1)."""
+    mask = b'\xde\xad\xbe\xef'
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    length = len(payload)
+    header = bytes([0x80 | opcode])
+    if length < 126:
+        header += bytes([0x80 | length])
+    elif length < 65536:
+        header += bytes([0x80 | 126]) + length.to_bytes(2, 'big')
+    else:
+        header += bytes([0x80 | 127]) + length.to_bytes(8, 'big')
+    return header + mask + masked
+
+
+class _FakeReader:
+    """Feed a pre-built byte string through asyncio StreamReader's API."""
+
+    def __init__(self, data: bytes):
+        self._buf = bytearray(data)
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            raise asyncio.IncompleteReadError(bytes(self._buf), n)
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    async def readuntil(self, sep: bytes) -> bytes:
+        idx = self._buf.find(sep)
+        if idx == -1:
+            raise asyncio.IncompleteReadError(bytes(self._buf), None)
+        chunk = bytes(self._buf[:idx + len(sep)])
+        del self._buf[:idx + len(sep)]
+        return chunk
+
+    async def readline(self) -> bytes:
+        return await self.readuntil(b'\n')
+
+
+class _FakeWriter:
+    """Capture everything written to the fake transport."""
+
+    def __init__(self):
+        self.written = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes):
+        self.written += data
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _encode_frame (Bug 5 pre-condition)
+# ---------------------------------------------------------------------------
+
+class TestEncodeFrame:
+    """_encode_frame must produce valid unmasked WebSocket frames."""
+
+    def test_small_text_frame(self):
+        """Payload < 126 bytes → 2-byte header."""
+        payload = b'hello'
+        frame = WebsocketHandler._encode_frame(payload, opcode=0x1)
+        assert frame[0] == 0x80 | 0x1          # FIN + text opcode
+        assert frame[1] == len(payload)          # no mask bit, length 5
+        assert frame[2:] == payload
+
+    def test_medium_frame_126(self):
+        """Payload == 126 bytes → 126-length indicator + 2-byte extended length."""
+        payload = b'x' * 126
+        frame = WebsocketHandler._encode_frame(payload, opcode=0x2)
+        assert frame[0] == 0x80 | 0x2
+        assert frame[1] == 126
+        assert int.from_bytes(frame[2:4], 'big') == 126
+        assert frame[4:] == payload
+
+    def test_large_frame(self):
+        """Payload == 65536 bytes → 127-length indicator + 8-byte extended length."""
+        payload = b'y' * 65536
+        frame = WebsocketHandler._encode_frame(payload, opcode=0x2)
+        assert frame[0] == 0x80 | 0x2
+        assert frame[1] == 127
+        assert int.from_bytes(frame[2:10], 'big') == 65536
+        assert frame[10:] == payload
+
+    def test_binary_opcode(self):
+        frame = WebsocketHandler._encode_frame(b'\x00\x01', opcode=0x2)
+        assert frame[0] & 0x0F == 0x2
+
+    def test_close_frame_opcode(self):
+        frame = WebsocketHandler._encode_frame(b'\x03\xe8', opcode=0x8)
+        assert frame[0] & 0x0F == 0x8
+
+
+# ---------------------------------------------------------------------------
+# _read_frame (Bug 4)
+# ---------------------------------------------------------------------------
+
+class TestReadFrame:
+    """_read_frame must correctly parse masked client frames per RFC 6455."""
+
+    @pytest.mark.asyncio
+    async def test_reads_text_frame(self):
+        """Bug 4: read_frame must await reader, not return a coroutine object."""
+        payload = b'Toshio'
+        data = _make_client_frame(payload, opcode=0x1)
+        reader = _FakeReader(data)
+        opcode, got = await WebsocketHandler._read_frame(reader)
+        assert opcode == 0x1
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_reads_binary_frame(self):
+        payload = bytes(range(16))
+        data = _make_client_frame(payload, opcode=0x2)
+        reader = _FakeReader(data)
+        opcode, got = await WebsocketHandler._read_frame(reader)
+        assert opcode == 0x2
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_reads_close_frame(self):
+        payload = b'\x03\xe8'
+        data = _make_client_frame(payload, opcode=0x8)
+        reader = _FakeReader(data)
+        opcode, got = await WebsocketHandler._read_frame(reader)
+        assert opcode == 0x8
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_unmask_is_applied(self):
+        """Masked frame: payload must be XOR-unmasked correctly."""
+        raw_payload = b'ABCD'
+        data = _make_client_frame(raw_payload, opcode=0x1)
+        reader = _FakeReader(data)
+        _, got = await WebsocketHandler._read_frame(reader)
+        assert got == raw_payload
+
+    @pytest.mark.asyncio
+    async def test_medium_payload_extended_length(self):
+        """Frames with 126-byte payloads use the 16-bit extended-length field."""
+        payload = b'z' * 126
+        data = _make_client_frame(payload, opcode=0x1)
+        reader = _FakeReader(data)
+        opcode, got = await WebsocketHandler._read_frame(reader)
+        assert got == payload
+
+    @pytest.mark.asyncio
+    async def test_incomplete_read_raises(self):
+        """Truncated stream must raise IncompleteReadError, not return partial data."""
+        reader = _FakeReader(b'\x81')   # only 1 byte – header requires 2
+        with pytest.raises(asyncio.IncompleteReadError):
+            await WebsocketHandler._read_frame(reader)
+
+
+# ---------------------------------------------------------------------------
+# receive() (Bug 4)
+# ---------------------------------------------------------------------------
+
+class TestReceive:
+    """WebsocketHandler.receive() must return ASGI event dicts, not coroutines."""
+
+    def _make_handler(self, raw_frame: bytes):
+        reader = _FakeReader(raw_frame)
+        writer = _FakeWriter()
+        scope = {'type': 'websocket', 'path': '/ws', 'headers': []}
+        return WebsocketHandler(AsyncMock(), reader, writer, scope)
+
+    @pytest.mark.asyncio
+    async def test_receive_text_returns_dict(self):
+        """Bug 4 regression: receive() must return an awaited dict, not a coroutine."""
+        handler = self._make_handler(_make_client_frame(b'hello', opcode=0x1))
+        event = await handler.receive()
+        # Must be a plain dict – never a coroutine
+        assert isinstance(event, dict), "receive() returned a coroutine instead of a dict"
+        assert event['type'] == 'websocket.receive'
+        assert event['text'] == 'hello'
+        assert event['bytes'] is None
+
+    @pytest.mark.asyncio
+    async def test_receive_binary_returns_dict(self):
+        handler = self._make_handler(_make_client_frame(b'\xde\xad', opcode=0x2))
+        event = await handler.receive()
+        assert event['type'] == 'websocket.receive'
+        assert event['text'] is None
+        assert event['bytes'] == b'\xde\xad'
+
+    @pytest.mark.asyncio
+    async def test_receive_close_returns_disconnect(self):
+        handler = self._make_handler(_make_client_frame(b'\x03\xe8', opcode=0x8))
+        event = await handler.receive()
+        assert event['type'] == 'websocket.disconnect'
+
+    @pytest.mark.asyncio
+    async def test_receive_is_awaitable(self):
+        """Verify receive() is a coroutine function so callers can await it."""
+        handler = self._make_handler(_make_client_frame(b'x', opcode=0x1))
+        import inspect
+        assert inspect.iscoroutinefunction(handler.receive)
+
+
+# ---------------------------------------------------------------------------
+# send() (Bug 5)
+# ---------------------------------------------------------------------------
+
+class TestSend:
+    """WebsocketHandler.send() must encode ASGI event dicts into wire bytes."""
+
+    def _make_handler(self):
+        reader = _FakeReader(b'')
+        writer = _FakeWriter()
+        scope = {'type': 'websocket', 'path': '/ws', 'headers': []}
+        handler = WebsocketHandler(AsyncMock(), reader, writer, scope)
+        return handler, writer
+
+    @pytest.mark.asyncio
+    async def test_send_text_writes_bytes(self):
+        """Bug 5 regression: send() must write bytes to the wire, not a raw dict."""
+        handler, writer = self._make_handler()
+        await handler.send({'type': 'websocket.send', 'text': 'hello'})
+        assert len(writer.written) > 0, "send() wrote nothing to the wire"
+        assert isinstance(writer.written, (bytes, bytearray))
+
+    @pytest.mark.asyncio
+    async def test_send_text_produces_text_opcode(self):
+        """Text payload must use opcode 0x1 (RFC 6455 §5.2)."""
+        handler, writer = self._make_handler()
+        await handler.send({'type': 'websocket.send', 'text': 'hi'})
+        assert writer.written[0] & 0x0F == 0x1
+
+    @pytest.mark.asyncio
+    async def test_send_text_payload_is_utf8(self):
+        handler, writer = self._make_handler()
+        msg = 'Toshio'
+        await handler.send({'type': 'websocket.send', 'text': msg})
+        # Parse back: 2-byte header (FIN+opcode, length), then payload
+        length = writer.written[1] & 0x7F
+        payload = bytes(writer.written[2:2 + length])
+        assert payload == msg.encode('utf-8')
+
+    @pytest.mark.asyncio
+    async def test_send_bytes_writes_binary_opcode(self):
+        """Binary payload must use opcode 0x2."""
+        handler, writer = self._make_handler()
+        await handler.send({'type': 'websocket.send', 'bytes': b'\xca\xfe'})
+        assert writer.written[0] & 0x0F == 0x2
+
+    @pytest.mark.asyncio
+    async def test_send_close_writes_close_opcode(self):
+        """websocket.close event must produce a close frame (opcode 0x8)."""
+        handler, writer = self._make_handler()
+        await handler.send({'type': 'websocket.close'})
+        assert len(writer.written) > 0
+        assert writer.written[0] & 0x0F == 0x8
+
+    @pytest.mark.asyncio
+    async def test_send_accept_writes_nothing(self):
+        """websocket.accept is handled in run(); send() should be a no-op for it."""
+        handler, writer = self._make_handler()
+        await handler.send({'type': 'websocket.accept', 'subprotocol': None})
+        assert len(writer.written) == 0
+
+
+# ---------------------------------------------------------------------------
+# run() scope forwarding (Bug 6)
+# ---------------------------------------------------------------------------
+
+class TestRunScopeForwarding:
+    """WebsocketHandler.run() must forward the original HTTP-upgrade scope to app.
+
+    Bug 6: the old code replaced the scope with ``{'type': 'websocket.connect'}``
+    (no 'path' key), which broke router dispatch.
+    """
+
+    def _make_upgrade_scope(self, path: str = '/ws') -> dict:
+        """Minimal scope as produced by parse() from an HTTP Upgrade request."""
+        # The Sec-WebSocket-Key value doesn't have to be valid Base64 here
+        # because we're only testing scope forwarding, not the handshake itself.
+        ws_key = b'dGhlIHNhbXBsZSBub25jZQ=='
+        return {
+            'type': 'websocket',
+            'path': path,
+            'scheme': 'ws',
+            'headers': [
+                (b'Host', b'localhost:9999'),
+                (b'Upgrade', b'websocket'),
+                (b'Sec-WebSocket-Key', ws_key),
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_app_is_awaited(self):
+        """Bug 3 regression: app() must be awaited, not just called."""
+        scope = self._make_upgrade_scope()
+
+        called_with = {}
+
+        async def fake_app(s, receive, send):
+            called_with['scope'] = s
+
+        reader = _FakeReader(b'')   # nothing to read after handshake
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, reader, writer, scope)
+
+        await handler.run()
+
+        assert called_with, "app coroutine was never awaited (Bug 3)"
+
+    @pytest.mark.asyncio
+    async def test_app_receives_original_scope_type(self):
+        """Bug 6 regression: scope type forwarded to app must be 'websocket'."""
+        scope = self._make_upgrade_scope('/chat')
+        captured = {}
+
+        async def fake_app(s, receive, send):
+            captured['scope'] = s
+
+        reader = _FakeReader(b'')
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, reader, writer, scope)
+        await handler.run()
+
+        fwd = captured['scope']
+        assert fwd['type'] == 'websocket', (
+            f"Expected type='websocket', got type={fwd['type']!r}. "
+            "The handler must NOT replace the scope with {{'type': 'websocket.connect'}}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_app_receives_original_path(self):
+        """Bug 6 regression: 'path' must survive forwarding to the application."""
+        scope = self._make_upgrade_scope('/chat')
+        captured = {}
+
+        async def fake_app(s, receive, send):
+            captured['scope'] = s
+
+        reader = _FakeReader(b'')
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, reader, writer, scope)
+        await handler.run()
+
+        assert 'path' in captured['scope'], (
+            "scope forwarded to app is missing 'path' – router cannot dispatch."
+        )
+        assert captured['scope']['path'] == '/chat'
+
+    @pytest.mark.asyncio
+    async def test_app_not_called_with_websocket_connect_type(self):
+        """The old incorrect scope {'type': 'websocket.connect'} must never appear."""
+        scope = self._make_upgrade_scope()
+        captured = {}
+
+        async def fake_app(s, receive, send):
+            captured['scope'] = s
+
+        reader = _FakeReader(b'')
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, reader, writer, scope)
+        await handler.run()
+
+        assert captured['scope'].get('type') != 'websocket.connect', (
+            "app received the old incorrect scope type 'websocket.connect'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# run() handshake response (general correctness)
+# ---------------------------------------------------------------------------
+
+class TestRunHandshake:
+    """run() must write a valid HTTP/1.1 101 Switching Protocols response."""
+
+    @pytest.mark.asyncio
+    async def test_101_header_is_written(self):
+        ws_key = b'dGhlIHNhbXBsZSBub25jZQ=='
+        scope = {
+            'type': 'websocket',
+            'path': '/ws',
+            'scheme': 'ws',
+            'headers': [(b'Sec-WebSocket-Key', ws_key)],
+        }
+
+        async def fake_app(s, receive, send):
+            pass
+
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, _FakeReader(b''), writer, scope)
+        await handler.run()
+
+        response_text = writer.written.decode('latin-1')
+        assert '101 Switching Protocols' in response_text
+        assert 'Upgrade: websocket' in response_text
+        assert 'Sec-WebSocket-Accept:' in response_text
+
+    @pytest.mark.asyncio
+    async def test_accept_key_is_correct(self):
+        """The Sec-WebSocket-Accept value must follow RFC 6455 §4.2.2."""
+        import base64, hashlib
+        ws_key = b'dGhlIHNhbXBsZSBub25jZQ=='
+        magic = b'258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
+        expected = base64.b64encode(
+            hashlib.sha1(ws_key + magic).digest()
+        ).decode('ascii')
+
+        scope = {
+            'type': 'websocket', 'path': '/ws', 'scheme': 'ws',
+            'headers': [(b'Sec-WebSocket-Key', ws_key)],
+        }
+
+        async def fake_app(s, receive, send):
+            pass
+
+        writer = _FakeWriter()
+        handler = WebsocketHandler(fake_app, _FakeReader(b''), writer, scope)
+        await handler.run()
+
+        assert expected in writer.written.decode('latin-1')


### PR DESCRIPTION
## Summary

This PR adds a comprehensive regression test suite covering every bug found and fixed during the WebSocket + dual-stack IPv4/IPv6 work. It also fixes one additional bug in `parse()` discovered while writing the tests.

---

## New test files

### `tests/test_websocket_handler.py`
Unit tests for `WebsocketHandler` (Bugs 3–6).

| Class | Covers |
|---|---|
| `TestEncodeFrame` | Bug 5 pre-condition: `_encode_frame()` produces correct RFC 6455 frames for small / medium / large payloads |
| `TestReadFrame` | Bug 4: `_read_frame()` must be awaited, correctly unmask client frames, handle extended-length fields |
| `TestReceive` | Bug 4: `receive()` returns a plain ASGI dict (not a coroutine), handles text/binary/close opcodes |
| `TestSend` | Bug 5: `send()` writes actual bytes to the wire with correct RFC 6455 opcodes |
| `TestRunScopeForwarding` | Bug 3 & 6: app is awaited; scope forwarded to app has `type='websocket'` and `path` |
| `TestRunHandshake` | General: 101 response contains correct `Sec-WebSocket-Accept` per RFC 6455 §4.2.2 |

### `tests/test_asgi_server.py`
Integration tests for `ASGIServer` (Bugs 1, 7, 8).

| Class | Covers |
|---|---|
| `TestASGIServerInit` | Bug 1: no `ValueError` when both certfile+keyfile given; `TypeError` if both `ssl_context` and certfile given |
| `TestMakeSSLContext` | Bug 1: `make_ssl_context()` defers silently until both cert+key are set |
| `TestOpenSocket` | Bug 7: all bound sockets share one port; Bug 8: `raw_sockets` are plain TCP (not `SSLSocket`) |
| `TestASGIServerRun` | Bug 8: `run()` starts without `TypeError`; TLS handshake succeeds without double-TLS layer |

### `tests/test_rsock.py`
Unit tests for socket helpers in `blackbull/rsock.py` (Bugs 7, 8).

| Class | Covers |
|---|---|
| `TestBindSocket` | IPv4 / IPv6 bind, `SO_REUSEADDR`, `IPV6_V6ONLY=1`, socket is in listen state |
| `TestCreateSocket` | Family selection from host string |
| `TestCreateDualStackSockets` | Bug 7: shared port across families; plain TCP sockets returned |

### `tests/test_server_dispatch.py`
Tests for `parse()` and `client_connected_cb()` dispatch (Bug 6 root-cause).

| Class | Covers |
|---|---|
| `TestParse` | HTTP method/path/version parsing; WebSocket upgrade detection sets `type='websocket'` and preserves `path` |
| `TestClientConnectedCbDispatch` | WS upgrade → `WebsocketHandler`; plain GET → `HTTP1_1Handler`; writer always closed |

---

## Extended tests

### `tests/test_response.py`
Added 10 new tests for `WebSocketResponse` (Bug 9) and `Response`:

- **Bug 9 regression**: plain strings must not be wrapped in `json.dumps()` (e.g. `'Toshio'` must not become `'"Toshio"'`)
- Bytes pass through unmodified; dicts and lists are JSON-serialised
- `Response()` raises `TypeError` for non-str/bytes content

---

## Bonus fix: `parse()` scheme overwrite

While writing `TestParse::test_websocket_upgrade_sets_scheme_ws` the test immediately failed, revealing that `parse()` set `scheme='ws'` from the `Upgrade` header and then immediately overwrote it with `scheme='Upgrade'` from the `Connection` header (`Connection: Upgrade`). Fixed in `blackbull/server/server.py`: the `Connection` header now only updates scheme when there is no `Upgrade` header.

---

## Test counts

| Before | After |
|---|---|
| 18 | **108** |

All 108 tests pass.