### PR TITLE
Sprint 36: TestClient + ASGI 3.0 fixes + __slots__ pass

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -8,10 +8,9 @@ protocol-level test coverage behind the standards-compliance claims;
 this file is the narrative "things to know before you build on top
 of it" list.
 
-The list is consolidated from internal sprint logs and the
-differential nginx fuzz corpus — every item here is something we
-*know about* and have a position on.  Items that are surprises to
-us as well belong on the GitHub issue tracker, not here.
+Every item here is something the project knows about and has a
+position on.  Behaviours that aren't listed below — anything that
+would surprise us as well — belong on the GitHub issue tracker.
 
 ---
 
@@ -27,45 +26,40 @@ accept Extended CONNECT bootstraps.
 
 **Why**: when TLS is active the browser may pick HTTP/2 via ALPN
 even for `ws://` upgrades; with RFC 8441 off, the upgrade is
-blocked and the browser falls back to HTTP/1.1.  We don't have
-the test coverage to promote this to default-on yet.
+blocked and the browser falls back to HTTP/1.1.  Test coverage
+isn't yet broad enough to promote this to default-on.
 
 ### HTTP/2 multiplex overhead vs HTTP/1.1
 
-In WSL2 single-host benchmarks (Sprint 27 close-out HttpArena
-sweep), HTTP/2 per-process throughput trailed HTTP/1.1 by
-roughly **10-35 %** depending on multiplex depth.  The H/2
-implementation is conformant (passes `h2spec`, RFC 9113) but
-the per-stream actor machinery (queue, sender state, priority
-tree) adds per-request overhead that the H/1.1 path doesn't pay.
-Single-stream H/2 latency at high mux (c=128 × m=32) can stretch
-into the hundreds of milliseconds under saturation.
+The HTTP/2 implementation is conformant (passes `h2spec`,
+RFC 9113) but each stream carries actor-machinery overhead — a
+per-stream queue, sender state, and priority-tree bookkeeping —
+that the HTTP/1.1 path doesn't pay.  Single-connection,
+high-multiplex workloads will spend more per request on HTTP/2
+than on HTTP/1.1; the difference grows with mux depth.
 
-**Position**: planned revisit after Sprint 28; not the current
-priority target.  If your workload needs maximum H/1.1
-throughput, BlackBull is competitive; if it needs maximum H/2
-multiplexed throughput on a single connection, a hand-tuned
-Rust server will do better today.
+If a workload needs maximum throughput on a single HTTP/2
+connection at high mux, a fronting HTTP/2 terminator (nginx,
+Envoy) is the usual production shape; BlackBull behind that
+terminator on HTTP/1.1 is the matched-cost path.
 
-### h2c prior-knowledge shares the H/1.1 port
+### h2c prior-knowledge shares the HTTP/1.1 port
 
-BlackBull's plaintext listener auto-detects the HTTP/2 connection
-preface and switches to h2c — there is no separate "h2c-only"
-port that refuses H/1.1.  This is RFC-permissible (RFC 9113
-allows h2c via prior knowledge on any port) but **diverges from
-HttpArena's expectation** of an h2c-only :8082; we don't claim
-the `baseline-h2c` / `json-h2c` HttpArena profiles in
-`bench/httparena/meta.json` for this reason.
+BlackBull's plaintext listener auto-detects the HTTP/2
+connection preface and switches to h2c — there is no separate
+"h2c-only" port that refuses HTTP/1.1.  This is RFC-permissible
+(RFC 9113 allows h2c via prior knowledge on any port) and means
+the same port serves both protocols at the framework's
+discretion.
 
 ### Slowloris response is correct but not quantitatively characterised
 
 Three timeouts (`BB_HEADER_TIMEOUT`, `BB_BODY_TIMEOUT`,
-`BB_KEEP_ALIVE_TIMEOUT`, Sprint 17) defend against partial-data
-attacks; tests verify a 408 is returned.  **What's not
-characterised**: the exact "with N slow connections, first new
-connection accepted within M ms" curve.  No quantitative
-hardening claim beyond "RFC 9110 §15.5.9 compliant 408 + the
-three timeouts work".
+`BB_KEEP_ALIVE_TIMEOUT`) defend against partial-data attacks;
+tests verify a 408 is returned.  What's *not* characterised is
+the exact "with N slow connections, first new connection
+accepted within M ms" curve — only the qualitative claim "RFC
+9110 §15.5.9 compliant 408 plus the three timeouts work".
 
 ---
 
@@ -88,42 +82,14 @@ appears.
 
 ---
 
-## Benchmark + measurement caveats
+## Deployment notes
 
-### WSL2 noise floor swallows optimisations under ~15 %
+### Multi-worker scaling tops out at physical core count
 
-Sprint 9d established that on WSL2 loopback, the B2r latency
-spread for an unchanged code path is 1.3-5.1 ms (a > 3× spread
-with no code change).  Any throughput / latency optimisation
-below ~15 % is invisible at WSL2 scale.  Sub-millisecond claims
-belong on EC2.
-
-### HttpArena local numbers are not directly comparable to their leaderboard
-
-HttpArena's public leaderboard runs on dedicated 64-core
-hardware.  The numbers in
-[`bench/CHARACTERIZATION.md`](bench/CHARACTERIZATION.md) and
-the Sprint 27 close-out HttpArena comparison are local WSL2
-single-host runs; they validate BlackBull's *shape* relative to
-peers on the same machine but absolute throughput does not
-predict leaderboard ranking.
-
-### Multi-worker scaling is sub-linear
-
-`R(W)` scales to roughly the **physical core count**, not the
-logical (SMT-thread) count (Sprint 21 Phase B `R(W)` formula;
-re-validated in the Sprint 27 close-out HttpArena sweep where
-both BlackBull and FastAPI clustered near `nproc / 2` for
-1w → Nw scaling).  Multiplying workers past the physical-core
-ceiling does not multiply throughput.
-
-### Single-host benchmark caveat
-
-When the load generator and server share a host, kernel
-scheduling and accept-queue contention skew both throughput
-*and* latency away from real-NIC behaviour.  Use a split
-topology (`bench/aws/up.sh TOPO=split`) for any number that
-needs to reflect production-shape traffic.
+Worker throughput scales roughly to the **physical core count**,
+not the logical (SMT-thread) count.  Multiplying workers past
+the physical-core ceiling does not multiply throughput.  Plan
+capacity against `nproc / 2` on typical SMT-enabled hardware.
 
 ---
 
@@ -141,9 +107,9 @@ serves files three ways:
   event-loop dispatch.  Opted in via the `http.response.pathsend`
   ASGI extension; cleartext HTTP/1.1 advertises it.
 - Chunked through `asyncio.to_thread` (TLS, HTTP/2, Range
-  requests) — correct, but the per-chunk thread-pool dispatch
-  costs roughly 64 µs each.  Use the fronting nginx path below if
-  this is on the critical path for you.
+  requests) — correct, but every chunk pays thread-pool dispatch
+  overhead.  Use the fronting nginx path below if this is on the
+  critical path for you.
 
 The in-memory cache is stat-invalidated per request — every
 request runs `path.stat()` and refills the entry when mtime or
@@ -158,17 +124,13 @@ static-file server (nginx, S3 + CloudFront).
 BlackBull is a protocol-layer framework.  There is no built-in
 ORM, no connection pool, no migration tool.  Apps should bring
 their own (`asyncpg`, `databases`, `tortoise-orm`, etc.).
-HttpArena's database-backed profiles (`async-db`, `crud`,
-`fortunes`, `api-4`, `api-16`) are intentionally not
-implemented in `bench/httparena/`.
 
 ### Optional `[speed-h1]` C parser stub not implemented
 
 `pyproject.toml` lists no `[speed-h1]` extra today.  The
-pure-Python HTTP/1 parser is fast enough on the cascade-rule
-metric (Sprint 27 profile showed `_parse` at ~2 % B1 self-time
-— sub-cascade).  A future user-facing knob to swap in
-`httptools` is documented in the roadmap but not built.
+pure-Python HTTP/1 parser is fast enough that swapping in a C
+parser (e.g. `httptools`) isn't on the critical path; a future
+opt-in knob is sketched in the roadmap but not built.
 
 ### No HTTP/3 / QUIC
 
@@ -180,23 +142,10 @@ Out of scope.
 
 ### CLI ergonomics are minimal
 
-The `blackbull` console script ships in 0.27.1 but only covers
-the basic ASGI-runner shape (`blackbull app:app --bind ...`).
-A few quality-of-life knobs (`--version`, helpful error on
-missing `app:module`, `--reload-dir`) are pending and tracked
-in Sprint 28 Task 5.
-
----
-
-## What's flagged but not yet measured
-
-These items will be addressed in Sprint 28 or Sprint 29 close:
-
-- **Quantitative slowloris characterisation** — current tests
-  verify 408 is returned, not the quantitative "N held conns →
-  M-ms new-connection latency" curve.
-- **Streaming-body partial-request fuzz** — atheris fuzz reaches
-  the header parser well, the streaming-body path less so.
+The `blackbull` console script covers the basic ASGI-runner
+shape (`blackbull app:app --bind ...`).  A few quality-of-life
+knobs (`--version`, helpful error on missing `app:module`,
+`--reload-dir`) are pending.
 
 ---
 

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -27,6 +27,7 @@ import traceback
 # import from this package
 import logging
 from .event import Event, EventDispatcher, EventHandler
+from .headers import Headers
 from .utils import Scheme
 from .router import Router, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, has_middleware_param
 logger = logging.getLogger(__name__)
@@ -35,17 +36,48 @@ logger = logging.getLogger(__name__)
 def _wrap_send(raw_send):
     """Wrap an ASGI send callable to also accept Response objects.
 
-    When a Response (or JSONResponse) is passed, unpacks it to
-    (body, status, headers) for the underlying sender.  All other arguments
-    (dicts, bytes) are forwarded unchanged.
+    Normalises every form a BlackBull handler may produce — Response
+    object, ASGI event dict, or raw ``bytes`` body — into the standard
+    ASGI 3.0 ``http.response.start`` + ``http.response.body`` event
+    pair forwarded to ``raw_send`` one event at a time.  This keeps
+    ``BlackBull.__call__`` truly ASGI 3.0 compliant so the app runs
+    unchanged under external ASGI servers (uvicorn, hypercorn,
+    httpx.ASGITransport, …) while BlackBull's own ``HTTP1Sender`` /
+    ``HTTP2Sender`` (which also accept dict events natively) handle
+    the same canonical sequence.
     """
     from .response import Response as _Response
 
     async def _send(event, status=HTTPStatus.OK, headers=[]):
         if isinstance(event, _Response):
-            await raw_send(event.body, event.status, event.headers)
+            await raw_send({
+                'type': 'http.response.start',
+                'status': int(event.status),
+                'headers': list(event.headers),
+            })
+            await raw_send({
+                'type': 'http.response.body',
+                'body': event.body,
+            })
+        elif isinstance(event, dict):
+            # Standard ASGI event from full-form handlers or middleware.
+            await raw_send(event)
+        elif isinstance(event, (bytes, bytearray, memoryview)):
+            # Legacy "bytes body + status + headers" form used by simplified
+            # handlers when they pass through the wrap from inside BlackBull.
+            await raw_send({
+                'type': 'http.response.start',
+                'status': int(status),
+                'headers': list(headers),
+            })
+            await raw_send({
+                'type': 'http.response.body',
+                'body': bytes(event) if not isinstance(event, bytes) else event,
+            })
         else:
-            await raw_send(event, status, headers)
+            # Unknown shapes are passed through; the underlying sender's
+            # type checking decides what to do with them.
+            await raw_send(event)
 
     return _send
 
@@ -473,6 +505,19 @@ class BlackBull:
 
         if self._chain is None:
             self._build_chain()
+
+        # BlackBull handlers and helpers (``parse_cookies``,
+        # ``TrustedProxy``, ``static.StaticFiles``) read ``scope['headers']``
+        # via the ``Headers.get`` / ``.getlist`` API.  BlackBull's own
+        # server attaches a :class:`Headers` instance in
+        # ``parser.py``; external ASGI transports (uvicorn, hypercorn,
+        # ``httpx.ASGITransport``) deliver the standard list-of-tuples
+        # form per the ASGI 3.0 spec.  Normalise once at the entry
+        # point so handlers don't need to care which side they're
+        # running under.
+        raw_headers = scope.get('headers')
+        if raw_headers is not None and not isinstance(raw_headers, Headers):
+            scope['headers'] = Headers(raw_headers)
 
         await self._chain(scope, receive, _wrap_send(send))
 

--- a/blackbull/protocol/stream.py
+++ b/blackbull/protocol/stream.py
@@ -42,6 +42,18 @@ class Stream:
     when omitted (the value lives on the sender, not the stream).
     """
 
+    # Per-stream object — allocated once per HTTP/2 stream and stored in the
+    # priority tree.  ``__slots__`` saves the ~56-byte ``__dict__`` overhead
+    # at the cost of forbidding dynamic attribute assignment.  Every
+    # attribute referenced anywhere on the class must be declared here.
+    __slots__ = (
+        'parent', 'weight', 'stream_id', 'window_size',
+        'children', 'scope', 'event', '_lock',
+        'end_stream', 'state', 'priority_hint',
+        'closed_via_rst',
+        'expected_content_length', 'received_data_bytes',
+    )
+
     def __init__(self, stream_id: int, parent: 'Stream | None' = None,
                  weight: int = 1, window_size: int | None = None):
         self.parent = parent

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -23,15 +23,28 @@ def parse_cookies(scope) -> dict[str, str]:
 
     Works identically for HTTP/1.1, HTTP/2, and WebSocket scopes.
     HTTP/1.1 sends a single combined ``Cookie`` header; HTTP/2 may split it
-    into multiple fields (RFC 7540 §8.1.2.5).  This function uses
-    ``Headers.getlist`` to collect all ``cookie`` fields before joining and
-    parsing, so both wire formats produce the same result.
+    into multiple fields (RFC 7540 §8.1.2.5).  All ``cookie`` fields are
+    collected and joined before parsing, so both wire formats produce the
+    same result.
+
+    Accepts either of the two header shapes that may appear on
+    ``scope['headers']``:
+
+    - A plain list/iterable of ``(name, value)`` bytes tuples — the
+      standard ASGI 3.0 form, used by external servers (uvicorn,
+      hypercorn, ``httpx.ASGITransport``).
+    - A :class:`blackbull.headers.Headers` instance — what BlackBull's
+      own server attaches as a handler ergonomics enhancement.
     """
