### PR TITLE
feat(server): _BlackBullProtocol — synchronous-close-on-EOF

### DIFF
--- a/blackbull/server/edge_protocol.py
+++ b/blackbull/server/edge_protocol.py
@@ -1,0 +1,217 @@
+"""Custom asyncio.Protocol for the keepalive-idle read path.
+
+Sprint 30 Tier 1.5 Step 2 — replaces the default
+``asyncio.StreamReaderProtocol`` used by ``asyncio.start_server`` so
+that the EOF → close chain folds into one event-loop turn per FD
+lifecycle (vs ~3-5 turns through the default StreamReader future
+wakeup chain).
+
+How it lands
+------------
+This is just the Protocol class.  Wiring it into ``server.py`` (Step 3)
+will switch ``ASGIServer`` from ``asyncio.start_server`` to
+``loop.create_server`` with this protocol factory.  Until then this
+module is dormant — landing now lets us tests it in isolation.
+
+State machine
+-------------
+::
+
+    ┌──────────────────────────────┐
+    │   __init__ (factory called)  │
+    └──────────────┬───────────────┘
+                   │ connection_made(transport)
+                   ▼
+        ┌───────────────────────────┐
+   ┌───►│  ACTIVE                   │
+   │    │  buffer = ProtocolBuffer()│
+   │    │  writer = StreamWriter()  │
+   │    │  task = create_task(cb)   │
+   │    └────┬─────────────────┬────┘
+   │         │ data_received   │ eof_received  (SYNCHRONOUS)
+   │         ▼                 ▼
+   │   ┌──────────┐    ┌────────────────────────┐
+   │   │buffer.   │    │ 1) transport.close()   │
+   │   │feed()    │    │ 2) buffer.feed_eof()   │
+   │   └────┬─────┘    │ 3) return False        │
+   │        │          └──────────┬─────────────┘
+   └────────┘                     │
+                                  ▼
+                     ┌──────────────────────────┐
+                     │  CLOSED                  │
+                     │  connection_lost(exc)    │
+                     │  buffer.close()          │
+                     │  (task winds itself up)  │
+                     └──────────────────────────┘
+
+The synchronous ``eof_received`` is the architectural change: it
+runs in the same event-loop iteration as the epoll batch that
+delivered the EOF.  By the time the actor task next runs, the FD
+is already on its way to ``connection_lost``-fired ``_sock.close()``
+— no readuntil-resume → break → finally → writer.close() chain
+needed to release the FD.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional
+
+from .protocol_buffer import ProtocolBuffer
+
+logger = logging.getLogger(__name__)
+
+
+# The callback registered with ``loop.create_server(...)``-style APIs.
+# We pass our ``ProtocolBuffer`` as the first arg and a writer compatible
+# with ``asyncio.StreamWriter`` as the second, mirroring
+# ``asyncio.start_server``'s (reader, writer) convention so the existing
+# AsyncioReader / AsyncioWriter shims need minimal adaptation in Step 4.
+ConnectedCallback = Callable[
+    [ProtocolBuffer, asyncio.StreamWriter],
+    Awaitable[None],
+]
+
+
+class _BlackBullProtocol(asyncio.streams.FlowControlMixin):
+    """asyncio.Protocol that fronts the ProtocolBuffer read path.
+
+    Subclasses ``FlowControlMixin`` (asyncio internal) so we get
+    ``pause_writing`` / ``resume_writing`` / ``_drain_helper`` for
+    free — letting us reuse ``asyncio.StreamWriter`` as-is for the
+    write side without losing backpressure.
+
+    Reuse of StreamWriter is deliberate: the write-side bottleneck
+    isn't where the Sprint 30 cliff lives, and the existing
+    ``AsyncioWriter`` shim already wraps StreamWriter cleanly.  The
+    read-side is where we win turns, and that's where the buffer
+    replaces StreamReader.
+    """
+
+    __slots__ = (
+        '_connected_cb',
+        '_buffer',
+        '_writer',
+        '_task',
+        '_transport',
+        '_eof_seen',
+    )
+
+    def __init__(
+        self,
+        connected_cb: ConnectedCallback,
+        *,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        super().__init__(loop=loop)
+        self._connected_cb = connected_cb
+        self._buffer: Optional[ProtocolBuffer] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._task: Optional[asyncio.Task] = None
+        self._transport: Optional[asyncio.Transport] = None
+        self._eof_seen: bool = False
+
+    # ------------------------------------------------------------------
+    # asyncio.Protocol overrides
+    # ------------------------------------------------------------------
+
+    def connection_made(self, transport: asyncio.BaseTransport) -> None:
+        # The ``asyncio.Transport`` invariant: SelectorTransport satisfies
+        # the StreamWriter contract (``write`` / ``writelines`` / ``close``
+        # / pause-writing-events).  We don't type-narrow at runtime
+        # because TLS variants subclass differently across Python versions.
+        self._transport = transport  # type: ignore[assignment]
+        self._buffer = ProtocolBuffer()
+        # ``asyncio.StreamWriter`` needs a Protocol that supplies
+        # _drain_helper + pause/resume_writing semantics — that's why
+        # we extend FlowControlMixin.  The ``reader=None`` argument is
+        # honoured by StreamWriter; reads never go through it.
+        self._writer = asyncio.StreamWriter(
+            transport, self, None, self._loop)
+        # Spawn the connection-actor task.  Once the actor returns
+        # (cleanly or via exception) the task is done; the protocol
+        # itself remains alive until ``connection_lost`` fires.
+        self._task = self._loop.create_task(
+            self._connected_cb(self._buffer, self._writer))
+
+    def data_received(self, data: bytes) -> None:
+        if self._buffer is None:
+            # connection_made not yet fired — should not happen in
+            # practice but defended-by-default per CodeQL's empty-except
+            # pattern from PR #33.
+            logger.debug('edge_protocol: data_received before connection_made'
+                         ' (%d bytes dropped)', len(data))
+            return
+        self._buffer.feed(data)
+
+    def eof_received(self) -> bool:
+        """Peer half-closed the connection.
+
+        Synchronously: close the transport, feed EOF into the buffer.
+        Returns False so asyncio fully closes (no half-open).
+
+        This is the architectural point of Tier 1.5 — all the
+        downstream cleanup runs without waiting on
+        readuntil-resume → break → finally chains.
+        """
+        self._eof_seen = True
+        if self._transport is not None:
+            try:
+                self._transport.close()
+            except Exception as exc:
+                # Best-effort: the transport may already be in a
+                # half-broken state (TLS aborted, etc.).  Logging at
+                # DEBUG mirrors the close-path style introduced in PR
+                # #33's CodeQL fix.
+                logger.debug(
+                    'edge_protocol: transport.close raised in eof_received'
+                    ' (%s) — ignoring; connection_lost will still fire', exc)
+        if self._buffer is not None:
+            self._buffer.feed_eof()
+        # Return False — asyncio should also close on its side.  True
+        # would keep the connection half-open (StreamReaderProtocol's
+        # default) which inflates the suspended-task count we're
+        # trying to bound.
+        return False
+
+    def connection_lost(self, exc: Optional[BaseException]) -> None:
+        """Transport fully closed.
+
+        Drains state and lets the actor task wind itself up.  Does
+        NOT cancel the actor task here — the buffer's ``feed_eof``
+        in ``eof_received`` already woke any suspended read, and the
+        actor's natural exit through ``IncompleteReadError`` → break
+        → finally is the safer cleanup path (cancellation can
+        interleave badly with the actor's own ``finally: await
+        writer.close()`` in ConnectionActor).
+        """
+        if self._buffer is not None:
+            # close() differs from feed_eof() in that it discards any
+            # remaining buffered bytes — by the time connection_lost
+            # fires we've decided the connection is dead, and a
+            # partial-request half-buffer would only confuse the
+            # actor.
+            self._buffer.close()
+        # Let FlowControlMixin clean up its pause/resume state.
+        super().connection_lost(exc)
+
+    # ------------------------------------------------------------------
+    # Inspection helpers (handy for tests, server.py's max_connections
+    # check, and future graceful-shutdown work)
+    # ------------------------------------------------------------------
+
+    @property
+    def buffer(self) -> Optional[ProtocolBuffer]:
+        return self._buffer
+
+    @property
+    def writer(self) -> Optional[asyncio.StreamWriter]:
+        return self._writer
+
+    @property
+    def task(self) -> Optional[asyncio.Task]:
+        return self._task
+
+    @property
+    def transport(self) -> Optional[asyncio.Transport]:
+        return self._transport

--- a/blackbull/server/protocol_buffer.py
+++ b/blackbull/server/protocol_buffer.py
@@ -1,0 +1,261 @@
+"""Cancellable byte buffer for the custom asyncio protocol path.
+
+Sprint 30 Tier 1.5 Step 1 — see
+``bench/sprint-logs/sprint-30-tier1.5-design.md`` for the architectural
+rationale.  Briefly: the existing ``asyncio.StreamReader`` uses a
+future-wakeup model whose per-readuntil-resume cost adds 1-2
+event-loop turns per connection close.  Under burst-keepalive (HttpArena
+``static`` at c=4096) that multiplies into a multi-second drain.  This
+buffer replaces ``StreamReader`` on the keepalive-idle read path so
+EOF — when it arrives via the ``_BlackBullProtocol.eof_received``
+callback — can short-circuit the chain by cancelling the awaiting task
+synchronously instead of waking it through a future and a subsequent
+loop tick.
+
+Design constraints
+------------------
+* Single-task consumer per buffer (one connection-actor reads one
+  buffer); single feeder per buffer (the protocol's
+  ``data_received`` / ``eof_received`` callbacks).  No locks needed
+  — asyncio is single-threaded.
+* Cancellation-safe: if the consumer task is cancelled mid-read,
+  the pending waiter resolves cleanly and the buffer remains usable
+  for a fresh reader (e.g. a graceful-shutdown handoff).  In
+  practice the actor exits on cancellation, so this matters mostly
+  for test ergonomics.
+* No internal call to ``asyncio.wait_for``: the per-phase
+  deadlines that ``http1_actor`` enforces (header / body /
+  keepalive) wrap our reads externally.  This keeps the buffer
+  itself transport-agnostic and free of timeout interactions.
+
+API mirrors ``asyncio.StreamReader``'s ``read`` / ``readuntil`` /
+``readexactly`` so the existing ``AsyncioReader`` shim can proxy
+through with minimal changes.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from .recipient import IncompleteReadError
+
+logger = logging.getLogger(__name__)
+
+
+class LimitOverrunError(Exception):
+    """Raised by :meth:`ProtocolBuffer.read_until` when ``max_size`` is
+    exceeded before the delimiter is found.
+
+    Mirrors ``asyncio.LimitOverrunError`` semantics (with attribute
+    ``consumed`` for diagnostics) so the existing per-line / per-block
+    size checks in ``http1_actor`` continue to work.
+    """
+
+    def __init__(self, message: str, consumed: int) -> None:
+        super().__init__(message)
+        self.consumed = consumed
+
+
+class ProtocolBuffer:
+    """Byte buffer fed by the protocol layer, drained by an
+    actor-side ``await`` consumer.
+
+    The consumer suspends in ``read_until`` / ``read_exactly`` /
+    ``read``; the feeder calls :meth:`feed` (after
+    ``protocol.data_received``) and :meth:`feed_eof` (after
+    ``protocol.eof_received``) to wake the consumer.
+
+    A single ``_waiter`` future drives the wakeup — there's no
+    queueing layer between the protocol callback and the consumer.
+    On EOF the consumer's pending await raises
+    :class:`IncompleteReadError` (matching ``AsyncioReader``'s
+    contract) once it next checks the buffer.
+    """
+
+    __slots__ = ('_buf', '_eof', '_waiter', '_closed')
+
+    def __init__(self) -> None:
+        # ``bytearray`` for O(1) append + cheap slice-delete from the
+        # front.  Empirically faster than ``bytes`` concatenation for
+        # the per-request feed-then-drain pattern.
+        self._buf: bytearray = bytearray()
+        self._eof: bool = False
+        # Single in-flight waiter — set by the consumer when it
+        # suspends, resolved by the feeder on the next data/eof event.
+        self._waiter: Optional[asyncio.Future] = None
+        # Once True, all subsequent reads raise IncompleteReadError
+        # without ever suspending; used as a "you cannot recover this
+        # connection" signal from ``_BlackBullProtocol``.
+        self._closed: bool = False
+
+    # ------------------------------------------------------------------
+    # Feed-side API (called from protocol callbacks, never awaited)
+    # ------------------------------------------------------------------
+
+    def feed(self, data: bytes) -> None:
+        """Append data and wake any suspended consumer."""
+        if not data:
+            return
+        if self._closed:
+            # Buffer was force-closed; drop the data.  Should be rare —
+            # the protocol stops calling feed() after eof_received /
+            # connection_lost.
+            logger.debug('protocol_buffer: feed on closed buffer (%d bytes dropped)',
+                         len(data))
+            return
+        self._buf.extend(data)
+        self._wake()
+
+    def feed_eof(self) -> None:
+        """Mark end-of-stream and wake any suspended consumer.
+
+        Subsequent reads return what's still buffered, then raise
+        :class:`IncompleteReadError` once the buffer is exhausted.
+        """
+        if self._eof:
+            return
+        self._eof = True
+        self._wake()
+
+    def close(self) -> None:
+        """Force-close: all future reads raise immediately.
+
+        Called by ``_BlackBullProtocol`` on connection_lost when an
+        error condition meant we should not even drain remaining
+        buffered bytes.
+        """
+        self._closed = True
+        self._eof = True
+        self._wake()
+
+    def _wake(self) -> None:
+        if self._waiter is not None and not self._waiter.done():
+            self._waiter.set_result(None)
+            # Don't None out; the awaiter resets in its finally.
+
+    # ------------------------------------------------------------------
+    # Properties (cheap, for ``_BlackBullProtocol``'s pause/resume logic)
+    # ------------------------------------------------------------------
+
+    @property
+    def buffered_bytes(self) -> int:
+        return len(self._buf)
+
+    @property
+    def eof_received(self) -> bool:
+        return self._eof
+
+    # ------------------------------------------------------------------
+    # Consumer-side API (await these)
+    # ------------------------------------------------------------------
+
+    async def read(self, n: int = -1) -> bytes:
+        """Read up to *n* bytes, or whatever is available.
+
+        Blocks until at least one byte is available, or EOF is
+        signalled.  ``n=-1`` means "everything buffered".  Returns
+        ``b''`` on EOF with empty buffer.
+        """
+        if not self._buf and not self._eof:
+            await self._suspend()
+        if n < 0 or n >= len(self._buf):
+            result = bytes(self._buf)
+            self._buf.clear()
+        else:
+            result = bytes(self._buf[:n])
+            del self._buf[:n]
+        return result
+
+    async def read_exactly(self, n: int) -> bytes:
+        """Read exactly *n* bytes.
+
+        Raises :class:`IncompleteReadError` if EOF arrives before *n*
+        bytes are available; the partial bytes are attached to the
+        exception via the standard asyncio API (``.partial``).
+        """
+        if n < 0:
+            raise ValueError(f'read_exactly: n must be non-negative, got {n}')
+        if n == 0:
+            return b''
+        while len(self._buf) < n:
+            if self._eof:
+                # Surface partial data via the asyncio
+                # IncompleteReadError convention.
+                partial = bytes(self._buf)
+                self._buf.clear()
+                exc = IncompleteReadError(f'EOF after {len(partial)} of {n} bytes')
+                exc.partial = partial          # type: ignore[attr-defined]
+                exc.expected = n               # type: ignore[attr-defined]
+                raise exc
+            await self._suspend()
+        result = bytes(self._buf[:n])
+        del self._buf[:n]
+        return result
+
+    async def read_until(self, sep: bytes, *, max_size: int = -1) -> bytes:
+        """Read until *sep* appears in the buffer; return the bytes
+        up to and including *sep*.
+
+        Raises :class:`IncompleteReadError` if EOF arrives before
+        *sep* is found.  Raises :class:`LimitOverrunError` if
+        ``max_size > 0`` and the buffer grows past it without seeing
+        *sep* — the caller should answer with the appropriate
+        protocol error (e.g. ``431 Request Header Fields Too Large``).
+        """
+        if not sep:
+            raise ValueError('read_until: sep must be a non-empty bytes object')
+        # Track the earliest possible position where sep could appear
+        # so we don't re-scan the whole buffer on each iteration.
+        scan_from = 0
+        while True:
+            idx = self._buf.find(sep, scan_from)
+            if idx >= 0:
+                end = idx + len(sep)
+                result = bytes(self._buf[:end])
+                del self._buf[:end]
+                return result
+            # Not found yet.
+            if max_size > 0 and len(self._buf) > max_size:
+                raise LimitOverrunError(
+                    f'read_until: buffer exceeded {max_size} bytes without '
+                    f'finding {sep!r}',
+                    consumed=len(self._buf),
+                )
+            if self._eof:
+                partial = bytes(self._buf)
+                self._buf.clear()
+                exc = IncompleteReadError(
+                    f'EOF after {len(partial)} bytes without finding {sep!r}'
+                )
+                exc.partial = partial          # type: ignore[attr-defined]
+                exc.expected = None            # type: ignore[attr-defined]
+                raise exc
+            # Avoid re-scanning bytes we've already checked, BUT keep
+            # the (len(sep) - 1) trailing bytes so we catch sep that
+            # straddles two feeds.
+            scan_from = max(0, len(self._buf) - (len(sep) - 1))
+            await self._suspend()
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _suspend(self) -> None:
+        """Park until the next ``feed`` / ``feed_eof`` / ``close`` call.
+
+        Single waiter at a time (enforced by an assertion to surface
+        misuse during tests; the production invariant is "one actor
+        per connection / per buffer").
+        """
+        if self._waiter is not None:
+            raise RuntimeError(
+                'ProtocolBuffer: concurrent suspends — only one consumer '
+                'is supported per buffer'
+            )
+        loop = asyncio.get_event_loop()
+        self._waiter = loop.create_future()
+        try:
+            await self._waiter
+        finally:
+            self._waiter = None

