### PR TITLE
perf(server): close-path quick wins for burst-keepalive workloads

### DIFF
--- a/blackbull/server/connection_actor.py
+++ b/blackbull/server/connection_actor.py
@@ -58,11 +58,10 @@ class ConnectionActor(Actor):
         if self._aggregator is not None:
             await self._aggregator.on_connection_accepted(self._peername)
         try:
-            async with asyncio.TaskGroup() as tg:
-                tg.create_task(self._dispatch())
-        except* Exception as eg:
+            await self._dispatch()
+        except Exception as exc:
             if self._aggregator is not None:
-                await self._aggregator.on_error({}, eg)
+                await self._aggregator.on_error({}, exc)
         finally:
             await self._writer.close()
 

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -96,12 +96,22 @@ class AsyncioWriter(AbstractWriter):
         await self._sw.drain()
 
     async def close(self) -> None:
+        # ``self._sw.close()`` is synchronous: it initiates the TCP
+        # shutdown and schedules the transport's ``connection_lost``
+        # callback for a later loop iteration.  We DO NOT await
+        # ``wait_closed()`` here — under burst-keepalive workloads
+        # (HttpArena ``static`` at c=4096) awaiting it serializes the
+        # connection-actor coroutine with the transport-close completion,
+        # adding 1-3 event-loop turns per connection.  With thousands of
+        # simultaneous closes that latency multiplies into a multi-second
+        # drain that monopolises the loop and starves the next wrk run.
+        #
+        # Safety: every ``write()`` above flushes via ``drain()``, so by
+        # the time we reach close() there is no buffered payload.  The
+        # transport tears down asynchronously; our coroutine exiting
+        # earlier is harmless for the connection-actor path (no
+        # follow-up state to flush).
         self._sw.close()
-        if hasattr(self._sw, 'wait_closed'):
-            try:
-                await self._sw.wait_closed()
-            except Exception:
-                pass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two small, independent server-side optimizations diagnosed in Sprint 30 Task 1 (event-loop integrity under burst-keepalive load):

### 1. Skip \`await wait_closed()\` in \`AsyncioWriter.close()\` (7a81b83)

\`StreamWriter.close()\` already initiates the TCP shutdown synchronously and schedules \`connection_lost\` for a later loop iteration. Awaiting \`wait_closed()\` afterwards just serialized our connection-actor coroutine with full transport-close completion, adding 1-3 event-loop turns per connection. Under burst-keepalive (HttpArena \`static\` at c=4096) those extra turns multiplied into multi-second drains.

Every \`write()\` flushes via \`drain()\`, so the buffer is already empty by the time \`close()\` runs — exiting the coroutine before the transport's async teardown is harmless for the connection-actor path.

### 2. Drop redundant TaskGroup wrap in \`ConnectionActor.run()\` (68cbcc8)

The outer \`asyncio.TaskGroup\` wrapping a single \`_dispatch()\` task was redundant: both HTTP/1.1 (via \`HTTP1Actor\`) and HTTP/2 (via \`HTTP2Actor\`) run their protocol-specific logic without spawning sibling tasks at this level. HTTP/2 manages per-stream tasks via its own internal TaskGroup inside \`HTTP2Actor.run()\` (see [\`http2_actor.py:428\`](blackbull/server/http2_actor.py#L428)), so the outer wrap added no supervision — just an extra Task allocation per connection (observed: 8,196 alive tasks for 4,096 connections — exactly 2× because of the wrap).

Replaces with direct \`await self._dispatch()\` + plain \`except Exception\` — ExceptionGroup support remains via HTTP2Actor's inner TaskGroup for stream-level errors.

## Measured impact

Local probe at c=4096, 3 back-to-back runs:

| | Run 1 r/s | Run 2/3 degradation |
|---|---:|---:|
| baseline | 4,630 | 12.6% |
| + skip wait_closed | 4,705 | 11.2% |
| + drop TaskGroup wrap | 4,691 | **6%** |

Modest individually; both stack. ~50% reduction in degradation amplitude. Throughput unchanged at peak.

These are the first two Tier 1 items per the [Sprint 30 plan](https://github.com/TOKUJI/BlackBull/blob/master/.claude/plans/wise-conjuring-sundae.md) — independent of the larger changes (write-timeout, max-connections cap, custom asyncio protocol) coming in the following PRs.

## Test plan

- [x] Pre-commit suite passes on both commits (1197 tests passing × 2).
- [ ] CodeQL + pip-audit clean on this PR.
- [ ] HTTP/2 conformance tests stay green (TaskGroup change touches a HTTP-protocol-agnostic layer).
- [ ] WebSocket tests stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)