-    # getlist returns [(name, value), ...]; join all values with "; "
-    cookie_pairs = scope['headers'].getlist(b'cookie')
-    if not cookie_pairs:
+    headers = scope.get('headers', ())
+    getlist = getattr(headers, 'getlist', None)
+    if getlist is not None:
+        cookie_values = [v for _, v in getlist(b'cookie')]
+    else:
+        cookie_values = [v for (k, v) in headers if k.lower() == b'cookie']
+    if not cookie_values:
         return {}
-    raw = b'; '.join(v for _, v in cookie_pairs)
+    raw = b'; '.join(cookie_values)
     result = {}
     for part in raw.split(b';'):
         k, _, v = part.strip().partition(b'=')

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -245,8 +245,19 @@ class BaseSender(ABC):
     logic is decoupled from asyncio internals.
     """
 
+    # Per-stream / per-request senders are allocated on the hot path; ABCs
+    # provide ``__slots__ = ()`` so adding slots here drops the per-instance
+    # ``__dict__``.  Subclasses extend with their own protocol-specific
+    # slots; together they declare every attribute referenced by the class.
+    __slots__ = ('_writer', '_closed')
+
     def __init__(self, writer: AbstractWriter):
         self._writer = writer
+        # ``_write`` / ``_write_many`` flip this to True on a peer-closed
+        # transport and silently drop further writes.  Initialised here so
+        # that the slot is bound from construction; the ``getattr(...,
+        # False)`` reads in the write methods remain compatible.
+        self._closed = False
 
     @abstractmethod
     async def __call__(self, body, status: HTTPStatus = HTTPStatus.OK, headers: HeaderList = []): ...
@@ -309,6 +320,11 @@ class HTTP1Sender(BaseSender):
     that Content-Length can be injected when the app omits it.
     """
 
+    __slots__ = (
+        '_buffered_status', '_buffered_headers', '_chunked',
+        '_expect_trailers', '_head_mode', '_log_record',
+    )
+
     def __init__(self, writer: AbstractWriter):
         super().__init__(writer)
         self._buffered_status: HTTPStatus | None = None
@@ -319,10 +335,6 @@ class HTTP1Sender(BaseSender):
         # have the same headers (including Content-Length) as a GET would
         # but no body.  HTTP1Actor sets this before dispatch.
         self._head_mode: bool = False
-        # Set once an http.disconnect arrives or a write hits broken-pipe.
-        # All subsequent writes silently drop — the peer is gone, there's
-        # nothing useful to do with the bytes.
-        self._closed: bool = False
         # Optional access-log record; set by the actor before dispatch.
         # When non-None, ``__call__`` updates ``status`` and
         # ``response_bytes`` inline as events flow through — this saves
@@ -567,6 +579,12 @@ class HTTP2Sender(BaseSender):
       Serialises and writes the frame directly.
     """
 
+    __slots__ = (
+        '_factory', '_stream_id', '_push_callback',
+        'connection_window_size', 'stream_window_size',
+        'max_frame_size', '_window_open',
+    )
+
     def __init__(self, writer: AbstractWriter, factory, stream_id: int,
                  push_callback=None):
         super().__init__(writer)
@@ -745,6 +763,9 @@ class WebSocketSender(BaseSender):
     The ``status`` and ``headers`` parameters are accepted for interface
     consistency but are unused for WebSocket connections.
     """
+
+    __slots__ = ('has_received_closed', '_compressor')
+
     def __init__(self, writer: AbstractWriter, *, compressor=None):
         super().__init__(writer)
         self.has_received_closed = False

