### PR TITLE
ci: drop paths filter from pip-audit triggers

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -3,11 +3,11 @@ name: pip-audit
 # Scans BlackBull's dependency tree against the PyPI advisory
 # database and OSV.  Fails the build on known-CVE matches.
 #
-# Triggers:
-#   - on every PR that touches pyproject.toml
-#   - weekly schedule to catch advisories filed against unchanged
-#     dependencies between PRs
-#   - manual dispatch
+# Triggers on every push and PR to master so the check appears in
+# branch-protection's required-status-checks dropdown for all PRs
+# (Dependabot bumps that don't touch pyproject.toml included).
+# Weekly schedule catches advisories filed against unchanged
+# dependencies between PRs; manual dispatch for ad-hoc runs.
 #
 # Dependabot security alerts are independent of this workflow and
 # will surface a CVE PR even when this job has not yet run.  The
@@ -16,14 +16,8 @@ name: pip-audit
 on:
   push:
     branches: [master]
-    paths:
-      - 'pyproject.toml'
-      - '.github/workflows/pip-audit.yml'
   pull_request:
     branches: [master]
-    paths:
-      - 'pyproject.toml'
-      - '.github/workflows/pip-audit.yml'
   schedule:
     - cron: '17 6 * * 1'   # weekly, Monday 06:17 UTC
   workflow_dispatch:


### PR DESCRIPTION
## Summary

The path-restricted trigger on \`.github/workflows/pip-audit.yml\` prevented the workflow from running on PRs that didn't touch \`pyproject.toml\` — including all Dependabot github-actions bumps. Branch protection's required-status-check then waited indefinitely for \`Audit dependencies\` on those PRs (observed on PR #28 before merge).

Drop the \`paths:\` filter on both \`push\` and \`pull_request\` triggers. The audit completes in ~10 s, so running it on every push and PR has negligible cost and required-status integration becomes reliable.

## Test plan

- [ ] CodeQL passes on this PR.
- [ ] \`Audit dependencies\` runs on this PR (previously would have skipped since no \`pyproject.toml\` change — that's the regression-equivalent we're fixing).
- [ ] After merge, PR #29 (codeql-action SHA bump) and any future Dependabot PRs will have \`Audit dependencies\` actually fire and report status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)