### PR TITLE
fix(ci): pin pypa/gh-action-pypi-publish by version, not commit SHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,13 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d   # v1.14.0
+        # SHA pin doesn't work for this action: when ``uses:`` is a
+        # commit SHA, GitHub Actions tries to pull a Docker image
+        # tagged with that same SHA from ghcr.io.  PyPA only publishes
+        # version-tagged images (no per-SHA tags), so SHA-pinning
+        # this action fails with ``manifest unknown`` at runtime.
+        # Pin to a specific version tag instead — PyPA maintains the
+        # tag, and Dependabot still tracks version updates here.
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         # No ``with: password:`` — Trusted Publishing exchanges the
         # GitHub OIDC token for a short-lived PyPI token automatically.


### PR DESCRIPTION
## Summary

First v0.29.0a1 tag push (#41 workflow run) failed at the publish step:

\`\`\`
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:6733eb7d...' locally
docker: Error response from daemon: manifest unknown
\`\`\`

Root cause: \`pypa/gh-action-pypi-publish\` is a **Docker container action**. When the \`uses:\` line is a commit SHA, GitHub Actions uses that same SHA as the Docker image tag on ghcr.io. PyPA only publishes version-tagged images (no per-SHA tags), so the pull fails.

## Fix

Pin to \`@v1.14.0\` instead of the SHA. PyPA maintains version tags; Dependabot will still track updates.

The other SHA pins in \`publish.yml\` (actions/checkout, setup-python, upload-/download-artifact) are JavaScript / composite actions — they work fine with SHA pinning and stay pinned per Sprint 30 Task 6's hygiene baseline. Only the Docker action gets the version-tag exception, with an inline comment explaining why.

## After merge

Re-trigger the publish for the existing v0.29.0a1 tag:

\`\`\`bash
git push origin :refs/tags/v0.29.0a1   # delete remote tag
git tag -d v0.29.0a1                    # delete local
git checkout master && git pull
git tag -a v0.29.0a1 -m "v0.29.0a1 — Sprint 30 alpha"
git push origin v0.29.0a1               # triggers publish.yml again
\`\`\`

Or alternatively: \`workflow_dispatch\` from the Actions tab on the existing master commit (skips the tag dance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)