### PR TITLE
perf(static): cache mime + throttle stat + vectored write on cache hit

### DIFF
--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -1,5 +1,7 @@
 import asyncio
 import mimetypes
+import os
+import time
 from collections import OrderedDict
 from pathlib import Path
 from urllib.parse import unquote
@@ -17,6 +19,14 @@ class StaticFiles:
     _CACHE_MAX_ENTRIES = 256
     # 64 KiB streaming chunk for files above the cache threshold.
     _CHUNK = 64 * 1024
+    # Per-entry stat throttle.  Once a cached entry is validated by
+    # ``stat()``, skip the syscall on subsequent requests until the
+    # monotonic clock has advanced this many seconds.  Default 1 s keeps
+    # edit-on-disk visibility under a second while removing the per-
+    # request stat from the cache-hit hot path.  Override via
+    # ``BB_STATIC_STAT_TTL_S`` (env var, float seconds); set to ``0`` to
+    # restore the pre-Sprint-33 every-request behaviour.
+    _STAT_TTL_S = float(os.environ.get('BB_STATIC_STAT_TTL_S', '1.0'))
 
     # Server preference order for precompressed variant selection.
     # Matches blackbull.middleware.compression's order (br > zstd > gzip).
@@ -34,11 +44,13 @@ class StaticFiles:
         self._root = Path(resolved).resolve()
         self._url_prefix = url_prefix.rstrip('/')
         # cache key = the actual file path served (original or sibling).
-        # value = (mtime_ns, size, body, mime, content_encoding).
+        # value = (mtime_ns, size, body, mime, content_encoding, last_stat).
         # content_encoding is b'' for uncompressed; b'br'/b'gzip'/b'zstd'
-        # for precompressed siblings.
+        # for precompressed siblings.  ``last_stat`` is the monotonic
+        # clock when ``stat()`` last confirmed the entry was still fresh
+        # — used to throttle the per-request stat syscall.
         self._cache: OrderedDict[
-            Path, tuple[int, int, bytes, bytes, bytes]
+            Path, tuple[int, int, bytes, bytes, bytes, float]
         ] = OrderedDict()
 
     async def __call__(self, scope, receive, send, call_next=None):
@@ -136,36 +148,63 @@ class StaticFiles:
     async def _serve(self, scope, send, path: Path):
         # Pick variant (precompressed sibling if available + accepted).
         served_path, content_encoding = self._negotiate(scope, path)
-        # Content-Type derives from the original path's extension, not
-        # the .br/.gz/.zst suffix — e.g. text/javascript for app.js.br.
-        mime = (mimetypes.guess_type(path.name)[0]
-                or 'application/octet-stream').encode()
 
-        # stat() is one cheap syscall (~µs).  Running it sync in the event
-        # loop avoids the asyncio thread-pool dispatch that became the
-        # bottleneck under HttpArena's c=1024-6800 load (Sprint 28).
-        try:
-            st = served_path.stat()
-        except OSError:
-            await self._respond(send, HTTPStatus.NOT_FOUND)
-            return
-        size = st.st_size
-        mtime_ns = st.st_mtime_ns
-
-        cached = self._lookup(served_path, mtime_ns, size)
         body: bytes | None
-        if cached is not None:
-            body = cached
-        elif size <= self._CACHE_MAX_BYTES_PER_FILE:
+        mime: bytes
+        size: int
+
+        # Fast path: cached entry, still within the per-entry stat TTL.
+        # No syscall, no ``mimetypes.guess_type`` regex.
+        cached_entry = self._cache.get(served_path)
+        now = time.monotonic()
+        if (cached_entry is not None
+                and self._STAT_TTL_S > 0
+                and now - cached_entry[5] < self._STAT_TTL_S):
+            _, size, body, mime, _, _ = cached_entry
+            self._cache.move_to_end(served_path)
+        else:
+            # Cache miss, stale TTL, or TTL disabled — re-stat to
+            # confirm the entry is still valid.
             try:
-                with open(served_path, 'rb') as f:
-                    body = f.read()
+                st = served_path.stat()
             except OSError:
                 await self._respond(send, HTTPStatus.NOT_FOUND)
                 return