--- a/tests/unit/test_edge_protocol.py
+++ b/tests/unit/test_edge_protocol.py
@@ -1,0 +1,396 @@
+"""Unit tests for _BlackBullProtocol — the asyncio.Protocol subclass
+that wires ProtocolBuffer into transport callbacks.
+
+Sprint 30 Tier 1.5 Step 2.  Tests use a fake Transport so the
+protocol's behaviour is exercised without spinning up a real
+asyncio.Server.
+
+Coverage:
+- connection_made: creates buffer + writer + spawns connected_cb task.
+- data_received: feeds the buffer.
+- eof_received: synchronously closes the transport and feeds EOF to
+  the buffer; returns False so asyncio also closes (no half-open).
+- connection_lost: closes the buffer (final cleanup) and lets
+  FlowControlMixin tidy its state.
+- Integration: an actor-style consumer reading from the buffer sees
+  data immediately when fed; sees IncompleteReadError when EOF
+  arrives via eof_received.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+import pytest
+
+from blackbull.server.edge_protocol import _BlackBullProtocol
+from blackbull.server.protocol_buffer import ProtocolBuffer
+from blackbull.server.recipient import IncompleteReadError
+
+
+# ---------------------------------------------------------------------------
+# Fake transport — minimal asyncio.Transport surface
+# ---------------------------------------------------------------------------
+
+class _FakeTransport(asyncio.Transport):
+    """A minimal asyncio.Transport for testing protocols in isolation.
+
+    Records calls to ``close``, ``write``, etc. so tests can assert on
+    them.  Doesn't actually transport anything.
+    """
+
+    def __init__(self, extra: Optional[dict] = None):
+        super().__init__(extra=extra or {})
+        self.closed: bool = False
+        self.writes: list[bytes] = []
+        self._protocol: Optional[asyncio.Protocol] = None
+
+    # --- BaseTransport ---
+
+    def close(self) -> None:
+        self.closed = True
+        # Real asyncio schedules connection_lost; tests can drive it
+        # explicitly via _fire_connection_lost.
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+    def get_extra_info(self, name, default=None):
+        if name == 'sslcontext':
+            return None
+        return self._extra.get(name, default)
+
+    # --- Transport (write side) ---
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(bytes(data))
+
+    def writelines(self, list_of_data) -> None:
+        for d in list_of_data:
+            self.write(d)
+
+    def write_eof(self) -> None:
+        pass
+
+    def can_write_eof(self) -> bool:
+        return True
+
+    def get_write_buffer_size(self) -> int:
+        return 0
+
+    def get_write_buffer_limits(self) -> tuple[int, int]:
+        return (0, 0)
+
+    def set_write_buffer_limits(self, high=None, low=None) -> None:
+        pass
+
+    def pause_reading(self) -> None:
+        pass
+
+    def resume_reading(self) -> None:
+        pass
+
+    def set_protocol(self, protocol) -> None:
+        self._protocol = protocol
+
+    def get_protocol(self):
+        return self._protocol
+
+    # --- Test helpers ---
+
+    def _fire_connection_lost(self, exc: Optional[BaseException] = None) -> None:
+        """Simulate asyncio firing connection_lost after a transport close."""
+        if self._protocol is not None:
+            self._protocol.connection_lost(exc)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+class _ConsumerRecorder:
+    """Records calls to the connected_cb so tests can assert on them
+    and drive the consumer task's read behaviour."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []          # (buffer, writer) pairs
+        self.read_result: Optional[bytes | BaseException] = None
+        self.consumer_done = asyncio.Event()
+
+    async def __call__(self, buffer: ProtocolBuffer,
+                       writer: asyncio.StreamWriter) -> None:
+        self.calls.append((buffer, writer))
+        # Default: read one request line then exit.  Tests can override
+        # by setting read_result before invoking.
+        try:
+            self.read_result = await buffer.read_until(b'\r\n')
+        except Exception as exc:
+            self.read_result = exc
+        finally:
+            self.consumer_done.set()
+
+
+# ---------------------------------------------------------------------------
+# connection_made
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_connection_made_creates_buffer_writer_and_task():
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+
+    # Wait one loop iteration for the spawned task to start.
+    await asyncio.sleep(0)
+
+    assert protocol.buffer is not None
+    assert protocol.writer is not None
+    assert protocol.task is not None
+    assert protocol.transport is transport
+    assert len(cb.calls) == 1
+    # The callback got our buffer + writer.
+    assert cb.calls[0][0] is protocol.buffer
+    assert cb.calls[0][1] is protocol.writer
+
+    # Clean up — fire EOF so the consumer task can exit.
+    protocol.eof_received()
+    transport._fire_connection_lost()
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# data_received
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_data_received_feeds_buffer_so_consumer_can_read():
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)   # let consumer suspend in read_until
+
+    protocol.data_received(b'GET /healthz HTTP/1.1\r\nHost: x\r\n\r\n')
+
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+    assert cb.read_result == b'GET /healthz HTTP/1.1\r\n'
+
+
+@pytest.mark.asyncio
+async def test_data_received_before_connection_made_is_dropped():
+    """Defensive: if data arrives before connection_made (shouldn't
+    happen in production), the protocol doesn't crash — just drops."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    # Don't call connection_made.
+    protocol.data_received(b'orphan bytes')
+    # No exception raised; buffer is still None.
+    assert protocol.buffer is None
+
+
+# ---------------------------------------------------------------------------
+# eof_received — the critical path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_eof_received_closes_transport_synchronously():
+    """The architectural promise of Tier 1.5: eof_received MUST close
+    the transport synchronously (in the same call), not schedule it
+    for a later loop iteration."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    assert transport.closed is False
+    result = protocol.eof_received()
+    # transport.close ran INSIDE eof_received — synchronously.
+    assert transport.closed is True
+    # And eof_received returns False to let asyncio fully close
+    # (no half-open).
+    assert result is False
+
+    # Drive cleanup.
+    transport._fire_connection_lost()
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_eof_received_wakes_consumer_with_incomplete_read():
+    """The consumer suspended in read_until should wake up with
+    IncompleteReadError after eof_received fires — no extra loop
+    iterations beyond the standard waiter resume."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)   # let consumer suspend in read_until
+
+    # No data, just an immediate EOF.
+    protocol.eof_received()
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+    assert isinstance(cb.read_result, IncompleteReadError)
+
+    # Cleanup.
+    transport._fire_connection_lost()
+
+
+@pytest.mark.asyncio
+async def test_eof_received_with_buffered_partial_data():
+    """If EOF arrives with partial data buffered (e.g. half a request
+    line), the consumer sees IncompleteReadError with .partial set to
+    the buffered bytes."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    protocol.data_received(b'GET /partial ')   # no CRLF
+    protocol.eof_received()
+
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+    assert isinstance(cb.read_result, IncompleteReadError)
+    assert cb.read_result.partial == b'GET /partial '   # type: ignore[union-attr]
+
+    transport._fire_connection_lost()
+
+
+@pytest.mark.asyncio
+async def test_eof_received_tolerates_transport_close_failure():
+    """If transport.close() raises (e.g. TLS already aborted), the
+    protocol still propagates EOF to the buffer and returns False —
+    doesn't escape the exception upward."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+
+    class _FaultyTransport(_FakeTransport):
+        def close(self) -> None:
+            self.closed = True
+            raise OSError('TLS aborted')
+
+    transport = _FaultyTransport()
+    transport.set_protocol(protocol)
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    # Should NOT raise.
+    result = protocol.eof_received()
+    assert result is False
+    # Buffer still got EOF.
+    assert protocol.buffer is not None
+    assert protocol.buffer.eof_received is True
+
+    transport._fire_connection_lost()
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# connection_lost
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_connection_lost_closes_buffer():
+    """After connection_lost, the buffer is force-closed — any future
+    feed() is ignored and any future suspend would immediately raise
+    IncompleteReadError."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    # Don't fire eof first — simulate abrupt connection loss.
+    protocol.connection_lost(None)
+
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+    # The consumer was suspended in read_until; close() woke it.
+    assert isinstance(cb.read_result, IncompleteReadError)
+
+
+@pytest.mark.asyncio
+async def test_connection_lost_after_eof_received_is_safe():
+    """Normal close sequence: eof_received → connection_lost.  Both
+    can run without issue."""
+    cb = _ConsumerRecorder()
+    protocol = _BlackBullProtocol(cb)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    protocol.eof_received()
+    transport._fire_connection_lost()      # invokes protocol.connection_lost
+
+    await asyncio.wait_for(cb.consumer_done.wait(), timeout=1.0)
+    assert isinstance(cb.read_result, IncompleteReadError)
+
+
+# ---------------------------------------------------------------------------
+# Integration — realistic HTTP/1.1 request flow
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_realistic_request_response_cycle():
+    """End-to-end inside one protocol instance: data_received feeds a
+    request, the consumer reads + responds via the writer, then EOF
+    arrives and the consumer cleans up."""
+    response_sent = asyncio.Event()
+
+    async def consumer(buffer, writer):
+        # Read request line + headers.
+        rline = await buffer.read_until(b'\r\n')
+        headers = await buffer.read_until(b'\r\n\r\n')
+        assert rline == b'GET / HTTP/1.1\r\n'
+        assert b'host:' in headers.lower()
+        # Send a minimal response.
+        writer.write(
+            b'HTTP/1.1 200 OK\r\n'
+            b'content-length: 2\r\n'
+            b'\r\n'
+            b'ok'
+        )
+        response_sent.set()
+        # Wait for EOF on next-request readuntil.
+        try:
+            await buffer.read_until(b'\r\n')
+        except IncompleteReadError:
+            pass
+
+    protocol = _BlackBullProtocol(consumer)
+    transport = _FakeTransport()
+    transport.set_protocol(protocol)
+    protocol.connection_made(transport)
+    await asyncio.sleep(0)
+
+    protocol.data_received(
+        b'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n')
+
+    await asyncio.wait_for(response_sent.wait(), timeout=1.0)
+    assert any(b'200 OK' in w for w in transport.writes)
+
+    # Peer closes — eof_received SYNCHRONOUSLY closes transport.
+    assert transport.closed is False
+    protocol.eof_received()
+    assert transport.closed is True
+
+    transport._fire_connection_lost()
+    # Consumer task should now finish.
+    await asyncio.sleep(0)
+    assert protocol.task is not None
+    assert protocol.task.done()

