### PR TITLE
release: v0.33.0 — Sprint 37: defaults reset to RFC/kernel baselines, static cache opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,109 @@ so the editable install's metadata catches up.
 
 ---
 
+## [0.33.0] — 2026-06-12
+
+**Sprint 37 — defaults reset to RFC / kernel baselines; static
+body cache becomes opt-in.**
+
+This release moves BlackBull's defaults from a benchmark-tuned
+posture to RFC 7540 / Linux kernel baselines, so a fresh install
+behaves predictably regardless of host tuning state and the
+framework can stand on its architecture alone.  The previous
+tuned values are preserved as documented production
+recommendations.
+
+### Changed
+
+- **`StaticFiles` body cache is now opt-in** (default
+  `cache=False`).  `app.static(url_prefix, root_dir)` reads files
+  from disk on every request unless explicitly opted in via
+  `app.static(url_prefix, root_dir, cache=True)`.  Sibling
+  existence (for `.br` / `.zst` / `.gz` precompressed serving) is
+  recomputed per-request when the cache is off; memoised when on.
+  Most production deployments terminate static traffic at nginx
+  or a CDN and won't notice — standalone setups that previously
+  benefitted from the in-process cache should opt in to keep
+  prior performance.  See
+  [`docs/guide/static-files.md`](docs/guide/static-files.md) for
+  the full discussion.
+
+- **Seven framework defaults reset to platform baselines**:
+
+  | Setting | Pre-0.33 | 0.33 | Baseline source |
+  |---|---|---|---|
+  | `BB_SOCKET_BACKLOG` | 4096 | 128 | kernel `net.core.somaxconn` traditional default |
+  | `BB_SOCKET_SNDBUF` | 262144 | 0 | kernel default (unchanged unless set) |
+  | `BB_SOCKET_RCVBUF` | 262144 | 0 | kernel default (unchanged unless set) |
+  | `BB_SOCKET_REUSEPORT` | True | False | kernel default |
+  | `BB_TCP_USER_TIMEOUT_MS` | 60000 | 0 | kernel default (off) |
+  | `BB_H2_INITIAL_WINDOW_SIZE` | 1048576 | 65535 | RFC 7540 §6.9.2 |
+  | `BB_H2_CONNECTION_WINDOW_SIZE` | 4194304 | 65535 | RFC 7540 §6.9.2 minimum |
+
+  Production deployments that need throughput should set these
+  explicitly — the previous values plus per-variable rationale
+  are documented under "Performance recommendations" in
+  [`docs/reference/env-vars.md`](docs/reference/env-vars.md).
+
+- **`BB_FRAME_YIELD_EVERY`, `BB_COMPRESSION_MAX_INFLIGHT`,
+  `BB_KEEP_ALIVE_TIMEOUT` deliberately kept** at their previous
+  values (8, `cpu*2`, 5.0 respectively).  These are
+  correctness / fairness / safety mechanisms (cooperative-yield
+  fairness, compression-offload backpressure cap, keep-alive
+  idle timer), not numerical optimisations above a platform
+  baseline.
+
+### Added
+
+- `cache` keyword parameter on
+  [`StaticFiles.__init__`](blackbull/middleware/static.py) and
+  [`app.static()`](blackbull/app.py) — opt in to the in-process
+  body cache for standalone deployments that serve static
+  traffic directly.
+
+- [`docs/guide/static-files.md`](docs/guide/static-files.md) —
+  rewrote "In-memory cache" as an opt-in feature with explicit
+  when-to-turn-on / when-to-leave-off guidance.  New
+  "Precompressed sibling serving" section documenting
+  `.br` / `.zst` / `.gz` lookup as an official feature (same
+  pattern as nginx's `gzip_static` / `brotli_static`), including
+  the Range-bypass and `Vary: Accept-Encoding` behaviour.
+
+- [`docs/reference/env-vars.md`](docs/reference/env-vars.md) —
+  new "Performance recommendations" section that documents the
+  pre-0.33 tuned values as production tuning targets with
+  per-variable rationale.
+
+### Tests
+
+- 1,268 tests pass on the release commit, 196 skipped
+  (testcontainer-gated), 0 failures.
+- Two H/2 architecture handshake tests reshaped to set non-default
+  values via `monkeypatch.setenv` + `reset_settings_cache()` and
+  assert the actor honours the configured value, instead of
+  tautologically asserting "value > RFC default" (which used to
+  pass by coincidence on the tuned defaults).  The new shape is
+  the right pattern for any future test reading framework-default
+  numerics — assert behaviour, not magic constants.
+
+### Notes
+
+- **Migration**: standalone deployments serving static files
+  directly should pass `cache=True` to `app.static(...)` to keep
+  prior performance.  Deployments behind nginx / a CDN are
+  unaffected — static traffic doesn't reach the framework on
+  that topology.
+- **Production tuning**: deployments that previously implicitly
+  benefitted from the tuned socket / H/2 window defaults should
+  set the recommended env vars explicitly — see
+  `docs/reference/env-vars.md` "Performance recommendations" for
+  the recipe.
+- BlackBull has no production users yet (per `CLAUDE.md`, this
+  is a personal learning project) so the default flip doesn't
+  break anyone in the wild.
+
+---
+
 ## [0.32.0] — 2026-06-11
 
 **Sprint 36 close — `TestClient`, per-stream `__slots__`, ASGI 3.0

--- a/bench/CHARACTERIZATION.md
+++ b/bench/CHARACTERIZATION.md
@@ -329,3 +329,63 @@ References:
 - TechEmpower Framework Benchmarks — <https://www.techempower.com/benchmarks/>
 - Granian benchmarks — <https://github.com/emmett-framework/granian/tree/master/benchmarks>
 - Vibora benchmarks — <https://github.com/vibora-io/benchmarks>
+
+## HttpArena submission scope and KNOWN_LIMITATIONS
+
+BlackBull's HttpArena framework directory lives at
+[`bench/httparena/`](httparena/) and is structured to be vendorable
+under [`MDA2AV/HttpArena`](https://github.com/MDA2AV/HttpArena) at
+`frameworks/blackbull/`.
+
+### Profiles claimed
+
+The `meta.json` `tests` array enumerates exactly what BlackBull
+claims:
+
+```
+baseline, pipelined, limited-conn, json, json-comp, json-tls,
+upload, static, baseline-h2, static-h2, echo-ws
+```
+
+`validate.sh blackbull` passes 47/47 on this set (last run:
+2026-06-11 on WSL2 against MDA2AV/HttpArena HEAD).
+
+### Profiles BlackBull does NOT claim, and why
+
+| Profile | Why not |
+|---|---|
+| `baseline-h2c`, `json-h2c` | Runtime-capable on the `:8082` listener BlackBull opens (see below), but not yet characterised on EC2.  Hold until the core set lands, then revisit. |
+| `static-h3`, `baseline-h3` | HTTP/3 / QUIC transport is intentionally out-of-scope per the roadmap "Items intentionally out of scope" table.  Not coming. |
+| `async-db`, `crud`, `fortunes`, `api-4`, `api-16` | BlackBull is a protocol-layer framework, not full-stack.  No Postgres integration.  See the same out-of-scope table for the rationale. |
+| `*-grpc` | No gRPC support.  HTTP/2 trailers are queued for Sprint 38 as the prerequisite primitive; a full gRPC product is a multi-sprint decision deferred until a real user need surfaces. |
+| `gateway-*`, `production-stack` | Need sidecar + DB work first; same scope rationale as the DB profiles. |
+
+### The `:8082` h2c listener strategy
+
+HttpArena's `validate.sh` opens a port-existence probe on `:8082`
+for every framework regardless of which profiles the framework
+claims.  Pre-Sprint-37, BlackBull's launcher spawned only :8080 /
+:8081 / :8443 — auto-detect on :8080 *could* answer h2c
+prior-knowledge, but :8082 was closed, so validate.sh would mark
+the port unreachable.
+
+Sprint 37 added a 4th cleartext listener on :8082 using the same
+`app.py` + worker count.  BlackBull's HTTP/2 preface auto-detect
+handles h2c on the same code path as :8080; the port stays idle
+during benchmark runs that don't exercise it.  Claiming
+`baseline-h2c` / `json-h2c` in `meta.json` is deferred — see the
+table above.
+
+### Submission-mode files vs in-repo files
+
+The `bench/httparena/` directory contains both submission-bound
+files (`app.py`, `launcher.py`, `Dockerfile`, `requirements.txt`,
+`meta.json`, `README.md`) and sprint-internal tooling
+(`sprint37/`, throwaway probes from past sprints).  When vendoring,
+strip the sprint-internal subset.  The vendor command sequence is
+documented at [`bench/httparena/sprint37/README.md`](httparena/sprint37/README.md).
+
+`bench/httparena/meta.json` carries `enabled: false` in the
+BlackBull repo; the flip to `enabled: true` happens on the
+*vendored* copy at submission time, gated on two clean
+c7i.8xlarge benchmark runs reproducing within ±5 %.

--- a/bench/httparena/.dockerignore
+++ b/bench/httparena/.dockerignore
@@ -1,6 +1,7 @@
 # Build context = bench/httparena/.  Keep the image small: only
-# app.py + launcher.py are copied into the image.
+# requirements.txt + app.py + launcher.py are copied into the image.
 **
+!requirements.txt
 !app.py
 !launcher.py
 # Dev-only: a locally-built wheel for Dockerfile.dev.  Untracked.

--- a/bench/httparena/Dockerfile
+++ b/bench/httparena/Dockerfile
@@ -6,8 +6,8 @@
 #
 #   docker build -t blackbull-httparena bench/httparena/
 #
-# Run with HttpArena-shaped mounts (cleartext on :8080, TLS on :8081
-# and :8443):
+# Run with HttpArena-shaped mounts (cleartext HTTP/1.1 on :8080, h2c
+# on :8082, TLS HTTP/1.1 on :8081, TLS HTTP/2 on :8443):
 #
 #   docker run --rm --network host \
 #     -v $PWD/bench/httparena/_local/data:/data:ro \
@@ -17,22 +17,21 @@
 FROM python:3.13-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
 # Install BlackBull from PyPI — same install path real users follow.
-# Pin the version so the container is reproducible; bump in lockstep
-# with pyproject.toml on each release.  The [compression] extra pulls
-# brotli + zstandard for the json-comp profile.
-RUN pip install 'blackbull[compression]==0.28.0'
+# Pins live in requirements.txt; bump in lockstep with each release.
+# The [compression] extra pulls brotli + zstandard for the json-comp
+# profile.  --no-cache-dir keeps the pip cache out of the image layer.
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy framework files last so app/launcher edits don't bust the
 # slow pip layer.
 COPY app.py launcher.py ./
 
-EXPOSE 8080 8081 8443
+EXPOSE 8080 8081 8082 8443
 
 CMD ["python", "launcher.py"]

--- a/bench/httparena/README.md
+++ b/bench/httparena/README.md
@@ -1,12 +1,10 @@
-# BlackBull on HttpArena — local-only prep
+# BlackBull on HttpArena
 
-Sprint 27 Task 4 scaffold for cross-checking BlackBull numbers against
-the [HttpArena](https://www.http-arena.com/) benchmark harness.
-**Not yet a leaderboard submission** — `meta.json` keeps
-`"enabled": false`; the directory is here so future sprints can lift
-the contents into a `frameworks/blackbull/` PR against
-[`MDA2AV/HttpArena`](https://github.com/MDA2AV/HttpArena) without
-re-deriving the integration.
+BlackBull's framework integration for the
+[HttpArena](https://www.http-arena.com/) benchmark harness.  The
+directory is structured so it can be vendored under
+[`MDA2AV/HttpArena`](https://github.com/MDA2AV/HttpArena) at
+`frameworks/blackbull/` without further modification.
 
 ## Layout
 
@@ -33,10 +31,18 @@ profiles BlackBull's runtime supports today:
 | json            | GET `/json/{count}`    | ✓ |
 | json-tls        | GET `/json/{count}` on :8081 | ✓ |
 | upload          | POST `/upload`         | ✓ |
-| baseline-h2     | GET/POST `/baseline11` on :8081 (TLS, ALPN h2) | ✓ |
-| baseline-h2c    | GET `/baseline11`  on :8080 (h2 prior-knowledge) | ✓ |
-| json-h2c        | GET `/json/{count}` on :8080 (h2 prior-knowledge) | ✓ |
+| baseline-h2     | GET/POST `/baseline11` on :8443 (TLS, ALPN h2) | ✓ (claimed in `meta.json`) |
+| baseline-h2c    | GET `/baseline11`  on :8082 (h2 prior-knowledge) | runtime-capable; not claimed in `meta.json` yet |
+| json-h2c        | GET `/json/{count}` on :8082 (h2 prior-knowledge) | runtime-capable; not claimed in `meta.json` yet |
 | echo-ws         | GET `/ws` upgrade      | ✓ (re-exported via the standard BlackBull WS handler — TODO mount at `/ws` here) |
+
+A dedicated `:8082` cleartext listener is opened so HttpArena's
+`validate.sh` port-open probe succeeds.  BlackBull's preface
+auto-detect dispatches h2c connections through the HTTP/2 actor on
+the same app/workers as `:8080`; the port stays idle during
+benchmark runs that do not exercise h2c.  `baseline-h2c` /
+`json-h2c` are runtime-capable on `:8082` but currently unclaimed in
+`meta.json`.
 
 Profiles **not** implemented (intentional carve-out):
 
@@ -64,8 +70,8 @@ curl -fL -o bench/httparena/_local/data/dataset.json \
 cp tests/cert.pem bench/httparena/_local/certs/server.crt
 cp tests/key.pem  bench/httparena/_local/certs/server.key
 
-# Build (context = repo root).
-docker build -f bench/httparena/Dockerfile -t blackbull-httparena .
+# Build (context = this directory; BlackBull is pip-installed from PyPI).
+docker build -t blackbull-httparena bench/httparena/
 
 # Run with the documented mounts.
 docker run --rm --network host \
@@ -101,19 +107,13 @@ cd ~/work/HttpArena
 ./scripts/benchmark.sh blackbull baseline # one profile
 ```
 
-A future sprint will automate the vendoring step
-(`bench/httparena/sync.sh`) once we commit to a leaderboard PR.
-
 ## Versioning + apples-to-apples
 
-The container build pulls `pyproject.toml` from the repo root, so the
-image's `blackbull.__version__` matches whatever sprint commit was
-checked out at `docker build` time.  Record the commit SHA in
-`bench/results/httparena/<scenario>-<ts>/` alongside any captured
-numbers.
+The Dockerfile pins `blackbull[compression]` to an explicit PyPI
+version (currently `0.33.0`).  Bump the pin in lockstep with the
+upstream release whose behaviour you intend the container to
+exercise.
 
 `BB_ACCESS_LOG=0` is set by `app.py` to match the peer benchmark
-convention documented in
-[.claude/patterns/cautions.md](../../.claude/patterns/cautions.md)
-(Sprint 9 lesson — every peer disables access logging during
-benchmarks).
+convention — every peer in the HttpArena framework set disables
+access logging during benchmark runs.

--- a/bench/httparena/app.py
+++ b/bench/httparena/app.py
@@ -15,19 +15,17 @@ profiles BlackBull supports today:
 Dataset is read from $DATASET_PATH (default /data/dataset.json — the
 read-only mount HttpArena's harness provides).
 
-Profiles intentionally NOT implemented yet (out of scope for Sprint 27
-Task 4 — local-only environment prep):
+Profiles intentionally NOT implemented:
   - async-db / crud   (no asyncpg integration)
-  - static / static-h2 (no static-file middleware yet)
   - api-4 / api-16    (multi-endpoint compositions)
   - *-h3              (no HTTP/3 transport)
   - *-grpc            (no gRPC support)
   - production-stack / gateway / fortunes
 
-The container starts two BlackBull processes via ``launcher.py``:
-one cleartext on :8080, one TLS on :8081.  Cleartext also serves the
-``baseline-h2c`` and ``json-h2c`` profiles via h2c prior-knowledge (no
-upgrade dance — BlackBull negotiates HTTP/2 on first preface bytes).
+The container starts four BlackBull processes via ``launcher.py``:
+cleartext on :8080, h2c on :8082, TLS HTTP/1.1 on :8081, TLS HTTP/2
+on :8443.  Cleartext also serves h2c via prior-knowledge — BlackBull
+negotiates HTTP/2 on first preface bytes.
 """
 import argparse
 import json
@@ -36,9 +34,8 @@ import sys
 from http import HTTPMethod
 from urllib.parse import parse_qs
 
-# bench/httparena/app.py imports Scheme to register the WebSocket route
-# (`echo-ws` HttpArena profile).  Use the same Scheme.websocket sentinel
-# as bench/app.py / examples/ChatServer/.
+# Scheme.websocket is the BlackBull marker used by `@app.route` to
+# register the `echo-ws` HttpArena profile handler.
 from blackbull.utils import Scheme
 
 # Ensure the BlackBull source tree is importable when the Docker image
@@ -75,11 +72,11 @@ app = BlackBull()
 # the container has installed.  Bodies below min_size (default 100 bytes)
 # pass through, so /baseline11 + /pipeline aren't affected.
 #
-# Sprint 35 probe toggle: BB_NO_COMPRESSION=1 skips registering Compression
-# entirely.  Used to isolate the cost of on-the-fly brotli encoding for
-# already-compressed payloads (e.g. .woff2 fonts) that lack a precompressed
-# sibling.  NOT for benchmark publication — disabling a default-on feature
-# violates the apples-to-apples rule.
+# Diagnostic toggle: BB_NO_COMPRESSION=1 skips registering Compression
+# entirely.  Useful for isolating the cost of on-the-fly brotli encoding
+# on already-compressed payloads (e.g. .woff2 fonts) that lack a
+# precompressed sibling.  Not for benchmark publication — disabling a
+# default-on feature breaks the apples-to-apples convention.
 if os.environ.get('BB_NO_COMPRESSION', '0') != '1':
     app.use(Compression())
 
@@ -167,10 +164,9 @@ async def json_endpoint(count: int, scope):
 
 @app.route(path='/json-comp/{count:int}', methods=[HTTPMethod.GET])
 async def json_comp_endpoint(count: int, scope):
-    # Same payload as /json; compression middleware (gzip/brotli) is
-    # supposed to wrap the response.  Sprint 27 Task 4 leaves
-    # compression off — the json-comp profile won't be exercised
-    # against this image until a compression-mw pass is wired up.
+    # Same payload as /json; the Compression middleware registered
+    # at module top wraps the response with gzip / brotli / zstd per
+    # the client's Accept-Encoding.
     if not DATASET_ITEMS:
         return Response(_NO_DATASET, status=500, content_type=_PLAIN)
     try:
@@ -202,9 +198,9 @@ async def healthz():
     return Response(b'ok', content_type=_PLAIN)
 
 
-# HttpArena `echo-ws` profile — RFC 6455 WebSocket echo.  Mirrors
-# ws_echo in bench/app.py — first message after accept is the receive
-# loop; text frames echo as text, binary frames echo as bytes.
+# HttpArena `echo-ws` profile — RFC 6455 WebSocket echo.  First
+# message after accept is the receive loop; text frames echo as text,
+# binary frames echo as bytes.
 @app.route(path='/ws', methods=[HTTPMethod.GET], scheme=Scheme.websocket)
 async def ws_echo(scope, receive, send):
     event = await receive()
@@ -227,7 +223,7 @@ async def ws_echo(scope, receive, send):
 
 
 # ---------------------------------------------------------------------------
-# Entry point — invoked by launcher.py twice (cleartext and TLS).
+# Entry point — invoked by launcher.py once per listener port.
 # ---------------------------------------------------------------------------
 
 def _parse_args():
@@ -243,16 +239,14 @@ if __name__ == '__main__':
     args = _parse_args()
     # Match peer benchmark posture: access log off (apples-to-apples).
     os.environ.setdefault('BB_ACCESS_LOG', '0')
-    # Sprint 35 phase-trace probe needs the access logger to actually
-    # emit at INFO so AccessLogRecord.format() lines (with the
-    # ``[loop_start→parsed=Xw/Yc ...]`` trailer when BB_PHASE_TRACE=1)
-    # reach stderr where ``docker logs`` can capture them.  BlackBull's
-    # default level inheritance leaves ``blackbull.access`` at WARNING
-    # (effective), so emit_access_log() is gated off even when
-    # cfg.access_log is True.  Wire a dedicated stderr handler with
-    # propagate=False so the access stream is self-contained and
-    # doesn't double-emit through the QueueHandler on the parent
-    # 'blackbull' logger.
+    # When BB_ACCESS_LOG=1 is opted in (e.g. for diagnostic phase
+    # tracing under BB_PHASE_TRACE=1), the access logger needs an
+    # explicit INFO handler — BlackBull's default level inheritance
+    # leaves ``blackbull.access`` at WARNING (effective), so
+    # emit_access_log() is gated off even when cfg.access_log is True.
+    # Wire a dedicated stderr handler with propagate=False so the
+    # access stream is self-contained and doesn't double-emit through
+    # the QueueHandler on the parent 'blackbull' logger.
     if os.environ.get('BB_ACCESS_LOG') == '1':
         import logging as _bb_logging
         _bb_access = _bb_logging.getLogger('blackbull.access')

--- a/bench/httparena/launcher.py
+++ b/bench/httparena/launcher.py
@@ -4,16 +4,21 @@ HttpArena's `scripts/validate.sh` uses four ports:
 
   :8080  HTTP/1.1 cleartext (also serves h2c via prior-knowledge)
   :8081  HTTPS HTTP/1.1     — the ``json-tls`` profile probes here
-  :8082  h2c only           — we don't claim baseline-h2c / json-h2c
+  :8082  h2c only           — BlackBull's HTTP/2 preface auto-detect
+                              handles h2c on the same app/workers as
+                              :8080.  The dedicated :8082 listener is
+                              opened so validate.sh's port-open probe
+                              succeeds even when ``baseline-h2c`` /
+                              ``json-h2c`` profiles aren't claimed in
+                              ``meta.json``.
   :8443  HTTPS HTTP/2 ALPN  — ``baseline-h2`` / ``static-h2`` probe here
 
-FastAPI uses :8080 + :8081 only (they don't claim H/2 profiles).
-BlackBull claims both H/1.1+TLS and H/2+TLS, so we expose both
-:8081 and :8443 — same BlackBull, same cert, different listeners.
-ALPN negotiates HTTP/1.1 on :8081 connections and h2 on :8443.
+BlackBull claims both H/1.1+TLS and H/2+TLS, so :8081 and :8443 are
+exposed simultaneously — same BlackBull, same cert, different
+listeners.  ALPN negotiates HTTP/1.1 on :8081 connections and h2
+on :8443.
 
-Follows the same shape as the fastapi reference launcher: parallel
-``subprocess.Popen`` for each port, both terminated on SIGTERM/
+Parallel ``subprocess.Popen`` per port, all terminated on SIGTERM /
 SIGINT.  No port-readiness gating — BlackBull's bind happens in
 ``serve()`` as the first awaited step, so by the time the
 subprocess is alive the kernel TCP accept queue is open.
@@ -28,15 +33,16 @@ import time
 
 HTTP_PORT      = int(os.environ.get('HTTPARENA_HTTP_PORT',      '8080'))
 HTTPS_H1_PORT  = int(os.environ.get('HTTPARENA_HTTPS_H1_PORT',  '8081'))
+H2C_PORT       = int(os.environ.get('HTTPARENA_H2C_PORT',       '8082'))
 HTTPS_H2_PORT  = int(os.environ.get('HTTPARENA_HTTPS_H2_PORT',  '8443'))
 TLS_CERT       = os.environ.get('TLS_CERT', '/certs/server.crt')
 TLS_KEY        = os.environ.get('TLS_KEY',  '/certs/server.key')
 
-# Worker count — explicit override via WEB_WORKERS env var (Sprint 34
-# Cell B uses this to sweep nproc/2 / nproc / nproc×2).  Otherwise
-# honour cgroup-aware CPU affinity if the platform exposes it (Linux),
-# else fall back to multiprocessing.cpu_count().  Capped at 128 as a
-# sanity guard.
+# Worker count — explicit override via WEB_WORKERS env var (the
+# harness sets this when sweeping nproc/2 / nproc / nproc×2).
+# Otherwise honour cgroup-aware CPU affinity if the platform exposes
+# it (Linux), else fall back to multiprocessing.cpu_count().  Capped
+# at 128 as a sanity guard.
 _web_workers = os.environ.get('WEB_WORKERS', '').strip()
 if _web_workers.isdigit() and int(_web_workers) > 0:
     WRK_COUNT = min(int(_web_workers), 128)
@@ -49,12 +55,13 @@ else:
 PY = sys.executable
 APP = os.path.join(os.path.dirname(__file__), 'app.py')
 
-# Sprint 34 Cell B: which listeners to spawn.  HttpArena validate.sh
-# requires all three; benchmark profiles only ever load one at a time,
-# so disabling the idle two during a benchmark removes 2/3 of the
-# worker-process scheduler pressure.  Comma-separated list of
-# {"http","https-h1","https-h2"}; default = all three (back-compat).
-_ports_env = os.environ.get('BB_HTTPARENA_PORTS', 'http,https-h1,https-h2')
+# Which listeners to spawn.  validate.sh requires all four;
+# benchmark profiles only ever load one at a time, so disabling the
+# idle three during a benchmark removes most of the worker-process
+# scheduler pressure.  Comma-separated list of
+# {"http","https-h1","h2c","https-h2"}; default = all four (so
+# validate.sh's port-open probe finds :8082 listening).
+_ports_env = os.environ.get('BB_HTTPARENA_PORTS', 'http,https-h1,h2c,https-h2')
 _enabled_ports = {p.strip() for p in _ports_env.split(',') if p.strip()}
 
 
@@ -63,6 +70,7 @@ def _spawn(extra):
 
 
 http_proc       = _spawn(['--port', str(HTTP_PORT)]) if 'http' in _enabled_ports else None
+h2c_proc        = _spawn(['--port', str(H2C_PORT)])  if 'h2c'  in _enabled_ports else None
 https_h1_proc   = None
 https_h2_proc   = None
 if os.path.exists(TLS_CERT) and os.path.exists(TLS_KEY):
@@ -78,7 +86,7 @@ else:
         f'starting cleartext only\n')
 
 
-_PROCS = (http_proc, https_h1_proc, https_h2_proc)
+_PROCS = (http_proc, h2c_proc, https_h1_proc, https_h2_proc)
 
 
 def _shutdown(*_):
@@ -98,7 +106,7 @@ signal.signal(signal.SIGINT,  _shutdown)
 try:
     rc = http_proc.wait()
 finally:
-    for p in (https_h1_proc, https_h2_proc):
+    for p in (h2c_proc, https_h1_proc, https_h2_proc):
         if p is not None:
             p.terminate()
 sys.exit(rc)

--- a/bench/httparena/meta.json
+++ b/bench/httparena/meta.json
@@ -1,7 +1,8 @@
 {
   "display_name": "blackbull",
   "language": "Python",
-  "type": "production",
+  "type": "emerging",
+  "mode": "standard",
   "engine": "blackbull",
   "description": "BlackBull — from-scratch async ASGI 3.0 framework with native HTTP/1.1, HTTP/2 and WebSocket implementations.  Pure-Python protocol stack; ALPN negotiates HTTP/2 on the same listener that serves HTTP/1.1.",
   "repo": "https://github.com/TOKUJI/BlackBull",

--- a/bench/httparena/requirements.txt
+++ b/bench/httparena/requirements.txt
@@ -1,0 +1,1 @@
+blackbull[compression]==0.33.0

--- a/bench/httparena/sprint37/README.md
+++ b/bench/httparena/sprint37/README.md
@@ -1,0 +1,146 @@
+# Sprint 37 Phase B — EC2 c7i.8xlarge reproduction
+
+Two clean runs on c7i.8xlarge to confirm the HttpArena profile sweep
+reproduces within noise.  Per the
+[sprint-37 plan](../../sprint-logs/sprint-37.md) workstream 3.
+
+## Smoke first, then measure
+
+Before spending c7i.8xlarge dollars on a real measurement run, do
+one c7i.xlarge smoke run (~$0.18/hr vs $1.43/hr — 8× cheaper) to
+debug the script chain end-to-end.  The smoke run's goal is
+**validate.sh passes + benchmark.sh completes**, not benchmark
+numbers — c7i.xlarge has 4 vCPUs so the harness's `0-31,64-95`
+cpuset will clamp to "all cores" and r/s will be modest.  That's
+fine for proving the orchestrator + remote scripts work; flip to
+c7i.8xlarge once the smoke run is green.
+
+```bash
+# Smoke on c7i.xlarge first.
+INSTANCE_TYPE=c7i.xlarge TOPO=single bash bench/aws/up.sh
+bash bench/aws/install.sh    # BlackBull bench harness — NOT Docker
+bash bench/httparena/sprint37/sprint37_drive.sh smoke
+#   ↑ drive.sh internally uploads + execs sprint37_install_docker.sh
+#     (SSH session 1) and sprint37_remote.sh (SSH session 2).
+bash bench/aws/down.sh
+```
+
+If the smoke run completes without script-level errors, then:
+
+## Workflow
+
+```bash
+# Once: clone HttpArena and vendor BlackBull locally.
+git clone https://github.com/MDA2AV/HttpArena.git ~/work/HttpArena
+cp -r bench/httparena/* ~/work/HttpArena/frameworks/blackbull/
+# Drop the sprint-specific dev files from the vendor (validate.sh
+# does not need them and they don't ship upstream).
+( cd ~/work/HttpArena/frameworks/blackbull && \
+  rm -rf __pycache__ _local *.whl USAGE.md Dockerfile.dev monitor.sh \
+         postprocess.sh runner.sh patch_httparena.py sprint* logging_access.ini )
+# Flip the VENDORED meta.json's enabled flag to true; leave the
+# repo-local meta.json at enabled:false until merge.
+sed -i 's/"enabled": false/"enabled": true/' \
+    ~/work/HttpArena/frameworks/blackbull/meta.json
+
+# Once per run: provision EC2, run, tear down.
+# sprint37_drive.sh internally uploads + execs
+# sprint37_install_docker.sh (SSH session 1) and
+# sprint37_remote.sh (SSH session 2).
+INSTANCE_TYPE=c7i.8xlarge TOPO=single bash bench/aws/up.sh
+bash bench/aws/install.sh    # BlackBull bench harness — NOT Docker
+bash bench/httparena/sprint37/sprint37_drive.sh run1
+bash bench/aws/down.sh
+
+# Re-up for the second clean run (re-using the same instance after a
+# benchmark sweep contaminates page cache / kernel state more than is
+# worth — fresh instance is the cleaner reproducibility test).
+INSTANCE_TYPE=c7i.8xlarge TOPO=single bash bench/aws/up.sh
+bash bench/aws/install.sh    # BlackBull bench harness — NOT Docker
+bash bench/httparena/sprint37/sprint37_drive.sh run2
+bash bench/aws/down.sh
+```
+
+Results land at `bench/results/httparena/sprint37-run{1,2}-<ts>/`.
+Phase C diffs Run #1 vs Run #2 and decides whether to ship.
+
+## Expected cost
+
+c7i.8xlarge at ~$1.45/hr × ~2 hr per run × 2 runs ≈ **$6** plus
+EBS/data-transfer pennies.  Set a $20 cap if validate.sh failures
+cascade into multiple re-up cycles.
+
+## Why this scripted shape
+
+Per the `feedback_remote_scripts_via_upload` memory: write remote
+scripts as local files, upload, then exec with args.  Don't embed
+logic inside `ssh "..."` heredocs — escaping and backslash handling
+introduces unnecessary retries.
+
+`sprint37_drive.sh` runs locally — sources `bench/aws/config.sh`
+to pick up the canonical `SSH_OPTS` / `SSH_USER` / `LOCAL_KEY` set
+(the same interface every `bench/aws/*.sh` script uses), then:
+
+1. rsyncs the local HttpArena tree to the instance,
+2. uploads + execs `sprint37_install_docker.sh` (SSH session #1),
+3. uploads + execs `sprint37_remote.sh` (SSH session #2 — a
+   fresh login so the `usermod -aG docker` from step 2 is in
+   effect),
+4. rsyncs results back.
+
+`sprint37_install_docker.sh` runs on the instance — installs
+Docker Engine + adds the `ubuntu` user to the docker group.
+Idempotent.  Required because `bench/aws/install.sh` sets up
+BlackBull's bench harness (native Python), not Docker, and
+HttpArena's framework images need Docker.
+
+`sprint37_remote.sh` runs on the instance — sets
+`LOADGEN_DOCKER=true`, builds the framework image, runs
+validate.sh, iterates `scripts/benchmark.sh` over every profile
+claimed in `meta.json["tests"]`, sanity-checks that every produced
+result JSON reports `rps > 0` (catches silent loadgen failures),
+snapshots system info, tarballs the output dir.
+
+### Why `LOADGEN_DOCKER=true`?
+
+`bench/aws/install.sh` installs `h2load` and `wrk` natively, but
+not `gcannon` (HttpArena's io_uring HTTP/1.1 loadgen — needs
+liburing 2.9 + a source build).  Most BlackBull profiles route
+through gcannon (baseline, pipelined, limited-conn, json,
+json-comp, upload, echo-ws), so a missing gcannon makes
+`benchmark.sh` silently write `rps=0` and continue.
+
+`LOADGEN_DOCKER=true` is HttpArena's documented escape hatch:
+`benchmark.sh` falls back to the same docker images
+`benchmark-lite.sh` uses, and benchmark.sh builds whichever loadgen
+images are missing on first invocation.  Methodology note: docker
+loadgens add one IPC hop relative to native binaries, so absolute
+numbers won't exactly match the leaderboard (where MDA2AV runs
+native loadgens).  For our purposes — Run #1 vs Run #2
+reproducibility + framework integration — this is fine.  The
+maintainer re-runs benchmarks on his own hardware when accepting
+submissions, so absolute leaderboard parity isn't our deliverable.
+
+## What we capture per run
+
+- `validate.log` — full validate.sh output.
+- `bench-<profile>.log` — full benchmark.sh output per profile.
+- `results/` — copies of the JSON files HttpArena's harness writes.
+- `system.txt` — uname / nproc / meminfo / docker info / ulimit /
+  git head.  Makes the run self-describing if we revisit it months
+  later.
+- `remote.log` — tee'd shell trace of the whole remote pass.
+
+## Verifying we have a clean run
+
+Phase C diff criteria:
+
+- Per (profile, conns) cell, r/s within ±5 % across run1 and run2.
+- No profile that passed in run1 fails in run2 (or vice versa).
+- validate.sh green on both runs.
+
+If divergence is wider than ±5 %, **stop and investigate** before
+flipping `meta.json` enabled:true on the repo side.  The Sprint 35
+cautions show the static profile can present bimodal r/s under
+small samples — pin loadgen CPUs per the Sprint 34 caution and
+re-run if necessary.

--- a/bench/httparena/sprint37/sprint37_drive.sh
+++ b/bench/httparena/sprint37/sprint37_drive.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# bench/httparena/sprint37/sprint37_drive.sh — local orchestrator.
+#
+# Per the `feedback_remote_scripts_via_upload` memory: local files
+# uploaded, then exec'd with args.  No SSH heredocs.
+#
+# Assumes:
+#   - A clean c7i.8xlarge has already been provisioned via
+#     `INSTANCE_TYPE=c7i.8xlarge TOPO=single bash bench/aws/up.sh`.
+#   - The HttpArena clone exists locally at ~/work/HttpArena/.
+#   - The BlackBull framework is vendored at
+#     ~/work/HttpArena/frameworks/blackbull/.
+#   - ~/work/HttpArena/frameworks/blackbull/meta.json has
+#     enabled:true on the vendored copy (do NOT commit this to the
+#     BlackBull repo — only flip on the vendored side for the run).
+#
+# Args: <run_id>
+# e.g.  bash sprint37_drive.sh run1
+#       bash sprint37_drive.sh run2   # second clean instance, after re-up
+
+set -euo pipefail
+
+RUN_ID="${1:?run_id required, eg run1 / run2}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BB_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HARENA_LOCAL="${HOME}/work/HttpArena"
+
+# Source the bench/aws/ config.sh — sets SSH_USER, SSH_OPTS array,
+# LOCAL_KEY, STATE_FILE.  Then load .state for SERVER_PUBLIC_IP.
+# shellcheck source=../../aws/config.sh
+source "${BB_ROOT}/bench/aws/config.sh"
+_bench_aws_load_state
+
+SERVER_PUBLIC_IP="${SERVER_PUBLIC_IP:?SERVER_PUBLIC_IP not in $STATE_FILE — has up.sh been run?}"
+SERVER="${SSH_USER}@${SERVER_PUBLIC_IP}"
+
+# rsync's -e needs the SSH command as a single string; flatten SSH_OPTS.
+SSH_E="ssh ${SSH_OPTS[*]}"
+
+if [ ! -d "$HARENA_LOCAL" ]; then
+    echo "FAIL: $HARENA_LOCAL not found — clone with 'git clone https://github.com/MDA2AV/HttpArena.git ~/work/HttpArena' first" >&2
+    exit 1
+fi
+
+if [ ! -d "$HARENA_LOCAL/frameworks/blackbull" ]; then
+    echo "FAIL: BlackBull not vendored at $HARENA_LOCAL/frameworks/blackbull" >&2
+    exit 1
+fi
+
+# ── 1. rsync HttpArena (incl. vendored BlackBull) to the instance ───────────
+echo "=== rsync HttpArena to ${SERVER}:~/HttpArena/ ==="
+# Strip .git to keep the upload tight; the remote side doesn't need
+# history.  Pull the framework's local .dockerignore so the build
+# context matches the local one.
+rsync -az --delete \
+    --exclude='.git/' \
+    --exclude='results/' \
+    -e "$SSH_E" \
+    "${HARENA_LOCAL}/" \
+    "${SERVER}:~/HttpArena/"
+
+# ── 2a. Install Docker (separate SSH session so docker-group membership
+#       takes effect for the run session below) ────────────────────────────
+echo "=== upload + run sprint37_install_docker.sh ==="
+scp "${SSH_OPTS[@]}" \
+    "${SCRIPT_DIR}/sprint37_install_docker.sh" \
+    "${SERVER}:~/sprint37_install_docker.sh"
+# shellcheck disable=SC2029
+ssh "${SSH_OPTS[@]}" "$SERVER" "bash ~/sprint37_install_docker.sh"
+
+# ── 2b. Upload + exec the remote benchmark script in a FRESH SSH session
+#       so the user's group membership now includes docker ────────────────
+echo "=== upload sprint37_remote.sh ==="
+scp "${SSH_OPTS[@]}" \
+    "${SCRIPT_DIR}/sprint37_remote.sh" \
+    "${SERVER}:~/sprint37_remote.sh"
+
+echo "=== exec remote script (run id: $RUN_ID) ==="
+# shellcheck disable=SC2029
+ssh "${SSH_OPTS[@]}" "$SERVER" "bash ~/sprint37_remote.sh $RUN_ID"
+
+# ── 3. Pull the result tarball back ─────────────────────────────────────────
+LOCAL_OUT="${BB_ROOT}/bench/results/httparena/sprint37-${RUN_ID}-$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$LOCAL_OUT"
+echo "=== rsync results to $LOCAL_OUT ==="
+rsync -az -e "$SSH_E" \
+    "${SERVER}:~/sprint37-results-${RUN_ID}/" \
+    "${LOCAL_OUT}/"
+
+echo "=== done: results at $LOCAL_OUT ==="

--- a/bench/httparena/sprint37/sprint37_install_docker.sh
+++ b/bench/httparena/sprint37/sprint37_install_docker.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# bench/httparena/sprint37/sprint37_install_docker.sh — runs on EC2.
+#
+# `bench/aws/install.sh` sets up BlackBull's bench harness (native
+# Python).  HttpArena's framework images need Docker, which Ubuntu
+# 24.04 doesn't ship by default.  This script installs Docker
+# Engine + adds the `ubuntu` user to the docker group.
+#
+# Idempotent — safe to re-run; checks `docker version` before
+# installing, and `usermod -aG` is a no-op if already a member.
+#
+# IMPORTANT: group-membership changes take effect on the NEXT SSH
+# session.  The orchestrator (sprint37_drive.sh) runs this in one
+# session, then opens a fresh session for sprint37_remote.sh so
+# the bench user is in the docker group when validate.sh /
+# benchmark.sh invoke `docker` without sudo.
+
+set -euo pipefail
+
+if command -v docker >/dev/null 2>&1 && docker version >/dev/null 2>&1; then
+    echo "docker already installed and reachable"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "=== installing Docker Engine via official convenience script ==="
+    curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+    sudo sh /tmp/get-docker.sh
+    rm -f /tmp/get-docker.sh
+fi
+
+echo "=== enabling + starting docker.service ==="
+sudo systemctl enable --now docker
+
+echo "=== adding 'ubuntu' to docker group ==="
+sudo usermod -aG docker ubuntu
+
+echo "=== docker installed; group membership will be effective in next SSH session ==="
+docker --version || sudo docker --version

--- a/bench/httparena/sprint37/sprint37_remote.sh
+++ b/bench/httparena/sprint37/sprint37_remote.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# bench/httparena/sprint37/sprint37_remote.sh — runs on EC2 instance.
+#
+# One full HttpArena pass over the profiles claimed in
+# `~/HttpArena/frameworks/blackbull/meta.json`.  Builds the framework
+# image, validates, runs benchmark.sh per profile, writes results
+# under ~/sprint37-results-<run>/.
+#
+# The orchestrator (sprint37_drive.sh, runs locally) rsyncs the
+# HttpArena tree to ~/HttpArena/ and invokes this with the run id.
+#
+# Args: <run_id>
+# e.g.  bash sprint37_remote.sh run1
+
+set -euo pipefail
+
+RUN_ID="${1:?run_id required, eg run1 / run2}"
+HARENA_DIR="${HOME}/HttpArena"
+FRAMEWORK=blackbull
+OUT_DIR="${HOME}/sprint37-results-${RUN_ID}"
+
+if [ ! -d "$HARENA_DIR" ]; then
+    echo "FAIL: $HARENA_DIR not found; orchestrator should rsync the HttpArena tree first" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+exec > >(tee -a "$OUT_DIR/remote.log") 2>&1
+echo "=== sprint37 remote run $RUN_ID @ $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "=== host: $(hostname) — $(uname -srm) — $(nproc) cores ==="
+
+cd "$HARENA_DIR"
+
+# ── 0. Loadgen choice ───────────────────────────────────────────────────────
+# benchmark.sh defaults to NATIVE load-generator binaries.  `bench/aws/
+# install.sh` already installs h2load + wrk on the instance, but NOT
+# gcannon (which needs liburing 2.9 + a source build).  HttpArena's
+# documented escape hatch is LOADGEN_DOCKER=true: benchmark.sh falls
+# back to the same docker images benchmark-lite.sh uses.  First
+# invocation builds whichever loadgen images are missing on-demand.
+#
+# Methodology note: docker-mode loadgens are NOT exactly the same as
+# native-mode (one extra IPC layer).  For our purposes — Run #1 vs
+# Run #2 reproducibility check + framework integration validation —
+# this is fine.  The maintainer re-measures on his own hardware when
+# accepting submissions, so absolute leaderboard parity isn't our
+# deliverable.
+export LOADGEN_DOCKER=true
+echo "=== LOADGEN_DOCKER=true (docker-mode loadgens, gcannon image will build on first use) ==="
+
+# ── 1. Build the framework image ────────────────────────────────────────────
+echo "=== build image ==="
+docker build -t "httparena-${FRAMEWORK}" "frameworks/${FRAMEWORK}/"
+
+# ── 2. Run validate.sh ──────────────────────────────────────────────────────
+echo "=== validate ==="
+bash scripts/validate.sh "$FRAMEWORK" | tee "$OUT_DIR/validate.log"
+
+# ── 3. Run benchmark.sh per claimed profile ─────────────────────────────────
+# Extract the profile list from meta.json so this script doesn't drift if
+# we change what we claim.
+PROFILES=$(python3 -c "
+import json
+with open('frameworks/${FRAMEWORK}/meta.json') as f:
+    print(' '.join(json.load(f)['tests']))
+")
+echo "=== claimed profiles: $PROFILES ==="
+
+for prof in $PROFILES; do
+    echo "=== benchmark: $prof ==="
+    # `--save` persists the per-cell result JSONs to
+    # ~/HttpArena/results/<round>/<framework>/.  Without it,
+    # benchmark.sh runs in dry-run mode and writes nothing to disk
+    # (logs still print the numbers).
+    if bash scripts/benchmark.sh "$FRAMEWORK" "$prof" --save 2>&1 | tee "$OUT_DIR/bench-${prof}.log"; then
+        echo "OK $prof"
+    else
+        echo "WARN $prof exited non-zero — continuing"
+    fi
+done
+
+# Count how many profiles we asked for, so the JSON-count sanity
+# check below has something to compare against.
+PROFILE_COUNT=$(echo "$PROFILES" | wc -w)
+
+# ── 4. Collect HttpArena's own result JSONs ─────────────────────────────────
+# benchmark.sh writes results to ~/HttpArena/results/<round>/<framework>/.
+# Snapshot whatever landed.
+if [ -d "results" ]; then
+    mkdir -p "$OUT_DIR/results"
+    rsync -a --include='*.json' --include='*/' --exclude='*' \
+          "results/" "$OUT_DIR/results/"
+fi
+
+# ── 4b. Sanity-check the produced result JSONs ──────────────────────────────
+# Two checks:
+#   (a) the number of JSONs is at least the number of claimed profiles —
+#       catches missing `--save` and benchmark.sh refusing to run an entire
+#       profile silently.
+#   (b) no JSON has rps=0 — catches silent loadgen failures (the
+#       gcannon-missing pattern from the previous iteration).
+# Either failure exits non-zero so the orchestrator surfaces the
+# problem and we don't waste another iteration discovering it on
+# the spend side.
+echo "=== sanity check: JSON count >= profile count, rps > 0 in every JSON ==="
+SANITY=$(python3 -c "
+import json, pathlib
+zero, ok = [], []
+for p in sorted(pathlib.Path('$OUT_DIR/results').rglob('*.json')):
+    try:
+        d = json.load(open(p))
+    except Exception:
+        continue
+    rps = d.get('rps')
+    if rps in (None, 0, '0', '0.00'):
+        zero.append(str(p))
+    else:
+        ok.append(str(p))
+for z in zero:
+    print('ZERO', z)
+print('TOTAL_OK', len(ok))
+print('TOTAL_ZERO', len(zero))
+" | tee "$OUT_DIR/sanity.log")
+
+OK_COUNT=$(echo "$SANITY" | awk '/^TOTAL_OK/  {print $2}')
+ZERO_COUNT=$(echo "$SANITY" | awk '/^TOTAL_ZERO/{print $2}')
+SANITY_FAILED=0
+
+if [ "${ZERO_COUNT:-0}" -gt 0 ]; then
+    echo "FAIL: $ZERO_COUNT result JSONs report rps=0 — likely missing loadgen or framework boot failure"
+    SANITY_FAILED=1
+fi
+if [ "${OK_COUNT:-0}" -lt "${PROFILE_COUNT:-1}" ]; then
+    echo "FAIL: only $OK_COUNT non-zero JSONs found, expected at least $PROFILE_COUNT (one per claimed profile)"
+    echo "  → check whether benchmark.sh was invoked with --save and whether every profile actually ran"
+    SANITY_FAILED=1
+fi
+if [ "$SANITY_FAILED" = 0 ]; then
+    echo "OK: $OK_COUNT result JSONs, all rps > 0 (claimed profiles: $PROFILE_COUNT)"
+fi
+
+# Snapshot system + docker info so the run is self-describing.
+{
+    echo '--- uname ---';        uname -a
+    echo '--- nproc ---';        nproc
+    echo '--- /proc/meminfo ---'; head -5 /proc/meminfo
+    echo '--- docker info ---';  docker info 2>/dev/null | head -30
+    echo '--- ulimit -a ---';    bash -c 'ulimit -a'
+    echo '--- git head ---';     git -C "$HARENA_DIR" rev-parse HEAD 2>/dev/null || echo 'not a git repo'
+} > "$OUT_DIR/system.txt"
+
+# Tarball for easy rsync-back.
+tar -C "$HOME" -czf "${OUT_DIR}.tar.gz" "$(basename "$OUT_DIR")"
+echo "=== done: results in $OUT_DIR and ${OUT_DIR}.tar.gz ==="
+
+exit "${SANITY_FAILED:-0}"

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -544,12 +544,24 @@ class BlackBull:
         self._global_middlewares.append(mw)
         self._chain = None  # invalidate cached chain
 
-    def static(self, url_prefix: str, root_dir: str | Path) -> None:
-        """Serve static files from *root_dir* under *url_prefix* via global middleware."""
+    def static(self, url_prefix: str, root_dir: str | Path, *,
+               cache: bool = False) -> None:
+        """Serve static files from *root_dir* under *url_prefix* via global middleware.
+
+        ``cache`` (default ``False``): when ``True``, file bodies are
+        held in-memory for fast cache-hit serving.  Useful for
+        standalone deployments where BlackBull terminates static
+        traffic directly.  Most production deployments place nginx /
+        a CDN in front of the framework for static traffic and don't
+        need the in-process cache; the default off is calibrated to
+        that majority.  See ``docs/guide/static-files.md`` for the
+        full discussion.
+        """
         from blackbull.middleware.static import StaticFiles
         root = Path(root_dir).resolve()
         self._static_roots.append((url_prefix, root))
-        self._global_middlewares.append(StaticFiles(url_prefix=url_prefix, root_dir=root))
+        self._global_middlewares.append(
+            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache))
         self._chain = None  # invalidate cached chain
 
     def on_error(self, key):

--- a/blackbull/env.py
+++ b/blackbull/env.py
@@ -40,25 +40,30 @@ BB_SOCKET_BACKLOG
     ``listen()`` backlog depth for the server socket.  Increasing this reduces
     silent connection drops during burst traffic when the accept loop falls
     behind.  Capped by ``net.core.somaxconn`` on Linux.
-    Default: ``1024``.
+    Default: ``128`` (matches the Linux ``net.core.somaxconn`` traditional
+    default).  Bump to 4096 for production traffic — see
+    docs/reference/env-vars.md "Performance recommendations".
 BB_SOCKET_SNDBUF
     Kernel send-buffer size (bytes) set on each accepted TCP socket via
     ``SO_SNDBUF``.  The kernel doubles the requested value internally.
     Larger values improve throughput for large responses (≥64 kB).
     ``0`` leaves the kernel default unchanged.
-    Default: ``262144`` (256 kB requested → ~512 kB effective).
+    Default: ``0`` (kernel default).  ``262144`` (256 kB) is a common
+    production value — see docs/reference/env-vars.md.
 BB_SOCKET_RCVBUF
     Kernel receive-buffer size (bytes) set on each accepted TCP socket via
     ``SO_RCVBUF``.  Same doubling rule as ``BB_SOCKET_SNDBUF``.
     ``0`` leaves the kernel default unchanged.
-    Default: ``262144`` (256 kB requested → ~512 kB effective).
+    Default: ``0`` (kernel default).  ``262144`` (256 kB) is a common
+    production value — see docs/reference/env-vars.md.
 BB_SOCKET_REUSEPORT
     ``1`` | ``true`` | ``yes`` to enable; ``0`` | ``false`` | ``no`` to disable.
     When enabled and the OS supports ``SO_REUSEPORT``, each worker binds its own
     listening socket so the kernel distributes incoming connections across workers
     independently, eliminating thundering-herd and improving CPU affinity.
     Has no effect with a single worker or on platforms without ``SO_REUSEPORT``.
-    Default: ``true``.
+    Default: ``false`` (kernel default).  Enable on multi-worker production
+    deployments — see docs/reference/env-vars.md.
 BB_REQUEST_TIMEOUT
     Maximum seconds a single HTTP/2 stream (request + response) is allowed to
     run before it is forcibly cancelled with RST_STREAM CANCEL.  Prevents slow
@@ -67,12 +72,17 @@ BB_REQUEST_TIMEOUT
 BB_H2_INITIAL_WINDOW_SIZE
     Per-stream flow-control window size (bytes) advertised to HTTP/2 peers in the
     server's initial SETTINGS frame.  Larger values allow peers to send more data
-    per stream before waiting for WINDOW_UPDATE.  Default: ``1048576`` (1 MiB).
+    per stream before waiting for WINDOW_UPDATE.
+    Default: ``65535`` (RFC 7540 §6.9.2 default).  ``1048576`` (1 MiB) is a
+    common tuned value for upload-heavy or multiplexed workloads — see
+    docs/reference/env-vars.md.
 BB_H2_CONNECTION_WINDOW_SIZE
     Connection-level flow-control window size (bytes) advertised to HTTP/2 peers
     via an initial WINDOW_UPDATE on stream 0 after the SETTINGS handshake.
     Must be ≥ 65535 (the RFC default); values below that are silently ignored.
-    Default: ``4194304`` (4 MiB).
+    Default: ``65535`` (RFC 7540 §6.9.2 minimum).  ``4194304`` (4 MiB) is a
+    common tuned value to allow concurrent streams to share the connection
+    budget without head-of-line stalls — see docs/reference/env-vars.md.
 BB_H2_MAX_CONCURRENT_STREAMS
     Maximum number of HTTP/2 streams the server accepts at the same time per
     connection, advertised to peers in the initial SETTINGS frame
@@ -409,20 +419,26 @@ def get_settings() -> Settings:
         ws_queue_depth=_int_env('BB_WS_QUEUE_DEPTH', 256),
         async_logging=_bool_env('BB_ASYNC_LOGGING', True),
         access_log=_bool_env('BB_ACCESS_LOG', True),
-        socket_backlog=_int_env('BB_SOCKET_BACKLOG', 4096),
-        socket_sndbuf=_int_env_nonneg('BB_SOCKET_SNDBUF', 262144),
-        socket_rcvbuf=_int_env_nonneg('BB_SOCKET_RCVBUF', 262144),
-        socket_reuseport=_bool_env('BB_SOCKET_REUSEPORT', True),
+        # Defaults match the Linux kernel baseline.  See
+        # docs/reference/env-vars.md "Performance recommendations"
+        # for the values to override these with on a tuned deployment.
+        socket_backlog=_int_env('BB_SOCKET_BACKLOG', 128),
+        socket_sndbuf=_int_env_nonneg('BB_SOCKET_SNDBUF', 0),
+        socket_rcvbuf=_int_env_nonneg('BB_SOCKET_RCVBUF', 0),
+        socket_reuseport=_bool_env('BB_SOCKET_REUSEPORT', False),
         keep_alive_timeout=_float_env_nonneg('BB_KEEP_ALIVE_TIMEOUT', 5.0),
-        tcp_user_timeout_ms=_int_env_nonneg('BB_TCP_USER_TIMEOUT_MS', 60_000),
+        tcp_user_timeout_ms=_int_env_nonneg('BB_TCP_USER_TIMEOUT_MS', 0),
         request_timeout=_float_env_nonneg('BB_REQUEST_TIMEOUT', 0.0),
         header_timeout=_float_env_nonneg('BB_HEADER_TIMEOUT', 10.0),
         body_timeout=_float_env_nonneg('BB_BODY_TIMEOUT', 30.0),
         write_timeout=_float_env_nonneg('BB_WRITE_TIMEOUT', 30.0),
         header_max_line=_int_env_nonneg('BB_HEADER_MAX_LINE', 8192),
         header_max_total=_int_env_nonneg('BB_HEADER_MAX_TOTAL', 65536),
-        h2_initial_window_size=_int_env('BB_H2_INITIAL_WINDOW_SIZE', 1048576),
-        h2_connection_window_size=_int_env('BB_H2_CONNECTION_WINDOW_SIZE', 4194304),
+        # RFC 7540 §6.9.2 default initial window size.  See
+        # docs/reference/env-vars.md "Performance recommendations" for the
+        # values commonly used on tuned production deployments.
+        h2_initial_window_size=_int_env('BB_H2_INITIAL_WINDOW_SIZE', 65535),
+        h2_connection_window_size=_int_env('BB_H2_CONNECTION_WINDOW_SIZE', 65535),
         h2_max_concurrent_streams=_int_env('BB_H2_MAX_CONCURRENT_STREAMS', 100),
         h2_enable_websocket=_bool_env('BB_H2_ENABLE_WEBSOCKET', False),
         ws_permessage_deflate=_bool_env('BB_WS_PERMESSAGE_DEFLATE', True),

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -63,7 +63,23 @@ class StaticFiles:
     )
 
     def __init__(self, directory: str | None = None, *,
-                 url_prefix: str = '', root_dir: str | Path | None = None):
+                 url_prefix: str = '', root_dir: str | Path | None = None,
+                 cache: bool = False):
+        """Serve files from ``directory`` (or ``root_dir``).
+
+        ``cache`` (default ``False``): when ``True``, file bodies up to
+        ``_CACHE_MAX_BYTES_PER_FILE`` are held in an in-memory
+        ``OrderedDict`` (capped at ``_CACHE_MAX_ENTRIES``), and the
+        per-request ``stat()`` syscall is throttled by
+        ``_STAT_TTL_S``.  When ``False`` (the default), every request
+        does a fresh ``stat()`` and reads the body from disk — matching
+        the behaviour of Starlette / FastAPI / Flask static serving and
+        the requirement HttpArena's standard-mode rules place on static
+        profiles ("read files from disk on every request, no in-memory
+        caching").  Set ``cache=True`` only for standalone deployments
+        where BlackBull terminates static traffic directly (i.e. no
+        nginx / CDN in front).
+        """
         resolved = directory or root_dir
         if resolved is None:
             raise ValueError('directory or root_dir is required')
@@ -77,6 +93,7 @@ class StaticFiles:
         # ``<root>/...`` exactly, reject ``<root>x/...``.
         self._root_sep: str = self._root_str + os.sep
         self._url_prefix = url_prefix.rstrip('/')
+        self._cache_enabled: bool = cache
         # cache key = the actual filesystem path served (original or
         # sibling), held as a ``str`` so the hash is cheap and the
         # key matches the value returned by ``os.path.realpath``.
@@ -85,13 +102,19 @@ class StaticFiles:
         # for precompressed siblings.  ``last_stat`` is the monotonic
         # clock when ``stat()`` last confirmed the entry was still fresh
         # — used to throttle the per-request stat syscall.
+        # Allocated even when caching is disabled so the read sites can
+        # check membership without a None-guard; the cache simply never
+        # gets populated.
         self._cache: OrderedDict[
             str, tuple[int, int, bytes, bytes, bytes, float]
         ] = OrderedDict()
         # Per-path sibling-availability cache: target → {b'br': sibling_path, ...}.
         # _negotiate calls os.path.isfile for each encoding suffix on every
-        # request; the file-existence answer is deterministic for the lifetime
-        # of the server, so we memoise it after the first lookup.
+        # request; when caching is enabled we memoise the answer after the
+        # first lookup (deterministic for the lifetime of the server).
+        # When caching is disabled we recompute siblings every request so
+        # the from-disk-every-request contract extends to the sibling
+        # existence check.
         # Key = original request path string, Value = dict of available encodings.
         self._sibling_cache: dict[str, dict[bytes, str]] = {}
 
@@ -193,15 +216,24 @@ class StaticFiles:
         if not accept:
             return target, b''
 
-        # Fast path: cached sibling set for this target path.
-        siblings = self._sibling_cache.get(target)
-        if siblings is None:
+        # Sibling existence: cached if `cache=True`, recomputed every
+        # request otherwise (so the from-disk-every-request contract
+        # extends to the sibling existence check).
+        if self._cache_enabled:
+            siblings = self._sibling_cache.get(target)
+            if siblings is None:
+                siblings = {}
+                for enc, suffix in self._ENCODING_SUFFIXES:
+                    sibling = target + suffix
+                    if os.path.isfile(sibling):
+                        siblings[enc] = sibling
+                self._sibling_cache[target] = siblings
+        else:
             siblings = {}
             for enc, suffix in self._ENCODING_SUFFIXES:
                 sibling = target + suffix
                 if os.path.isfile(sibling):
                     siblings[enc] = sibling
-            self._sibling_cache[target] = siblings
 
         for enc, _suffix in self._ENCODING_SUFFIXES:
             sibling = siblings.get(enc)
@@ -218,8 +250,9 @@ class StaticFiles:
         size: int
 
         # Fast path: cached entry, still within the per-entry stat TTL.
-        # No syscall, no ``mimetypes.guess_type`` regex.
-        cached_entry = self._cache.get(served_path)
+        # Only consulted when caching is enabled — when ``cache=False``
+        # every request flows through the stat + read branch below.
+        cached_entry = self._cache.get(served_path) if self._cache_enabled else None
         now = time.monotonic()
         if (cached_entry is not None
                 and self._STAT_TTL_S > 0
@@ -227,8 +260,9 @@ class StaticFiles:
             _, size, body, mime, _, _ = cached_entry
             self._cache.move_to_end(served_path)
         else:
-            # Cache miss, stale TTL, or TTL disabled — re-stat to
-            # confirm the entry is still valid.
+            # Cache miss, stale TTL, or caching disabled — re-stat to
+            # confirm the entry is still valid (or to learn it for the
+            # first time when caching is off).
             try:
                 st = os.stat(served_path)
             except OSError:
@@ -242,13 +276,16 @@ class StaticFiles:
                     and cached_entry[1] == size):
                 # Entry still matches the file on disk: reuse body + mime
                 # and refresh ``last_stat`` so the next request can take
-                # the fast path again.
+                # the fast path again.  Only reachable when caching is on.
                 _, _, body, mime, _, _ = cached_entry
                 self._cache[served_path] = (
                     mtime_ns, size, body, mime, content_encoding, now)
                 self._cache.move_to_end(served_path)
             elif size <= self._CACHE_MAX_BYTES_PER_FILE:
-                # First fill or stale entry — read once and store.
+                # Read from disk.  When caching is enabled, also store
+                # the body for next time.  When caching is disabled,
+                # this branch fires on every request and the read is
+                # always fresh.
                 # Content-Type derives from the ORIGINAL request's path
                 # extension, not the .br/.gz/.zst suffix — e.g. app.js.br
                 # is still ``text/javascript``.  ``mimetypes.guess_type``
@@ -263,12 +300,14 @@ class StaticFiles:
                 except OSError:
                     await self._respond(send, HTTPStatus.NOT_FOUND)
                     return
-                self._store(served_path, mtime_ns, size, body, mime,
-                            content_encoding, now)
+                if self._cache_enabled:
+                    self._store(served_path, mtime_ns, size, body, mime,
+                                content_encoding, now)
             else:
                 # Above the cache threshold — drop any stale entry and
                 # fall through to the streaming/pathsend branch.
-                self._cache.pop(served_path, None)
+                if self._cache_enabled:
+                    self._cache.pop(served_path, None)
                 mime = (mimetypes.guess_type(path)[0]
                         or 'application/octet-stream').encode()
                 body = None

--- a/docs/guide/static-files.md
+++ b/docs/guide/static-files.md
@@ -59,13 +59,45 @@ double-serving the same files.
 
 ## How it serves files
 
-### In-memory cache
+### In-memory cache (opt-in)
 
-Small files (default ≤ 4 MiB each, up to 256 entries) are cached
-in process memory keyed on `(path, mtime, size)`.  Cache hits
-serve directly — no disk I/O on the hot path.  When a file's
-modification time or size changes on disk, the next request
-re-reads it and replaces the cached copy.
+`StaticFiles` supports an in-process body cache for fast cache-hit
+serving.  It is **off by default**: every request does a fresh
+`stat()` and reads the body from disk.  This matches the behaviour
+of Starlette / FastAPI / Flask static serving and keeps BlackBull's
+default behaviour compatible with standards that require "read
+files from disk on every request, no in-memory caching" (e.g. the
+HttpArena standard-mode static profile).
+
+Opt in by passing `cache=True`:
+
+```python
+# Default — read from disk every request.
+app.static('/assets', 'public/assets')
+
+# Opt-in — small files (≤ 4 MiB each, up to 256 entries) held in
+# process memory; stat() syscall throttled to once per second per
+# entry; sibling-existence answers memoised across requests.
+app.static('/assets', 'public/assets', cache=True)
+```
+
+When you should turn it on:
+
+- BlackBull terminates static traffic directly (no nginx / no CDN
+  in front).
+- The asset set is small enough that all files fit in 256 × 4 MiB
+  of process memory and small enough that the cache hit rate is
+  high.
+- You're OK with edit-on-disk visibility up to ~1 second behind
+  (the stat-throttle window, override via `BB_STATIC_STAT_TTL_S`).
+
+When to leave it off (the default):
+
+- nginx / a CDN fronts the framework — they handle the static path
+  far more efficiently than any in-process cache can.
+- You want edit-on-disk visibility to be immediate.
+- You're running the benchmark suites HttpArena's standard-mode
+  rules describe.
 
 The cache is per-process — multi-worker deployments hold a
 separate cache in each worker.
@@ -73,6 +105,42 @@ separate cache in each worker.
 For files above the cache threshold, `StaticFiles` streams the
 body in chunks so peak per-request memory stays bounded
 regardless of file size.
+
+### Precompressed sibling serving
+
+If a file `app.js` has a sibling on disk like `app.js.br`,
+`app.js.zst`, or `app.js.gz`, `StaticFiles` will serve the
+sibling (with the right `Content-Encoding` header) when the
+client's `Accept-Encoding` allows it.  Preference order is
+`br > zstd > gzip`.
+
+```
+public/
+  app.js          # 50 KiB original
+  app.js.br       # 12 KiB pre-compressed (served when Accept-Encoding: br)
+  app.js.gz       # 17 KiB pre-compressed (served when Accept-Encoding: gzip)
+```
+
+This is the same pattern as nginx's
+[`gzip_static`](https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html)
+/ `brotli_static` modules and ASP.NET's `MapStaticAssets`.
+Generating the siblings is a build-time concern (CI script, asset
+pipeline) — BlackBull does not produce them at runtime.
+
+Range requests bypass sibling lookup — encoded bodies have a
+different size than the original and serving a `Range` over an
+encoded variant is messy.  Matches nginx's `gzip_static` +
+`Range` behaviour.
+
+`StaticFiles` always advertises `Vary: Accept-Encoding` on
+responses where a precompressed sibling was selected, so HTTP
+caches don't mis-cache an encoded body to a client that didn't
+ask for it.
+
+When `cache=True` is set, the per-path sibling-existence answer
+is memoised after the first lookup (the file set is deterministic
+for the lifetime of the server).  When `cache=False`, sibling
+existence is rechecked on every request.
 
 ### Range requests (RFC 7233)
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -1,8 +1,11 @@
 # Environment variables
 
 Exhaustive table of `BB_*` and `BLACKBULL_*` environment
-variables.  Defaults are conservative for development; raise the
-limits and tune the sockets in production.
+variables.  Defaults match Linux kernel / RFC 7540 baselines so a
+fresh BlackBull install behaves predictably regardless of host
+tuning state.  For values that improve throughput / tail latency
+on busy production deployments, see
+[Performance recommendations](#performance-recommendations) below.
 
 For the precedence order (CLI flags > env > TOML), see
 [Configuration](../guide/configuration.md).
@@ -25,7 +28,7 @@ For the precedence order (CLI flags > env > TOML), see
 | `BB_BODY_TIMEOUT` | `30.0` | Per-chunk deadline for the request body once headers are parsed.  Slowloris body-half defence.  Each `await receive()` is bounded by this; exceed → the recipient surfaces `http.disconnect` and the connection tears down.  `0` disables. |
 | `BB_WRITE_TIMEOUT` | `30.0` | Seconds the server will wait for a single response write to flush to the peer (via `StreamWriter.drain()`).  Defends against the *slow-read* shape of slowloris: a client that reads the response 1 byte/sec eventually fills the kernel send buffer and our drain blocks indefinitely.  On timeout the transport is force-closed and the failure surfaces as a peer-side `ConnectionResetError` for the sender's existing error path.  `0` disables. |
 | `BB_KEEP_ALIVE_TIMEOUT` | `5.0` | Seconds an idle HTTP/1.1 keep-alive connection is held open after a complete response.  Lower for high-fan-in deployments; higher for chatty clients on slow links. |
-| `BB_TCP_USER_TIMEOUT_MS` | `0` (off) | `TCP_USER_TIMEOUT` socket option (Linux).  Per-connection upper bound on how long an unacknowledged sent segment can linger before the kernel kills the connection.  Useful to evict dead peers behind NATs without waiting for keepalives. |
+| `BB_TCP_USER_TIMEOUT_MS` | `0` (off, kernel default) | `TCP_USER_TIMEOUT` socket option (Linux).  Per-connection upper bound on how long an unacknowledged sent segment can linger before the kernel kills the connection.  Useful to evict dead peers behind NATs without waiting for keepalives.  See "Performance recommendations" below for production tuning. |
 | `BB_HEADER_MAX_LINE` | `8192` | Maximum bytes in a single HTTP/1.1 request-line or header line.  Matches Apache `LimitRequestLine` / nginx `large_client_header_buffers`.  Exceeded → `431 Request Header Fields Too Large`. |
 | `BB_HEADER_MAX_TOTAL` | `65536` | Maximum total bytes in the entire HTTP/1.1 header block.  Exceeded → `431`. |
 | `BB_STREAM_QUEUE_DEPTH` | `64` | `asyncio.Queue` depth for HTTP/2 per-stream request-body events.  Caps memory growth when an ASGI handler is slower than the client uploading data. |
@@ -35,10 +38,10 @@ For the precedence order (CLI flags > env > TOML), see
 
 | Variable | Default | Controls |
 |---|---|---|
-| `BB_SOCKET_BACKLOG` | `1024` | `listen()` backlog depth.  Reduces silent connection drops during burst traffic.  Linux caps the effective value at `net.core.somaxconn`. |
-| `BB_SOCKET_REUSEPORT` | `1` | When supported by the OS (Linux, modern BSDs), bind each worker to its own listening socket so the kernel hashes incoming connections across workers — eliminates the thundering-herd accept pattern.  No effect with one worker. |
-| `BB_SOCKET_SNDBUF` | `262144` | `SO_SNDBUF` (bytes) on each accepted socket.  Linux doubles the requested value internally.  Larger helps throughput for responses ≥ 64 kB.  `0` keeps the kernel default. |
-| `BB_SOCKET_RCVBUF` | `262144` | `SO_RCVBUF` (bytes) on each accepted socket.  Same doubling rule.  `0` keeps the kernel default. |
+| `BB_SOCKET_BACKLOG` | `128` (kernel `somaxconn` default) | `listen()` backlog depth.  Linux caps the effective value at `net.core.somaxconn`.  See "Performance recommendations" below for production tuning. |
+| `BB_SOCKET_REUSEPORT` | `0` (kernel default) | When supported by the OS (Linux, modern BSDs), bind each worker to its own listening socket so the kernel hashes incoming connections across workers — eliminates the thundering-herd accept pattern.  No effect with one worker.  Enable on multi-worker deployments. |
+| `BB_SOCKET_SNDBUF` | `0` (kernel default) | `SO_SNDBUF` (bytes) on each accepted socket.  `0` leaves the kernel default unchanged.  Linux doubles the requested value internally; larger values help throughput for responses ≥ 64 kB. |
+| `BB_SOCKET_RCVBUF` | `0` (kernel default) | `SO_RCVBUF` (bytes) on each accepted socket.  `0` leaves the kernel default unchanged.  Same doubling rule as `BB_SOCKET_SNDBUF`. |
 
 ## Logging
 
@@ -51,8 +54,8 @@ For the precedence order (CLI flags > env > TOML), see
 
 | Variable | Default | Controls |
 |---|---|---|
-| `BB_H2_INITIAL_WINDOW_SIZE` | `1048576` (1 MiB) | Per-stream flow-control window advertised in the server's initial `SETTINGS` frame.  Larger lets peers send more data per stream before waiting for `WINDOW_UPDATE`. |
-| `BB_H2_CONNECTION_WINDOW_SIZE` | `4194304` (4 MiB) | Connection-level flow-control window advertised via an initial `WINDOW_UPDATE` on stream 0.  Must be ≥ 65535 (the RFC default); smaller values are silently ignored. |
+| `BB_H2_INITIAL_WINDOW_SIZE` | `65535` (RFC 7540 §6.9.2 default) | Per-stream flow-control window advertised in the server's initial `SETTINGS` frame.  Larger lets peers send more data per stream before waiting for `WINDOW_UPDATE`.  See "Performance recommendations" below. |
+| `BB_H2_CONNECTION_WINDOW_SIZE` | `65535` (RFC 7540 §6.9.2 minimum) | Connection-level flow-control window advertised via an initial `WINDOW_UPDATE` on stream 0.  Must be ≥ 65535; smaller values are silently ignored.  See "Performance recommendations" below. |
 | `BB_H2_MAX_CONCURRENT_STREAMS` | `100` | `SETTINGS_MAX_CONCURRENT_STREAMS` (RFC 9113 §6.5.2 id `0x3`).  Streams beyond the cap receive `RST_STREAM REFUSED_STREAM` and are not dispatched. |
 | `BB_H2_ACTIVE_STREAMS` | `20` | Per-connection `asyncio.Semaphore` cap on stream handlers actually running concurrently, under multi-worker.  Prevents one high-mux connection from saturating a single event loop.  `0` disables (no cap beyond `BB_H2_MAX_CONCURRENT_STREAMS`). |
 | `BB_H2_ACTIVE_STREAMS_1W` | `20` | Same as above, but used when `BB_WORKERS=1`. |
@@ -83,6 +86,35 @@ For the precedence order (CLI flags > env > TOML), see
 | Variable | Default | Controls |
 |---|---|---|
 | `BB_DEADLINE_TICK_MS` | `300` | Polling interval (milliseconds) for the per-process deadline scanner that enforces connection timeouts.  Smaller = tighter timeout granularity at a small CPU cost; larger = more slack but cheaper. |
+
+## Performance recommendations
+
+The defaults above match Linux kernel / RFC 7540 baselines so a
+fresh BlackBull install behaves predictably regardless of host
+tuning state.  On a busy production deployment — multi-worker,
+high-fan-in, mixed HTTP/1.1 + HTTP/2 — the following values give
+measurably better throughput and tail latency at the cost of more
+kernel/process memory and one custom socket option:
+
+| Variable | Default | Recommended | Why |
+|---|---|---|---|
+| `BB_SOCKET_BACKLOG` | `128` | `4096` | Reduces silent connection drops during burst arrivals when the accept loop is briefly behind.  Effective value is capped by `net.core.somaxconn` — bump it too (`sysctl -w net.core.somaxconn=4096`). |
+| `BB_SOCKET_REUSEPORT` | `0` | `1` | When running > 1 worker on Linux, lets the kernel hash incoming connections across workers instead of a single accept loop fanning them out.  Eliminates thundering-herd and improves CPU affinity. |
+| `BB_SOCKET_SNDBUF` | `0` | `262144` | 256 kB requested → ~512 kB effective after the kernel doubles.  Helps throughput on responses ≥ 64 kB (static assets, JSON arrays, streamed bodies). |
+| `BB_SOCKET_RCVBUF` | `0` | `262144` | Same shape as `SNDBUF`, for inbound traffic (large `POST` bodies). |
+| `BB_TCP_USER_TIMEOUT_MS` | `0` | `60000` | Linux `TCP_USER_TIMEOUT`.  Forces the kernel to drop connections where the peer hasn't ACKed a sent segment within the window.  Evicts dead peers behind NATs / load balancers faster than keepalives. |
+| `BB_H2_INITIAL_WINDOW_SIZE` | `65535` | `1048576` (1 MiB) | RFC 7540's 64 kB per-stream window is small for modern broadband; 1 MiB lets peers send a respectable chunk before they have to wait for a `WINDOW_UPDATE`. |
+| `BB_H2_CONNECTION_WINDOW_SIZE` | `65535` | `4194304` (4 MiB) | Same logic at the connection level — letting multiple concurrent streams share a 4 MiB connection budget reduces head-of-line stalls when one stream's flow control is tight. |
+
+For containerised deployments, set the socket-buffer values via
+the container environment (`docker run -e BB_SOCKET_SNDBUF=...`)
+since the host's `net.ipv4.tcp_wmem` won't apply inside the
+container's network namespace.
+
+For benchmarks that compare BlackBull on its own terms (no
+peer-framework framing), leave the defaults alone — RFC / kernel
+baselines are the right starting point and tuning above them is a
+deployment concern, not a framework one.
 
 ## See also
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.32.0"
+version = "0.33.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/architecture/test_http2_actor.py
+++ b/tests/architecture/test_http2_actor.py
@@ -220,8 +220,23 @@ def _parse_frames(data: bytes) -> list:
 
 
 @pytest.mark.asyncio
-async def test_handshake_sends_settings_initial_window_size(fake_h2_reader, mock_app):
-    """HTTP2Actor.run() must include SETTINGS_INITIAL_WINDOW_SIZE in the server's SETTINGS."""
+async def test_handshake_sends_settings_initial_window_size(
+        fake_h2_reader, mock_app, monkeypatch):
+    """HTTP2Actor.run() must advertise the configured
+    ``BB_H2_INITIAL_WINDOW_SIZE`` in the server's SETTINGS frame.
+
+    Sprint 37 lowered BlackBull's default to the RFC 7540 §6.9.2
+    baseline (65535).  This test sets a non-default value via env so
+    the emitted frame is unambiguously distinguishable from the RFC
+    default and the test asserts the actor honours the configured
+    value rather than asserting "larger than the default" (which
+    would tautologically pass on the old default and fail on the new
+    one without exercising the actual code path).
+    """
+    monkeypatch.setenv('BB_H2_INITIAL_WINDOW_SIZE', '1048576')
+    from blackbull.env import reset_settings_cache
+    reset_settings_cache()
+
     writer = _FakeWriter()
     aggregator = AsyncMock(spec=EventAggregator)
     actor = HTTP2Actor(fake_h2_reader, writer, mock_app, aggregator)
@@ -231,12 +246,25 @@ async def test_handshake_sends_settings_initial_window_size(fake_h2_reader, mock
                        if f.FrameType() == FrameTypes.SETTINGS
                        and getattr(f, 'initial_window_size', None) is not None]
     assert settings_frames, 'Server must send SETTINGS with INITIAL_WINDOW_SIZE'
-    assert settings_frames[0].initial_window_size > DEFAULT_INITIAL_WINDOW_SIZE
+    assert settings_frames[0].initial_window_size == 1048576
+    reset_settings_cache()
 
 
 @pytest.mark.asyncio
-async def test_handshake_sends_connection_window_update(fake_h2_reader, mock_app):
-    """HTTP2Actor.run() must send WINDOW_UPDATE(stream_id=0) to expand the inbound window."""
+async def test_handshake_sends_connection_window_update(
+        fake_h2_reader, mock_app, monkeypatch):
+    """HTTP2Actor.run() must send WINDOW_UPDATE(stream_id=0) when the
+    configured connection window exceeds the RFC 7540 default (65535).
+
+    Sprint 37 lowered BlackBull's default to 65535 (no
+    WINDOW_UPDATE needed at handshake — peer's connection window
+    already starts there).  This test sets a non-default to assert
+    the actor emits the expansion frame when one is required.
+    """
+    monkeypatch.setenv('BB_H2_CONNECTION_WINDOW_SIZE', '4194304')
+    from blackbull.env import reset_settings_cache
+    reset_settings_cache()
+
     writer = _FakeWriter()
     aggregator = AsyncMock(spec=EventAggregator)
     actor = HTTP2Actor(fake_h2_reader, writer, mock_app, aggregator)
@@ -246,6 +274,7 @@ async def test_handshake_sends_connection_window_update(fake_h2_reader, mock_app
                 if f.FrameType() == FrameTypes.WINDOW_UPDATE and f.stream_id == 0]
     assert conn_wus, 'Server must send a connection-level WINDOW_UPDATE at startup'
     assert conn_wus[0].window_size > 0
+    reset_settings_cache()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -461,8 +461,10 @@ class TestPrecompressedVariant:
         assert body == b'console.log("hi");' * 200
 
     async def test_cache_hit_returns_same_sibling(self, precompressed_dir):
+        """Opting in to caching (``cache=True``): the second request
+        serves the cached body of the first, no re-read from disk."""
         from blackbull.middleware.static import StaticFiles
-        app = StaticFiles(directory=str(precompressed_dir))
+        app = StaticFiles(directory=str(precompressed_dir), cache=True)
         # First request fills the cache
         start1, body1 = await _collect(
             app, _scope(path='/app.js', headers={'accept-encoding': 'br'}))
@@ -474,8 +476,11 @@ class TestPrecompressedVariant:
         assert dict(start2['headers'])[b'content-encoding'] == b'br'
 
     async def test_different_encoding_uses_different_cache_entries(self, precompressed_dir):
+        """With caching opted in, requesting a different encoding
+        than the previously-cached one still serves the right
+        sibling (cache key includes the served path)."""
         from blackbull.middleware.static import StaticFiles
-        app = StaticFiles(directory=str(precompressed_dir))
+        app = StaticFiles(directory=str(precompressed_dir), cache=True)
         # Fill cache with br
         _, body_br = await _collect(
             app, _scope(path='/app.js', headers={'accept-encoding': 'br'}))
@@ -484,6 +489,30 @@ class TestPrecompressedVariant:
             app, _scope(path='/app.js', headers={'accept-encoding': 'gzip'}))
         assert body_br == b'BR-COMPRESSED-BYTES'
         assert body_gz == b'GZ-COMPRESSED-BYTES'
+
+    async def test_default_cache_off_no_body_stored(self, precompressed_dir):
+        """Default (``cache=False``): the ``_cache`` dict stays empty
+        even after multiple requests — every response is freshly read
+        from disk."""
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(precompressed_dir))
+        assert app._cache_enabled is False
+        for _ in range(3):
+            _, body = await _collect(
+                app, _scope(path='/app.js', headers={'accept-encoding': 'br'}))
+            assert body == b'BR-COMPRESSED-BYTES'
+        assert len(app._cache) == 0
+        assert len(app._sibling_cache) == 0
+
+    async def test_cache_true_populates_cache(self, precompressed_dir):
+        """Sanity-check the opt-in: a single request with
+        ``cache=True`` leaves an entry in ``_cache``."""
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(precompressed_dir), cache=True)
+        assert app._cache_enabled is True
+        await _collect(
+            app, _scope(path='/app.js', headers={'accept-encoding': 'br'}))
+        assert len(app._cache) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -555,9 +584,10 @@ class TestStaticFilesPathsend:
         assert all(e.get('type') != 'http.response.pathsend' for e in events)
 
     async def test_small_file_does_not_use_pathsend(self, static_dir):
-        """Cached (small) files stay on the in-memory body path even
-        when pathsend is advertised — no point opening a file we already
-        have in RAM."""
+        """Small files (≤ ``_CACHE_MAX_BYTES_PER_FILE``) stay on the
+        in-memory body path even when pathsend is advertised — the body
+        is read into memory either way, so there's no point handing
+        the file path to the sender for a second open."""
         from blackbull.middleware.static import StaticFiles
         app = StaticFiles(directory=str(static_dir))
         events: list = []


### PR DESCRIPTION
See [CHANGELOG.md](https://github.com/TOKUJI/BlackBull/blob/release/v0.33.0/CHANGELOG.md) — `[0.33.0]` section.

Sprint 37 close:
- Static body cache now opt-in (Path C)
- Seven defaults reset to RFC 7540 / Linux kernel baselines (Path F)
- Previous tuned values preserved as production recommendations in `docs/reference/env-vars.md`
- 1,268 tests pass / 196 skipped / 0 failures

Once merged, the v0.33.0 tag pushes from master and the auto-release pipeline publishes to PyPI.