### PR TITLE
release: v0.31.2 — fix relative documentation links on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,28 @@ so the editable install's metadata catches up.
 
 ---
 
+## [0.31.2] — 2026-06-10
+
+**README documentation links on PyPI now resolve.**  `v0.31.1`'s
+README used GitHub-relative paths (`docs/guide.md`, `CHANGELOG.md`,
+…) which render correctly on github.com but 404 under
+`pypi.org/project/blackbull/`.  Rewritten as absolute
+`https://github.com/TOKUJI/BlackBull/blob/master/<path>` URLs.
+
+### Fixed
+
+- Six relative documentation links in `README.md`
+  (`docs/about/conformance.md`, `KNOWN_LIMITATIONS.md`,
+  `docs/guide.md`, `docs/ActorDesign.md`, two refs to
+  `CHANGELOG.md`) now point at GitHub so PyPI's rendered
+  project page resolves them.
+
+### Notes
+
+- No code change; no API surface change; no migration needed.
+
+---
+
 ## [0.31.1] — 2026-06-10
 
 **Sprint 33 static-path perf fixes reach PyPI.**  `v0.31.0` shipped

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # BlackBull
 
 > ⚠ **Early Alpha — API may break between MINOR versions.**
-> Conformance evidence: [`docs/about/conformance.md`](docs/about/conformance.md).
-> Things to know before adopting: [`KNOWN_LIMITATIONS.md`](KNOWN_LIMITATIONS.md).
+> Conformance evidence: [`docs/about/conformance.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/conformance.md).
+> Things to know before adopting: [`KNOWN_LIMITATIONS.md`](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md).
 
 **Async ASGI 3.0 framework** with a from-scratch HTTP/1.1 parser,
 HTTP/2 frame layer, and WebSocket codec — no `httptools`, no
@@ -148,15 +148,15 @@ instance, no manual `json.loads`.
 
 ## Documentation
 
-- **Guide**: [`docs/guide.md`](docs/guide.md)
-- **Architecture**: [`docs/ActorDesign.md`](docs/ActorDesign.md)
-- **Changelog**: [`CHANGELOG.md`](CHANGELOG.md)
+- **Guide**: [`docs/guide.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide.md)
+- **Architecture**: [`docs/ActorDesign.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/ActorDesign.md)
+- **Changelog**: [`CHANGELOG.md`](https://github.com/TOKUJI/BlackBull/blob/master/CHANGELOG.md)
 
 ## Versioning
 
 BlackBull uses [ZeroVer](https://0ver.org/) prior to a 1.0 commitment.
 `MINOR` advances at each sprint close; `PATCH` is for bug fixes and
-harness work between sprints.  See [`CHANGELOG.md`](CHANGELOG.md) for
+harness work between sprints.  See [`CHANGELOG.md`](https://github.com/TOKUJI/BlackBull/blob/master/CHANGELOG.md) for
 the full release history.
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.31.1"
+version = "0.31.2"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Rewrites six `docs/...` and `CHANGELOG.md` README links from GitHub-relative paths to absolute https://github.com/TOKUJI/BlackBull/blob/master/<path> URLs so they resolve on pypi.org/project/blackbull/. No code change.