--- a/blackbull/testing.py
+++ b/blackbull/testing.py
@@ -1,0 +1,547 @@
+"""In-memory test client for ASGI 3.0 applications.
+
+Lets you exercise a BlackBull (or any ASGI 3.0) app from a synchronous
+pytest test without binding a TCP socket.  Built on
+``httpx.ASGITransport`` for HTTP; uses a background-thread event loop
+to bridge sync calls to the (async-only) ASGI transport, to drive the
+``lifespan`` protocol, and to host WebSocket sessions.
+
+Typical usage::
+
+    from blackbull import BlackBull
+    from blackbull.testing import TestClient
+
+    app = BlackBull()
+
+    @app.route('/')
+    async def hello():
+        return "hi"
+
+    def test_hello():
+        with TestClient(app) as client:
+            response = client.get('/')
+            assert response.status_code == 200
+            assert response.text == "hi"
+
+The client is a context manager so that ASGI ``lifespan.startup`` runs
+before any request and ``lifespan.shutdown`` runs on exit.  Apps that
+don't implement the lifespan protocol are tolerated silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+from typing import Any
+
+import httpx
+
+
+class WebSocketDisconnect(Exception):
+    """Raised when the server side closes (or rejects) the WebSocket."""
+
+    def __init__(self, code: int = 1000, reason: str = ''):
+        self.code = code
+        self.reason = reason
+        super().__init__(f'WebSocket disconnected: code={code} reason={reason!r}')
+
+
+class _LoopThread:
+    """A dedicated background thread running an asyncio event loop.
+
+    ``run_coro`` schedules a coroutine on the loop and blocks the caller
+    until it returns; ``stop`` joins the thread cleanly.  ``server_to_client``
+    is a threading queue carrying events the ASGI app emits via ``send``;
+    ``client_to_server`` is an asyncio queue carrying events the test
+    writes that the app reads via ``receive``.  The queues are only used
+    for lifespan / WebSocket sessions; HTTP requests go through httpx.
+    """
+
+    def __init__(self) -> None:
+        self.loop: asyncio.AbstractEventLoop | None = None
+        self.client_to_server: asyncio.Queue | None = None
+        self.server_to_client: queue.Queue = queue.Queue()
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, daemon=True, name='blackbull-testclient-loop')
+        self._thread.start()
+        self._ready.wait()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        if self.loop is not None and self.loop.is_running():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def run_coro(self, coro, timeout: float | None = 60.0):
+        """Schedule ``coro`` on the loop thread and block until it returns."""
+        assert self.loop is not None
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout=timeout)
+
+    def _run(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+        self.client_to_server = asyncio.Queue()
+        self._ready.set()
+        try:
+            self.loop.run_forever()
+        finally:
+            self.loop.close()
+
+
+class _LifespanManager:
+    """Drives the ASGI ``lifespan`` protocol for the duration of a TestClient session.
+
+    Runs on the TestClient's shared loop thread so the lifespan task and
+    the HTTP request tasks see the same event loop (apps may store
+    asyncio primitives on ``scope['state']`` during startup that get
+    used in request handlers).
+    """
+
+    def __init__(self, app: Any, loop_thread: _LoopThread,
+                 startup_timeout: float = 10.0, shutdown_timeout: float = 10.0):
+        self.app = app
+        self.loop_thread = loop_thread
+        self.startup_timeout = startup_timeout
+        self.shutdown_timeout = shutdown_timeout
+        self._app_task: asyncio.Task | None = None
+        self._unsupported = False
+
+    def startup(self) -> None:
+        async def _spawn():
+            scope = {
+                'type': 'lifespan',
+                'asgi': {'version': '3.0', 'spec_version': '2.0'},
+            }
+
+            async def receive():
+                return await self.loop_thread.client_to_server.get()
+
+            async def send(event):
+                self.loop_thread.server_to_client.put(event)
+
+            self._app_task = asyncio.create_task(self.app(scope, receive, send))
+
+        self.loop_thread.run_coro(_spawn(), timeout=self.startup_timeout)
+        self.loop_thread.run_coro(
+            self.loop_thread.client_to_server.put({'type': 'lifespan.startup'}),
+            timeout=self.startup_timeout,
+        )
+
+        event = self._wait_for_lifespan_event(self.startup_timeout)
+        if event is None:
+            # The app task ended before acking startup — treat as
+            # "lifespan unsupported" and continue without it.  This is
+            # how ASGI-2.0-style apps signal they don't implement the
+            # lifespan protocol.
+            self._unsupported = True
+            return
+        if event['type'] == 'lifespan.startup.failed':
+            raise RuntimeError(
+                f"Lifespan startup failed: {event.get('message', '')}",
+            )
+
+    def shutdown(self) -> None:
+        if self._unsupported:
+            return
+        try:
+            self.loop_thread.run_coro(
+                self.loop_thread.client_to_server.put({'type': 'lifespan.shutdown'}),
+                timeout=self.shutdown_timeout,
+            )
+            self._wait_for_lifespan_event(self.shutdown_timeout)
+        finally:
+            if self._app_task is not None:
+                try:
+                    self.loop_thread.run_coro(self._await_task(), timeout=self.shutdown_timeout)
+                except Exception:
+                    pass
+
+    async def _await_task(self):
+        assert self._app_task is not None
+        try:
+            await self._app_task
+        except Exception:
+            pass
+
+    def _wait_for_lifespan_event(self, timeout: float):
+        """Return the next lifespan event, or None if the app finished without one.
+
+        If the app task ended with an exception, surface it as a
+        RuntimeError so test authors see the underlying cause rather
+        than a silent "lifespan unsupported" outcome.
+        """
+        deadline = timeout
+        while True:
+            try:
+                return self.loop_thread.server_to_client.get(timeout=0.05)
+            except queue.Empty:
+                deadline -= 0.05
+                if self._app_task is not None and self._app_task.done():
+                    exc = self._app_task.exception()
+                    if exc is not None:
+                        raise RuntimeError(
+                            f"Lifespan startup failed: {exc!r}"
+                        ) from exc
+                    return None
+                if deadline <= 0:
+                    raise TimeoutError('Timed out waiting for lifespan event')
+
+
+class WebSocketTestSession:
+    """Synchronous WebSocket session against an ASGI application.
+
+    Open via :meth:`TestClient.websocket_connect` as a context manager::
+
+        with client.websocket_connect('/ws') as ws:
+            ws.send_text('ping')
+            assert ws.receive_text() == 'pong'
+
+    Raises :class:`WebSocketDisconnect` when the server closes (or
+    rejects) the connection.
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        path: str,
+        subprotocols: list[str] | None = None,
+        headers: list[tuple[str, str]] | None = None,
+        cookies: dict[str, str] | None = None,
+        timeout: float = 5.0,
+    ):
+        self.app = app
+        self.timeout = timeout
+        if '?' in path:
+            raw_path, query = path.split('?', 1)
+        else:
+            raw_path, query = path, ''
+        encoded_headers: list[tuple[bytes, bytes]] = []
+        for k, v in (headers or []):
+            encoded_headers.append((k.lower().encode('latin-1'), v.encode('latin-1')))
+        if cookies:
+            cookie_str = '; '.join(f'{k}={v}' for k, v in cookies.items())
+            encoded_headers.append((b'cookie', cookie_str.encode('latin-1')))
+        self.scope = {
+            'type': 'websocket',
+            'asgi': {'version': '3.0', 'spec_version': '2.4'},
+            'http_version': '1.1',
+            'scheme': 'ws',
+            'path': raw_path,
+            'raw_path': raw_path.encode('latin-1'),
+            'query_string': query.encode('latin-1'),
+            'root_path': '',
+            'headers': encoded_headers,
+            'client': ('testclient', 50000),
+            'server': ('testserver', 80),
+            'subprotocols': list(subprotocols or []),
+            'state': {},
+        }
+        self._loop_thread = _LoopThread()
+        self._app_task: asyncio.Task | None = None
+        self._accepted = False
+
+    def __enter__(self) -> 'WebSocketTestSession':
+        self._loop_thread.start()
+
+        async def _spawn():
+            async def receive():
+                return await self._loop_thread.client_to_server.get()
+
+            async def send(event):
+                self._loop_thread.server_to_client.put(event)
+
+            self._app_task = asyncio.create_task(self.app(self.scope, receive, send))
+
+        self._loop_thread.run_coro(_spawn(), timeout=self.timeout)
+        self._loop_thread.run_coro(
+            self._loop_thread.client_to_server.put({'type': 'websocket.connect'}),
+            timeout=self.timeout,
+        )
+        event = self._recv_event()
+        if event['type'] == 'websocket.close':
+            self._teardown()
+            raise WebSocketDisconnect(code=event.get('code', 1000), reason=event.get('reason', ''))
+        if event['type'] != 'websocket.accept':
+            self._teardown()
+            raise RuntimeError(f"Expected websocket.accept, got {event['type']!r}")
+        self._accepted = True
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self.close()
+
+    def send_text(self, text: str) -> None:
+        self._send_client_event({'type': 'websocket.receive', 'text': text})
+
+    def send_bytes(self, data: bytes) -> None:
+        self._send_client_event({'type': 'websocket.receive', 'bytes': data})
+
+    def send_json(self, data: Any) -> None:
+        import json
+        self.send_text(json.dumps(data))
+
+    def receive_text(self) -> str:
+        event = self._recv_event()
+        if event['type'] == 'websocket.close':
+            raise WebSocketDisconnect(code=event.get('code', 1000), reason=event.get('reason', ''))
+        if event['type'] != 'websocket.send':
+            raise RuntimeError(f"Expected websocket.send, got {event['type']!r}")
+        if event.get('text') is None:
+            raise RuntimeError('Expected text frame; got binary')
+        return event['text']
+
+    def receive_bytes(self) -> bytes:
+        event = self._recv_event()
+        if event['type'] == 'websocket.close':
+            raise WebSocketDisconnect(code=event.get('code', 1000), reason=event.get('reason', ''))
+        if event['type'] != 'websocket.send':
+            raise RuntimeError(f"Expected websocket.send, got {event['type']!r}")
+        if event.get('bytes') is None:
+            raise RuntimeError('Expected binary frame; got text')
+        return event['bytes']
+
+    def receive_json(self) -> Any:
+        import json
+        return json.loads(self.receive_text())
+
+    def iter_text(self):
+        """Yield successive text messages from the server until the WebSocket closes.
+
+        Stops cleanly when the server emits a ``websocket.close`` — the
+        :class:`WebSocketDisconnect` raised by the underlying receive
+        is caught and converted into normal iterator termination, so
+        the test can write::
+
+            with client.websocket_connect('/stream') as ws:
+                for msg in ws.iter_text():
+                    ...
+
+        without an explicit try/except around the loop.
+        """
+        try:
+            while True:
+                yield self.receive_text()
+        except WebSocketDisconnect:
+            return
+
+    def iter_bytes(self):
+        """Yield successive binary messages from the server until the WebSocket closes.
+
+        Mirror of :meth:`iter_text` for binary frames.
+        """
+        try:
+            while True:
+                yield self.receive_bytes()
+        except WebSocketDisconnect:
+            return
+
+    def close(self, code: int = 1000) -> None:
+        if self._loop_thread.loop is None:
+            return
+        if self._accepted:
+            try:
+                self._send_client_event({'type': 'websocket.disconnect', 'code': code})
+            except Exception:
+                pass
+        self._teardown()
+
+    def _send_client_event(self, event: dict) -> None:
+        self._loop_thread.run_coro(
+            self._loop_thread.client_to_server.put(event),
+            timeout=self.timeout,
+        )
+
+    def _recv_event(self) -> dict:
+        deadline = self.timeout
+        while True:
+            try:
+                return self._loop_thread.server_to_client.get(timeout=0.05)
+            except queue.Empty:
+                deadline -= 0.05
+                if self._app_task is not None and self._app_task.done():
+                    exc = self._app_task.exception()
+                    if exc is not None:
+                        raise exc
+                    raise WebSocketDisconnect(code=1006, reason='application ended without close frame')
+                if deadline <= 0:
+                    raise TimeoutError('Timed out waiting for WebSocket event from app')
+
+    def _teardown(self) -> None:
+        try:
+            if self._app_task is not None:
+                async def _await():
+                    try:
+                        await asyncio.wait_for(self._app_task, timeout=self.timeout)
+                    except (asyncio.TimeoutError, Exception):
+                        pass
+                try:
+                    self._loop_thread.run_coro(_await(), timeout=self.timeout + 1.0)
+                except Exception:
+                    pass
+        finally:
+            self._loop_thread.stop()
+
+
+class TestClient:
+    """In-memory HTTP+WebSocket test client for ASGI 3.0 applications.
+
+    Provides a synchronous façade over ``httpx.AsyncClient`` +
+    ``httpx.ASGITransport`` by hosting an event loop in a background
+    thread.  HTTP request methods (``get``, ``post``, ``put``, …)
+    forward to the underlying ``httpx.AsyncClient``; WebSocket sessions
+    use a dedicated bridge to the ASGI receive/send channels.
+
+    Use as a context manager so that the ASGI ``lifespan`` protocol
+    runs around the test::
+
+        with TestClient(app) as client:
+            ...
+    """
+
+    # Tell pytest not to collect this class as a test container — the
+    # ``Test*`` prefix triggers pytest's default collection heuristic
+    # but this is a fixture, not a test class.
+    __test__ = False
+
+    def __init__(
+        self,
+        app: Any,
+        base_url: str = 'http://testserver',
+        raise_app_exceptions: bool = True,
+        root_path: str = '',
+        cookies: Any | None = None,
+        headers: Any | None = None,
+        follow_redirects: bool = False,
+    ) -> None:
+        self.app = app
+        self.base_url = base_url
+        self._raise_app_exceptions = raise_app_exceptions
+        self._root_path = root_path
+        self._cookies = cookies
+        self._headers = headers
+        self._follow_redirects = follow_redirects
+        self._loop_thread = _LoopThread()
+        self._lifespan: _LifespanManager | None = None
+        self._async_client: httpx.AsyncClient | None = None
+
+    def __enter__(self) -> 'TestClient':
+        self._loop_thread.start()
+        self._async_client = httpx.AsyncClient(
+            transport=httpx.ASGITransport(
+                app=self.app,
+                raise_app_exceptions=self._raise_app_exceptions,
+                root_path=self._root_path,
+            ),
+            base_url=self.base_url,
+            cookies=self._cookies,
+            headers=self._headers,
+            follow_redirects=self._follow_redirects,
+        )
+        self._lifespan = _LifespanManager(self.app, self._loop_thread)
+        try:
+            self._lifespan.startup()
+        except Exception:
+            self._loop_thread.stop()
+            raise
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        try:
+            if self._lifespan is not None:
+                self._lifespan.shutdown()
+        finally:
+            try:
+                if self._async_client is not None:
+                    self._loop_thread.run_coro(self._async_client.aclose())
+            finally:
+                self._loop_thread.stop()
+
+    # ----- HTTP methods -----------------------------------------------------
+
+    def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        if self._async_client is None:
+            raise RuntimeError(
+                'TestClient must be used as a context manager: '
+                '`with TestClient(app) as client: ...`',
+            )
+        return self._loop_thread.run_coro(
+            self._async_client.request(method, url, **kwargs),
+        )
+
+    @property
+    def cookies(self):
+        """Persistent cookie jar, forwarded from the underlying ``httpx.AsyncClient``.
+
+        Same semantics as ``httpx.Client.cookies``: cookies set by
+        responses persist across requests on the same client.
+        """
+        if self._async_client is None:
+            raise RuntimeError(
+                'TestClient must be used as a context manager before '
+                'accessing cookies.',
+            )
+        return self._async_client.cookies
+
+    @property
+    def headers(self):
+        """Default headers applied to every request, forwarded from the
+        underlying ``httpx.AsyncClient``."""
+        if self._async_client is None:
+            raise RuntimeError(
+                'TestClient must be used as a context manager before '
+                'accessing headers.',
+            )
+        return self._async_client.headers
+
+    def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('GET', url, **kwargs)
+
+    def head(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('HEAD', url, **kwargs)
+
+    def options(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('OPTIONS', url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('POST', url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('PUT', url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('PATCH', url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('DELETE', url, **kwargs)
+
+    # ----- WebSocket --------------------------------------------------------
+
+    def websocket_connect(
+        self,
+        url: str,
+        subprotocols: list[str] | None = None,
+        headers: list[tuple[str, str]] | None = None,
+        cookies: dict[str, str] | None = None,
+        timeout: float = 5.0,
+    ) -> WebSocketTestSession:
+        """Open a WebSocket session against the application.
+
+        ``url`` is a path (relative to the app), e.g. ``/ws`` or
+        ``/ws?token=abc``.  Returns a :class:`WebSocketTestSession`
+        that should itself be used as a context manager.
+        """
+        return WebSocketTestSession(
+            app=self.app,
+            path=url,
+            subprotocols=subprotocols,
+            headers=headers,
+            cookies=cookies,
+            timeout=timeout,
+        )
+
+
+__all__ = ['TestClient', 'WebSocketTestSession', 'WebSocketDisconnect']

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,16 +1,19 @@
 # Testing
 
-BlackBull's `app` is a plain ASGI 3.0 callable and ships its own
-async HTTP/1.1, HTTP/2, and WebSocket clients, so there are three
-useful shapes for tests:
+BlackBull's `app` is a plain ASGI 3.0 callable, so most application
+tests can drive it in-memory through a synchronous client and never
+touch a TCP socket.  Four useful shapes exist:
 
+- **`blackbull.testing.TestClient`** — synchronous, in-memory,
+  lifespan-aware.  The default starting point: ordinary
+  `pytest` style, no `async def`, no fixture overhead.
 - **End-to-end with BlackBull's own clients** — start the server
   on an ephemeral port, drive it through real sockets via
   `HTTP1Client` / `HTTP2Client` / `Client` / `WebSocketClient`.
   Best fidelity: exercises the wire, ALPN, TLS, framing.
-- **In-process integration via `httpx.ASGITransport`** — no
-  sockets, no ports.  Drives the app object directly.  Good for
-  fast, hermetic suites where transport detail doesn't matter.
+- **In-process integration via `httpx.ASGITransport`** — async
+  variant of `TestClient` for tests that want full control over
+  the loop or the underlying `httpx.AsyncClient`.
 - **Direct handler / middleware unit tests** — hand-rolled
   scope dict + stub callables.  For asserting a single
   function's behaviour without involving routing or transport.
@@ -34,7 +37,256 @@ asyncio_mode = strict
 Strict mode requires every async test to carry
 `@pytest.mark.asyncio` explicitly — matching BlackBull's own
 suite — so tests don't accidentally run in the wrong loop
-shape.
+shape.  Tests written against `TestClient` are synchronous and
+don't need this mark.
+
+## Quick start with `TestClient`
+
+`blackbull.testing.TestClient` is a synchronous in-memory client
+modelled on `httpx.Client`: GET / POST / PUT / DELETE all work
+the same way they would over the network, but the request is
+dispatched directly into the ASGI app — no socket, no port.
+The ASGI `lifespan` protocol runs around the `with` block, so
+`@app.on_startup` / `@app.on_shutdown` handlers fire in the
+expected order.
+
+```python
+from blackbull import BlackBull
+from blackbull.testing import TestClient
+
+app = BlackBull()
+
+
+@app.route(path='/')
+async def hello():
+    return "hello, world"
+
+
+@app.route(path='/items/{item_id:int}')
+async def get_item(item_id: int):
+    return {"id": item_id, "kind": "widget"}
+
+
+def test_hello():
+    with TestClient(app) as client:
+        response = client.get('/')
+    assert response.status_code == 200
+    assert response.text == "hello, world"
+
+
+def test_get_item():
+    with TestClient(app) as client:
+        response = client.get('/items/42')
+    assert response.json() == {"id": 42, "kind": "widget"}
+```
+
+The response object is `httpx.Response` — same shape as a
+production HTTP client, so `.status_code`, `.headers`,
+`.json()`, `.text`, `.content`, cookies, redirects all work
+unchanged.
+
+### POST and JSON bodies
+
+```python
+def test_create_item():
+    with TestClient(app) as client:
+        response = client.post('/items', json={'name': 'widget'})
+    assert response.status_code == 201
+```
+
+`client.post`, `.put`, `.patch`, `.delete`, `.head`,
+`.options`, and the underlying `client.request(method, url, ...)`
+all accept the same arguments as `httpx.Client`:
+
+- `content=` for raw bytes
+- `data=` for form-encoded fields
+- `json=` for JSON-encoded bodies
+- `headers=` for request headers
+- `cookies=` for cookies
+- `params=` for query parameters
+- `follow_redirects=False` (default) to assert on 3xx
+  responses directly; pass `follow_redirects=True` on the
+  `TestClient` constructor or per-call kwarg to traverse them.
+
+### File uploads, auth, timeouts, and other httpx parameters
+
+`TestClient`'s HTTP methods forward `**kwargs` straight to the
+underlying `httpx.AsyncClient`, so anything httpx accepts works
+unchanged.  Patterns worth knowing:
+
+**Multipart file upload** — pass `files=` (and optional `data=`
+for accompanying form fields).  Each `files` entry is
+`(field_name, (filename, fileobj, content_type))`:
+
+```python
+def test_upload():
+    with TestClient(app) as client:
+        response = client.post(
+            '/upload',
+            files={'attachment': ('report.pdf', b'%PDF-1.4...', 'application/pdf')},
+            data={'note': 'monthly'},
+        )
+    assert response.status_code == 201
+```
+
+**HTTP authentication** — pass `auth=`:
+
+```python
+# Basic auth
+response = client.get('/private', auth=('alice', 'hunter2'))
+
+# Custom scheme via httpx.Auth subclass — e.g. a bearer token
+response = client.get('/api/me', headers={'Authorization': 'Bearer abc.def.ghi'})
+```
+
+**Per-request timeout** — pass `timeout=` (seconds, or an
+`httpx.Timeout` for finer control):
+
+```python
+response = client.get('/slow', timeout=5.0)
+```
+
+Default timeouts can be passed on the `TestClient` constructor
+via the `headers=` / `cookies=` / `follow_redirects=` options,
+or set after construction by mutating `client.headers` /
+`client.cookies` — both forward to the underlying
+`httpx.AsyncClient`, so the standard httpx jar semantics apply
+(cookies set by responses persist across subsequent requests on
+the same client).
+
+```python
+with TestClient(app, headers={'X-Test-Tag': 'integration'}) as client:
+    # X-Test-Tag goes out on every request below
+    client.get('/api/one')
+    client.get('/api/two')
+```
+
+### WebSocket sessions
+
+`client.websocket_connect(path)` returns a synchronous
+context-managed session.  The session lives inside its own
+background event loop, so all of `send_text` / `send_bytes` /
+`send_json` and the matching receive methods are blocking
+synchronous calls:
+
+```python
+from blackbull.router import Scheme
+
+
+@app.route(path='/ws', scheme=Scheme.websocket)
+async def ws_echo(scope, receive, send):
+    await receive()                              # websocket.connect
+    await send({'type': 'websocket.accept'})
+    while True:
+        event = await receive()
+        if event['type'] == 'websocket.disconnect':
+            return
+        if event.get('text') is not None:
+            await send({'type': 'websocket.send', 'text': event['text']})
+
+
+def test_ws_echo():
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws') as ws:
+            ws.send_text('ping')
+            assert ws.receive_text() == 'ping'
+```
+
+When the application closes (or rejects) the WebSocket,
+`receive_text` / `receive_bytes` raise
+`blackbull.testing.WebSocketDisconnect` carrying the RFC 6455
+close code:
+
+```python
+from blackbull.testing import WebSocketDisconnect
+
+
+@app.route(path='/ws-auth', scheme=Scheme.websocket)
+async def ws_auth(scope, receive, send):
+    await receive()
+    await send({'type': 'websocket.close', 'code': 4401})
+
+
+def test_ws_rejects_unauthenticated():
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect('/ws-auth'):
+                pass
+        assert excinfo.value.code == 4401
+```
+
+For server-streamed sessions where the handler emits a sequence
+of frames and then closes, `ws.iter_text()` and
+`ws.iter_bytes()` consume the stream until the close arrives —
+the `WebSocketDisconnect` is caught and turned into normal
+iterator termination so the test reads as a single `for` loop:
+
+```python
+@app.route(path='/notifications', scheme=Scheme.websocket)
+async def notifications(scope, receive, send):
+    await receive()                              # websocket.connect
+    await send({'type': 'websocket.accept'})
+    for n in range(3):
+        await send({'type': 'websocket.send', 'text': f'event-{n}'})
+    await send({'type': 'websocket.close', 'code': 1000})
+
+
+def test_notifications_stream():
+    with TestClient(app) as client:
+        with client.websocket_connect('/notifications') as ws:
+            messages = list(ws.iter_text())
+    assert messages == ['event-0', 'event-1', 'event-2']
+```
+
+### Lifespan startup and shutdown
+
+`TestClient` drives the ASGI `lifespan` protocol automatically
+around the `with` block:
+
+```python
+events = []
+
+@app.on_startup
+async def _start():
+    events.append('startup')
+
+@app.on_shutdown
+async def _stop():
+    events.append('shutdown')
+
+
+def test_lifespan_runs():
+    with TestClient(app) as client:
+        assert events == ['startup']
+        client.get('/')
+    assert events == ['startup', 'shutdown']
+```
+
+If a startup handler raises, `TestClient.__enter__` re-raises a
+`RuntimeError` describing the failure, so a broken startup
+fails the test rather than silently leaving the app in a
+half-initialised state.  Apps that don't implement the
+lifespan protocol (i.e. legacy ASGI-2.0-style callables) are
+tolerated silently.
+
+### Construction options
+
+```python
+TestClient(
+    app,
+    base_url='http://testserver',
+    raise_app_exceptions=True,    # let handler exceptions bubble up
+    root_path='',                 # ASGI scope['root_path']
+    cookies=None,
+    headers=None,
+    follow_redirects=False,
+)
+```
+
+`raise_app_exceptions=True` (the default) is what you want in
+tests — handler tracebacks surface as the test failure.  Set it
+to `False` to assert on the 500 response the framework would
+emit to a real client.
 
 ## End-to-end with BlackBull's clients
 
@@ -246,11 +498,12 @@ When to pick which:
 
 For unit-level assertions on a single handler — no transport,
 no routing — call the app callable directly with a hand-rolled
-scope:
+scope.  `BlackBull.__call__` is a standard ASGI 3.0 callable so
+the stub `send` is a single-argument coroutine that receives
+event dicts:
 
 ```python
 import pytest
-from http import HTTPStatus
 from blackbull import BlackBull, JSONResponse
 from blackbull.server.headers import Headers
 
@@ -279,20 +532,22 @@ async def fake_receive():
 
 @pytest.mark.asyncio
 async def test_ping_handler():
-    responses = []
+    events = []
 
-    async def fake_send(body, status=HTTPStatus.OK, headers=[]):
-        responses.append({'body': body, 'status': status})
+    async def fake_send(event):
+        events.append(event)
 
     await app(make_scope(), fake_receive, fake_send)
-    assert responses[0]['status'] == HTTPStatus.OK
-    assert b'"pong"' in responses[0]['body']
+    start = next(e for e in events if e['type'] == 'http.response.start')
+    body = next(e for e in events if e['type'] == 'http.response.body')
+    assert start['status'] == 200
+    assert b'"pong"' in body['body']
 ```
 
-Useful when you want to assert on response shape without
-involving HTTP framing or transport.  Prefer the integration
-patterns above for anything routing-shaped — they cost almost
-nothing more and exercise more of the framework.
+Useful when you want to assert on the raw ASGI event sequence.
+Prefer the `TestClient` pattern above for anything routing-
+shaped — it costs almost nothing more and exercises more of the
+framework.
 
 ## Middleware in isolation
 
@@ -305,14 +560,13 @@ header mutation, or scope injection:
 async def test_auth_mw_rejects_missing_token():
     from myapp import auth_mw
     from blackbull.server.headers import Headers
-    from http import HTTPStatus
 
     scope = {'type': 'http', 'method': 'GET', 'path': '/tasks',
              'headers': Headers([]), 'state': {}}
 
-    responses = []
-    async def fake_send(body, status=HTTPStatus.OK, headers=[]):
-        responses.append(status)
+    events = []
+    async def fake_send(event):
+        events.append(event)
 
     call_next_called = False
     async def fake_call_next(scope, receive, send):
@@ -322,7 +576,8 @@ async def test_auth_mw_rejects_missing_token():
     await auth_mw(scope, None, fake_send, fake_call_next)
 
     assert not call_next_called          # short-circuited
-    assert responses[0] == HTTPStatus.UNAUTHORIZED
+    start = next(e for e in events if e['type'] == 'http.response.start')
+    assert start['status'] == 401
 ```
 
 The pattern works for async-function middleware and

--- a/tests/integration/test_cache_middleware.py
+++ b/tests/integration/test_cache_middleware.py
@@ -1,21 +1,16 @@
 """Integration test for the response-cache middleware.
 
-Drives a real BlackBull server with ``Cache`` installed and a
+Exercises ``Cache`` end-to-end through the full app stack with a
 handler that increments a counter on every invocation.  Two requests
 to the same path must hit the handler only once (cache HIT on the
 second).  Adds an ``If-None-Match`` round-trip against the auto-
 generated ETag.
 """
-import asyncio
-from multiprocessing import Process
-
-import httpx
 import pytest
-import pytest_asyncio
 
 from blackbull import BlackBull
 from blackbull.middleware.cache import Cache
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -44,54 +39,42 @@ def _make_app() -> BlackBull:
     return app
 
 
-@pytest_asyncio.fixture
-async def cache_app():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
+@pytest.fixture
+def client():
+    # Per-test rather than per-module: each test wants the cache to start clean.
+    with TestClient(_make_app()) as c:
+        yield c
+
+
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_second_request_served_from_cache(cache_app):
-    """Two requests to / must yield the same body — the counter must
-    have only ticked once on the server side."""
-    base = f'http://127.0.0.1:{cache_app.port}'
-    async with httpx.AsyncClient() as c:
-        r1 = await c.get(f'{base}/')
-        r2 = await c.get(f'{base}/')
+def test_second_request_served_from_cache(client):
+    """Two requests to / must yield the same body — the counter only ticks once."""
+    r1 = client.get('/')
+    r2 = client.get('/')
     assert r1.text == r2.text, (
         f'cached response should match; got {r1.text!r} vs {r2.text!r}')
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_if_none_match_returns_304(cache_app):
-    base = f'http://127.0.0.1:{cache_app.port}'
-    async with httpx.AsyncClient() as c:
-        r1 = await c.get(f'{base}/')
-        etag = r1.headers.get('etag')
-        assert etag is not None, 'middleware must inject an ETag'
+def test_if_none_match_returns_304(client):
+    r1 = client.get('/')
+    etag = r1.headers.get('etag')
+    assert etag is not None, 'middleware must inject an ETag'
 
-        r2 = await c.get(f'{base}/', headers={'If-None-Match': etag})
-        assert r2.status_code == 304, (
-            f'matching If-None-Match must return 304; got {r2.status_code}')
-        assert r2.content == b''
+    r2 = client.get('/', headers={'If-None-Match': etag})
+    assert r2.status_code == 304, (
+        f'matching If-None-Match must return 304; got {r2.status_code}')
+    assert r2.content == b''
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_cache_control_private_not_cached(cache_app):
+def test_cache_control_private_not_cached(client):
     """A handler emitting ``Cache-Control: private`` must NOT be cached
     by the middleware — the counter increments every request."""
-    base = f'http://127.0.0.1:{cache_app.port}'
-    async with httpx.AsyncClient() as c:
-        await c.get(f'{base}/private')
-        await c.get(f'{base}/private')
-        await c.get(f'{base}/private')
-        # The body always says 'private' so we can't distinguish.  Use the
-        # /private handler's counter side-effect by then asking for / (a
-        # different cache key) and inspecting the counter via its response.
-        r = await c.get(f'{base}/')
-    # We hit /private three times AND / once → counter is 4.  The body of
-    # / shows the counter at that moment.
+    client.get('/private')
+    client.get('/private')
+    client.get('/private')
+    # The body of /private is constant so we observe via the / counter.
+    r = client.get('/')
     assert r.text == '4', (
         f'private responses must not be cached; expected counter=4, got {r.text}')

--- a/tests/integration/test_cookies.py
+++ b/tests/integration/test_cookies.py
@@ -1,14 +1,10 @@
-"""Integration tests for cookie_header() and parse_cookies() over HTTP."""
-import asyncio
-from multiprocessing import Process
-
-import httpx
+"""Integration tests for cookie_header() and parse_cookies()."""
 import pytest
 
 from blackbull import BlackBull, JSONResponse
 from blackbull.response import cookie_header
 from blackbull.request import parse_cookies
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -30,35 +26,27 @@ def _make_app() -> BlackBull:
 
     @app.route(path='/read-cookies')
     async def read_cookies(scope):
-        jar = parse_cookies(scope)
-        return jar
+        return parse_cookies(scope)
 
     return app
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_set_cookie_present_in_response(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/set-cookie')
+def test_set_cookie_present_in_response(client):
+    r = client.get('/set-cookie')
     assert r.status_code == 200
     assert 'set-cookie' in r.headers
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_set_cookie_httponly_and_samesite(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/set-cookie')
+def test_set_cookie_httponly_and_samesite(client):
+    r = client.get('/set-cookie')
     cookie = r.headers.get('set-cookie', '')
     assert 'session=abc123' in cookie
     assert 'HttpOnly' in cookie
@@ -66,23 +54,16 @@ async def test_set_cookie_httponly_and_samesite(live):
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_set_cookie_no_httponly(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/set-cookie-no-httponly')
+def test_set_cookie_no_httponly(client):
+    r = client.get('/set-cookie-no-httponly')
     cookie = r.headers.get('set-cookie', '')
     assert 'pref=dark' in cookie
     assert 'HttpOnly' not in cookie
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_multi_cookie_parsed(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live)}/read-cookies',
-            headers={'Cookie': 'a=1; b=hello'},
-        )
+def test_multi_cookie_parsed(client):
+    r = client.get('/read-cookies', headers={'Cookie': 'a=1; b=hello'})
     assert r.status_code == 200
     data = r.json()
     assert data.get('a') == '1'
@@ -90,20 +71,12 @@ async def test_multi_cookie_parsed(live):
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_cookie_roundtrip(live):
+def test_cookie_roundtrip(client):
     """Browser flow: server sets cookie, client sends it back, handler reads it."""
-    async with httpx.AsyncClient() as c:
-        # Get the Set-Cookie
-        r1 = await c.get(f'{_base(live)}/set-cookie')
-        set_cookie = r1.headers.get('set-cookie', '')
-        # Extract name=value (before the first ';')
-        name_value = set_cookie.split(';')[0].strip()
+    r1 = client.get('/set-cookie')
+    set_cookie = r1.headers.get('set-cookie', '')
+    name_value = set_cookie.split(';')[0].strip()
 
-        # Send it back as a Cookie header
-        r2 = await c.get(
-            f'{_base(live)}/read-cookies',
-            headers={'Cookie': name_value},
-        )
+    r2 = client.get('/read-cookies', headers={'Cookie': name_value})
     assert r2.status_code == 200
     assert r2.json().get('session') == 'abc123'

--- a/tests/integration/test_error_handling.py
+++ b/tests/integration/test_error_handling.py
@@ -1,13 +1,10 @@
 """Integration tests for error handling — on_error() and default error responses."""
-import asyncio
 from http import HTTPMethod, HTTPStatus
-from multiprocessing import Process
 
-import httpx
 import pytest
 
 from blackbull import BlackBull, JSONResponse
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -49,55 +46,42 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_custom_404(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/unknown-path')
+def test_custom_404(client):
+    r = client.get('/unknown-path')
     assert r.status_code == 404
     assert r.json() == {'error': 'not_found'}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_default_405_has_allow_header(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/get-only')
+def test_default_405_has_allow_header(client):
+    r = client.post('/get-only')
     assert r.status_code == 405
     assert 'allow' in r.headers
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_custom_exception_handler(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/raises-value-error')
+def test_custom_exception_handler(client):
+    r = client.get('/raises-value-error')
     assert r.status_code == 400
     assert r.json() == {'error': 'value_error'}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_mro_dispatch_catches_subclass(live):
+def test_mro_dispatch_catches_subclass(client):
     """on_error(Exception) must catch TypeError even though only Exception is registered."""
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/raises-type-error')
+    r = client.get('/raises-type-error')
     assert r.status_code == 500
     assert r.json() == {'error': 'exception'}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_unhandled_exception_uses_fallback_500(live):
+def test_unhandled_exception_uses_fallback_500(client):
     """RuntimeError has no specific handler; the Exception base handler fires."""
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/raises-runtime-error')
+    r = client.get('/raises-runtime-error')
     assert r.status_code == 500

--- a/tests/integration/test_helloworld_cors.py
+++ b/tests/integration/test_helloworld_cors.py
@@ -1,26 +1,17 @@
-"""Integration tests for helloworld-cors.py.
+"""Integration tests for the helloworld-cors example.
 
-Starts the app in a child process on a random port (HTTP/1.1, no TLS) and
-exercises the CORS middleware end-to-end through real network calls.
+Re-creates the helloworld-cors app inline and exercises the CORS
+middleware end-to-end through the full app stack.
 """
-import asyncio
 import json
 from http import HTTPMethod
-from multiprocessing import Process
 
-import httpx
 import pytest
-import pytest_asyncio
 
 from blackbull import CORS, BlackBull, JSONResponse
 from blackbull.request import read_body
-from .conftest import live_server
+from blackbull.testing import TestClient
 
-
-# ---------------------------------------------------------------------------
-# Re-create the helloworld-cors app inline so the test is self-contained.
-# Using the same routes and CORS config as the example file.
-# ---------------------------------------------------------------------------
 
 def _make_app(allow_origins) -> BlackBull:
     app = BlackBull()
@@ -44,46 +35,32 @@ def _make_app(allow_origins) -> BlackBull:
     return app
 
 
-def _run(app):
-    asyncio.run(app.run())
+@pytest.fixture(scope="module")
+def cors_client():
+    """Explicit-origin CORS config."""
+    with TestClient(_make_app(allow_origins=['https://example.com'])) as c:
+        yield c
 
 
-@pytest_asyncio.fixture
-async def cors_app():
-    """BlackBull app with explicit CORS origin; runs in a child process."""
-    app = _make_app(allow_origins=['https://example.com'])
-    with live_server(app) as handle:
-        yield handle
-@pytest_asyncio.fixture
-async def cors_wildcard_app():
-    """BlackBull app with wildcard CORS origin; runs in a child process."""
-    app = _make_app(allow_origins=['*'])
-    with live_server(app) as handle:
-        yield handle
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+@pytest.fixture(scope="module")
+def cors_wildcard_client():
+    """Wildcard-origin CORS config."""
+    with TestClient(_make_app(allow_origins=['*'])) as c:
+        yield c
 
 
 # ---------------------------------------------------------------------------
 # No Origin header — CORS middleware passes through, no CORS headers added
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_no_origin_no_cors_headers(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(cors_app)}/api/hello')
+def test_no_origin_no_cors_headers(cors_client):
+    r = cors_client.get('/api/hello')
     assert r.status_code == 200
     assert 'access-control-allow-origin' not in r.headers
 
 
-@pytest.mark.asyncio
-async def test_no_origin_body_still_returned(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(cors_app)}/api/hello')
+def test_no_origin_body_still_returned(cors_client):
+    r = cors_client.get('/api/hello')
     assert r.json()['greeting'] == 'Hello, world!'
 
 
@@ -91,24 +68,14 @@ async def test_no_origin_body_still_returned(cors_app):
 # Allowed origin — CORS headers present in response
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_allowed_origin_acao_header(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(cors_app)}/api/hello',
-            headers={'Origin': 'https://example.com'},
-        )
+def test_allowed_origin_acao_header(cors_client):
+    r = cors_client.get('/api/hello', headers={'Origin': 'https://example.com'})
     assert r.status_code == 200
     assert r.headers['access-control-allow-origin'] == 'https://example.com'
 
 
-@pytest.mark.asyncio
-async def test_allowed_origin_vary_origin(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(cors_app)}/api/hello',
-            headers={'Origin': 'https://example.com'},
-        )
+def test_allowed_origin_vary_origin(cors_client):
+    r = cors_client.get('/api/hello', headers={'Origin': 'https://example.com'})
     assert r.headers.get('vary', '').lower() == 'origin'
 
 
@@ -116,13 +83,8 @@ async def test_allowed_origin_vary_origin(cors_app):
 # Disallowed origin — response goes through, but without CORS headers
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_disallowed_origin_no_cors_headers(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(cors_app)}/api/hello',
-            headers={'Origin': 'https://evil.com'},
-        )
+def test_disallowed_origin_no_cors_headers(cors_client):
+    r = cors_client.get('/api/hello', headers={'Origin': 'https://evil.com'})
     assert r.status_code == 200
     assert 'access-control-allow-origin' not in r.headers
 
@@ -131,13 +93,8 @@ async def test_disallowed_origin_no_cors_headers(cors_app):
 # Wildcard origin
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_wildcard_origin_returns_star(cors_wildcard_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(cors_wildcard_app)}/api/hello',
-            headers={'Origin': 'https://any-origin.com'},
-        )
+def test_wildcard_origin_returns_star(cors_wildcard_client):
+    r = cors_wildcard_client.get('/api/hello', headers={'Origin': 'https://any-origin.com'})
     assert r.headers['access-control-allow-origin'] == '*'
     assert 'vary' not in r.headers
 
@@ -146,45 +103,30 @@ async def test_wildcard_origin_returns_star(cors_wildcard_app):
 # Preflight OPTIONS
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_preflight_returns_200(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.options(
-            f'{_base(cors_app)}/api/hello',
-            headers={
-                'Origin': 'https://example.com',
-                'Access-Control-Request-Method': 'GET',
-            },
-        )
+def test_preflight_returns_200(cors_client):
+    r = cors_client.options('/api/hello', headers={
+        'Origin': 'https://example.com',
+        'Access-Control-Request-Method': 'GET',
+    })
     assert r.status_code == 200
 
 
-@pytest.mark.asyncio
-async def test_preflight_cors_headers_present(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.options(
-            f'{_base(cors_app)}/api/hello',
-            headers={
-                'Origin': 'https://example.com',
-                'Access-Control-Request-Method': 'POST',
-            },
-        )
+def test_preflight_cors_headers_present(cors_client):
+    r = cors_client.options('/api/hello', headers={
+        'Origin': 'https://example.com',
+        'Access-Control-Request-Method': 'POST',
+    })
     assert r.headers['access-control-allow-origin'] == 'https://example.com'
     assert 'GET' in r.headers['access-control-allow-methods']
     assert 'POST' in r.headers['access-control-allow-methods']
     assert r.headers['access-control-max-age'] == '3600'
 
 
-@pytest.mark.asyncio
-async def test_preflight_body_is_empty(cors_app):
-    async with httpx.AsyncClient() as c:
-        r = await c.options(
-            f'{_base(cors_app)}/api/hello',
-            headers={
-                'Origin': 'https://example.com',
-                'Access-Control-Request-Method': 'GET',
-            },
-        )
+def test_preflight_body_is_empty(cors_client):
+    r = cors_client.options('/api/hello', headers={
+        'Origin': 'https://example.com',
+        'Access-Control-Request-Method': 'GET',
+    })
     assert r.content == b''
 
 
@@ -192,15 +134,9 @@ async def test_preflight_body_is_empty(cors_app):
 # POST /api/echo with CORS
 # ---------------------------------------------------------------------------
 
-@pytest.mark.asyncio
-async def test_post_echo_with_cors(cors_app):
+def test_post_echo_with_cors(cors_client):
     payload = {'message': 'hello'}
-    async with httpx.AsyncClient() as c:
-        r = await c.post(
-            f'{_base(cors_app)}/api/echo',
-            json=payload,
-            headers={'Origin': 'https://example.com'},
-        )
+    r = cors_client.post('/api/echo', json=payload, headers={'Origin': 'https://example.com'})
     assert r.status_code == 200
     assert r.json()['echo'] == payload
     assert r.headers['access-control-allow-origin'] == 'https://example.com'

--- a/tests/integration/test_lifespan_events.py
+++ b/tests/integration/test_lifespan_events.py
@@ -1,73 +1,67 @@
 """Integration tests for lifespan event hooks (guide.md §9).
 
-Startup hooks fire before the first request; shutdown hooks fire after
-graceful stop. Both are invisible to unit tests because they require a
-running server process with a live asyncio event loop.
+Startup hooks fire before the first request via the ASGI ``lifespan``
+protocol; shutdown hooks fire on the matching ``lifespan.shutdown``
+event.  The first test drives both ends through :class:`TestClient`,
+which speaks the lifespan protocol natively.  The second test
+exercises :class:`LifespanManager` directly via a child process — it's
+verifying server-side wiring, not app behaviour, so it stays
+out-of-process.
 """
 import asyncio
 import time
 from multiprocessing import Process, Value
 
-import httpx
 import pytest
 
 from blackbull import BlackBull
 from blackbull.server.server import LifespanManager
-
-from .conftest import live_server
-
-
-def _make_startup_app(startup_counter) -> BlackBull:
-    app = BlackBull()
-
-    @app.on_startup
-    async def on_start():
-        startup_counter.value += 1
-
-    @app.route(path='/startup-count')
-    async def startup_count():
-        return {'count': startup_counter.value}
-
-    return app
+from blackbull.testing import TestClient
 
 
 def _run_lifespan_only(app, ready_flag, stop_flag, shutdown_flag):
     """Run startup→idle→shutdown in an isolated event loop with no HTTP server.
 
-    This exercises the full ASGI lifespan protocol without the complexity of
-    stopping a live TCP server gracefully.
+    Exercises the full ASGI lifespan protocol without binding sockets.
+    ``shutdown_flag`` is written by ``app``'s ``on_shutdown`` handler.
     """
     async def _go():
         async with LifespanManager(app):
             ready_flag.value = 1
             while not stop_flag.value:
                 await asyncio.sleep(0.05)
-        # LifespanManager.__aexit__ has now fired the shutdown handshake and
-        # the on_shutdown hook has updated shutdown_flag before we get here.
+        # LifespanManager.__aexit__ has now fired the shutdown handshake
+        # and the on_shutdown hook has updated shutdown_flag before we
+        # get here.
 
     asyncio.run(_go())
 
 
-@pytest.fixture(scope="module")
-def live_startup():
-    counter = Value('i', 0)
-    app = _make_startup_app(counter)
-    with live_server(app) as handle:
-        yield handle
-
-
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_startup_hook_runs_before_first_request(live_startup):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'http://127.0.0.1:{live_startup.port}/startup-count')
+def test_startup_hook_runs_before_first_request():
+    counter = {'value': 0}
+    app = BlackBull()
+
+    @app.on_startup
+    async def on_start():
+        counter['value'] += 1
+
+    @app.route(path='/startup-count')
+    async def startup_count():
+        return {'count': counter['value']}
+
+    with TestClient(app) as client:
+        r = client.get('/startup-count')
     assert r.status_code == 200
-    # startup ran exactly once before the server became ready
+    # Startup ran exactly once before the first request.
     assert r.json()['count'] == 1
 
 
 @pytest.mark.integration
 def test_shutdown_hook_runs_on_graceful_stop():
+    """Verifies the server's :class:`LifespanManager` fires the shutdown
+    handshake on graceful exit.  Kept out-of-process so the
+    server-side lifespan flow is exercised end-to-end."""
     ready_flag    = Value('i', 0)
     stop_flag     = Value('i', 0)
     shutdown_flag = Value('i', 0)
@@ -82,13 +76,11 @@ def test_shutdown_hook_runs_on_graceful_stop():
                 args=(app, ready_flag, stop_flag, shutdown_flag))
     p.start()
 
-    # wait for the lifespan task to finish startup
     deadline = time.monotonic() + 10.0
     while not ready_flag.value and time.monotonic() < deadline:
         time.sleep(0.05)
     assert ready_flag.value, 'lifespan startup did not complete in time'
 
-    # signal the child to begin graceful shutdown
     stop_flag.value = 1
     p.join(timeout=10)
 

--- a/tests/integration/test_methods.py
+++ b/tests/integration/test_methods.py
@@ -1,15 +1,12 @@
 """Integration tests for HTTP method routing and 405 Method Not Allowed."""
-import asyncio
 import json
 from http import HTTPMethod
-from multiprocessing import Process
 
-import httpx
 import pytest
 
 from blackbull import BlackBull, JSONResponse
 from blackbull.request import read_body
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -43,55 +40,42 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_put(live):
+def test_put(client):
     payload = {'key': 'value'}
-    async with httpx.AsyncClient() as c:
-        r = await c.put(f'{_base(live)}/resource', json=payload)
+    r = client.put('/resource', json=payload)
     assert r.status_code == 200
     assert r.json() == payload
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_patch(live):
+def test_patch(client):
     payload = {'field': 'updated'}
-    async with httpx.AsyncClient() as c:
-        r = await c.patch(f'{_base(live)}/resource', json=payload)
+    r = client.patch('/resource', json=payload)
     assert r.status_code == 200
     assert r.json() == payload
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_delete(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.delete(f'{_base(live)}/resource/7')
+def test_delete(client):
+    r = client.delete('/resource/7')
     assert r.status_code == 200
     assert r.json() == {'deleted': 7}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_head_returns_200_no_body(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.head(f'{_base(live)}/resource')
+def test_head_returns_200_no_body(client):
+    r = client.head('/resource')
     assert r.status_code == 200
     assert r.content == b''
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_wrong_method_405(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/resource/1')
+def test_wrong_method_405(client):
+    r = client.post('/resource/1')
     assert r.status_code == 405

--- a/tests/integration/test_middleware_composition.py
+++ b/tests/integration/test_middleware_composition.py
@@ -1,12 +1,8 @@
 """Integration tests for middleware composition — per-route, groups, short-circuit, global."""
-import asyncio
-from multiprocessing import Process
-
-import httpx
 import pytest
 
-from blackbull import BlackBull, JSONResponse
-from .conftest import live_server
+from blackbull import BlackBull
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -43,8 +39,6 @@ def _make_app() -> BlackBull:
 
     # --- short-circuit: handler must not be called ---
 
-    _handler_called = []
-
     async def blocking_mw(scope, receive, send, call_next):
         await send({'type': 'http.response.start', 'status': 403, 'headers': []})
         await send({'type': 'http.response.body', 'body': b'blocked', 'more_body': False})
@@ -52,7 +46,6 @@ def _make_app() -> BlackBull:
 
     @app.route(path='/blocked', middlewares=[blocking_mw])
     async def blocked_handler():
-        _handler_called.append(True)
         return {}
 
     # --- route group ---
@@ -83,65 +76,50 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_per_route_middleware_runs(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/with-mw')
+def test_per_route_middleware_runs(client):
+    r = client.get('/with-mw')
     assert r.status_code == 200
     assert r.json()['mw_ran'] is True
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_per_route_middleware_does_not_affect_other_routes(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/without-mw')
+def test_per_route_middleware_does_not_affect_other_routes(client):
+    r = client.get('/without-mw')
     assert r.status_code == 200
     assert r.json()['mw_ran'] is False
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_per_route_middleware_order(live):
+def test_per_route_middleware_order(client):
     """Middleware runs outer-before-inner; handler sees both; list return works."""
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/order')
+    r = client.get('/order')
     assert r.status_code == 200
     assert r.json() == ['outer', 'inner', 'handler']
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_short_circuit_skips_handler(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/blocked')
+def test_short_circuit_skips_handler(client):
+    r = client.get('/blocked')
     assert r.status_code == 403
     assert r.content == b'blocked'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_route_group_middleware_runs(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/group/resource')
+def test_route_group_middleware_runs(client):
+    r = client.get('/group/resource')
     assert r.status_code == 200
     assert r.json()['group'] is True
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_global_middleware_affects_all_routes(live):
-    async with httpx.AsyncClient() as c:
-        r1 = await c.get(f'{_base(live)}/global')
-        r2 = await c.get(f'{_base(live)}/without-mw')
+def test_global_middleware_affects_all_routes(client):
+    r1 = client.get('/global')
+    r2 = client.get('/without-mw')
     assert r1.json()['global'] is True
     assert r2.json()['mw_ran'] is False   # per-route mw absent, but global ran

--- a/tests/integration/test_request_body.py
+++ b/tests/integration/test_request_body.py
@@ -1,16 +1,13 @@
-"""Integration tests for request body reading — read_body() over real TCP."""
-import asyncio
+"""Integration tests for request body reading — read_body() through the full app stack."""
 import json
 from http import HTTPMethod
-from multiprocessing import Process
 from urllib.parse import parse_qs
 
-import httpx
 import pytest
 
 from blackbull import BlackBull, JSONResponse
 from blackbull.request import read_body
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -37,61 +34,48 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_small_post_body(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/echo', content=b'hello world')
+def test_small_post_body(client):
+    r = client.post('/echo', content=b'hello world')
     assert r.status_code == 200
     assert r.json()['body'] == 'hello world'
     assert r.json()['length'] == 11
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_large_post_body(live):
+def test_large_post_body(client):
     payload = b'x' * (1024 * 1024)  # 1 MB
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/echo', content=payload)
+    r = client.post('/echo', content=payload)
     assert r.status_code == 200
     assert r.json()['length'] == len(payload)
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_json_post_roundtrip(live):
+def test_json_post_roundtrip(client):
     data = {'key': 'value', 'number': 42}
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/json-echo', json=data)
+    r = client.post('/json-echo', json=data)
     assert r.status_code == 200
     assert r.json() == data
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_empty_body(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.post(f'{_base(live)}/echo', content=b'')
+def test_empty_body(client):
+    r = client.post('/echo', content=b'')
     assert r.status_code == 200
     assert r.json()['length'] == 0
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_form_urlencoded(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.post(
-            f'{_base(live)}/form',
-            content=b'name=alice&role=admin',
-            headers={'content-type': 'application/x-www-form-urlencoded'},
-        )
+def test_form_urlencoded(client):
+    r = client.post(
+        '/form',
+        content=b'name=alice&role=admin',
+        headers={'content-type': 'application/x-www-form-urlencoded'},
+    )
     assert r.status_code == 200
     assert r.json() == {'name': 'alice', 'role': 'admin'}

--- a/tests/integration/test_request_events.py
+++ b/tests/integration/test_request_events.py
@@ -1,9 +1,17 @@
 """Integration tests for per-request event hooks (guide.md §9).
 
-request_received, before_handler, after_handler, and request_completed
-all fire during normal request processing.  Each test drives the counter
-via HTTP and reads the result back through a /state endpoint in the same
-server process.
+``request_received`` and ``request_completed`` are fired by the
+server-side :class:`EventAggregator` in
+[`blackbull/server/http1_actor.py`](../../blackbull/server/http1_actor.py)
+— they're outside the path taken by ``BlackBull.__call__`` alone, so
+``TestClient`` can't see them.  These tests therefore stay
+socket-bound (forked worker + ephemeral TCP port) to exercise the
+real server-side aggregator wiring.
+
+The app-side hooks ``before_handler`` and ``after_handler`` *are*
+dispatched from inside ``BlackBull._dispatch`` and so can be — and
+are — tested through ``TestClient`` directly elsewhere (e.g. via the
+unit tests in ``tests/unit/``).
 """
 import asyncio
 import time
@@ -20,11 +28,11 @@ def _make_app() -> BlackBull:
     app = BlackBull()
 
     _state = {
-        'received': 0,
-        'before':   0,
-        'after':    0,
+        'received':  0,
+        'before':    0,
+        'after':     0,
         'completed': 0,
-        'injected': False,
+        'injected':  False,
     }
 
     @app.on('request_received')
@@ -63,6 +71,8 @@ def live():
     app = _make_app()
     with live_server(app) as handle:
         yield handle
+
+
 def _base(app) -> str:
     return f'http://127.0.0.1:{app.port}'
 
@@ -72,11 +82,10 @@ def _get_state(base: str) -> dict:
 
     Polls briefly to allow fire-and-forget observer tasks to complete.
     """
-    import httpx as _httpx
     deadline = time.monotonic() + 2.0
     last = {}
     while time.monotonic() < deadline:
-        r = _httpx.get(f'{base}/state')
+        r = httpx.get(f'{base}/state')
         last = r.json()
         if last.get('completed', 0) >= 1:
             return last

--- a/tests/integration/test_request_features.py
+++ b/tests/integration/test_request_features.py
@@ -1,13 +1,9 @@
 """Integration tests for request header access, cookie parsing, and query strings."""
-import asyncio
-from multiprocessing import Process
-
-import httpx
 import pytest
 
-from blackbull import BlackBull, JSONResponse
+from blackbull import BlackBull
 from blackbull.request import parse_cookies
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -25,58 +21,38 @@ def _make_app() -> BlackBull:
 
     @app.route(path='/cookies')
     async def cookies(scope):
-        jar = parse_cookies(scope)
-        return jar
+        return parse_cookies(scope)
 
     @app.route(path='/query')
     async def query(scope):
-        qs = scope.get('query_string', b'').decode()
-        return {'query_string': qs}
+        return {'query_string': scope.get('query_string', b'').decode()}
 
     return app
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_case_insensitive_header(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live)}/header-echo',
-            headers={'X-Custom-Header': 'hello'},
-        )
+def test_case_insensitive_header(client):
+    r = client.get('/header-echo', headers={'X-Custom-Header': 'hello'})
     assert r.status_code == 200
     assert r.json()['value'] == 'hello'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_multi_value_header_getlist(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live)}/header-multivalue',
-            headers={'Accept': 'text/html, application/json'},
-        )
+def test_multi_value_header_getlist(client):
+    r = client.get('/header-multivalue', headers={'Accept': 'text/html, application/json'})
     assert r.status_code == 200
     assert len(r.json()['values']) >= 1
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_cookie_parsed(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live)}/cookies',
-            headers={'Cookie': 'a=1; b=2'},
-        )
+def test_cookie_parsed(client):
+    r = client.get('/cookies', headers={'Cookie': 'a=1; b=2'})
     assert r.status_code == 200
     data = r.json()
     assert data.get('a') == '1'
@@ -84,10 +60,8 @@ async def test_cookie_parsed(live):
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_query_string(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/query', params={'q': 'hello', 'page': '2'})
+def test_query_string(client):
+    r = client.get('/query', params={'q': 'hello', 'page': '2'})
     assert r.status_code == 200
     qs = r.json()['query_string']
     assert 'q=hello' in qs

--- a/tests/integration/test_response_features.py
+++ b/tests/integration/test_response_features.py
@@ -1,14 +1,11 @@
 """Integration tests for Response variations — content-type, headers, redirects, cookies."""
-import asyncio
 from http import HTTPStatus
-from multiprocessing import Process
 
-import httpx
 import pytest
 
 from blackbull import BlackBull, JSONResponse
 from blackbull.response import Response, cookie_header
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -49,57 +46,44 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_plain_text_response(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/text')
+def test_plain_text_response(client):
+    r = client.get('/text')
     assert r.status_code == 200
     assert 'text/plain' in r.headers['content-type']
     assert r.text == 'hello'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_custom_content_type(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/xml')
+def test_custom_content_type(client):
+    r = client.get('/xml')
     assert r.status_code == 200
     assert 'application/xml' in r.headers['content-type']
     assert r.content == b'<root/>'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_redirect(live):
-    async with httpx.AsyncClient(follow_redirects=False) as c:
-        r = await c.get(f'{_base(live)}/redirect')
+def test_redirect(client):
+    r = client.get('/redirect')  # follow_redirects defaults to False
     assert r.status_code == 302
     assert r.headers['location'] == '/text'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_custom_response_header(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/custom-header')
+def test_custom_response_header(client):
+    r = client.get('/custom-header')
     assert r.status_code == 200
     assert r.headers.get('x-request-id') == 'abc123'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_set_cookie_httponly_and_samesite(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/set-cookie')
+def test_set_cookie_httponly_and_samesite(client):
+    r = client.get('/set-cookie')
     assert r.status_code == 200
     cookie = r.headers.get('set-cookie', '')
     assert 'session=tok123' in cookie
@@ -108,10 +92,8 @@ async def test_set_cookie_httponly_and_samesite(live):
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_set_cookie_no_httponly(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/set-cookie-no-httponly')
+def test_set_cookie_no_httponly(client):
+    r = client.get('/set-cookie-no-httponly')
     cookie = r.headers.get('set-cookie', '')
     assert 'pref=dark' in cookie
     assert 'HttpOnly' not in cookie

--- a/tests/integration/test_routing.py
+++ b/tests/integration/test_routing.py
@@ -1,17 +1,16 @@
 """Integration tests for URL routing — path parameters and named routes.
 
-Unit tests mock the scope dict; these tests prove that the router, parser,
-and simplified-handler wiring work together over a real TCP connection.
+These run in-process through :class:`blackbull.testing.TestClient`; the
+router, parser, and simplified-handler wiring are exercised end-to-end
+but no TCP socket is bound.  See ``tests/conformance/`` for the
+real-wire equivalents.
 """
-import asyncio
 import uuid
-from multiprocessing import Process
 
-import httpx
 import pytest
 
-from blackbull import BlackBull, JSONResponse
-from .conftest import live_server
+from blackbull import BlackBull
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -41,68 +40,52 @@ def _make_app() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def client():
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_int_path_param(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/users/42')
+def test_int_path_param(client):
+    r = client.get('/users/42')
     assert r.status_code == 200
     assert r.json() == {'id': 42}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_str_path_param(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/items/hello-world')
+def test_str_path_param(client):
+    r = client.get('/items/hello-world')
     assert r.status_code == 200
     assert r.json() == {'slug': 'hello-world'}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_uuid_path_param_valid(live):
+def test_uuid_path_param_valid(client):
     doc_id = '12345678-1234-5678-1234-567812345678'
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/docs/{doc_id}')
+    r = client.get(f'/docs/{doc_id}')
     assert r.status_code == 200
     assert r.json()['doc_id'] == doc_id
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_uuid_path_param_malformed_is_404(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/docs/not-a-uuid')
+def test_uuid_path_param_malformed_is_404(client):
+    r = client.get('/docs/not-a-uuid')
     assert r.status_code == 404
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_path_converter_preserves_slashes(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/files/a/b/c.txt')
+def test_path_converter_preserves_slashes(client):
+    r = client.get('/files/a/b/c.txt')
     assert r.status_code == 200
     assert r.json() == {'path': 'a/b/c.txt'}
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_named_route_url_for(live):
-    assert live.url_path_for('search') == '/search'
+def test_named_route_url_for(client):
+    assert client.app.url_path_for('search') == '/search'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_unknown_route_404(live):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{_base(live)}/not-found')
+def test_unknown_route_404(client):
+    r = client.get('/not-found')
     assert r.status_code == 404

--- a/tests/integration/test_session_middleware.py
+++ b/tests/integration/test_session_middleware.py
@@ -1,20 +1,15 @@
 """Integration test for the signed-cookie session middleware.
 
-Drives a real BlackBull server with the session middleware installed and
-sends two HTTP/1.1 requests over the same client: one to set a session
-value, one to read it back.  Confirms the Set-Cookie / Cookie round-trip
-works end-to-end.
+Drives the full app stack through TestClient — sends sequenced requests
+sharing httpx's cookie jar to confirm the Set-Cookie / Cookie round-trip
+works end-to-end, including session clear, tamper rejection, and the
+no-Set-Cookie-when-unmodified optimisation.
 """
-import asyncio
-from multiprocessing import Process
-
-import httpx
 import pytest
-import pytest_asyncio
 
 from blackbull import BlackBull
 from blackbull.middleware.session import Session
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app() -> BlackBull:
@@ -65,80 +60,67 @@ def _make_app() -> BlackBull:
     return app
 
 
-@pytest_asyncio.fixture
-async def session_app():
-    app = _make_app()
-    with live_server(app) as handle:
-        yield handle
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_round_trip_sets_then_reads(session_app):
-    base = f'http://127.0.0.1:{session_app.port}'
-    async with httpx.AsyncClient() as c:
-        r1 = await c.get(f'{base}/set')
-        assert r1.status_code == 200
-        # The client follows Set-Cookie automatically via the Cookie jar.
-        assert 'session' in (r1.cookies or {})
-
-        r2 = await c.get(f'{base}/get')
-        assert r2.status_code == 200
-        assert r2.text == 'user=alice count=1'
+@pytest.fixture
+def client():
+    # Per-test so each starts with a fresh cookie jar.
+    with TestClient(_make_app()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_session_survives_across_requests(session_app):
-    base = f'http://127.0.0.1:{session_app.port}'
-    async with httpx.AsyncClient() as c:
-        for expected in (1, 2, 3, 4):
-            r = await c.get(f'{base}/bump')
-            assert r.text == str(expected)
+def test_round_trip_sets_then_reads(client):
+    r1 = client.get('/set')
+    assert r1.status_code == 200
+    # httpx.Client persists the Set-Cookie in its jar automatically.
+    assert 'session' in client.cookies
+
+    r2 = client.get('/get')
+    assert r2.status_code == 200
+    assert r2.text == 'user=alice count=1'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_clear_emits_tombstone(session_app):
-    base = f'http://127.0.0.1:{session_app.port}'
-    async with httpx.AsyncClient() as c:
-        await c.get(f'{base}/set')
-        assert 'session' in c.cookies
-
-        r = await c.get(f'{base}/clear')
-        assert r.status_code == 200
-        # After /clear the server has set Max-Age=0 → httpx's cookie jar
-        # interprets that as expiration and drops it.
-        assert 'session' not in c.cookies, (
-            f'cleared session must not persist; jar={dict(c.cookies)}')
+def test_session_survives_across_requests(client):
+    for expected in (1, 2, 3, 4):
+        r = client.get('/bump')
+        assert r.text == str(expected)
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_unmodified_session_does_not_emit_set_cookie(session_app):
-    base = f'http://127.0.0.1:{session_app.port}'
-    async with httpx.AsyncClient() as c:
-        r = await c.get(f'{base}/noop')
-        assert r.status_code == 200
-        # No Set-Cookie header in the response — the session was read but
-        # never modified, so no need to round-trip a new cookie.
-        assert 'set-cookie' not in {k.lower() for k in r.headers}, (
-            f'unmodified session must not emit Set-Cookie; got headers={dict(r.headers)}')
+def test_clear_emits_tombstone(client):
+    client.get('/set')
+    assert 'session' in client.cookies
+
+    r = client.get('/clear')
+    assert r.status_code == 200
+    # After /clear the server sets Max-Age=0 → httpx's cookie jar
+    # interprets that as expiration and drops it.
+    assert 'session' not in client.cookies, (
+        f'cleared session must not persist; jar={dict(client.cookies)}')
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_tampered_cookie_treated_as_empty(session_app):
-    base = f'http://127.0.0.1:{session_app.port}'
-    async with httpx.AsyncClient() as c:
-        # Set a real cookie first, then mangle the MAC.
-        await c.get(f'{base}/set')
-        real = c.cookies.get('session')
+def test_unmodified_session_does_not_emit_set_cookie(client):
+    r = client.get('/noop')
+    assert r.status_code == 200
+    # No Set-Cookie header in the response — the session was read but
+    # never modified, so no need to round-trip a new cookie.
+    assert 'set-cookie' not in {k.lower() for k in r.headers}, (
+        f'unmodified session must not emit Set-Cookie; got headers={dict(r.headers)}')
+
+
+@pytest.mark.integration
+def test_tampered_cookie_treated_as_empty():
+    # New client so the tampered cookie is the only one in the jar.
+    with TestClient(_make_app()) as c1:
+        c1.get('/set')
+        real = c1.cookies.get('session')
         assert real is not None
-        # Replace the MAC half with zeros.
         payload, _, mac = real.partition('.')
         tampered = payload + '.' + '0' * len(mac)
-        # New client with the tampered cookie only.
-        async with httpx.AsyncClient(cookies={'session': tampered}) as c2:
-            r = await c2.get(f'{base}/get')
-            # The middleware silently drops the tampered session →
-            # empty dict → handler sees None for both keys.
-            assert r.text == 'user=None count=None'
+
+    with TestClient(_make_app(), cookies={'session': tampered}) as c2:
+        r = c2.get('/get')
+        # The middleware silently drops the tampered session →
+        # empty dict → handler sees None for both keys.
+        assert r.text == 'user=None count=None'

--- a/tests/integration/test_trusted_proxy.py
+++ b/tests/integration/test_trusted_proxy.py
@@ -1,17 +1,18 @@
 """Integration tests for TrustedProxy — X-Forwarded-* header rewriting."""
-import asyncio
-from multiprocessing import Process
-
-import httpx
 import pytest
 
-from blackbull import BlackBull, JSONResponse
+from blackbull import BlackBull
 from blackbull.middleware.proxy import TrustedProxy
-from .conftest import live_server
+from blackbull.testing import TestClient
 
 
 def _make_app_trusted() -> BlackBull:
-    """App that trusts 127.0.0.1 (the loopback default)."""
+    """App that trusts 127.0.0.1 (the loopback default).
+
+    ``httpx.ASGITransport`` sets ``scope['client']`` to ``('127.0.0.1', 123)``
+    by default, so 127.0.0.1 in the trust list is what makes TestClient
+    requests appear to come from a trusted peer.
+    """
     app = BlackBull()
     app.use(TrustedProxy(['127.0.0.1', '::1']))
 
@@ -27,7 +28,8 @@ def _make_app_trusted() -> BlackBull:
 
 
 def _make_app_untrusted() -> BlackBull:
-    """App that trusts only 10.0.0.1 — so 127.0.0.1 is NOT trusted."""
+    """App that trusts only 10.0.0.1 — so 127.0.0.1 (TestClient's default
+    peer) is NOT trusted."""
     app = BlackBull()
     app.use(TrustedProxy(['10.0.0.1']))
 
@@ -39,52 +41,35 @@ def _make_app_untrusted() -> BlackBull:
 
 
 @pytest.fixture(scope="module")
-def live_trusted():
-    app = _make_app_trusted()
-    with live_server(app) as handle:
-        yield handle
+def trusted():
+    with TestClient(_make_app_trusted()) as c:
+        yield c
+
+
 @pytest.fixture(scope="module")
-def live_untrusted():
-    app = _make_app_untrusted()
-    with live_server(app) as handle:
-        yield handle
-def _base(app) -> str:
-    return f'http://127.0.0.1:{app.port}'
+def untrusted():
+    with TestClient(_make_app_untrusted()) as c:
+        yield c
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_x_forwarded_for_rewritten(live_trusted):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live_trusted)}/client-ip',
-            headers={'X-Forwarded-For': '203.0.113.1'},
-        )
+def test_x_forwarded_for_rewritten(trusted):
+    r = trusted.get('/client-ip', headers={'X-Forwarded-For': '203.0.113.1'})
     assert r.status_code == 200
     assert r.json()['ip'] == '203.0.113.1'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_x_forwarded_proto_rewritten(live_trusted):
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live_trusted)}/scheme',
-            headers={'X-Forwarded-Proto': 'https'},
-        )
+def test_x_forwarded_proto_rewritten(trusted):
+    r = trusted.get('/scheme', headers={'X-Forwarded-Proto': 'https'})
     assert r.status_code == 200
     assert r.json()['scheme'] == 'https'
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_untrusted_sender_header_ignored(live_untrusted):
+def test_untrusted_sender_header_ignored(untrusted):
     """When the peer is not trusted, X-Forwarded-For must not rewrite scope['client']."""
-    async with httpx.AsyncClient() as c:
-        r = await c.get(
-            f'{_base(live_untrusted)}/client-ip',
-            headers={'X-Forwarded-For': '203.0.113.99'},
-        )
+    r = untrusted.get('/client-ip', headers={'X-Forwarded-For': '203.0.113.99'})
     assert r.status_code == 200
-    # The IP should be 127.0.0.1 (the actual peer), not the forwarded value
+    # The IP should be the actual peer (127.0.0.1), not the forwarded value.
     assert r.json()['ip'] != '203.0.113.99'

--- a/tests/properties/test_handler_return_types.py
+++ b/tests/properties/test_handler_return_types.py
@@ -23,13 +23,16 @@ def _make_send():
     """Return a (_wrap_send-wrapped send, body_parts list).
 
     _adapt_handler passes Response/JSONResponse objects to send; _wrap_send
-    unpacks them into (body, status, headers) calls on the underlying raw_send.
+    decomposes them into standard ASGI ``http.response.start`` +
+    ``http.response.body`` event dicts on the underlying raw_send.
     """
     body_parts = []
 
-    async def raw_send(body_or_event, status=None, headers=None):
-        if isinstance(body_or_event, (bytes, bytearray)):
-            body_parts.append(bytes(body_or_event))
+    async def raw_send(event):
+        if isinstance(event, dict) and event.get('type') == 'http.response.body':
+            body = event.get('body', b'')
+            if body:
+                body_parts.append(bytes(body))
 
     return _wrap_send(raw_send), body_parts
 

--- a/tests/unit/test_error_routing.py
+++ b/tests/unit/test_error_routing.py
@@ -8,9 +8,17 @@ Unit tests for registration and lookup by HTTPStatus and exception class/instanc
 
 BlackBull error dispatch
 ------------------------
-Integration tests that verify the correct handler is called for 404, 405,
-and custom on_error registrations, using an in-process ASGI call rather than
-a real server so there are no port or subprocess concerns.
+Two layers of coverage:
+
+* **TestClient-based** (``TestBlackBullErrorDispatchViaTestClient``) —
+  exercises 404 / 405 / exception dispatch through the public
+  ``blackbull.testing.TestClient`` surface.  These are the
+  dogfooding tests for the TestClient feature.
+
+* **Raw ASGI** (``TestBlackBullErrorDispatch``) — exercises scope
+  inspection (``scope['state']['allowed_methods']``,
+  ``scope['state']['error_exception']``) that the TestClient public
+  API does not expose.  Kept for internal error-routing coverage.
 """
 
 import pytest
@@ -18,6 +26,7 @@ from http import HTTPStatus, HTTPMethod
 
 from blackbull.router import ErrorRouter
 from blackbull.app import BlackBull, _default_error_handler
+from blackbull.testing import TestClient
 from blackbull.utils import Scheme
 
 
@@ -300,95 +309,79 @@ class TestBlackBullErrorDispatch:
         app = BlackBull()
 
         @app.route(path='/hello', methods=[HTTPMethod.GET])
-        async def hello(scope, receive, send):
-            await send(b'hello', HTTPStatus.OK)
+        async def hello():
+            return 'hello'
 
         @app.route(path='/post-only', methods=[HTTPMethod.POST])
-        async def post_only(scope, receive, send):
-            await send(b'posted', HTTPStatus.OK)
+        async def post_only():
+            return 'posted'
 
         return app
 
-    @pytest.mark.asyncio
-    async def test_404_calls_default_handler(self):
-        app = self._make_app()
-        scope = _make_scope('/nonexistent')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        assert send.status == 404
+    # -- Tests replaced with TestClient (same guarantees, public API) -----
 
-    @pytest.mark.asyncio
-    async def test_404_calls_custom_on_error_handler(self):
+    def test_404_calls_default_handler(self):
         app = self._make_app()
-        called = []
+        with TestClient(app) as client:
+            response = client.get('/nonexistent')
+        assert response.status_code == 404
+
+    def test_404_calls_custom_on_error_handler(self):
+        app = self._make_app()
 
         @app.on_error(HTTPStatus.NOT_FOUND)
         async def custom_404(scope, receive, send):
-            called.append(True)
             await send(b'custom not found', HTTPStatus.NOT_FOUND)
 
-        scope = _make_scope('/nonexistent')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        assert called, "custom on_error handler was not called"
-        assert send.status == 404
-        assert send.body == b'custom not found'
+        with TestClient(app) as client:
+            response = client.get('/nonexistent')
+        assert response.status_code == 404
+        assert response.text == 'custom not found'
 
-    @pytest.mark.asyncio
-    async def test_405_returns_method_not_allowed(self):
+    def test_405_returns_method_not_allowed(self):
         """GET to a POST-only route must yield 405, not 404."""
         app = self._make_app()
-        scope = _make_scope('/post-only', method='GET')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        assert send.status == 405
+        with TestClient(app) as client:
+            response = client.get('/post-only')
+        assert response.status_code == 405
 
-    @pytest.mark.asyncio
-    async def test_405_allow_header_lists_registered_methods(self):
+    def test_405_allow_header_lists_registered_methods(self):
         app = self._make_app()
-        scope = _make_scope('/post-only', method='GET')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        start = next(e for e in send.events if e['type'] == 'http.response.start')
-        headers = dict(start['headers'])
-        assert b'allow' in headers
-        assert b'POST' in headers[b'allow'].upper()
+        with TestClient(app) as client:
+            response = client.get('/post-only')
+        assert response.status_code == 405
+        assert 'allow' in response.headers
+        assert 'POST' in response.headers['allow'].upper()
 
-    @pytest.mark.asyncio
-    async def test_405_calls_custom_on_error_handler(self):
+    def test_405_calls_custom_on_error_handler(self):
         app = self._make_app()
-        called = []
 
         @app.on_error(HTTPStatus.METHOD_NOT_ALLOWED)
         async def custom_405(scope, receive, send):
-            called.append(scope['state'].get('allowed_methods'))
             await send(b'custom 405', HTTPStatus.METHOD_NOT_ALLOWED)
 
-        scope = _make_scope('/post-only', method='GET')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        assert called, "custom 405 handler was not called"
-        assert send.body == b'custom 405'
+        with TestClient(app) as client:
+            response = client.get('/post-only')
+        assert response.status_code == 405
+        assert response.text == 'custom 405'
 
-    @pytest.mark.asyncio
-    async def test_exception_in_handler_calls_error_router(self):
+    def test_exception_in_handler_calls_error_router(self):
         app = self._make_app()
-        caught = []
 
         @app.on_error(RuntimeError)
         async def handle_runtime(scope, receive, send):
-            caught.append(scope['state'].get('error_exception'))
             await send(b'runtime error caught', HTTPStatus.INTERNAL_SERVER_ERROR)
 
         @app.route(path='/boom')
-        async def boom(scope, receive, send):
+        async def boom():
             raise RuntimeError("kaboom")
 
-        scope = _make_scope('/boom')
-        send = _CaptureSend()
-        await app(scope, None, send)
-        assert caught, "error handler for RuntimeError was not called"
-        assert isinstance(caught[0], RuntimeError)
+        with TestClient(app) as client:
+            response = client.get('/boom')
+        assert response.status_code == 500
+        assert response.text == 'runtime error caught'
+
+    # -- Tests kept as raw ASGI (need scope['state'] inspection) -----------
 
     @pytest.mark.asyncio
     async def test_on_error_with_exception_base_class_catches_subclass(self):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -116,40 +116,44 @@ def test_cookie_header_path():
 
 @pytest.mark.asyncio
 async def test_wrap_send_unpacks_response():
+    """A Response object becomes a standard ASGI start + body event pair."""
     calls = []
 
-    async def raw(body, status=HTTPStatus.OK, headers=[]):
-        calls.append((body, status, headers))
+    async def raw(event):
+        calls.append(event)
 
     r = Response(b'hi', status=HTTPStatus.CREATED)
     await _wrap_send(raw)(r)
-    assert len(calls) == 1
-    body, status, headers = calls[0]
-    assert body == b'hi'
-    assert status == HTTPStatus.CREATED
-    assert (b'content-type', b'text/html; charset=utf-8') in headers
+    assert len(calls) == 2
+    start, body = calls
+    assert start['type'] == 'http.response.start'
+    assert start['status'] == int(HTTPStatus.CREATED)
+    assert (b'content-type', b'text/html; charset=utf-8') in start['headers']
+    assert body == {'type': 'http.response.body', 'body': b'hi'}
 
 
 @pytest.mark.asyncio
 async def test_wrap_send_unpacks_jsonresponse():
     calls = []
 
-    async def raw(body, status=HTTPStatus.OK, headers=[]):
-        calls.append((body, status, headers))
+    async def raw(event):
+        calls.append(event)
 
     r = JSONResponse({'ok': True}, status=HTTPStatus.UNAUTHORIZED)
     await _wrap_send(raw)(r)
-    body, status, headers = calls[0]
-    assert body == b'{"ok": true}'
-    assert status == HTTPStatus.UNAUTHORIZED
-    assert (b'content-type', b'application/json') in headers
+    assert len(calls) == 2
+    start, body = calls
+    assert start['status'] == int(HTTPStatus.UNAUTHORIZED)
+    assert (b'content-type', b'application/json') in start['headers']
+    assert body['body'] == b'{"ok": true}'
 
 
 @pytest.mark.asyncio
 async def test_wrap_send_passes_dict_through():
+    """Standard ASGI event dicts forward unchanged to the raw send callable."""
     calls = []
 
-    async def raw(event, status=HTTPStatus.OK, headers=[]):
+    async def raw(event):
         calls.append(event)
 
     evt = {'type': 'http.response.start', 'status': 200, 'headers': []}
@@ -159,13 +163,16 @@ async def test_wrap_send_passes_dict_through():
 
 @pytest.mark.asyncio
 async def test_wrap_send_passes_bytes_through():
+    """Bytes are emitted as a start + body event pair carrying the bytes payload."""
     calls = []
 
-    async def raw(body, status=HTTPStatus.OK, headers=[]):
-        calls.append(body)
+    async def raw(event):
+        calls.append(event)
 
     await _wrap_send(raw)(b'raw bytes')
-    assert calls[0] == b'raw bytes'
+    assert len(calls) == 2
+    assert calls[0]['type'] == 'http.response.start'
+    assert calls[1] == {'type': 'http.response.body', 'body': b'raw bytes'}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_slots_microbench.py
+++ b/tests/unit/test_slots_microbench.py
@@ -1,0 +1,163 @@
+"""Regression + sizing for hot-path classes that use ``__slots__``.
+
+The classes under test are allocated per HTTP/2 stream or per HTTP/1.1
+response and therefore live on the request hot path; dropping the
+per-instance ``__dict__`` saves both bytes and ``dict_setitem`` work
+on every construction.  The assertions here are regression guards —
+if a future change reintroduces ``__dict__`` (e.g. by adding an attribute
+without extending ``__slots__``), the test fails before the perf
+regression hits a benchmark.
+
+The printed sizes are informational only: ``sys.getsizeof`` reports the
+base object size, not the recursive footprint of the slot values, but
+that's the dimension this sprint set out to compress.
+"""
+import sys
+
+import pytest
+
+from blackbull.protocol.stream import Stream
+from blackbull.server.sender import (
+    AbstractWriter,
+    HTTP1Sender,
+    HTTP2Sender,
+    WebSocketSender,
+)
+
+
+class _FakeWriter(AbstractWriter):
+    """Stand-in for ``AbstractWriter`` — the senders only need an object
+    to bind to ``self._writer``; they don't call into it during construction.
+    Inherits from ``AbstractWriter`` so beartype's ``writer: AbstractWriter``
+    parameter check on ``HTTP1Sender.__init__`` is satisfied.
+    """
+    async def write(self, data: bytes) -> None:  # pragma: no cover - test stub
+        return None
+
+    async def writelines(self, parts) -> None:  # pragma: no cover - test stub
+        return None
+
+    async def drain(self) -> None:  # pragma: no cover - test stub
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Slots-in-effect regression: __dict__ must be absent on instances.
+# ---------------------------------------------------------------------------
+
+def test_stream_has_no_dict():
+    s = Stream(1)
+    assert not hasattr(s, '__dict__'), (
+        '__dict__ resurfaced on Stream; an attribute was added to __init__ '
+        'without extending __slots__.'
+    )
+    assert hasattr(Stream, '__slots__')
+
+
+def test_http1_sender_has_no_dict():
+    s = HTTP1Sender(_FakeWriter())
+    assert not hasattr(s, '__dict__'), (
+        '__dict__ resurfaced on HTTP1Sender; check BaseSender and '
+        'HTTP1Sender __slots__ declarations.'
+    )
+
+
+def test_http2_sender_has_no_dict():
+    from blackbull.protocol.frame import FrameFactory
+    s = HTTP2Sender(_FakeWriter(), FrameFactory(), stream_id=1)
+    assert not hasattr(s, '__dict__'), (
+        '__dict__ resurfaced on HTTP2Sender; check BaseSender and '
+        'HTTP2Sender __slots__ declarations.'
+    )
+
+
+def test_websocket_sender_has_no_dict():
+    s = WebSocketSender(_FakeWriter())
+    assert not hasattr(s, '__dict__'), (
+        '__dict__ resurfaced on WebSocketSender; check BaseSender and '
+        'WebSocketSender __slots__ declarations.'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sizing report — printed under -s, not asserted (machine-dependent).
+# ---------------------------------------------------------------------------
+
+def _sizeof(obj):
+    """Best-effort per-instance size including the slot-storage descriptor.
+
+    ``sys.getsizeof`` on a slot-equipped instance returns just the
+    fixed-size object header + the inline slot pointers; the values the
+    slots point at are not included.  For documentation that's the
+    dimension we want — it characterises the per-instance overhead the
+    framework pays for *holding* one of these objects, not the cost of
+    the values themselves.
+    """
+    return sys.getsizeof(obj)
+
+
+def test_print_per_instance_sizes(capsys):
+    from blackbull.protocol.frame import FrameFactory
+
+    sizes = {
+        'Stream':           _sizeof(Stream(1)),
+        'HTTP1Sender':      _sizeof(HTTP1Sender(_FakeWriter())),
+        'HTTP2Sender':      _sizeof(HTTP2Sender(_FakeWriter(), FrameFactory(), 1)),
+        'WebSocketSender':  _sizeof(WebSocketSender(_FakeWriter())),
+    }
+    # Print under pytest -s (or always — captured otherwise) so the values
+    # land in the test log when the sprint-close measurement is taken.
+    print('\nPer-instance sizes (sys.getsizeof, bytes):')
+    for name, size in sizes.items():
+        print(f'  {name:<20s} {size:>4d}')
+
+    # Loose upper bounds — guard against accidental dict resurrection.
+    # A ``__dict__``-equipped instance picks up ~56 bytes from the
+    # PyDictObject header alone on CPython 3.12, so any per-instance
+    # size above ~200 bytes here would suggest slots have been broken.
+    for name, size in sizes.items():
+        assert size < 200, (
+            f'{name} is {size} bytes — far above the slots-equipped '
+            f'baseline (~48-96 bytes); check that __slots__ is still in '
+            f'effect.'
+        )
+
+
+# ---------------------------------------------------------------------------
+# Functional smoke: a slot-equipped Stream must still support every
+# operation the priority tree depends on.
+# ---------------------------------------------------------------------------
+
+def test_stream_priority_tree_still_works():
+    root = Stream(0)
+    child = root.add_child(1)
+    grandchild = child.add_child(3)
+    assert root.find_child(3) is grandchild
+    assert grandchild.parent is child
+
+    # Closing should remove the child from its parent.
+    grandchild.close()
+    assert child.find_child(3) is None
+
+
+def test_stream_state_transitions_still_work():
+    from blackbull.protocol.stream import StreamState
+
+    s = Stream(1)
+    assert s.state is StreamState.IDLE
+    s.on_headers_received(end_stream=False)
+    assert s.state is StreamState.OPEN
+    s.on_data_received(end_stream=True)
+    assert s.state is StreamState.CLOSED
+
+
+def test_stream_rejects_undeclared_attribute():
+    """Hard regression: assigning an undeclared attribute must raise.
+
+    If this stops raising, ``__slots__`` has been silently broken (e.g.
+    by adding ``__dict__`` to the slots list) and the memory win is
+    gone.
+    """
+    s = Stream(1)
+    with pytest.raises(AttributeError):
+        s.brand_new_attribute = 1  # type: ignore[attr-defined]

--- a/tests/unit/test_testclient.py
+++ b/tests/unit/test_testclient.py
@@ -1,0 +1,250 @@
+"""Golden-path tests for ``blackbull.testing.TestClient``.
+
+The tests below double as the worked examples for the feature: they
+should be the first place a reader looks to learn how to use
+TestClient against a BlackBull app.
+"""
+
+from http import HTTPMethod
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.router import Scheme
+from blackbull.testing import TestClient, WebSocketDisconnect
+
+
+def _make_app() -> BlackBull:
+    """Construct a tiny app exercising the handler shapes TestClient cares about."""
+    app = BlackBull()
+
+    @app.route(path='/')
+    async def index():
+        return 'hello, world'
+
+    @app.route(path='/items/{item_id:int}')
+    async def get_item(item_id: int):
+        return {'id': item_id, 'kind': 'widget'}
+
+    @app.route(path='/echo', methods=[HTTPMethod.POST])
+    async def echo(body: bytes):
+        return body
+
+    @app.route(path='/echo-json', methods=[HTTPMethod.POST])
+    async def echo_json(scope, receive, send):
+        # Stream-aware variant — used to exercise httpx → ASGITransport
+        # full-body buffering with explicit start/body events.
+        chunks: list[bytes] = []
+        more_body = True
+        while more_body:
+            event = await receive()
+            chunks.append(event.get('body', b''))
+            more_body = event.get('more_body', False)
+        body = b''.join(chunks)
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [(b'content-type', b'application/json')],
+        })
+        await send({'type': 'http.response.body', 'body': body})
+
+    @app.route(path='/ws', scheme=Scheme.websocket)
+    async def ws_echo(scope, receive, send):
+        event = await receive()
+        if event['type'] != 'websocket.connect':
+            await send({'type': 'websocket.close', 'code': 1002})
+            return
+        await send({'type': 'websocket.accept'})
+        while True:
+            event = await receive()
+            t = event.get('type', '')
+            if t == 'websocket.disconnect':
+                return
+            if t == 'websocket.receive':
+                if event.get('text') is not None:
+                    await send({'type': 'websocket.send', 'text': event['text']})
+                elif event.get('bytes') is not None:
+                    await send({'type': 'websocket.send', 'bytes': event['bytes']})
+
+    @app.route(path='/ws-reject', scheme=Scheme.websocket)
+    async def ws_reject(scope, receive, send):
+        await receive()  # consume the websocket.connect
+        await send({'type': 'websocket.close', 'code': 4401})
+
+    @app.route(path='/ws-stream', scheme=Scheme.websocket)
+    async def ws_stream(scope, receive, send):
+        await receive()  # consume the websocket.connect
+        await send({'type': 'websocket.accept'})
+        for i in range(3):
+            await send({'type': 'websocket.send', 'text': f'msg-{i}'})
+        await send({'type': 'websocket.close', 'code': 1000})
+
+    @app.route(path='/ws-stream-bytes', scheme=Scheme.websocket)
+    async def ws_stream_bytes(scope, receive, send):
+        await receive()
+        await send({'type': 'websocket.accept'})
+        for i in range(3):
+            await send({'type': 'websocket.send', 'bytes': bytes([i, i, i])})
+        await send({'type': 'websocket.close', 'code': 1000})
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+def test_get_returns_text() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        response = client.get('/')
+    assert response.status_code == 200
+    assert response.text == 'hello, world'
+
+
+def test_path_param_coerced_and_json_response() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        response = client.get('/items/42')
+    assert response.status_code == 200
+    assert response.json() == {'id': 42, 'kind': 'widget'}
+
+
+def test_post_body_round_trip_via_simplified_handler() -> None:
+    app = _make_app()
+    payload = b'\x00\x01\x02the quick brown fox\xff'
+    with TestClient(app) as client:
+        response = client.post('/echo', content=payload)
+    assert response.status_code == 200
+    assert response.content == payload
+
+
+def test_post_streaming_body_via_full_form_handler() -> None:
+    app = _make_app()
+    payload = {'name': 'BlackBull', 'count': 3}
+    with TestClient(app) as client:
+        response = client.post('/echo-json', json=payload)
+    assert response.status_code == 200
+    assert response.headers['content-type'] == 'application/json'
+    assert response.json() == payload
+
+
+def test_404_for_unknown_path() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        response = client.get('/nope')
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# WebSocket
+# ---------------------------------------------------------------------------
+
+def test_websocket_text_round_trip() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws') as ws:
+            ws.send_text('hello')
+            assert ws.receive_text() == 'hello'
+
+
+def test_websocket_binary_round_trip() -> None:
+    app = _make_app()
+    payload = b'\x00\xff\x10\x20'
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws') as ws:
+            ws.send_bytes(payload)
+            assert ws.receive_bytes() == payload
+
+
+def test_websocket_json_helper() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws') as ws:
+            ws.send_json({'msg': 'ping', 'n': 1})
+            assert ws.receive_json() == {'msg': 'ping', 'n': 1}
+
+
+def test_websocket_iter_text_streams_until_close() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws-stream') as ws:
+            messages = list(ws.iter_text())
+    assert messages == ['msg-0', 'msg-1', 'msg-2']
+
+
+def test_websocket_iter_bytes_streams_until_close() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws-stream-bytes') as ws:
+            chunks = list(ws.iter_bytes())
+    assert chunks == [b'\x00\x00\x00', b'\x01\x01\x01', b'\x02\x02\x02']
+
+
+def test_websocket_rejected_raises_disconnect() -> None:
+    app = _make_app()
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect('/ws-reject'):
+                pass
+        assert excinfo.value.code == 4401
+
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+def test_lifespan_startup_and_shutdown_fire_once_each() -> None:
+    app = BlackBull()
+    events: list[str] = []
+
+    @app.on_startup
+    async def _startup() -> None:
+        events.append('startup')
+
+    @app.on_shutdown
+    async def _shutdown() -> None:
+        events.append('shutdown')
+
+    @app.route(path='/')
+    async def index():
+        return 'ok'
+
+    with TestClient(app) as client:
+        assert events == ['startup']
+        response = client.get('/')
+        assert response.status_code == 200
+    assert events == ['startup', 'shutdown']
+
+
+def test_app_without_lifespan_still_works() -> None:
+    """An ASGI app that doesn't speak the lifespan protocol must not break TestClient."""
+    async def app(scope, receive, send):
+        if scope['type'] == 'lifespan':
+            # Refuse to participate — return without acking startup.  This
+            # is the legacy ASGI-2.0 signal for "lifespan unsupported".
+            return
+        # http
+        await send({
+            'type': 'http.response.start',
+            'status': 200,
+            'headers': [(b'content-type', b'text/plain')],
+        })
+        await send({'type': 'http.response.body', 'body': b'no-lifespan'})
+
+    with TestClient(app) as client:
+        response = client.get('/')
+    assert response.status_code == 200
+    assert response.text == 'no-lifespan'
+
+
+def test_lifespan_startup_failure_surfaces() -> None:
+    app = BlackBull()
+
+    @app.on_startup
+    async def _boom() -> None:
+        raise RuntimeError('intentional startup failure')
+
+    with pytest.raises(RuntimeError, match='startup failed'):
+        with TestClient(app):
+            pass


### PR DESCRIPTION
## Summary

- **New public API `blackbull.testing.TestClient`** — synchronous in-memory ASGI 3.0 driver (HTTP + WebSocket + lifespan) modelled on Starlette/FastAPI's TestClient.  Used by the new unit suite and dogfooded across 14 integration test files (−271 net lines).
- **Three latent ASGI 3.0 compliance bugs fixed** in `BlackBull.__call__` surfaced by TestClient and required for any external ASGI server (uvicorn, hypercorn, httpx.ASGITransport) to work: `_wrap_send` now emits standard event dicts, `scope['headers']` is normalised to `Headers` once at the entry point, `parse_cookies` accepts both shapes.
- **`__slots__` on the per-stream / per-frame hot path** (`Stream`, `BaseSender`, `HTTP1Sender`, `HTTP2Sender`, `WebSocketSender`) with regression micro-bench.  `StreamActor` / `HTTP2Actor` deferred — per-connection, not per-stream.
- **`KNOWN_LIMITATIONS.md` rewrite** to user-facing only: 209 → 157 lines, sprint refs / WSL2 measurements / peer-framework comparisons all moved into sprint logs and `bench/CHARACTERIZATION.md`.

## Commits (in order)

1. `fix(app)` — ASGI 3.0 compliance: `_wrap_send` emits dicts, scope headers normalised, `parse_cookies` dual-shape.
2. `feat(testing)` — `blackbull.testing.TestClient` + `WebSocketTestSession` + `iter_text` / `iter_bytes` + 14 golden-path unit tests + doc-page rewrite + unit-level dogfood in `test_error_routing.py`.
3. `test(integration)` — 14 integration files converted from `live_server` + httpx to TestClient.
4. `perf(slots)` — `__slots__` + regression micro-bench (per-instance sizes: Stream 144 B, HTTP1Sender 96 B, HTTP2Sender 104 B, WebSocketSender 64 B).
5. `docs(known-limitations)` — user-facing rewrite, restructured "Deployment notes" section.

## Test plan

- [x] `tests/unit` — 891 passed (incl. new TestClient + slots micro-bench)
- [x] `tests/architecture` + `tests/conformance` + `tests/properties` — 373 passed, 88 skipped
- [x] `tests/integration` (incl. converted + remaining socket-bound) — 115 passed
- [x] `mkdocs build --strict` — same 5 pre-existing warnings, no new ones
- [x] Pre-commit hook (full suite + `--beartype-packages=blackbull`) green on every commit

Ships as **v0.32.0** (minor bump because of the new public `blackbull.testing` surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)