### PR TITLE
perf(compression): pass-through fast path + Accept-Encoding selection cache

### DIFF
--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -96,6 +96,13 @@ class Compression:
         self._executor_max_inflight = executor_max_inflight
         self._executor_inflight: int = 0
         self._available = _detect_codecs()
+        # ``Accept-Encoding`` header bytes → selection.  Real-world traffic
+        # has very few distinct Accept-Encoding values (browsers send a
+        # constant string; benchmark generators send one); parsing the
+        # q-values + iterating the server-preference list on every request
+        # showed up in the Sprint 33 py-spy profile.  Bounded so a hostile
+        # peer can't grow it unboundedly.
+        self._codec_cache: dict[bytes, tuple[str, Callable[[bytes], bytes]] | None] = {}
 
     @staticmethod
     def _parse_accept_encoding(header: bytes) -> list[str]:
@@ -128,11 +135,18 @@ class Compression:
         server knows which codec yields better compression.
         Returns ``None`` when there is no overlap.
         """
+        cache = self._codec_cache
+        if accept_header in cache:
+            return cache[accept_header]
         accepted = set(self._parse_accept_encoding(accept_header))
+        result: tuple[str, Callable[[bytes], bytes]] | None = None
         for codec in _SERVER_PREFERENCE:
             if codec in accepted and codec in self._available:
-                return codec, self._available[codec]
-        return None
+                result = (codec, self._available[codec])
+                break
+        if len(cache) < 256:
+            cache[accept_header] = result
+        return result
 
     async def __call__(self, scope, receive, send, call_next):
         if scope.get('type') != 'http':
@@ -157,6 +171,16 @@ class Compression:
 
         async def intercepting_send(event: dict) -> None:
             nonlocal streaming, skip_compression, start_forwarded
+            # Fast path: once the start event has been forwarded under a
+            # pass-through decision (already-encoded response, non-
+            # compressible Content-Type, or streaming chunks), subsequent
+            # events are forwarded verbatim — no parse, no re-wrap, no
+            # match.  Sprint 33 py-spy showed this overhead at ~35 % of
+            # the static-path CPU on responses StaticFiles already
+            # encoded via a precompressed sibling.
+            if start_forwarded and (skip_compression or streaming):
+                await send(event)
+                return
             parsed = parse_response_event(event)
             match parsed:
                 case ResponseStart():

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -20,9 +20,14 @@ def _normalize_send(inner_send):
     would otherwise need an ``isinstance`` guard for every response type.
     This wrapper intercepts ``Response`` objects and emits the two ASGI events
     (``http.response.start`` + ``http.response.body``) that ``inner_send``
-    expects, forwarding all other arguments unchanged.
+    expects, forwarding all other event dicts unchanged.
+
+    ASGI ``send`` is always called with a single positional event — no
+    ``*args/**kwargs`` form needs to be preserved here, and dropping it
+    shaves a per-event call-frame setup that showed in the Sprint 33
+    py-spy profile on the static path.
     """
-    async def normalized(event, *args, **kwargs):
+    async def normalized(event):
         if isinstance(event, Response):
             await inner_send({
                 'type': ASGIEvent.HTTP_RESPONSE_START,
@@ -35,7 +40,7 @@ def _normalize_send(inner_send):
                 'more_body': False,
             })
         else:
-            await inner_send(event, *args, **kwargs)
+            await inner_send(event)
 
     return normalized
 

--- a/tests/unit/test_compression_backpressure.py
+++ b/tests/unit/test_compression_backpressure.py
@@ -209,3 +209,96 @@ async def test_small_body_under_threshold_ignores_inflight_cap():
     res = await _run_through(mw, small, accept=b'gzip')
     # Compression still happens — it's on the event loop, no executor offload.
     assert res['headers'].get(b'content-encoding') == b'gzip'
