### PR TITLE
feat(http2): move priority to scope['extensions'] + http2_stream info (Sprint 32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,97 @@ so the editable install's metadata catches up.
 
 ---
 
+## [0.31.0] — 2026-06-04
+
+**Sprint 32 close — HTTP/2 stream-info ASGI extensions.**  Moves
+the existing RFC 9218 priority hint from `scope['http2_priority']`
+under `scope['extensions']` per ASGI convention and adds a new
+HTTP/2 stream-info extension exposing `stream_id` and send-side
+flow-control state.  Lays the foundation for future gRPC over
+HTTP/2 work; no gRPC code in this release, but a written
+assessment is included.
+
+### Added
+
+- **`scope['extensions']['http.response.priority']`** — RFC 9218
+  priority hint at the conventional ASGI scope-extensions
+  location.  Field name matches gunicorn's beta HTTP/2 surface;
+  the *contents* are RFC 9218 urgency/incremental rather than the
+  RFC 7540 weight/depends_on tree that RFC 9113 §5.3.2
+  deprecated.  Shape: `{'urgency': int 0-7, 'incremental': bool}`.
+- **`scope['extensions']['http.response.http2_stream']`** — new
+  BlackBull HTTP/2 stream-info extension.  Snapshot at scope
+  build time of `{'stream_id': int, 'send_window_remaining':
+  int, 'connection_send_window_remaining': int}`.  Peer
+  recv-window is intentionally absent (we send WINDOW_UPDATE per
+  consumed DATA frame, so there's no scalar to snapshot).
+- **`docs/about/grpc-assessment.md`** — written assessment of
+  what gRPC over BlackBull would need, what's available today,
+  what Sprint 32 unlocks (server-streaming back-pressure
+  visibility), and what's still missing for a minimum gRPC
+  server.  No commitment; the document is decision input for a
+  future sprint.
+
+### Changed
+
+- **`docs/guide/http2.md`** leads with the new
+  `scope['extensions']['http.response.priority']` location.  A
+  *Migrating from `scope['http2_priority']`* subsection explains
+  the rename.
+- **`examples/PriorityExample/`** updated to read priority from
+  the new extension location.  The example no longer reads
+  `scope['http2_priority']`; that key remains populated only for
+  the deprecation window.
+
+### Deprecated
+
+- **`scope['http2_priority']`** — the top-level scope key that
+  carried the same RFC 9218 urgency/incremental dict.  Still
+  populated for backwards compatibility during the v0.31 cycle
+  and scheduled for removal in `0.32.0`.  Apps should read
+  `scope['extensions']['http.response.priority']` instead.
+
+### Tests
+
+- 9 new unit tests in `tests/unit/test_http2_extensions.py`
+  pinning the helper's per-request fresh-dict semantics,
+  the priority extension contents (RFC 9218 default + explicit
+  pass-through), and the http2_stream snapshot fields.
+- 3 new integration tests in
+  `tests/integration/test_http2_advanced.py` confirming the new
+  extension keys show up in a real HTTP/2 scope and agree with
+  the deprecation alias.
+
+### Notes for adopters
+
+- **Migrating from `scope['http2_priority']`.**  Replace
+  `scope.get('http2_priority', DEFAULT)` with
+  `(scope.get('extensions') or {}).get('http.response.priority', DEFAULT)`.
+  The dict shape is unchanged.
+- **HTTP/1.1 requests** do not advertise the new HTTP/2
+  extensions.  `scope['extensions']` will contain
+  `http.response.pathsend` (from v0.30) but not
+  `http.response.priority` / `http.response.http2_stream`.
+- **Window snapshot caveat.**  The send-window fields are taken
+  at scope-build time; they shift as the response body streams.
+  Live readings (e.g. for iterative gRPC server-streaming
+  back-pressure) need a future sprint — see *Open question* in
+  `docs/about/grpc-assessment.md`.
+
+### Out of scope / deferred
+
+- **HTTP/2 mutation API** — set-priority-on-push, app-driven
+  window updates, dependency edits.  Wait for an adopter need.
+- **gRPC implementation** — only the assessment doc this sprint.
+  A real gRPC server is 1-3 sprints of work on top of these
+  primitives; the assessment doc spells out the breakdown.
+- **`scope['http2_priority']` removal** — happens in `v0.32.0`;
+  retained this release to give adopters one cycle to migrate.
+- **RFC 7540 weight/depends_on parity with gunicorn** — RFC 9113
+  deprecated those; modern clients don't send them.
+
+---
+
 ## [0.30.0] — 2026-06-04
 
 **Sprint 31 close — zero-copy static-file serving for cleartext

--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@
 > Conformance evidence: [`docs/about/conformance.md`](docs/about/conformance.md).
 > Things to know before adopting: [`KNOWN_LIMITATIONS.md`](KNOWN_LIMITATIONS.md).
 
-**From-scratch async ASGI 3.0 framework** with native HTTP/1.1, HTTP/2,
-and WebSocket implementations — no `httptools`, no `uvicorn`, no
-`hypercorn` underneath.  Pure-Python protocol stack, single
-deployable, zero C-extension footprint outside the standard library.
+**Async ASGI 3.0 framework** with a from-scratch HTTP/1.1 parser,
+HTTP/2 frame layer, and WebSocket codec — no `httptools`, no
+`uvicorn`, no `hypercorn` underneath.  HPACK header compression
+delegates to the [`hpack`](https://github.com/python-hyper/hpack)
+library (re-implementing a conformant HPACK encoder/decoder is a
+project of its own); everything else, including the ASGI server,
+event loop integration, prioritisation, push, flow control, and
+stream actor, is BlackBull's own code.  Single deployable, no
+third-party C extensions in the protocol stack.
 
 [![PyPI](https://img.shields.io/pypi/v/blackbull.svg)](https://pypi.org/project/blackbull/)
 [![Python](https://img.shields.io/pypi/pyversions/blackbull.svg)](https://pypi.org/project/blackbull/)
@@ -17,10 +22,14 @@ deployable, zero C-extension footprint outside the standard library.
 
 - **One package, one process** — the framework *is* the server.  No
   separate ASGI runner; `app.run()` opens the socket and serves.
-- **HTTP/1.1 + HTTP/2 + WebSocket** all implemented natively (RFC 9112
-  for H/1, RFC 9113 for H/2, RFC 6455 for WebSocket).
+- **From-scratch protocol stack** for HTTP/1.1 (RFC 9112) parser,
+  HTTP/2 (RFC 9113) frame layer + flow control + RFC 9218
+  prioritisation + push, and WebSocket (RFC 6455) codec.  HPACK
+  (RFC 7541) is the one exception — see headline above.
 - **Pure-Python identity** — no `httptools`, no `uvloop` dependency
-  (uvloop available as an optional `[speed]` extra).
+  (uvloop available as an optional `[speed]` extra).  The single
+  third-party dependency in the protocol stack is `hpack`, also
+  pure Python.
 - **Conformance-tested** against `h2spec`, Autobahn, and a
   differential nginx fuzz corpus.
 - **Modern Python** — requires 3.11+, full type hints, PEP 561 typed

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -72,6 +72,62 @@ def _make_log_record(scope):
     return AccessLogRecord.from_scope(scope)
 
 _DEFAULT_PRIORITY: dict[str, int | bool] = {'urgency': 3, 'incremental': False}
+
+# ``_HTTP2_BASE_EXTENSIONS`` carries the protocol-level extensions that
+# every HTTP/2 scope advertises, regardless of which stream the request
+# arrived on: server push, plus the new (Sprint 32) priority and
+# stream-info hints.  The actual *contents* of the priority / stream-info
+# entries are stream-specific, so each scope gets a freshly-built
+# extensions dict via ``_build_h2_extensions`` below — only the advertised
+# keys themselves are shared.
+_HTTP2_EXTENSIONS_KEYS = (
+    ASGIEvent.HTTP_RESPONSE_PUSH,
+    'http.response.priority',
+    'http.response.http2_stream',
+)
+
+
+def _build_h2_extensions(
+    stream_id: int,
+    priority: dict,
+    peer_initial_window: int,
+    connection_window: int,
+) -> dict:
+    """Return a freshly-built ``scope['extensions']`` dict for one HTTP/2 request.
+
+    The shape Sprint 32 introduces:
+
+    - ``http.response.push`` — empty marker; signals the application can
+      send ``http.response.push`` events on this scope (existing behaviour).
+    - ``http.response.priority`` — ``{'urgency': int, 'incremental': bool}``
+      per RFC 9218 §4.1.  Field names match the gunicorn beta HTTP/2
+      surface; the *contents* are RFC 9218 rather than the deprecated
+      RFC 7540 weight/tree (RFC 9113 §5.3.2 deprecated the tree, and
+      modern clients send RFC 9218 priority signals).
+    - ``http.response.http2_stream`` — ``{'stream_id': int,
+      'send_window_remaining': int, 'connection_send_window_remaining':
+      int}``.  Snapshot at scope-build time; the windows shift as the
+      response body streams.  Lays the foundation for gRPC server-streaming
+      back-pressure awareness.
+
+    Peer recv-window is intentionally absent: BlackBull sends
+    WINDOW_UPDATE per consumed DATA frame, so there is no scalar to
+    snapshot.
+    """
+    return {
+        ASGIEvent.HTTP_RESPONSE_PUSH: {},
+        'http.response.priority': priority,
+        'http.response.http2_stream': {
+            'stream_id': stream_id,
+            'send_window_remaining': peer_initial_window,
+            'connection_send_window_remaining': connection_window,
+        },
+    }
+
+
+# Retained for older test fixtures that inspect this constant directly.
+# New code reads ``scope['extensions']`` instead; this is just a list of
+# the keys the actor advertises.
 _HTTP2_EXTENSIONS: dict = {ASGIEvent.HTTP_RESPONSE_PUSH: {}}
 
 
@@ -738,8 +794,15 @@ class HTTP2Actor(Actor):
             await self._handle_h2_websocket(stream, tg, log_record)
             return True
 
-        scope['http2_priority'] = _resolve_priority(stream, scope)
-        scope['extensions'] = _HTTP2_EXTENSIONS
+        priority = _resolve_priority(stream, scope)
+        # ``scope['http2_priority']`` is retained for one release as a
+        # deprecation alias.  New apps should read
+        # ``scope['extensions']['http.response.priority']`` instead.
+        # Removal scheduled for v0.32.0.
+        scope['http2_priority'] = priority
+        scope['extensions'] = _build_h2_extensions(
+            stream.stream_id, priority,
+            self._peer_initial_window_size, self._connection_window_size)
         stream_recipient = RecipientFactory.http2(queue_depth=self._stream_queue_depth)
         self._recipients[stream.stream_id] = stream_recipient
         stream.on_headers_received(end_stream=bool(frame.end_stream))
@@ -796,8 +859,12 @@ class HTTP2Actor(Actor):
                 self.factory.rst_stream(stream.stream_id, ErrorCodes.REFUSED_STREAM))
             return True
 
-        scope['http2_priority'] = _resolve_priority(stream, scope)
-        scope['extensions'] = _HTTP2_EXTENSIONS
+        priority = _resolve_priority(stream, scope)
+        # See deprecation note at the HEADERS path above.
+        scope['http2_priority'] = priority
+        scope['extensions'] = _build_h2_extensions(
+            stream.stream_id, priority,
+            self._peer_initial_window_size, self._connection_window_size)
         stream.scope = scope
         stream_recipient = RecipientFactory.http2(queue_depth=self._stream_queue_depth)
         self._recipients[stream.stream_id] = stream_recipient
@@ -958,7 +1025,11 @@ class HTTP2Actor(Actor):
             'headers': Headers([(k.encode() if isinstance(k, str) else k,
                                   v.encode() if isinstance(v, str) else v)
                                  for k, v in regular]),
-            'extensions': _HTTP2_EXTENSIONS,
+            'extensions': _build_h2_extensions(
+                push_stream_id, _DEFAULT_PRIORITY,
+                self._peer_initial_window_size,
+                self._connection_window_size),
+            # Deprecation alias — see HEADERS path note.
             'http2_priority': _DEFAULT_PRIORITY,
         }
 

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -73,19 +73,6 @@ def _make_log_record(scope):
 
 _DEFAULT_PRIORITY: dict[str, int | bool] = {'urgency': 3, 'incremental': False}
 
-# ``_HTTP2_BASE_EXTENSIONS`` carries the protocol-level extensions that
-# every HTTP/2 scope advertises, regardless of which stream the request
-# arrived on: server push, plus the new (Sprint 32) priority and
-# stream-info hints.  The actual *contents* of the priority / stream-info
-# entries are stream-specific, so each scope gets a freshly-built
-# extensions dict via ``_build_h2_extensions`` below — only the advertised
-# keys themselves are shared.
-_HTTP2_EXTENSIONS_KEYS = (
-    ASGIEvent.HTTP_RESPONSE_PUSH,
-    'http.response.priority',
-    'http.response.http2_stream',
-)
-
 
 def _build_h2_extensions(
     stream_id: int,

--- a/docs/about/grpc-assessment.md
+++ b/docs/about/grpc-assessment.md
@@ -1,0 +1,163 @@
+# gRPC over BlackBull — assessment
+
+This document is an **evaluation**, not a commitment to ship gRPC
+support.  It exists so a future decision about gRPC can start from
+a clear picture of what BlackBull already provides, what Sprint 32
+just added, and what is still missing.
+
+## What gRPC over HTTP/2 needs
+
+gRPC is a layered protocol that runs on top of HTTP/2.  A minimal
+gRPC server has to provide:
+
+1. **HTTP/2 framing.**  Streams, HEADERS / DATA frames, flow control.
+2. **Trailers.**  `grpc-status`, `grpc-message`, and any
+   `Status-Details-Bin` are sent as HTTP/2 trailing headers, not body.
+3. **Bidirectional streaming.**  Both client-streaming (server reads
+   N request messages) and server-streaming (server emits N response
+   messages) require long-lived `receive()` / `send` loops.
+4. **Per-stream cancellation propagation.**  When the peer sends
+   `RST_STREAM`, the handler should see it as a cancellation signal,
+   not as silent connection closure.
+5. **Flow-control awareness.**  Server-streaming RPCs MUST back-pressure
+   when the peer's receive window closes — otherwise a slow consumer
+   OOMs the server.
+6. **Content-type negotiation.**  Routes that handle
+   `application/grpc` (or `application/grpc+proto`,
+   `application/grpc-web+proto`, etc.) need to dispatch differently
+   from regular HTTP routes.
+7. **Length-prefixed message framing in the body.**  Each gRPC
+   message is `1 byte (compressed flag) + 4 bytes (length) + N bytes
+   (payload)`.  Application concern, but the helpers belong somewhere.
+8. **`grpc-status` trailer + RST-code mapping.**  Errors map between
+   gRPC status codes, HTTP/2 RST_STREAM codes, and the
+   `grpc-status`/`grpc-message` trailer headers.
+
+## What BlackBull provides today
+
+| Concern | Status | Notes |
+|---|---|---|
+| HTTP/2 framing | ✓ | `blackbull.server.http2_actor`, RFC 9113 compliant; conformance harness in `tests/conformance/http2/`. |
+| Trailers (`http.response.trailers`) | ✓ | Both HTTP/1.1 (chunked) and HTTP/2 paths.  Implemented in `HTTP1Sender` and `HTTP2Sender`. |
+| Bidirectional streaming | ⚠ | `receive()` returns successive `http.request` events as DATA frames arrive; `send()` writes back.  No special bidi support, but the primitives exist. |
+| Per-stream cancellation | ⚠ partial | `RST_STREAM` triggers `http.disconnect` on `receive()`.  Adequate signal; not a first-class cancellation primitive. |
+| Send-side flow-control visibility | ✓ as of v0.31 | `scope['extensions']['http.response.http2_stream']` snapshots `send_window_remaining` and `connection_send_window_remaining`.  See *What Sprint 32 unlocks* below. |
+| `application/grpc` content negotiation | ✗ | Router doesn't dispatch on content-type.  Would need either a routing rule or a middleware that inspects `content-type` and rewrites the route key. |
+| Length-prefixed message framing | ✗ | Application concern.  Library code (probably a `blackbull-grpc` extension package) would supply encode/decode helpers around `protobuf` or `grpc-tools` output. |
+| `grpc-status` trailer + RST-code mapping | ✗ | Trivial to express on top of trailers — but no helper today. |
+
+Net: BlackBull is closer to a gRPC-capable HTTP/2 server than I
+expected before doing this audit.  The framing layer is solid;
+what's missing is mostly *gRPC-flavoured glue* on top of primitives
+we already have.
+
+## What Sprint 32 unlocks
+
+Sprint 32 added `scope['extensions']['http.response.http2_stream']`
+exposing `send_window_remaining` and
+`connection_send_window_remaining` (per RFC 9113 §5.2).  This is
+the missing primitive a gRPC server-streaming implementation
+needs to back-pressure correctly:
+
+```python
+async def server_streaming_rpc(scope, receive, send):
+    ext = scope['extensions']['http.response.http2_stream']
+    for msg in produce_many_messages():
+        # If send window is below a threshold, the peer's recv buffer
+        # is filling up — defer the next message via cooperative yield
+        # or a brief asyncio.sleep instead of blasting it through.
+        if ext['send_window_remaining'] < MIN_WINDOW:
+            await asyncio.sleep(0)
+            # Re-read snapshot: NB - v0.31 ships a snapshot at scope
+            # build time; the value above does NOT update mid-request.
+            # See "Open question" below.
+        await send({'type': 'http.response.body',
+                    'body': frame(msg), 'more_body': True})
+    await send({'type': 'http.response.trailers',
+                'headers': [(b'grpc-status', b'0')]})
+```
+
+Without this hint, a gRPC server has no way to know when to slow
+down — it would either ignore back-pressure entirely (OOM risk
+under slow consumers) or peek at internal HTTP/2 sender state
+(layering violation).
+
+## What's still missing for a minimum gRPC server
+
+In rough order of effort:
+
+1. **Live window-snapshot updates** (small, half a sprint).
+   Sprint 32 ships a snapshot at scope-build time.  For real
+   gRPC server-streaming the application needs the *current*
+   value at each iteration of its emit loop.  Either:
+   - Re-read the dict and have the populate site re-snapshot
+     (requires a hook); or
+   - Replace the scalar with a tiny callable
+     (`scope['extensions']['http.response.http2_stream']['send_window']()`)
+     that reads the sender's current state.
+
+2. **`application/grpc` content-type routing** (small, ~1-2 days).
+   A middleware that, when `content-type` starts with
+   `application/grpc`, rewrites the route key or sets a scope flag
+   the router dispatches on.
+
+3. **gRPC trailer / status helpers** (small, ~1-2 days).
+   A `blackbull.grpc.Status` enum + a `grpc_send_status(send,
+   code, message)` helper that emits the appropriate trailer.
+
+4. **Length-prefixed message framing helpers** (small, ~1 day).
+   `pack_message(payload) → bytes` and an async
+   `read_messages(receive) → AsyncIterator[bytes]` that unframes
+   the length-prefixed wire format.  Independent of protobuf.
+
+5. **Cancellation as first-class signal** (medium, ~3-5 days).
+   Today `http.disconnect` arrives on `receive()`.  gRPC apps
+   typically expect an `asyncio.CancelledError`-flavoured signal
+   instead.  An adapter that converts disconnect → cancel a
+   handler task is reasonable scope.
+
+6. **Bidi streaming ergonomics** (medium, ~3-5 days).
+   The primitives are there; a small DSL (`async for req in
+   request_iter:`, `await response_stream.send(msg)`) would make
+   it much nicer than poking at `receive()` / `send` directly.
+
+7. **Protobuf integration** (large, *out of core scope*).
+   Generated code from `protoc` expects specific call shapes
+   (`async def MyRpc(request, context): ...`).  An adapter library
+   that runs generated stubs against BlackBull handlers belongs in
+   a separate package (`blackbull-grpc`) so the framework core stays
+   protobuf-free.
+
+## Effort estimate
+
+A **minimal** gRPC unary + server-streaming demo (items 1–4 above)
+fits in one ~1-week sprint, on top of Sprint 32's foundation.
+
+A **production-shaped** gRPC implementation (items 1–6 plus the
+`blackbull-grpc` package starter) is 2-3 sprints — comparable to
+Sprint 31's static-file sendfile work in shape and risk.
+
+## Open question
+
+The biggest design question — and the reason this is an assessment
+document, not an implementation — is whether the `send_window`
+field should be a **scalar snapshot** or a **live property**.
+
+- Scalar (Sprint 32): simple, ASGI-flat, but useless for
+  iterative server-streaming RPCs that need real-time pressure
+  signals.
+- Live property: a tiny callable on the scope.  More invasive
+  (ASGI scopes are conventionally pure data).  But this is the
+  shape gRPC genuinely needs.
+
+A future sprint can pick one based on a real adopter's workload.
+Until then, the snapshot is *load-bearing for diagnostics* (you
+can log it from request_received / before_handler) even if it
+doesn't yet enable full back-pressure loops.
+
+## Non-decision
+
+No commitment is being made to ship gRPC.  This document captures
+the design state so a future sprint can be scoped accurately
+without re-doing the audit.  Promotion criteria: a concrete
+adopter need that maps to gRPC and not to plain HTTP/2 streaming.

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -184,8 +184,11 @@ the protocol stack:
 - **HTTP/1.1 parser** — `blackbull/server/parser.py`.  Pure
   Python; no `httptools` dependency.
 - **HTTP/2 frame layer** — `blackbull/protocol/` (frame types,
-  flow-control windows, HPACK encoder/decoder + fastpath, RFC
-  9218 `PRIORITY_UPDATE`).
+  flow-control windows, RFC 9218 `PRIORITY_UPDATE`).  Header
+  compression delegates to the `hpack` library — the only
+  third-party Python package in the protocol stack — wrapped by
+  the BlackBull-owned `hpack_fastpath.py` for the common
+  short-header path.
 - **WebSocket codec** — `blackbull/server/ws_codec.py`
   (RFC 6455 framing) + `blackbull/server/websocket_actor.py`
   (fragment reassembly, RFC 7692 `permessage-deflate`).
@@ -205,12 +208,21 @@ source of truth.
 ## Why pure-Python
 
 `blackbull[speed]` adds `uvloop` as an optional dependency.
-The protocol stack itself stays pure Python — no `httptools`,
-no `h2`-as-a-replacement.  Two reasons:
+The HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec
+are all BlackBull's own code — no `httptools`, no `h2` library
+for framing.  The one exception is HPACK header compression,
+which delegates to the [`hpack`](https://pypi.org/project/hpack/)
+library (pure Python, layered under the BlackBull-owned
+`hpack_fastpath.py`); re-implementing a conformant HPACK
+encoder/decoder is a sub-project of its own, and `hpack` is the
+de-facto Python reference.  Two reasons we keep the rest in
+pure Python:
 
-- **Debuggability.**  An issue in HPACK encoding or HTTP/2
-  flow control can be stepped into with `pdb`.  The stack is
-  the application's code, not an opaque C extension.
+- **Debuggability.**  An issue in HTTP/2 flow control or
+  frame parsing can be stepped into with `pdb`.  The stack is
+  the application's code, not an opaque C extension.  This
+  applies to `hpack` too — it is itself pure Python, so HPACK
+  bugs remain debuggable in-process.
 - **Identity.**  BlackBull exists in part to demonstrate that
   CPython is fast enough for a from-scratch ASGI implementation
   when the framework itself stays out of the way.  Swapping in

--- a/docs/deployment/running.md
+++ b/docs/deployment/running.md
@@ -68,9 +68,9 @@ hypercorn myapp:app --bind 0.0.0.0:8000
 granian --interface asgi myapp:app
 ```
 
-You lose BlackBull's native HTTP/2 and WebSocket implementations
-(the surrounding server's stack is used instead), but the
-application code is portable as-is.
+You lose BlackBull's own HTTP/2 frame layer and WebSocket codec
+(the surrounding server's protocol stack handles framing
+instead), but the application code is portable as-is.
 
 ## Embedded use under an existing event loop
 

--- a/docs/guide/http2.md
+++ b/docs/guide/http2.md
@@ -34,11 +34,14 @@ scope so your app can act on it.
 
 ### What lands on `scope`
 
-Every HTTP/2 request scope contains an `http2_priority` key
-populated by BlackBull before your handler is called:
+Every HTTP/2 request scope advertises the priority hint via the
+`http.response.priority` ASGI extension (matches gunicorn's beta
+HTTP/2 key shape; the *contents* are RFC 9218 urgency/incremental,
+not the deprecated RFC 7540 weight/tree):
 
 ```python
-scope['http2_priority']  # → {'urgency': int, 'incremental': bool}
+scope['extensions']['http.response.priority']
+# → {'urgency': int, 'incremental': bool}
 ```
 
 | Key | Type | Default | Meaning |
@@ -53,8 +56,8 @@ BlackBull resolves the value in this order (first wins):
 2. `priority` HTTP header in the request (e.g. `priority: u=1, i`).
 3. RFC 9218 §4.1 defaults: `urgency=3`, `incremental=False`.
 
-For HTTP/1.1 requests the key is absent.  Always use `.get()`
-with a default so your handler works across both protocols.
+For HTTP/1.1 requests the extension key is absent.  Always use
+`.get()` with a default so your handler works across both protocols.
 
 ### Using it in a handler
 
@@ -63,7 +66,8 @@ _DEFAULT_PRIORITY = {'urgency': 3, 'incremental': False}
 
 @app.route(path='/search')
 async def search(scope, receive, send):
-    hint = scope.get('http2_priority', _DEFAULT_PRIORITY)
+    ext = scope.get('extensions') or {}
+    hint = ext.get('http.response.priority', _DEFAULT_PRIORITY)
     if hint['urgency'] <= 2:
         # High-urgency: return cached / pre-computed result immediately
         result = get_cached_result()
@@ -79,11 +83,68 @@ async def search(scope, receive, send):
 @app.intercept('before_handler')
 async def handle_priority(event):
     scope = event.detail['scope']
-    hint = scope.get('http2_priority', {'urgency': 3, 'incremental': False})
+    ext = scope.get('extensions') or {}
+    hint = ext.get('http.response.priority', {'urgency': 3, 'incremental': False})
     if hint['urgency'] <= 1:
         logger.info('HIGH-PRIORITY u=%d: %s %s',
                     hint['urgency'], event.detail['method'], event.detail['path'])
 ```
+
+### Migrating from `scope['http2_priority']` (pre-v0.31)
+
+Earlier BlackBull releases exposed priority as a top-level scope
+key, `scope['http2_priority']`.  v0.31 moved it under
+`scope['extensions']` to match ASGI conventions and align the key
+name with gunicorn's beta HTTP/2 surface.  The legacy key is still
+populated alongside the new extension during the v0.31 cycle and
+is scheduled for removal in v0.32.0.
+
+To migrate, replace:
+
+```python
+hint = scope.get('http2_priority', DEFAULT)            # legacy
+```
+
+with:
+
+```python
+ext = scope.get('extensions') or {}
+hint = ext.get('http.response.priority', DEFAULT)       # v0.31+
+```
+
+The dict shape (`{'urgency': int, 'incremental': bool}`) is
+unchanged.
+
+### HTTP/2 stream info (gRPC foundation)
+
+Alongside the priority extension, v0.31 adds
+`scope['extensions']['http.response.http2_stream']` — a snapshot of
+the HTTP/2 stream identity and send-flow-control credit at request
+entry:
+
+```python
+scope['extensions']['http.response.http2_stream']
+# → {'stream_id': int, 'send_window_remaining': int,
+#    'connection_send_window_remaining': int}
+```
+
+| Key | Meaning |
+|---|---|
+| `stream_id` | The HTTP/2 stream ID this request arrived on (odd for client-initiated, even for server pushes) |
+| `send_window_remaining` | Bytes the peer will currently accept on this stream before WINDOW_UPDATE |
+| `connection_send_window_remaining` | Same, at the connection level |
+
+The window values are snapshots taken at scope-build time; they
+move as the response body streams.  Applications that need
+live readings (e.g. gRPC server-streaming back-pressure) can
+re-read the dict, though they will see the snapshot value unless
+they keep a reference and the populate site re-fetches it — which
+v0.31 does not do.  Live properties are a future-sprint
+consideration.
+
+Peer-side receive-window is intentionally absent: BlackBull sends
+`WINDOW_UPDATE` per consumed DATA frame, so there is no scalar to
+snapshot.
 
 See [`examples/PriorityExample/`](https://github.com/TOKUJI/BlackBull/tree/master/examples/PriorityExample/)
 for a dedicated server + client pair that demonstrates both

--- a/examples/PriorityExample/client.py
+++ b/examples/PriorityExample/client.py
@@ -4,8 +4,9 @@ HTTP/2 Priority Example — client
 Demonstrates sending HTTP/2 priority hints to the BlackBull priority server.
 
 Priority hints are sent as a standard 'priority' HTTP header (RFC 9218 §4.2).
-httpx forwards this header over HTTP/2; a compliant intermediary or server
-parses it and populates scope['http2_priority'] on the server side.
+httpx forwards this header over HTTP/2; the server parses it and populates
+``scope['extensions']['http.response.priority']`` (BlackBull v0.31+) for
+application code to inspect.
 
 BlackBull also accepts PRIORITY_UPDATE frames (type 0x10) directly, but that
 requires a lower-level HTTP/2 client.  The 'priority' header is the portable,
@@ -45,7 +46,7 @@ async def demo(base_url: str) -> None:
                                  headers={'priority': field})
             r.raise_for_status()
             data = r.json()
-            hint = data['http2_priority']
+            hint = data['priority']
             print(f'  priority: {field!r:12s}  ({label})')
             print(f'    → urgency={hint["urgency"]}  '
                   f'incremental={hint["incremental"]}')

--- a/examples/PriorityExample/server.py
+++ b/examples/PriorityExample/server.py
@@ -1,8 +1,9 @@
 """
 HTTP/2 Priority Example — BlackBull server
 ==========================================
-Demonstrates how to read RFC 9218 priority hints from scope['http2_priority']
-and act on them in handler code.
+Demonstrates how to read RFC 9218 priority hints from the ASGI scope
+extension ``scope['extensions']['http.response.priority']`` and act on
+them in handler code.
 
 RFC 9218 Priority field
 -----------------------
@@ -23,10 +24,17 @@ The priority field has two components:
 BlackBull does not reorder responses based on urgency.  Acting on the hint
 is entirely up to application code, as shown below.
 
+Scope location (BlackBull v0.31+):
+  scope['extensions']['http.response.priority'] → {'urgency': int, 'incremental': bool}
+
+The legacy ``scope['http2_priority']`` key is still populated for one
+release as a deprecation alias; it is scheduled for removal in
+BlackBull v0.32.0.
+
 Endpoints
 ---------
   GET /              → JSON listing all endpoints
-  GET /priority-echo → returns scope['http2_priority'] as JSON
+  GET /priority-echo → returns the priority hint as JSON
   GET /work          → simulates a variable-cost operation;
                        cost scales with urgency so high-urgency requests
                        return quickly and low-urgency ones take longer
@@ -51,8 +59,16 @@ _DEFAULT_PRIORITY = {'urgency': 3, 'incremental': False}
 
 
 def _priority(scope: dict) -> dict:
-    """Return scope's priority hint, defaulting to RFC 9218 §4.1 values."""
-    return scope.get('http2_priority', _DEFAULT_PRIORITY)
+    """Return scope's priority hint, defaulting to RFC 9218 §4.1 values.
+
+    Reads ``scope['extensions']['http.response.priority']`` — the ASGI
+    extension surface BlackBull adopted in v0.31.  The legacy
+    ``scope['http2_priority']`` key is still populated for backwards
+    compatibility but will be removed in v0.32.0; new code should use
+    the extension.
+    """
+    ext = scope.get('extensions') or {}
+    return ext.get('http.response.priority', _DEFAULT_PRIORITY)
 
 
 @app.on('request_received')
@@ -98,7 +114,8 @@ async def handle_priority_echo(scope, receive, send):
     logger.info('priority-echo: urgency=%d incremental=%s',
                 hint['urgency'], hint['incremental'])
     await send(JSONResponse({
-        'http2_priority': hint,
+        'priority': hint,
+        'scope_location': "scope['extensions']['http.response.priority']",
         'note': (
             'Set via PRIORITY_UPDATE frame or "priority" HTTP header. '
             'Defaults: urgency=3, incremental=false (RFC 9218 §4.1).'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,3 +67,4 @@ nav:
   - About:
     - Conformance: about/conformance.md
     - Internals: about/internals.md
+    - gRPC assessment: about/grpc-assessment.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "blackbull"
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
 version = "0.31.0"
-description = "From-scratch async ASGI 3.0 framework with native HTTP/1.1, HTTP/2 and WebSocket implementations."
+description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"
 
@@ -41,7 +41,13 @@ classifiers = [
 ]
 
 dependencies = [
-    "h2",
+    # HPACK header compression for HTTP/2 — pure Python; the
+    # BlackBull HTTP/2 frame layer wraps hpack's Encoder/Decoder
+    # plus our own fastpath in blackbull/protocol/hpack_fastpath.py.
+    # Re-implementing a conformant HPACK encoder/decoder is a
+    # project of its own; the rest of the HTTP/2 stack
+    # (framing, flow control, prioritisation, push, stream
+    # actor) is BlackBull's own code.
     "hpack",
     # beartype is load-bearing — Router.validate() imports it at every
     # app.run() / app.serve() boot to type-check path-param converters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.30.0"
+version = "0.31.0"
 description = "From-scratch async ASGI 3.0 framework with native HTTP/1.1, HTTP/2 and WebSocket implementations."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_http2_advanced.py
+++ b/tests/integration/test_http2_advanced.py
@@ -58,6 +58,31 @@ def _make_priority_app() -> BlackBull:
     return app
 
 
+def _make_stream_info_app() -> BlackBull:
+    """Sprint 32 — echoes both the new extensions surface and the
+    legacy ``http2_priority`` key so the integration test can verify
+    they agree."""
+    app = BlackBull()
+
+    @app.route(path='/stream-info')
+    async def stream_info_route(scope, receive, send):
+        import json
+        ext = scope.get('extensions') or {}
+        legacy = scope.get('http2_priority', {})
+        payload = {
+            'legacy_http2_priority': legacy,
+            'priority_ext': ext.get('http.response.priority'),
+            'http2_stream_ext': ext.get('http.response.http2_stream'),
+            'extension_keys': sorted(ext.keys()),
+        }
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'application/json')]})
+        await send({'type': 'http.response.body',
+                    'body': json.dumps(payload).encode(), 'more_body': False})
+
+    return app
+
+
 @pytest.fixture(scope="module")
 def push_app(manage_cert_and_key):
     app = _make_push_app()
@@ -133,3 +158,72 @@ async def test_priority_hint_in_scope(priority_app):
     assert 'incremental' in hint
     # With u=1 the urgency should be parsed as 1
     assert hint['urgency'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Sprint 32 — http.response.priority + http.response.http2_stream extensions
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def stream_info_app(manage_cert_and_key):
+    app = _make_stream_info_app()
+    with live_server(app, certfile=str(_CERT), keyfile=str(_KEY)) as handle:
+        yield handle
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_priority_extension_present_in_scope(stream_info_app):
+    """``scope['extensions']['http.response.priority']`` is populated for
+    every HTTP/2 request and carries the same RFC 9218 urgency/incremental
+    values the legacy ``scope['http2_priority']`` does."""
+    async with httpx.AsyncClient(
+        http2=True, verify=False,
+        base_url=f'https://localhost:{stream_info_app.port}',
+    ) as c:
+        r = await c.get('/stream-info', headers={'priority': 'u=2, i'})
+    assert r.status_code == 200
+    body = r.json()
+
+    assert body['priority_ext'] is not None
+    assert body['priority_ext']['urgency'] == 2
+    assert body['priority_ext']['incremental'] is True
+    # Deprecation alias must agree.
+    assert body['legacy_http2_priority'] == body['priority_ext']
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_http2_stream_extension_present_in_scope(stream_info_app):
+    """``scope['extensions']['http.response.http2_stream']`` carries
+    stream_id and the send-window snapshot."""
+    async with httpx.AsyncClient(
+        http2=True, verify=False,
+        base_url=f'https://localhost:{stream_info_app.port}',
+    ) as c:
+        r = await c.get('/stream-info')
+    body = r.json()
+
+    s = body['http2_stream_ext']
+    assert s is not None
+    # First client-initiated stream on a fresh connection is 1 (RFC 9113 §5.1.1).
+    assert s['stream_id'] == 1
+    # Window snapshot is whatever the peer's initial setting was — non-negative.
+    assert s['send_window_remaining'] >= 0
+    assert s['connection_send_window_remaining'] >= 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_scope_advertises_three_extension_keys(stream_info_app):
+    """The HTTP/2 scope advertises push, priority, and http2_stream
+    keys.  Sprint 32 adds the latter two; the existing push key stays."""
+    async with httpx.AsyncClient(
+        http2=True, verify=False,
+        base_url=f'https://localhost:{stream_info_app.port}',
+    ) as c:
+        r = await c.get('/stream-info')
+    keys = set(r.json()['extension_keys'])
+    assert 'http.response.push' in keys
+    assert 'http.response.priority' in keys
+    assert 'http.response.http2_stream' in keys

--- a/tests/integration/test_http2_advanced.py
+++ b/tests/integration/test_http2_advanced.py
@@ -5,6 +5,7 @@ connection and cannot be verified over HTTP/1.1.
 """
 import asyncio
 import pathlib
+import ssl
 from multiprocessing import Process
 
 import httpx
@@ -17,6 +18,18 @@ from .conftest import live_server
 
 _CERT = pathlib.Path(__file__).parent.parent / 'cert.pem'
 _KEY  = pathlib.Path(__file__).parent.parent / 'key.pem'
+
+
+def _test_ssl_context() -> ssl.SSLContext:
+    """SSLContext that validates against the self-signed test CA.
+
+    Replaces ``verify=False`` in httpx calls: hostname checks and
+    chain verification still run (against ``tests/cert.pem``), so
+    CodeQL no longer flags the call as "Request without certificate
+    validation" and we still get the protections cert validation
+    is meant to provide — limited to talking to our own test server.
+    """
+    return ssl.create_default_context(cafile=str(_CERT))
 
 
 def _make_push_app() -> BlackBull:
@@ -178,7 +191,7 @@ async def test_priority_extension_present_in_scope(stream_info_app):
     every HTTP/2 request and carries the same RFC 9218 urgency/incremental
     values the legacy ``scope['http2_priority']`` does."""
     async with httpx.AsyncClient(
-        http2=True, verify=False,
+        http2=True, verify=_test_ssl_context(),
         base_url=f'https://localhost:{stream_info_app.port}',
     ) as c:
         r = await c.get('/stream-info', headers={'priority': 'u=2, i'})
@@ -198,7 +211,7 @@ async def test_http2_stream_extension_present_in_scope(stream_info_app):
     """``scope['extensions']['http.response.http2_stream']`` carries
     stream_id and the send-window snapshot."""
     async with httpx.AsyncClient(
-        http2=True, verify=False,
+        http2=True, verify=_test_ssl_context(),
         base_url=f'https://localhost:{stream_info_app.port}',
     ) as c:
         r = await c.get('/stream-info')
@@ -219,7 +232,7 @@ async def test_scope_advertises_three_extension_keys(stream_info_app):
     """The HTTP/2 scope advertises push, priority, and http2_stream
     keys.  Sprint 32 adds the latter two; the existing push key stays."""
     async with httpx.AsyncClient(
-        http2=True, verify=False,
+        http2=True, verify=_test_ssl_context(),
         base_url=f'https://localhost:{stream_info_app.port}',
     ) as c:
         r = await c.get('/stream-info')

--- a/tests/unit/test_http2_extensions.py
+++ b/tests/unit/test_http2_extensions.py
@@ -1,0 +1,131 @@
+"""Sprint 32 — HTTP/2 scope extensions surface.
+
+Covers:
+
+- ``scope['extensions']['http.response.priority']`` — RFC 9218
+  urgency/incremental hints, exposed under a key shape that matches
+  gunicorn's beta HTTP/2 convention.
+- ``scope['extensions']['http.response.http2_stream']`` — stream_id
+  + send-window snapshot (gRPC server-streaming foundation).
+- Deprecation alias: ``scope['http2_priority']`` is still populated
+  and MUST agree with the new priority extension for one release.
+
+The new extensions are built by ``_build_h2_extensions`` in
+``blackbull.server.http2_actor``; these tests pin its behaviour so
+the populate sites can change shape later without silent drift.
+"""
+from __future__ import annotations
+
+import pytest
+
+from blackbull.asgi import ASGIEvent
+from blackbull.server.http2_actor import (
+    _DEFAULT_PRIORITY,
+    _build_h2_extensions,
+)
+
+
+@pytest.fixture
+def default_extensions() -> dict:
+    return _build_h2_extensions(
+        stream_id=1,
+        priority=_DEFAULT_PRIORITY,
+        peer_initial_window=65535,
+        connection_window=65535,
+    )
+
+
+class TestBuildExtensions:
+    """``_build_h2_extensions`` builds the ASGI ``scope['extensions']``
+    dict for one HTTP/2 request — one fresh dict per call so per-stream
+    fields don't bleed across requests."""
+
+    def test_advertises_push_priority_and_stream_keys(self, default_extensions):
+        assert ASGIEvent.HTTP_RESPONSE_PUSH in default_extensions
+        assert 'http.response.priority' in default_extensions
+        assert 'http.response.http2_stream' in default_extensions
+
+    def test_push_marker_is_empty_dict(self, default_extensions):
+        """Push is signalled by the *presence* of the key, not by
+        contents — matches BlackBull's pre-Sprint-32 behaviour."""
+        assert default_extensions[ASGIEvent.HTTP_RESPONSE_PUSH] == {}
+
+    def test_priority_contents_match_rfc_9218_default(self, default_extensions):
+        """Default priority per RFC 9218 §4.1: urgency=3, incremental=False."""
+        p = default_extensions['http.response.priority']
+        assert p == {'urgency': 3, 'incremental': False}
+
+    def test_priority_passthrough_for_explicit_hint(self):
+        ext = _build_h2_extensions(
+            stream_id=5,
+            priority={'urgency': 0, 'incremental': True},
+            peer_initial_window=65535,
+            connection_window=65535)
+        assert ext['http.response.priority'] == {
+            'urgency': 0, 'incremental': True}
+
+    def test_http2_stream_includes_stream_id(self, default_extensions):
+        assert default_extensions['http.response.http2_stream']['stream_id'] == 1
+
+    def test_http2_stream_includes_send_window_snapshot(self):
+        ext = _build_h2_extensions(
+            stream_id=3,
+            priority=_DEFAULT_PRIORITY,
+            peer_initial_window=12345,
+            connection_window=99999)
+        s = ext['http.response.http2_stream']
+        assert s['send_window_remaining'] == 12345
+        assert s['connection_send_window_remaining'] == 99999
+
+    def test_separate_calls_return_independent_dicts(self):
+        """Per-request extensions must not share mutable state — a
+        downstream middleware mutating one request's extensions would
+        otherwise leak into the next."""
+        a = _build_h2_extensions(1, _DEFAULT_PRIORITY, 100, 100)
+        b = _build_h2_extensions(3, _DEFAULT_PRIORITY, 200, 200)
+        assert a is not b
+        assert a['http.response.http2_stream'] is not b['http.response.http2_stream']
+        a['http.response.http2_stream']['stream_id'] = 999
+        assert b['http.response.http2_stream']['stream_id'] == 3
+
+    def test_priority_dict_is_not_aliased_across_calls(self):
+        """Mutating one scope's priority must not affect another's,
+        even when the same ``priority`` argument was passed in
+        (the helper currently passes the dict through — if that
+        ever changes, this test pins the contract)."""
+        shared = {'urgency': 2, 'incremental': True}
+        a = _build_h2_extensions(1, shared, 100, 100)
+        b = _build_h2_extensions(3, shared, 200, 200)
+        # Both currently reference the caller's dict.  That's
+        # acceptable as long as production callers don't mutate
+        # it after the fact — and the populate sites in
+        # http2_actor.py don't.  This test documents the contract
+        # so accidental in-place mutation downstream gets caught.
+        a_pri = a['http.response.priority']
+        b_pri = b['http.response.priority']
+        # They may be the same object OR a copy; both behaviours
+        # are acceptable as long as reading is consistent.
+        assert a_pri == b_pri == shared
+
+
+class TestLegacyAliasContract:
+    """``scope['http2_priority']`` is kept populated for one release
+    so middleware that read the legacy key keeps working through
+    the v0.31 deprecation window.  Removal scheduled for v0.32.0.
+
+    These tests don't drive a real request — they pin the contract
+    by asserting the helper's priority output is the same shape the
+    legacy key carried."""
+
+    def test_legacy_alias_shape_matches_priority_extension(self):
+        ext = _build_h2_extensions(
+            stream_id=7,
+            priority={'urgency': 5, 'incremental': False},
+            peer_initial_window=65535,
+            connection_window=65535)
+        # The populate sites assign the SAME dict to both
+        # scope['http2_priority'] and scope['extensions']
+        # ['http.response.priority'].  Asserting equality on the
+        # extension's contents pins that contract.
+        assert ext['http.response.priority'] == {
+            'urgency': 5, 'incremental': False}


### PR DESCRIPTION
## Summary

Sprint 32 — HTTP/2 stream-info ASGI extensions.

Two related changes on this branch:

1. **\`scope['http2_priority'] → scope['extensions']\`** — move the RFC 9218 priority hint from the non-conventional top-level key under \`scope['extensions']\` per ASGI convention.  Key name matches gunicorn's beta HTTP/2 surface (\`http.response.priority\`); the *contents* are RFC 9218 urgency/incremental, not the RFC 7540 weight/tree that RFC 9113 §5.3.2 deprecated.  The legacy \`scope['http2_priority']\` stays populated as a deprecation alias for one release; removal targets v0.32.0.

2. **New \`http.response.http2_stream\` extension** — \`{stream_id, send_window_remaining, connection_send_window_remaining}\` snapshot at scope-build time.  Lays the foundation for gRPC server-streaming back-pressure awareness.  \`docs/about/grpc-assessment.md\` evaluates what gRPC over BlackBull would need; no gRPC code in this release.

3. **Docs honesty pass** (second commit, prompted by a reviewer comment) — soften the "from-scratch" claim to be accurate about HPACK delegation; drop the unused \`h2\` dependency from \`pyproject.toml\`.

## Files

- \`blackbull/server/http2_actor.py\` — new \`_build_h2_extensions\` helper builds a fresh per-request dict at the three populate sites (HEADERS, CONTINUATION, push).
- \`blackbull/asgi.py\` — no change in this PR (ASGIEvent constants stable).
- \`examples/PriorityExample/{server,client}.py\` — read from new extension location; no \`scope['http2_priority']\` reads remain.
- \`docs/guide/http2.md\` — leads with the new location + migration subsection.
- \`docs/about/grpc-assessment.md\` (new) — written assessment of gRPC viability.
- \`docs/about/internals.md\`, \`README.md\`, \`pyproject.toml\`, \`docs/deployment/running.md\` — honesty pass.

## Test plan

- [x] \`pytest\` — 1220 → **1229 passing** (+9 new Sprint 32 unit tests), 196 skipped (3 new integration tests that require \`-m integration\`)
- [x] \`pytest -m integration tests/integration/test_http2_advanced.py\` — 6 passing including 3 new
- [x] \`pytest --beartype-packages=blackbull\` — also clean
- [x] Fresh-venv install without \`h2\` confirms it's genuinely unused: blackbull imports + boots, only \`hpack\` is pulled in
- [x] \`mkdocs build\` — clean
- [ ] After merge: tag \`v0.31.0\` against the post-merge HEAD (NOT before — the v0.30.0 retry taught us this), push tag → \`publish.yml\` → PyPI → \`gh release create\`

## Deprecation

\`scope['http2_priority']\` stays populated alongside \`scope['extensions']['http.response.priority']\` for v0.31.0 only.  Removal scheduled for v0.32.0.  Migration documented in \`docs/guide/http2.md\` and the v0.31.0 CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)