--- a/tests/unit/test_protocol_buffer.py
+++ b/tests/unit/test_protocol_buffer.py
@@ -1,0 +1,316 @@
+"""Unit tests for ProtocolBuffer — the cancellable byte buffer at the
+heart of Sprint 30 Tier 1.5's custom asyncio protocol.
+
+The buffer replaces ``asyncio.StreamReader`` on the keepalive-idle
+read path.  Tests cover:
+
+- Feed-then-read sequences (data already buffered, data after feed).
+- EOF semantics (read what's left, then raise IncompleteReadError).
+- read_until: delimiter found mid-buffer, across-feed boundaries,
+  EOF before delimiter, max_size overflow.
+- read_exactly: short reads, exact reads, EOF mid-read.
+- read: partial reads, EOF returns b''.
+- Cancellation safety: suspended consumer can be cancelled; buffer
+  recovers for a fresh reader.
+- Concurrent-suspend guard: second suspend while another is active
+  raises RuntimeError (test-only invariant; production has one
+  consumer per buffer).
+
+No asyncio.Server involved — tests run against the bare class so
+they exercise the buffer's logic without transport-layer noise.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from blackbull.server.protocol_buffer import LimitOverrunError, ProtocolBuffer
+from blackbull.server.recipient import IncompleteReadError
+
+
+# ---------------------------------------------------------------------------
+# read_exactly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_exactly_data_already_buffered():
+    """When the buffer already has >= n bytes, read_exactly returns
+    immediately without suspending."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abcdefghij')
+    assert await buf.read_exactly(5) == b'abcde'
+    # Remaining bytes still available.
+    assert await buf.read_exactly(5) == b'fghij'
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_waits_for_more_data():
+    """When the buffer has fewer than n bytes, the call suspends
+    until enough data arrives via feed()."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abc')
+
+    async def feed_more():
+        await asyncio.sleep(0)   # let the consumer suspend first
+        buf.feed(b'defgh')
+
+    task = asyncio.create_task(buf.read_exactly(5))
+    asyncio.create_task(feed_more())
+    result = await task
+    assert result == b'abcde'
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_eof_before_n_bytes_raises_incomplete():
+    """If EOF arrives before n bytes are available, IncompleteReadError
+    is raised with .partial set to whatever was buffered."""
+    buf = ProtocolBuffer()
+    buf.feed(b'ab')
+    buf.feed_eof()
+    with pytest.raises(IncompleteReadError) as info:
+        await buf.read_exactly(10)
+    assert info.value.partial == b'ab'        # type: ignore[attr-defined]
+    assert info.value.expected == 10          # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_zero_returns_empty_without_waiting():
+    """n=0 is a no-op fast path — does not suspend even on an empty
+    buffer."""
+    buf = ProtocolBuffer()
+    assert await buf.read_exactly(0) == b''
+
+
+@pytest.mark.asyncio
+async def test_read_exactly_negative_n_raises():
+    buf = ProtocolBuffer()
+    with pytest.raises(ValueError, match='non-negative'):
+        await buf.read_exactly(-1)
+
+
+# ---------------------------------------------------------------------------
+# read_until
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_until_finds_sep_in_buffer():
+    buf = ProtocolBuffer()
+    buf.feed(b'GET /healthz HTTP/1.1\r\nHost: x\r\n\r\nbody')
+    line = await buf.read_until(b'\r\n')
+    assert line == b'GET /healthz HTTP/1.1\r\n'
+    # Remaining data still in buffer.
+    rest = await buf.read(1024)
+    assert rest == b'Host: x\r\n\r\nbody'
+
+
+@pytest.mark.asyncio
+async def test_read_until_finds_sep_after_feed():
+    """Suspended read_until wakes up when sep arrives across multiple
+    feeds."""
+    buf = ProtocolBuffer()
+    buf.feed(b'partial line ')
+
+    async def complete():
+        await asyncio.sleep(0)
+        buf.feed(b'with delim\r\n')
+
+    task = asyncio.create_task(buf.read_until(b'\r\n'))
+    asyncio.create_task(complete())
+    line = await task
+    assert line == b'partial line with delim\r\n'
+
+
+@pytest.mark.asyncio
+async def test_read_until_sep_straddles_two_feeds():
+    """sep is multi-byte and the boundary falls between feeds — the
+    buffer's scan-from optimization must not miss it."""
+    buf = ProtocolBuffer()
+    buf.feed(b'abc\r')           # first half of delimiter
+    async def feed_rest():
+        await asyncio.sleep(0)
+        buf.feed(b'\ndef')        # second half completes \r\n
+    task = asyncio.create_task(buf.read_until(b'\r\n'))
+    asyncio.create_task(feed_rest())
+    result = await task
+    assert result == b'abc\r\n'
+
+
+@pytest.mark.asyncio
+async def test_read_until_eof_before_sep_raises_incomplete():
+    buf = ProtocolBuffer()
+    buf.feed(b'no delimiter here')
+    buf.feed_eof()
+    with pytest.raises(IncompleteReadError) as info:
+        await buf.read_until(b'\r\n')
+    assert info.value.partial == b'no delimiter here'   # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_read_until_max_size_overflow_raises():
+    """If max_size is exceeded before sep is found, LimitOverrunError
+    is raised with .consumed set to the buffer length."""
+    buf = ProtocolBuffer()
+    big = b'a' * 100
+    buf.feed(big)
+    with pytest.raises(LimitOverrunError) as info:
+        await buf.read_until(b'\r\n', max_size=50)
+    assert info.value.consumed >= 50
+
+
+@pytest.mark.asyncio
+async def test_read_until_empty_sep_raises():
+    buf = ProtocolBuffer()
+    with pytest.raises(ValueError, match='non-empty'):
+        await buf.read_until(b'')
+
+
+# ---------------------------------------------------------------------------
+# read
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_returns_everything_when_n_negative():
+    buf = ProtocolBuffer()
+    buf.feed(b'hello world')
+    assert await buf.read(-1) == b'hello world'
+    # And subsequent reads (no more data, no EOF yet) would suspend.
+
+
+@pytest.mark.asyncio
+async def test_read_returns_partial_when_n_smaller_than_buffer():
+    buf = ProtocolBuffer()
+    buf.feed(b'abcdef')
+    assert await buf.read(3) == b'abc'
+    assert await buf.read(3) == b'def'
+
+
+@pytest.mark.asyncio
+async def test_read_returns_empty_on_eof():
+    buf = ProtocolBuffer()
+    buf.feed_eof()
+    assert await buf.read(100) == b''
+
+
+@pytest.mark.asyncio
+async def test_read_drains_remaining_then_returns_empty_on_eof():
+    buf = ProtocolBuffer()
+    buf.feed(b'last')
+    buf.feed_eof()
+    assert await buf.read(100) == b'last'
+    assert await buf.read(100) == b''
+
+
+# ---------------------------------------------------------------------------
+# Cancellation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_suspended_read_can_be_cancelled():
+    """If the consumer task is cancelled while parked, the cancellation
+    propagates cleanly and the buffer is reusable afterwards."""
+    buf = ProtocolBuffer()
+    task = asyncio.create_task(buf.read_exactly(100))
+    await asyncio.sleep(0)   # let it suspend
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    # Buffer's waiter slot is released; a fresh consumer can read.
+    buf.feed(b'recovered')
+    # Note: we can't readuntil for sep that's not there without another
+    # suspend; just confirm the buffer state is sane.
+    assert buf.buffered_bytes == len(b'recovered')
+
+
+@pytest.mark.asyncio
+async def test_concurrent_suspend_is_rejected():
+    """Spawning a second consumer task while the first is suspended
+    raises RuntimeError — surfaces misuse during dev/tests.  Production
+    contract: one consumer per buffer."""
+    buf = ProtocolBuffer()
+    first = asyncio.create_task(buf.read_exactly(10))
+    await asyncio.sleep(0)   # let first suspend
+    second = asyncio.create_task(buf.read_exactly(5))
+    with pytest.raises(RuntimeError, match='concurrent suspends'):
+        await second
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+
+
+# ---------------------------------------------------------------------------
+# close() — force-close path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_close_wakes_pending_consumer_with_incomplete_read():
+    """ProtocolBuffer.close() marks the buffer as eof and wakes any
+    suspended consumer.  Pending reads then raise IncompleteReadError
+    (since no data was buffered)."""
+    buf = ProtocolBuffer()
+    task = asyncio.create_task(buf.read_exactly(10))
+    await asyncio.sleep(0)
+    buf.close()
+    with pytest.raises(IncompleteReadError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_feed_after_close_is_dropped():
+    """Defensive: if the protocol erroneously calls feed() after
+    eof/close, the bytes are silently dropped (logged at DEBUG)."""
+    buf = ProtocolBuffer()
+    buf.close()
+    buf.feed(b'too late')
+    assert buf.buffered_bytes == 0
+
+
+@pytest.mark.asyncio
+async def test_feed_eof_is_idempotent():
+    buf = ProtocolBuffer()
+    buf.feed_eof()
+    buf.feed_eof()
+    assert buf.eof_received is True
+
+
+# ---------------------------------------------------------------------------
+# Mixed sequences (realistic HTTP/1.1 flow)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_http1_request_then_eof():
+    """Realistic shape: receive a full HTTP/1.1 request, then EOF.
+
+    Mirrors what http1_actor.run() does — readuntil for headers,
+    optionally readexactly for body, then next-iteration readuntil
+    that hits EOF."""
+    buf = ProtocolBuffer()
+    request = (b'GET /static/app.js HTTP/1.1\r\n'
+               b'Host: localhost\r\n'
+               b'Accept-Encoding: br\r\n'
+               b'\r\n')
+    buf.feed(request)
+    buf.feed_eof()
+
+    # Request line.
+    rline = await buf.read_until(b'\r\n')
+    assert rline == b'GET /static/app.js HTTP/1.1\r\n'
+    # Headers up to and including CRLFCRLF.
+    rest = await buf.read_until(b'\r\n\r\n')
+    assert rest == b'Host: localhost\r\nAccept-Encoding: br\r\n\r\n'
+    # Next-iteration readuntil hits EOF.
+    with pytest.raises(IncompleteReadError):
+        await buf.read_until(b'\r\n')
+
+
+@pytest.mark.asyncio
+async def test_http1_pipelined_requests_drain_in_order():
+    """Two HTTP/1.1 requests fed together drain in order without
+    confusing read_until's scan."""
+    buf = ProtocolBuffer()
+    buf.feed(b'GET /a HTTP/1.1\r\n\r\nGET /b HTTP/1.1\r\n\r\n')
+
+    first = await buf.read_until(b'\r\n\r\n')
+    assert first == b'GET /a HTTP/1.1\r\n\r\n'
+    second = await buf.read_until(b'\r\n\r\n')
+    assert second == b'GET /b HTTP/1.1\r\n\r\n'


### PR DESCRIPTION
## Summary

Sprint 30 Tier 1.5 Step 2: the asyncio.Protocol subclass that wires \`ProtocolBuffer\` (from #36) into transport callbacks. Builds on \`FlowControlMixin\` so \`asyncio.StreamWriter\` keeps working unchanged on the write side; only the read side is replaced.

**Stacks on PR #36.** The branch carries the ProtocolBuffer commit too because Step 2 imports it. Once #36 merges, this PR's diff becomes just the new commit \`7221082\`.

## Architectural change

\`eof_received\` runs SYNCHRONOUSLY in the same event-loop turn as the epoll batch that delivered the FIN:

1. \`self._transport.close()\` — sync, releases the FD via \`connection_lost\` on the next iteration.
2. \`self._buffer.feed_eof()\` — sync, wakes the consumer's pending readuntil with IncompleteReadError on its next step.
3. \`return False\` — tells asyncio to also close (no half-open semantics).

vs the default \`StreamReaderProtocol\`, where \`transport.close()\` only happens later, after the actor's readuntil-resume → break → finally → writer.close() chain runs. The diagnosed cliff comes from those extra event-loop turns multiplied across 4,096 simultaneous close events.

## When does it activate?

Step 2 is **dormant** — landing it now lets us validate the protocol's behaviour in isolation. Step 3 (a follow-up PR) wires it into \`server.py\` behind \`BB_USE_CUSTOM_PROTOCOL\` env flag, default off for the first release cycle.

## Tests

10 unit tests in [\`tests/unit/test_edge_protocol.py\`](tests/unit/test_edge_protocol.py) using a fake \`_FakeTransport\` (asyncio.Transport surface) and a \`_ConsumerRecorder\` callback:

- connection_made: creates buffer + writer + spawns task
- data_received: feeds buffer so consumer can read
- data_received-before-connection_made: defensively dropped
- eof_received: transport closed SYNCHRONOUSLY (the architectural promise)
- eof_received wakes pending consumer with IncompleteReadError
- eof_received preserves buffered partial data on the exception
- eof_received tolerates transport.close() failure (logs at DEBUG)
- connection_lost without prior eof: closes buffer cleanly
- connection_lost after eof_received: safe / no double-cleanup
- Realistic flow: full request → response → EOF → cleanup

Total unit-test count: **1229 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)