+
+
+# ---------------------------------------------------------------------------
+# Sprint 33 — pass-through fast path + Accept-Encoding selection cache
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_passthrough_skips_event_reparsing(monkeypatch):
+    """When the inner handler already sets ``Content-Encoding`` (e.g.
+    StaticFiles serving a precompressed sibling), the middleware's
+    ``intercepting_send`` must forward subsequent body events verbatim —
+    no second ``parse_response_event`` call.
+
+    This is what gives the static-file cache-hit path its Sprint 33 win.
+    Without the fast path, ``parse_response_event`` runs once per ASGI
+    event; the precompressed-sibling response is 2 events so the cost
+    doubles for no useful work."""
+    from blackbull.middleware import compression as _compression
+
+    calls: list[bytes] = []
+    real_parse = _compression.parse_response_event
+
+    def counting_parse(event):
+        calls.append(event.get('type', b''))
+        return real_parse(event)
+
+    monkeypatch.setattr(_compression, 'parse_response_event', counting_parse)
+
+    async def already_encoded_handler(scope, receive, send):
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [
+                (b'content-type', b'text/javascript'),
+                (b'content-encoding', b'br'),
+                (b'content-length', b'19'),
+            ],
+        })
+        await send({'type': 'http.response.body',
+                    'body': b'BR-COMPRESSED-BYTES', 'more_body': False})
+
+    events: list[dict] = []
+
+    async def out_send(event):
+        events.append(event)
+
+    async def call_next(scope, receive, send):
+        await already_encoded_handler(scope, receive, send)
+
+    mw = Compression()
+    await mw(_scope(b'br, gzip'), _noop_receive, out_send, call_next)
+
+    # The start event must be parsed (we need to inspect Content-Encoding
+    # to decide to skip).  The body event must NOT be parsed — that's the
+    # fast path.
+    assert 'http.response.start' in calls, \
+        f'expected start to be parsed; got {calls!r}'
+    assert 'http.response.body' not in calls, \
+        f'fast path bypassed: body event re-parsed; got {calls!r}'
+
+    # Sanity: response still round-trips correctly.
+    starts = [e for e in events if e['type'] == 'http.response.start']
+    bodies = [e for e in events if e['type'] == 'http.response.body']
+    assert len(starts) == 1 and len(bodies) == 1
+    assert bodies[0]['body'] == b'BR-COMPRESSED-BYTES'
+
+
+@pytest.mark.asyncio
+async def test_codec_selection_cache_returns_same_result_on_repeat():
+    """Same ``Accept-Encoding`` header → same selection.  The cache must
+    not affect correctness; it just avoids re-parsing q-values on every
+    request when clients send a constant header (browsers, benchmarks)."""
+    mw = Compression()
+    header = b'br;q=1, gzip;q=0.8'
+    first = mw._select_codec(header)
+    second = mw._select_codec(header)
+    third = mw._select_codec(header)
+    assert first == second == third
+    assert first is not None and first[0] == 'br'
+    # Different header → different cache entry (still correct).
+    gzip_only = mw._select_codec(b'gzip')
+    assert gzip_only is not None and gzip_only[0] == 'gzip'
+
+
+@pytest.mark.asyncio
+async def test_codec_selection_cache_bounded():
+    """The cache must not grow unboundedly under hostile-peer load that
+    rotates Accept-Encoding header values."""
+    mw = Compression()
+    for i in range(300):
+        mw._select_codec(f'gzip;q=0.{i:03d}'.encode())
+    assert len(mw._codec_cache) <= 256, \
+        f'cache exceeded bound: {len(mw._codec_cache)}'


### PR DESCRIPTION
## Summary

Sprint 33 follow-up — two complementary wins on the Compression
middleware hot path.

### Pass-through fast path

`intercepting_send` previously called `parse_response_event` on
*every* ASGI event, including the body event of an already-encoded
response (e.g. StaticFiles serving a precompressed sibling).
After the start event triggers a pass-through decision
(`Content-Encoding` already set, non-compressible content-type, or
streaming), subsequent events are now forwarded verbatim — no
parse, no `match`, no re-wrap.

Sprint 33 py-spy on a single worker placed this re-parse work at
~35 % of the static-path CPU when serving brotli siblings.

### Accept-Encoding selection cache

`_codec_cache: dict[bytes, ...]` bounded at 256 entries.  Real-world
clients send a small handful of distinct `Accept-Encoding` values
(browsers send a constant string; benchmark generators send one),
so the q-value parse + server-preference iteration in `_select_codec`
runs once per distinct header instead of once per request.  Bound
prevents a hostile peer from growing the dict unboundedly by
rotating the header.

## Test plan

- [x] `tests/unit/test_compression_backpressure.py` — 10 pass (3 new):
  - `test_passthrough_skips_event_reparsing`
  - `test_codec_selection_cache_returns_same_result_on_repeat`
  - `test_codec_selection_cache_bounded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)