-            self._store(served_path, mtime_ns, size, body, mime, content_encoding)
-        else:
-            body = None  # streaming path below
+            size = st.st_size
+            mtime_ns = st.st_mtime_ns
+
+            if (cached_entry is not None
+                    and cached_entry[0] == mtime_ns
+                    and cached_entry[1] == size):
+                # Entry still matches the file on disk: reuse body + mime
+                # and refresh ``last_stat`` so the next request can take
+                # the fast path again.
+                _, _, body, mime, _, _ = cached_entry
+                self._cache[served_path] = (
+                    mtime_ns, size, body, mime, content_encoding, now)
+                self._cache.move_to_end(served_path)
+            elif size <= self._CACHE_MAX_BYTES_PER_FILE:
+                # First fill or stale entry — read once and store.
+                # Content-Type derives from the original path's extension,
+                # not the .br/.gz/.zst suffix — e.g. text/javascript for
+                # app.js.br.
+                mime = (mimetypes.guess_type(path.name)[0]
+                        or 'application/octet-stream').encode()
+                try:
+                    with open(served_path, 'rb') as f:
+                        body = f.read()
+                except OSError:
+                    await self._respond(send, HTTPStatus.NOT_FOUND)
+                    return
+                self._store(served_path, mtime_ns, size, body, mime,
+                            content_encoding, now)
+            else:
+                # Above the cache threshold — drop any stale entry and
+                # fall through to the streaming/pathsend branch.
+                self._cache.pop(served_path, None)
+                mime = (mimetypes.guess_type(path.name)[0]
+                        or 'application/octet-stream').encode()
+                body = None
 
         range_hdr = None
         for k, v in scope.get('headers', []):
@@ -266,21 +305,11 @@ class StaticFiles:
         finally:
             await asyncio.to_thread(fobj.close)
 
-    def _lookup(self, path: Path, mtime_ns: int, size: int) -> bytes | None:
-        entry = self._cache.get(path)
-        if entry is None:
-            return None
-        if entry[0] != mtime_ns or entry[1] != size:
-            # stale — drop and force refill
-            self._cache.pop(path, None)
-            return None
-        # mark as recently used
-        self._cache.move_to_end(path)
-        return entry[2]
-
     def _store(self, path: Path, mtime_ns: int, size: int,
-               body: bytes, mime: bytes, content_encoding: bytes):
-        self._cache[path] = (mtime_ns, size, body, mime, content_encoding)
+               body: bytes, mime: bytes, content_encoding: bytes,
+               last_stat: float):
+        self._cache[path] = (mtime_ns, size, body, mime, content_encoding,
+                             last_stat)
         self._cache.move_to_end(path)
         while len(self._cache) > self._CACHE_MAX_ENTRIES:
             self._cache.popitem(last=False)

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -74,6 +74,16 @@ class AbstractWriter(ABC):
         """Write *data* to the transport and ensure it is flushed."""
         ...
 
+    async def writelines(self, parts) -> None:
+        """Write multiple byte segments without joining them in user space.
+
+        Default joins-and-writes so subclasses can opt out.  Override in
+        transports whose ``writelines`` does vectored I/O (``writev`` /
+        ``sendmsg``) to skip the full-body memcpy on the static-file
+        cache-hit path.
+        """
+        await self.write(b''.join(parts))
+
     async def close(self) -> None:
         """Close the underlying transport. Default: no-op."""
 
@@ -145,6 +155,37 @@ class AsyncioWriter(AbstractWriter):
                     # lets us still raise ConnectionResetError below so
                     # the sender's existing peer-disconnect handling
                     # runs uniformly.
+                    logger.debug(
+                        'write timeout: transport.close() also failed (%s) — '
+                        'continuing with ConnectionResetError', close_exc)
+                raise ConnectionResetError(
+                    f'write timeout after {self._write_timeout:.1f}s'
+                ) from None
+        else:
+            await self._sw.drain()
+
+    async def writelines(self, parts) -> None:
+        """Vectored write via the underlying StreamWriter.
+
+        ``asyncio.StreamWriter.writelines`` hands the iterable to
+        ``transport.writelines``, which on the selector transport uses
+        ``socket.sendmsg(iovec, …)`` for the immediate-send case and on
+        uvloop is implemented as a real vectored write.  Either way the
+        body bytes never get copied into a fresh ``bytes`` object before
+        the syscall.
+        """
+        self._sw.writelines(parts)
+        if self._write_timeout > 0:
+            try:
+                await asyncio.wait_for(self._sw.drain(),
+                                       timeout=self._write_timeout)
+            except (asyncio.TimeoutError, TimeoutError):
+                logger.warning(
+                    'write timeout (%.1fs) exceeded — closing connection',
+                    self._write_timeout)
+                try:
+                    self._sw.close()
+                except Exception as close_exc:
                     logger.debug(
                         'write timeout: transport.close() also failed (%s) — '
                         'continuing with ConnectionResetError', close_exc)
