### PR TITLE
ci: add publish.yml for tag-triggered PyPI release via OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,82 @@
+name: Publish to PyPI
+
+# Triggered by pushing a ``v*`` tag (e.g. ``v0.29.0a1``, ``v0.29.0``).
+# Builds wheel + sdist, then uploads via PyPI Trusted Publishing (OIDC) —
+# no long-lived API token required.
+#
+# Prerequisite (one-time, already configured by maintainer):
+# PyPI project "blackbull" has a Trusted Publisher entry naming
+# ``TOKUJI/BlackBull`` + workflow ``publish.yml``.  If the configured
+# workflow filename differs, this file must be renamed to match —
+# PyPI's OIDC token exchange will reject any other filename.
+#
+# Third-party actions pinned to commit SHAs per Sprint 30 Task 6's
+# supply-chain hygiene baseline; Dependabot tracks updates.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+# Default to least-privilege; the publish job locally upgrades id-token.
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10   # v6.0.3
+        with:
+          fetch-depth: 0   # so `python -m build` sees full git context if needed
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405   # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build wheel + sdist
+        run: python -m build
+
+      - name: List build artefacts
+        run: ls -la dist/
+
+      - name: Upload artefacts for the publish job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a   # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI via OIDC
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Optional: bind to a deployment environment so review/approval
+    # gates can guard prod releases.  The PyPI Trusted Publisher entry
+    # may or may not require the environment name to match — verify
+    # against the maintainer's PyPI project settings.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/blackbull/
+    permissions:
+      id-token: write   # required for OIDC token exchange
+    steps:
+      - name: Download artefacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d   # v1.14.0
+        # No ``with: password:`` — Trusted Publishing exchanges the
+        # GitHub OIDC token for a short-lived PyPI token automatically.


### PR DESCRIPTION
## Summary

Adds the tag-triggered publish workflow so v0.29.0a1 (and future releases) auto-publish to PyPI via Trusted Publishing on tag push.

Reason for the gap: v0.28.1 was published manually (or via a workflow that wasn't committed). With Sprint 30 heading into release territory and the v0.29.0a1 alpha needed for EC2 cross-check, the publish path needs to be workflow-driven.

## What lands

\`.github/workflows/publish.yml\`:
- Trigger: \`v*\` tag push + manual \`workflow_dispatch\`
- Two jobs: \`build\` (python -m build → wheel + sdist) and \`publish\` (Trusted Publishing via \`pypa/gh-action-pypi-publish\`)
- All third-party actions pinned to commit SHAs (Dependabot tracks)
- \`id-token: write\` scoped only to publish job
- Environment-bound to \`pypi\` so future review gates can guard prod releases

## Operator verification before merging

PyPI's Trusted Publisher entry for project \`blackbull\` must name this workflow's filename. Check PyPI project Settings → Publishing → Trusted Publishers:
- **Workflow filename** = \`publish.yml\`
- **Environment** = \`pypi\` (or whatever was configured — adjust this file if different)

Token exchange fails silently otherwise.

## After merge

\`\`\`bash
git checkout master && git pull
git tag -s v0.29.0a1 -m "v0.29.0a1 — Sprint 30 alpha"
git push origin v0.29.0a1   # triggers publish.yml
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)