### PR TITLE
docs(known-limitations): clarify static cache is stat-invalidated

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -145,8 +145,11 @@ serves files three ways:
   costs roughly 64 µs each.  Use the fronting nginx path below if
   this is on the critical path for you.
 
-There is still no in-process file watcher, ETag-driven
-revalidation, byte-range-multipart, or CDN edge-cache
+The in-memory cache is stat-invalidated per request — every
+request runs `path.stat()` and refills the entry when mtime or
+size changes, so edits on disk show up on the next request with
+no staleness window.  What's still missing: ETag-driven
+revalidation, byte-range-multipart, and CDN edge-cache
 invalidation glue.  For anything user-visible, front a real
 static-file server (nginx, S3 + CloudFront).
 


### PR DESCRIPTION
## Summary

The KNOWN_LIMITATIONS line under static-file serving said:

> There is still no in-process file watcher, ETag-driven revalidation, byte-range-multipart, or CDN edge-cache invalidation glue.

That phrasing implied the in-memory cache could go stale until restart, which is wrong: [`blackbull/middleware/static.py`](blackbull/middleware/static.py) runs ``path.stat()`` on every request and refills the cache entry whenever ``mtime_ns`` or ``size`` changes (see ``_lookup`` and ``_store``).

This change rewrites the paragraph to describe what the cache actually does, and keeps the still-missing items (ETag-driven revalidation, byte-range-multipart, CDN invalidation) on their own line.

## Test plan
- [x] No code changes — docs-only edit
- [x] Confirmed cache invalidation behaviour matches new wording by reading ``_lookup`` / ``_store`` in [`blackbull/middleware/static.py`](blackbull/middleware/static.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)