@@ -229,6 +270,24 @@ class BaseSender(ABC):
         except OSError as exc:
             # SSLEOFError / SSLZeroReturnError land here on TLS connections
             # whose peer dropped without a proper close-notify.
+            self._closed = True
+            logger.debug('sender: write failed on closed TLS transport (%s)', exc.__class__.__name__)
+
+    async def _write_many(self, parts) -> None:
+        """Vectored variant of :meth:`_write` — avoids joining the parts.
+
+        Used by the HTTP/1.1 ``_flush`` for the headers+body cache-hit
+        path: the body bytes already live in the static-file cache, and
+        ``head + body`` would allocate a full-body copy on every hit.
+        """
+        if getattr(self, '_closed', False):
+            return
+        try:
+            await self._writer.writelines(parts)
+        except (ConnectionResetError, BrokenPipeError) as exc:
+            self._closed = True
+            logger.debug('sender: peer closed write side (%s)', exc.__class__.__name__)
+        except OSError as exc:
             self._closed = True
             logger.debug('sender: write failed on closed TLS transport (%s)', exc.__class__.__name__)
 
@@ -390,8 +449,14 @@ class HTTP1Sender(BaseSender):
             if not more_body and not self._expect_trailers:
                 chunk += b'0\r\n\r\n'
             await self._write(chunk)
+        elif body:
+            # Vectored write: avoids the full-body memcpy that ``head + body``
+            # forced.  At static-file rates of ~5k req/s × ~17 KB on average,
+            # that allocation was ~88 MB/s of pure user-space copy before the
+            # bytes even reached the transport.
+            await self._write_many((head, body))
         else:
-            await self._write(head + body if body else head)
+            await self._write(head)
 
     def _render_start(self, status: HTTPStatus, headers: HeaderList) -> bytes:
         """Build the status line + headers + blank-line as a single bytes blob."""


### PR DESCRIPTION
## Summary

Three small wins on the static-file cache-hit hot path, surfaced by the sprint32 peer-compare numbers where BlackBull's per-byte transport cost was the dominant factor against FastAPI on the static profile.

1. **Cached ``mime``** — was re-derived from ``mimetypes.guess_type(path.name)`` on every request even though the cached tuple already had the right value stored at fill time.  Now read from the cache entry on hits, skipping the regex.
2. **Throttled ``stat()``** — ran on every cache hit for the *edit-on-disk shows up next request* guarantee.  Replaced with a per-entry throttle: ``last_stat`` is recorded on validation and the syscall is skipped while the monotonic clock is within ``_STAT_TTL_S`` (default 1.0 s; controllable via ``BB_STATIC_STAT_TTL_S``; ``0`` restores per-request behaviour).  Edit-on-disk visibility goes from per-request to under a second — still sub-human-perceptible.
3. **Vectored body write** — ``_flush`` in ``HTTP1Sender`` concatenated ``head + body`` and wrote the resulting bytes, allocating a full-body copy on every response.  Replaced with ``_write_many((head, body))`` which calls ``StreamWriter.writelines`` — selector transports use ``socket.sendmsg(iovec, …)`` and uvloop does a real vectored write either way.

## Measurement

EC2 c7i.8xlarge ([bench/results/httparena/sprint33-static-perf-20260604-133027Z](bench/results/httparena/sprint33-static-perf-20260604-133027Z)):
- Static profile: 5,185 r/s (prior 0.31.0) → 4,983 r/s (patched).  Inside the ~4% run-to-run noise on this hardware — patches verified correct, but no measurable speedup at this signal level.
- uvloop helps non-static profiles (+12-15%) but not static, confirming the static bottleneck is not in event-loop / transport overhead.  The actual hot spot still needs py-spy data.

## Test plan
- [x] ``timeout 180 python -m pytest --timeout=30 -q`` — 1229 passed / 196 skipped / 0 failed
- [x] ``timeout 60 python -m pytest tests/unit/test_static.py --timeout=30 -q`` — 38 passed (covers mime via .br sibling, cache-hit semantics, precompressed serving)
- [x] EC2 cross-check confirms no static regression beyond noise floor
- [x] HttpArena validate: 47/47 passes on patched build

🤖 Generated with [Claude Code](https://claude.com/claude-code)