### PR TITLE
feat(server): ProtocolBuffer — cancellable byte buffer for Tier 1.5

### DIFF
--- a/blackbull/server/protocol_buffer.py
+++ b/blackbull/server/protocol_buffer.py
@@ -1,0 +1,261 @@
+"""Cancellable byte buffer for the custom asyncio protocol path.
+
+Sprint 30 Tier 1.5 Step 1 — see
+``bench/sprint-logs/sprint-30-tier1.5-design.md`` for the architectural
+rationale.  Briefly: the existing ``asyncio.StreamReader`` uses a
+future-wakeup model whose per-readuntil-resume cost adds 1-2
+event-loop turns per connection close.  Under burst-keepalive (HttpArena
+``static`` at c=4096) that multiplies into a multi-second drain.  This
+buffer replaces ``StreamReader`` on the keepalive-idle read path so
+EOF — when it arrives via the ``_BlackBullProtocol.eof_received``
+callback — can short-circuit the chain by cancelling the awaiting task
+synchronously instead of waking it through a future and a subsequent
+loop tick.
+
+Design constraints
+------------------
+* Single-task consumer per buffer (one connection-actor reads one
+  buffer); single feeder per buffer (the protocol's
+  ``data_received`` / ``eof_received`` callbacks).  No locks needed
+  — asyncio is single-threaded.
+* Cancellation-safe: if the consumer task is cancelled mid-read,
+  the pending waiter resolves cleanly and the buffer remains usable
+  for a fresh reader (e.g. a graceful-shutdown handoff).  In
+  practice the actor exits on cancellation, so this matters mostly
+  for test ergonomics.
+* No internal call to ``asyncio.wait_for``: the per-phase
+  deadlines that ``http1_actor`` enforces (header / body /
+  keepalive) wrap our reads externally.  This keeps the buffer
+  itself transport-agnostic and free of timeout interactions.
+
+API mirrors ``asyncio.StreamReader``'s ``read`` / ``readuntil`` /
+``readexactly`` so the existing ``AsyncioReader`` shim can proxy
+through with minimal changes.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .recipient import IncompleteReadError
+
+logger = logging.getLogger(__name__)
+
+
+class LimitOverrunError(Exception):
+    """Raised by :meth:`ProtocolBuffer.read_until` when ``max_size`` is
+    exceeded before the delimiter is found.
+
+    Mirrors ``asyncio.LimitOverrunError`` semantics (with attribute
+    ``consumed`` for diagnostics) so the existing per-line / per-block
+    size checks in ``http1_actor`` continue to work.
+    """
+
+    def __init__(self, message: str, consumed: int) -> None:
+        super().__init__(message)
+        self.consumed = consumed
+
+
+class ProtocolBuffer:
+    """Byte buffer fed by the protocol layer, drained by an
+    actor-side ``await`` consumer.
+
+    The consumer suspends in ``read_until`` / ``read_exactly`` /
+    ``read``; the feeder calls :meth:`feed` (after
+    ``protocol.data_received``) and :meth:`feed_eof` (after
+    ``protocol.eof_received``) to wake the consumer.
+
+    A single ``_waiter`` future drives the wakeup — there's no
+    queueing layer between the protocol callback and the consumer.
+    On EOF the consumer's pending await raises
+    :class:`IncompleteReadError` (matching ``AsyncioReader``'s
+    contract) once it next checks the buffer.
+    """
+
+    __slots__ = ('_buf', '_eof', '_waiter', '_closed')
+
+    def __init__(self) -> None:
+        # ``bytearray`` for O(1) append + cheap slice-delete from the
+        # front.  Empirically faster than ``bytes`` concatenation for
+        # the per-request feed-then-drain pattern.
+        self._buf: bytearray = bytearray()
+        self._eof: bool = False
+        # Single in-flight waiter — set by the consumer when it
+        # suspends, resolved by the feeder on the next data/eof event.
+        self._waiter: Optional[asyncio.Future] = None
+        # Once True, all subsequent reads raise IncompleteReadError
+        # without ever suspending; used as a "you cannot recover this
+        # connection" signal from ``_BlackBullProtocol``.
+        self._closed: bool = False
+
+    # ------------------------------------------------------------------
+    # Feed-side API (called from protocol callbacks, never awaited)
+    # ------------------------------------------------------------------
+
+    def feed(self, data: bytes) -> None:
+        """Append data and wake any suspended consumer."""
+        if not data:
+            return
+        if self._closed:
+            # Buffer was force-closed; drop the data.  Should be rare —
+            # the protocol stops calling feed() after eof_received /
+            # connection_lost.
+            logger.debug('protocol_buffer: feed on closed buffer (%d bytes dropped)',
+                         len(data))
+            return
+        self._buf.extend(data)
+        self._wake()
+
+    def feed_eof(self) -> None:
+        """Mark end-of-stream and wake any suspended consumer.
+
+        Subsequent reads return what's still buffered, then raise
+        :class:`IncompleteReadError` once the buffer is exhausted.
+        """
+        if self._eof:
+            return
+        self._eof = True
+        self._wake()
+
+    def close(self) -> None:
+        """Force-close: all future reads raise immediately.
+
+        Called by ``_BlackBullProtocol`` on connection_lost when an
+        error condition meant we should not even drain remaining
+        buffered bytes.
+        """
+        self._closed = True
+        self._eof = True
+        self._wake()
+
+    def _wake(self) -> None:
+        if self._waiter is not None and not self._waiter.done():
+            self._waiter.set_result(None)
+            # Don't None out; the awaiter resets in its finally.
+
+    # ------------------------------------------------------------------
+    # Properties (cheap, for ``_BlackBullProtocol``'s pause/resume logic)
+    # ------------------------------------------------------------------
+
+    @property
+    def buffered_bytes(self) -> int:
+        return len(self._buf)
+
+    @property
+    def eof_received(self) -> bool:
+        return self._eof
+
+    # ------------------------------------------------------------------
+    # Consumer-side API (await these)
+    # ------------------------------------------------------------------
+
+    async def read(self, n: int = -1) -> bytes:
+        """Read up to *n* bytes, or whatever is available.
+
+        Blocks until at least one byte is available, or EOF is
+        signalled.  ``n=-1`` means "everything buffered".  Returns
+        ``b''`` on EOF with empty buffer.
+        """
+        if not self._buf and not self._eof:
+            await self._suspend()
+        if n < 0 or n >= len(self._buf):
+            result = bytes(self._buf)
+            self._buf.clear()
+        else:
+            result = bytes(self._buf[:n])
+            del self._buf[:n]
+        return result
+
+    async def read_exactly(self, n: int) -> bytes:
+        """Read exactly *n* bytes.
+
+        Raises :class:`IncompleteReadError` if EOF arrives before *n*
+        bytes are available; the partial bytes are attached to the
+        exception via the standard asyncio API (``.partial``).
+        """
+        if n < 0:
+            raise ValueError(f'read_exactly: n must be non-negative, got {n}')
+        if n == 0:
+            return b''
+        while len(self._buf) < n:
+            if self._eof:
+                # Surface partial data via the asyncio
+                # IncompleteReadError convention.
+                partial = bytes(self._buf)
+                self._buf.clear()
+                exc = IncompleteReadError(f'EOF after {len(partial)} of {n} bytes')
+                exc.partial = partial          # type: ignore[attr-defined]
+                exc.expected = n               # type: ignore[attr-defined]
+                raise exc
+            await self._suspend()
+        result = bytes(self._buf[:n])
+        del self._buf[:n]
+        return result
+
+    async def read_until(self, sep: bytes, *, max_size: int = -1) -> bytes:
+        """Read until *sep* appears in the buffer; return the bytes
+        up to and including *sep*.
+
+        Raises :class:`IncompleteReadError` if EOF arrives before
+        *sep* is found.  Raises :class:`LimitOverrunError` if
+        ``max_size > 0`` and the buffer grows past it without seeing
+        *sep* — the caller should answer with the appropriate
+        protocol error (e.g. ``431 Request Header Fields Too Large``).
+        """
+        if not sep:
+            raise ValueError('read_until: sep must be a non-empty bytes object')
+        # Track the earliest possible position where sep could appear
+        # so we don't re-scan the whole buffer on each iteration.
+        scan_from = 0
+        while True:
+            idx = self._buf.find(sep, scan_from)
+            if idx >= 0:
+                end = idx + len(sep)
+                result = bytes(self._buf[:end])
+                del self._buf[:end]
+                return result
+            # Not found yet.
+            if max_size > 0 and len(self._buf) > max_size:
+                raise LimitOverrunError(
+                    f'read_until: buffer exceeded {max_size} bytes without '
+                    f'finding {sep!r}',
+                    consumed=len(self._buf),
+                )
+            if self._eof:
+                partial = bytes(self._buf)
+                self._buf.clear()
+                exc = IncompleteReadError(
+                    f'EOF after {len(partial)} bytes without finding {sep!r}'
+                )
+                exc.partial = partial          # type: ignore[attr-defined]
+                exc.expected = None            # type: ignore[attr-defined]
+                raise exc
+            # Avoid re-scanning bytes we've already checked, BUT keep
+            # the (len(sep) - 1) trailing bytes so we catch sep that
+            # straddles two feeds.
+            scan_from = max(0, len(self._buf) - (len(sep) - 1))
+            await self._suspend()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _suspend(self) -> None:
+        """Park until the next ``feed`` / ``feed_eof`` / ``close`` call.
+
+        Single waiter at a time (enforced by an assertion to surface
+        misuse during tests; the production invariant is "one actor
+        per connection / per buffer").
+        """
+        if self._waiter is not None:
+            raise RuntimeError(
+                'ProtocolBuffer: concurrent suspends — only one consumer '
+                'is supported per buffer'
+            )
+        loop = asyncio.get_event_loop()
+        self._waiter = loop.create_future()
+        try:
+            await self._waiter
+        finally:
+            self._waiter = None

--- a/tests/unit/test_protocol_buffer.py
+++ b/tests/unit/test_protocol_buffer.py
@@ -1,0 +1,316 @@
+"""Unit tests for ProtocolBuffer — the cancellable byte buffer at the
+heart of Sprint 30 Tier 1.5's custom asyncio protocol.
+
+The buffer replaces ``asyncio.StreamReader`` on the keepalive-idle
+read path.  Tests cover:
+
+- Feed-then-read sequences (data already buffered, data after feed).
+- EOF semantics (read what's left, then raise IncompleteReadError).
+- read_until: delimiter found mid-buffer, across-feed boundaries,
+  EOF before delimiter, max_size overflow.
+- read_exactly: short reads, exact reads, EOF mid-read.
+- read: partial reads, EOF returns b''.
+- Cancellation safety: suspended consumer can be cancelled; buffer
+  recovers for a fresh reader.
+- Concurrent-suspend guard: second suspend while another is active
+  raises RuntimeError (test-only invariant; production has one
+  consumer per buffer).
+
+No asyncio.Server involved — tests run against the bare class so
+they exercise the buffer's logic without transport-layer noise.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from blackbull.server.protocol_buffer import LimitOverrunError, ProtocolBuffer
+from blackbull.server.recipient import IncompleteReadError
+
+
+# ---------------------------------------------------------------------------
+# read_exactly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_exactly_data_already_buffered():
+    """When the buffer already has >= n bytes, read_exactly returns
+    immediately without suspending."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abcdefghij')
+    assert await buf.read_exactly(5) == b'abcde'
+    # Remaining bytes still available.
+    assert await buf.read_exactly(5) == b'fghij'
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_waits_for_more_data():
+    """When the buffer has fewer than n bytes, the call suspends
+    until enough data arrives via feed()."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abc')
+
+    async def feed_more():
+        await asyncio.sleep(0)   # let the consumer suspend first
+        buf.feed(b'defgh')
+
+    task = asyncio.create_task(buf.read_exactly(5))
+    asyncio.create_task(feed_more())
+    result = await task
+    assert result == b'abcde'
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_eof_before_n_bytes_raises_incomplete():
+    """If EOF arrives before n bytes are available, IncompleteReadError
+    is raised with .partial set to whatever was buffered."""
+    buf = ProtocolBuffer()
+    buf.feed(b'ab')
+    buf.feed_eof()
+    with pytest.raises(IncompleteReadError) as info:
+        await buf.read_exactly(10)
+    assert info.value.partial == b'ab'        # type: ignore[attr-defined]
+    assert info.value.expected == 10          # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_zero_returns_empty_without_waiting():
+    """n=0 is a no-op fast path — does not suspend even on an empty
+    buffer."""
+    buf = ProtocolBuffer()
+    assert await buf.read_exactly(0) == b''
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_negative_n_raises():
+    buf = ProtocolBuffer()
+    with pytest.raises(ValueError, match='non-negative'):
+        await buf.read_exactly(-1)
+
+
+# ---------------------------------------------------------------------------
+# read_until
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_until_finds_sep_in_buffer():
+    buf = ProtocolBuffer()
+    buf.feed(b'GET /healthz HTTP/1.1\r\nHost: x\r\n\r\nbody')
+    line = await buf.read_until(b'\r\n')
+    assert line == b'GET /healthz HTTP/1.1\r\n'
+    # Remaining data still in buffer.
+    rest = await buf.read(1024)
+    assert rest == b'Host: x\r\n\r\nbody'
+
+
+@pytest.mark.asyncio
+async def test_read_until_finds_sep_after_feed():
+    """Suspended read_until wakes up when sep arrives across multiple
+    feeds."""
+    buf = ProtocolBuffer()
+    buf.feed(b'partial line ')
+
+    async def complete():
+        await asyncio.sleep(0)
+        buf.feed(b'with delim\r\n')
+
+    task = asyncio.create_task(buf.read_until(b'\r\n'))
+    asyncio.create_task(complete())
+    line = await task
+    assert line == b'partial line with delim\r\n'
+
+
+@pytest.mark.asyncio
+async def test_read_until_sep_straddles_two_feeds():
+    """sep is multi-byte and the boundary falls between feeds — the
+    buffer's scan-from optimization must not miss it."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abc\r')           # first half of delimiter
+    async def feed_rest():
+        await asyncio.sleep(0)
+        buf.feed(b'\ndef')        # second half completes \r\n
+    task = asyncio.create_task(buf.read_until(b'\r\n'))
+    asyncio.create_task(feed_rest())
+    result = await task
+    assert result == b'abc\r\n'
+
+
+@pytest.mark.asyncio
+async def test_read_until_eof_before_sep_raises_incomplete():
+    buf = ProtocolBuffer()
+    buf.feed(b'no delimiter here')
+    buf.feed_eof()
+    with pytest.raises(IncompleteReadError) as info:
+        await buf.read_until(b'\r\n')
+    assert info.value.partial == b'no delimiter here'   # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_read_until_max_size_overflow_raises():
+    """If max_size is exceeded before sep is found, LimitOverrunError
+    is raised with .consumed set to the buffer length."""
+    buf = ProtocolBuffer()
+    big = b'a' * 100
+    buf.feed(big)
+    with pytest.raises(LimitOverrunError) as info:
+        await buf.read_until(b'\r\n', max_size=50)
+    assert info.value.consumed >= 50
+
+
+@pytest.mark.asyncio
+async def test_read_until_empty_sep_raises():
+    buf = ProtocolBuffer()
+    with pytest.raises(ValueError, match='non-empty'):
+        await buf.read_until(b'')
+
+
+# ---------------------------------------------------------------------------
+# read
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_returns_everything_when_n_negative():
+    buf = ProtocolBuffer()
+    buf.feed(b'hello world')
+    assert await buf.read(-1) == b'hello world'
+    # And subsequent reads (no more data, no EOF yet) would suspend.
+
+
+@pytest.mark.asyncio
+async def test_read_returns_partial_when_n_smaller_than_buffer():
+    buf = ProtocolBuffer()
+    buf.feed(b'abcdef')
+    assert await buf.read(3) == b'abc'
+    assert await buf.read(3) == b'def'
+
+
+@pytest.mark.asyncio
+async def test_read_returns_empty_on_eof():
+    buf = ProtocolBuffer()
+    buf.feed_eof()
+    assert await buf.read(100) == b''
+
+
+@pytest.mark.asyncio
+async def test_read_drains_remaining_then_returns_empty_on_eof():
+    buf = ProtocolBuffer()
+    buf.feed(b'last')
+    buf.feed_eof()
+    assert await buf.read(100) == b'last'
+    assert await buf.read(100) == b''
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_suspended_read_can_be_cancelled():
+    """If the consumer task is cancelled while parked, the cancellation
+    propagates cleanly and the buffer is reusable afterwards."""
+    buf = ProtocolBuffer()
+    task = asyncio.create_task(buf.read_exactly(100))
+    await asyncio.sleep(0)   # let it suspend
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # Buffer's waiter slot is released; a fresh consumer can read.
+    buf.feed(b'recovered')
+    # Note: we can't readuntil for sep that's not there without another
+    # suspend; just confirm the buffer state is sane.
+    assert buf.buffered_bytes == len(b'recovered')
+
+
+@pytest.mark.asyncio
+async def test_concurrent_suspend_is_rejected():
+    """Spawning a second consumer task while the first is suspended
+    raises RuntimeError — surfaces misuse during dev/tests.  Production
+    contract: one consumer per buffer."""
+    buf = ProtocolBuffer()
+    first = asyncio.create_task(buf.read_exactly(10))
+    await asyncio.sleep(0)   # let first suspend
+    second = asyncio.create_task(buf.read_exactly(5))
+    with pytest.raises(RuntimeError, match='concurrent suspends'):
+        await second
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+
+# ---------------------------------------------------------------------------
+# close() — force-close path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_close_wakes_pending_consumer_with_incomplete_read():
+    """ProtocolBuffer.close() marks the buffer as eof and wakes any
+    suspended consumer.  Pending reads then raise IncompleteReadError
+    (since no data was buffered)."""
+    buf = ProtocolBuffer()
+    task = asyncio.create_task(buf.read_exactly(10))
+    await asyncio.sleep(0)
+    buf.close()
+    with pytest.raises(IncompleteReadError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_feed_after_close_is_dropped():
+    """Defensive: if the protocol erroneously calls feed() after
+    eof/close, the bytes are silently dropped (logged at DEBUG)."""
+    buf = ProtocolBuffer()
+    buf.close()
+    buf.feed(b'too late')
+    assert buf.buffered_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_feed_eof_is_idempotent():
+    buf = ProtocolBuffer()
+    buf.feed_eof()
+    buf.feed_eof()
+    assert buf.eof_received is True
+
+
+# ---------------------------------------------------------------------------
+# Mixed sequences (realistic HTTP/1.1 flow)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_http1_request_then_eof():
+    """Realistic shape: receive a full HTTP/1.1 request, then EOF.
+
+    Mirrors what http1_actor.run() does — readuntil for headers,
+    optionally readexactly for body, then next-iteration readuntil
+    that hits EOF."""
+    buf = ProtocolBuffer()
+    request = (b'GET /static/app.js HTTP/1.1\r\n'
+               b'Host: localhost\r\n'
+               b'Accept-Encoding: br\r\n'
+               b'\r\n')
+    buf.feed(request)
+    buf.feed_eof()
+
+    # Request line.
+    rline = await buf.read_until(b'\r\n')
+    assert rline == b'GET /static/app.js HTTP/1.1\r\n'
+    # Headers up to and including CRLFCRLF.
+    rest = await buf.read_until(b'\r\n\r\n')
+    assert rest == b'Host: localhost\r\nAccept-Encoding: br\r\n\r\n'
+    # Next-iteration readuntil hits EOF.
+    with pytest.raises(IncompleteReadError):
+        await buf.read_until(b'\r\n')
+
+
+@pytest.mark.asyncio
+async def test_http1_pipelined_requests_drain_in_order():
+    """Two HTTP/1.1 requests fed together drain in order without
+    confusing read_until's scan."""
+    buf = ProtocolBuffer()
+    buf.feed(b'GET /a HTTP/1.1\r\n\r\nGET /b HTTP/1.1\r\n\r\n')
+
+    first = await buf.read_until(b'\r\n\r\n')
+    assert first == b'GET /a HTTP/1.1\r\n\r\n'
+    second = await buf.read_until(b'\r\n\r\n')
+    assert second == b'GET /b HTTP/1.1\r\n\r\n'


### PR DESCRIPTION
## Summary

Sprint 30 Tier 1.5 Step 1: the foundation byte-buffer that replaces \`asyncio.StreamReader\` on the keepalive-idle read path. Pure data structure — testable in isolation, no \`asyncio.Server\` / \`asyncio.Protocol\` involved yet.

Sees its first real use in Step 2 (\`_BlackBullProtocol\`) and Step 3 (wire into \`server.py\` behind \`BB_USE_CUSTOM_PROTOCOL\` env flag).

## Why

Sprint 30 Task 1's \`py-spy\` diagnosis showed 4,094 connection tasks parked at \`StreamReader._wait_for_data\` after wrk's burst-FIN at end-of-benchmark. The future-wakeup chain is 4-5 event-loop turns per FD: epoll EOF → \`eof_received\` → \`feed_eof\` → schedule waiter → next iteration → readuntil resumes → break. With 4,096 simultaneous FINs that takes ~5 seconds.

ProtocolBuffer's \`feed_eof()\` / \`close()\` are designed to be called **synchronously** from \`_BlackBullProtocol.eof_received\`, collapsing the chain to one event-loop turn. That's the architectural change that should eliminate the cliff in Step 5's measurement.

## Surface

- \`feed(data)\` / \`feed_eof()\` / \`close()\` — sync, from protocol callbacks.
- \`await read(n)\` — drain up to n bytes (or all when n=-1).
- \`await read_exactly(n)\` — strict n bytes or \`IncompleteReadError\` (asyncio-compatible: \`.partial\` + \`.expected\`).
- \`await read_until(sep, max_size=N)\` — find delimiter; raises \`IncompleteReadError\` on EOF-before-sep, \`LimitOverrunError\` on overshoot (mirrors \`asyncio.LimitOverrunError.consumed\` for the 431 path).

## Tests

22 new unit tests covering: feed-then-read sequences, EOF semantics, sep-straddles-two-feeds, max_size overflow, cancellation safety, concurrent-suspend guard, and two realistic HTTP/1.1 flows (single request + EOF, pipelined requests).

Total unit-test count: **1219 passing**.

## Stacks on Tier 1 PRs

This PR doesn't touch any file the Tier 1 PRs (#32, #33, #34, #35) touch. Either order of merge works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)