### PR TITLE
docs: humbler framing + sync stale env-var docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Project overview
 
-BlackBull is a Python ASGI 3.0 web framework built from scratch.
-It handles HTTP/1.1, HTTP/2, and WebSocket at the protocol level.
+BlackBull is a Python ASGI 3.0 web framework with pure-Python
+HTTP/1.1, HTTP/2, and WebSocket implementations at the protocol level.
 The codebase is a personal learning project, so correctness over the wire matters more than API stability.
 
 ---

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -98,10 +98,12 @@ capacity against `nproc / 2` on typical SMT-enabled hardware.
 ### Static-file serving is not a production CDN
 
 [`blackbull/middleware/static.py`](blackbull/middleware/static.py)
-serves files three ways:
+serves files three ways at runtime:
 
-- Cached in-memory (≤ 4 MiB) — first hit reads sync, subsequent
-  hits serve from a per-process LRU.
+- Read from disk on every request (the default since 0.33) — each
+  hit runs `path.stat()` + `open().read()`.  Correct under file
+  edits with no staleness window, but pays the per-request syscall
+  cost.
 - Zero-copy via `loop.sendfile` (cleartext HTTP/1.1, > 4 MiB,
   no Range) — single kernel-side transfer, no per-chunk
   event-loop dispatch.  Opted in via the `http.response.pathsend`
@@ -111,13 +113,18 @@ serves files three ways:
   overhead.  Use the fronting nginx path below if this is on the
   critical path for you.
 
-The in-memory cache is stat-invalidated per request — every
-request runs `path.stat()` and refills the entry when mtime or
-size changes, so edits on disk show up on the next request with
-no staleness window.  What's still missing: ETag-driven
-revalidation, byte-range-multipart, and CDN edge-cache
-invalidation glue.  For anything user-visible, front a real
-static-file server (nginx, S3 + CloudFront).
+An optional in-memory cache (≤ 4 MiB) is available with
+`app.static(prefix, root, cache=True)`: first hit reads sync,
+subsequent hits serve from a per-process LRU, and the entry is
+stat-invalidated per request so edits on disk show up on the
+next request with no staleness window.  Default is `cache=False`;
+standalone deployments serving static traffic directly should opt
+in to keep prior performance.
+
+What's still missing across all paths: ETag-driven revalidation,
+byte-range-multipart, and CDN edge-cache invalidation glue.  For
+anything user-visible, front a real static-file server (nginx,
+S3 + CloudFront).
 
 ### No internal database layer
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@
 > Conformance evidence: [`docs/about/conformance.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/conformance.md).
 > Things to know before adopting: [`KNOWN_LIMITATIONS.md`](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md).
 
-**Async ASGI 3.0 framework** with a from-scratch HTTP/1.1 parser,
-HTTP/2 frame layer, and WebSocket codec — no `httptools`, no
-`uvicorn`, no `hypercorn` underneath.  HPACK header compression
+**Async ASGI 3.0 framework** with pure-Python HTTP/1.1, HTTP/2
+framing, and WebSocket implementations.  HPACK header compression
 delegates to the [`hpack`](https://github.com/python-hyper/hpack)
 library (re-implementing a conformant HPACK encoder/decoder is a
 project of its own); everything else, including the ASGI server,
@@ -22,14 +21,13 @@ third-party C extensions in the protocol stack.
 
 - **One package, one process** — the framework *is* the server.  No
   separate ASGI runner; `app.run()` opens the socket and serves.
-- **From-scratch protocol stack** for HTTP/1.1 (RFC 9112) parser,
+- **Pure-Python protocol stack** for HTTP/1.1 (RFC 9112) parser,
   HTTP/2 (RFC 9113) frame layer + flow control + RFC 9218
   prioritisation + push, and WebSocket (RFC 6455) codec.  HPACK
   (RFC 7541) is the one exception — see headline above.
-- **Pure-Python identity** — no `httptools`, no `uvloop` dependency
-  (uvloop available as an optional `[speed]` extra).  The single
-  third-party dependency in the protocol stack is `hpack`, also
-  pure Python.
+- **Pure-Python identity** — uvloop is available as an optional
+  `[speed]` extra.  The single third-party dependency in the
+  protocol stack is `hpack`, also pure Python.
 - **Conformance-tested** against `h2spec`, Autobahn, and a
   differential nginx fuzz corpus.
 - **Modern Python** — requires 3.11+, full type hints, PEP 561 typed

--- a/bench/CHARACTERIZATION.md
+++ b/bench/CHARACTERIZATION.md
@@ -42,7 +42,7 @@ In order of priority:
    this matrix.
 4. **Predictable multi-worker scaling** on commodity Linux —
    characterised by Sprint 21 Phase B's closed-form `R(W)` formula.
-5. **Implementation clarity / from-scratch identity.**
+5. **Implementation clarity / pure-Python identity.**
 
 Peak req/s comes after all five.  External servers in the matrix are
 diagnostic references — see "Reference servers and diagnostic roles"

--- a/bench/httparena/meta.json
+++ b/bench/httparena/meta.json
@@ -4,7 +4,7 @@
   "type": "emerging",
   "mode": "standard",
   "engine": "blackbull",
-  "description": "BlackBull — from-scratch async ASGI 3.0 framework with native HTTP/1.1, HTTP/2 and WebSocket implementations.  Pure-Python protocol stack; ALPN negotiates HTTP/2 on the same listener that serves HTTP/1.1.",
+  "description": "BlackBull — pure-Python async ASGI 3.0 framework supporting HTTP/1.1, HTTP/2, and WebSocket. ALPN negotiates HTTP/2 on the same listener that serves HTTP/1.1.",
   "repo": "https://github.com/TOKUJI/BlackBull",
   "enabled": false,
   "tests": [

--- a/blackbull/env.py
+++ b/blackbull/env.py
@@ -16,7 +16,11 @@ BB_MAX_CONNECTIONS
     cap is reached, new connections receive HTTP/1.1 ``503 Service
     Unavailable`` with ``Retry-After: 1`` (a load-balancer-friendly
     response, not a silent reset).  ``0`` disables the cap and relies
-    on the OS file-descriptor limit instead.  Default: ``1024``.
+    on the OS file-descriptor limit instead.  Default: ``0`` (uncapped).
+    Production deployments on untrusted hosts should set this to a
+    finite ceiling — 1024 is a sensible single-loop value; multi-worker
+    deployments multiply (so ``workers=8`` × ``BB_MAX_CONNECTIONS=1024``
+    → 8K connections per process).
 BB_STREAM_QUEUE_DEPTH
     ``asyncio.Queue`` depth for HTTP/2 per-stream request-body events.
     Limits memory growth when an ASGI handler is slower than the client.
@@ -64,40 +68,91 @@ BB_SOCKET_REUSEPORT
     Has no effect with a single worker or on platforms without ``SO_REUSEPORT``.
     Default: ``false`` (kernel default).  Enable on multi-worker production
     deployments — see docs/reference/env-vars.md.
+BB_KEEP_ALIVE_TIMEOUT
+    Idle timeout (seconds) on a keep-alive HTTP/1.1 connection that is
+    awaiting the *next* request.  Application-level timer; same
+    ghost-eviction guarantee as ``SO_KEEPALIVE`` without the per-accept
+    syscall cost.  ``0`` disables the timer.  Default: ``5.0``.
+BB_TCP_USER_TIMEOUT_MS
+    ``TCP_USER_TIMEOUT`` value in **milliseconds** for accepted sockets
+    (Linux only).  Forces a connection-level error if a peer fails to
+    ACK in this window — defends against dead-mid-write peers that
+    ``SO_KEEPALIVE`` misses.  ``0`` leaves the kernel default
+    unchanged.  Default: ``0``.
+BB_HEADER_TIMEOUT
+    Maximum seconds the server will wait for a complete HTTP/1.1
+    request-header block (request-line + headers + CRLFCRLF).  Primary
+    slowloris defence.  When the deadline elapses the server returns
+    ``408 Request Timeout`` and closes.  ``0`` disables.
+    Default: ``10.0``.
+BB_BODY_TIMEOUT
+    Maximum seconds for the HTTP/1.1 request body to arrive once headers
+    are parsed.  Mirrors ``BB_HEADER_TIMEOUT`` for the body half;
+    defeats slowloris-style ``Content-Length: N`` connections that drip
+    body bytes after the headers have arrived.  ``0`` disables.
+    Default: ``30.0``.
+BB_WRITE_TIMEOUT
+    Maximum seconds the server will wait for a single write to flush to
+    the peer (via ``StreamWriter.drain()``).  Defends against the
+    *slow-read* shape of slowloris: a client that reads 1 byte/sec
+    eventually fills the kernel send buffer and ``drain()`` would block
+    indefinitely.  ``0`` disables.  Default: ``30.0``.
 BB_REQUEST_TIMEOUT
     Maximum seconds a single HTTP/2 stream (request + response) is allowed to
     run before it is forcibly cancelled with RST_STREAM CANCEL.  Prevents slow
     or stalled handlers from holding stream slots indefinitely.
     ``0`` disables the timeout.  Default: ``0`` (disabled).
+BB_HEADER_MAX_LINE
+    Maximum bytes in a single HTTP/1.1 request-line or header line.
+    Enforced before parsing so an attacker cannot exhaust memory with a
+    pathological 1 GB header.  Default: ``8192`` (matches Apache
+    ``LimitRequestLine`` / nginx ``large_client_header_buffers``).
+BB_HEADER_MAX_TOTAL
+    Maximum total bytes in the entire HTTP/1.1 request header block
+    (request-line + all headers + CRLFCRLF).  Default: ``65536``
+    (matches typical reverse-proxy defaults).
 BB_H2_INITIAL_WINDOW_SIZE
     Per-stream flow-control window size (bytes) advertised to HTTP/2 peers in the
     server's initial SETTINGS frame.  Larger values allow peers to send more data
     per stream before waiting for WINDOW_UPDATE.
-    Default: ``65535`` (RFC 7540 §6.9.2 default).  ``1048576`` (1 MiB) is a
+    Default: ``65535`` (RFC 9113 §6.9.2 default).  ``1048576`` (1 MiB) is a
     common tuned value for upload-heavy or multiplexed workloads — see
     docs/reference/env-vars.md.
 BB_H2_CONNECTION_WINDOW_SIZE
     Connection-level flow-control window size (bytes) advertised to HTTP/2 peers
     via an initial WINDOW_UPDATE on stream 0 after the SETTINGS handshake.
     Must be ≥ 65535 (the RFC default); values below that are silently ignored.
-    Default: ``65535`` (RFC 7540 §6.9.2 minimum).  ``4194304`` (4 MiB) is a
+    Default: ``65535`` (RFC 9113 §6.9.2 minimum).  ``4194304`` (4 MiB) is a
     common tuned value to allow concurrent streams to share the connection
     budget without head-of-line stalls — see docs/reference/env-vars.md.
 BB_H2_MAX_CONCURRENT_STREAMS
     Maximum number of HTTP/2 streams the server accepts at the same time per
     connection, advertised to peers in the initial SETTINGS frame
-    (RFC 7540 §6.5.2 — SETTINGS_MAX_CONCURRENT_STREAMS, identifier 0x0003).
+    (RFC 9113 §6.5.2 — SETTINGS_MAX_CONCURRENT_STREAMS, identifier 0x0003).
     Incoming streams that would exceed this limit receive RST_STREAM
     REFUSED_STREAM and are not dispatched to the application.
     Default: ``100``.
+BB_H2_ACTIVE_STREAMS_1W
+    Per-connection ``asyncio.Semaphore`` cap on running stream handlers
+    when ``workers == 1``.  Counterpart of ``BB_H2_ACTIVE_STREAMS`` for
+    the single-worker case (where one event loop sees all connections).
+    ``0`` disables the cap.  Default: ``20``.
 BB_H2_ACTIVE_STREAMS
-    Maximum number of HTTP/2 stream handlers that run concurrently per
-    connection.  When > 0, each connection gets an ``asyncio.Semaphore``
-    of this size; newly-spawned stream tasks queue for the semaphore instead
-    of running immediately.  This prevents one high-mux connection from
-    monopolising the event loop and starving other connections on the same
-    worker.  ``0`` disables the semaphore (no cap beyond
-    ``BB_H2_MAX_CONCURRENT_STREAMS``).  Default: ``0`` (disabled).
+    Per-connection ``asyncio.Semaphore`` cap on running stream handlers
+    when ``workers > 1``.  Newly-spawned stream tasks queue for the
+    semaphore instead of running immediately, which prevents one high-mux
+    connection from monopolising the event loop and starving other
+    connections on the same worker.  ``0`` disables the cap (no upper
+    bound beyond ``BB_H2_MAX_CONCURRENT_STREAMS``).  Default: ``20``.
+BB_H2_ENABLE_WEBSOCKET
+    Advertise ``SETTINGS_ENABLE_CONNECT_PROTOCOL=1`` (RFC 8441 §3) so
+    peers may bootstrap WebSocket over HTTP/2 via Extended CONNECT.
+    Off by default — this path has fewer conformance tests than the
+    HTTP/1.1 upgrade path.  Default: ``false``.
+BB_WS_PERMESSAGE_DEFLATE
+    Negotiate ``permessage-deflate`` (RFC 7692) on incoming WebSocket
+    handshakes when the peer offers it.  Matches modern browsers and
+    major WebSocket libraries.  Default: ``true``.
 BB_COMPRESSION_MIN_SIZE
     Minimum response body size in bytes below which
     :class:`~blackbull.middleware.compression.Compression` skips
@@ -114,8 +169,10 @@ BB_COMPRESSION_MAX_INFLIGHT
     concurrently in the asyncio default thread pool.  When at or above
     this cap, additional eligible responses are served **uncompressed**
     rather than queued — bounded fall-back rather than unbounded queue
-    growth.  Tied to executor size: setting this above ``os.cpu_count()
-    + 4`` provides no benefit (Python's default executor pool size).
+    growth.  Tied to executor size: setting this above Python's default
+    ``ThreadPoolExecutor`` ``max_workers`` provides no benefit.  That
+    default is ``min(32, os.cpu_count() + 4)`` on Python ≤ 3.12 and
+    ``min(128, os.cpu_count() * 5)`` on Python ≥ 3.13.
     ``0`` disables backpressure (unbounded queue, pre-0.29 behaviour).
     Default: ``os.cpu_count() * 2``.
 BB_BROTLI_QUALITY
@@ -135,6 +192,22 @@ BB_FRAME_YIELD_EVERY
     spawns caps the maximum synchronous run to N × ~50 µs regardless of
     burst size.  ``0`` disables cooperative yielding (legacy behaviour).
     Default: ``8``.
+BB_UVLOOP
+    Install the ``uvloop`` event loop policy before each
+    ``asyncio.run()`` when the optional ``[speed]`` extra is installed.
+    Falls back to the standard asyncio loop with a warning if uvloop is
+    not importable.  Default: ``false``.
+BB_DEADLINE_TICK_MS
+    Polling interval (milliseconds) for the per-process deadline scanner
+    that enforces connection timeouts (``BB_HEADER_TIMEOUT``,
+    ``BB_BODY_TIMEOUT``, ``BB_WRITE_TIMEOUT``, ``BB_KEEP_ALIVE_TIMEOUT``).
+    Smaller = tighter timeout granularity at a small CPU cost; larger =
+    more slack but cheaper.  Default: ``300``.
+BB_SESSION_SECRET
+    HMAC secret used by the :class:`~blackbull.middleware.session.Session`
+    middleware to sign cookies.  Pass ``secret=`` to the constructor or
+    set this env var; if neither is set, ``Session()`` construction
+    raises (no insecure default).  Default: *(unset)*.
 """
 import dataclasses
 import functools as _functools
@@ -231,13 +304,12 @@ class Settings:
     #: integrity).  Unbounded per-worker concurrency lets a single
     #: client (or burst, or slowloris-class workload) park thousands of
     #: suspended-readuntil tasks on the event loop, amplifying drain
-    #: time on burst-close and inflating worst-case latency.  1024 is
-    #: the typical ceiling for a single asyncio loop on commodity
-    #: hardware; the multi-worker ``workers=N`` setting multiplies the
-    #: ceiling (so N=8 workers → 8K concurrent connections per
-    #: process).  Set ``BB_MAX_CONNECTIONS=0`` to opt back into
-    #: unbounded behaviour on trusted hosts.
-    max_connections: int = 1024
+    #: time on burst-close and inflating worst-case latency.  Set
+    #: ``BB_MAX_CONNECTIONS`` to a finite ceiling on untrusted hosts;
+    #: 1024 is a typical single-asyncio-loop ceiling, and multi-worker
+    #: deployments multiply (so ``workers=8`` × ``BB_MAX_CONNECTIONS=1024``
+    #: → 8K connections per process).
+    max_connections: int = 0
 
     #: asyncio.Queue depth for HTTP/2 per-stream request-body events.
     stream_queue_depth: int = 64
@@ -251,20 +323,23 @@ class Settings:
     #: Emit one access log record per completed request on blackbull.access.
     access_log: bool = True
 
-    #: listen() backlog depth for the server socket.  4096 matches the
-    #: Linux >=5.4 default for ``net.core.somaxconn`` (the kernel silently
-    #: caps to that anyway).  Raised from 1024 because a c=1024 wrk burst
-    #: was overflowing the queue and producing connect-RSTs.
-    socket_backlog: int = 4096
+    #: listen() backlog depth for the server socket.  128 is the
+    #: traditional kernel ``SOMAXCONN`` default.  Production deployments
+    #: under burst load should raise this — see
+    #: docs/reference/env-vars.md "Performance recommendations".
+    socket_backlog: int = 128
 
     #: SO_SNDBUF for accepted sockets (0 = leave kernel default).
-    socket_sndbuf: int = 262144  # 256 kB requested → ~512 kB effective
+    socket_sndbuf: int = 0
 
     #: SO_RCVBUF for accepted sockets (0 = leave kernel default).
-    socket_rcvbuf: int = 262144  # 256 kB requested → ~512 kB effective
+    socket_rcvbuf: int = 0
 
     #: Use SO_REUSEPORT to give each worker its own kernel accept queue.
-    socket_reuseport: bool = True
+    #: Off by default — only meaningful under ``workers > 1``.  Production
+    #: multi-worker deployments should enable it; see
+    #: docs/reference/env-vars.md "Performance recommendations".
+    socket_reuseport: bool = False
 
     #: Idle timeout (seconds) on a keep-alive connection that is awaiting
     #: the *next* request.  Replaces per-accept ``SO_KEEPALIVE`` syscalls
@@ -278,10 +353,9 @@ class Settings:
     #: integrity).  60 s parks ghost / idle connections in the loop's
     #: ``readuntil`` for far longer than necessary, inflating the
     #: suspended-task count and amplifying burst-close drain time.
-    #: 5 s matches uvicorn / granian / Caddy / Go-net/http and is the
-    #: industry-standard short-idle value.  Long-lived clients on slow
-    #: links should set ``BB_KEEP_ALIVE_TIMEOUT`` explicitly to a
-    #: higher value.
+    #: 5 s is a common short-idle value for request-pipeline keep-alive.
+    #: Long-lived clients on slow links should set
+    #: ``BB_KEEP_ALIVE_TIMEOUT`` explicitly to a higher value.
     keep_alive_timeout: float = 5.0
 
     #: ``TCP_USER_TIMEOUT`` value in **milliseconds** for accepted sockets.
@@ -289,7 +363,7 @@ class Settings:
     #: Forces a connection-level error if a peer fails to ACK in this
     #: window — protects against dead-mid-write peers that ``SO_KEEPALIVE``
     #: misses.  0 leaves the kernel default unchanged.
-    tcp_user_timeout_ms: int = 60_000
+    tcp_user_timeout_ms: int = 0
 
     #: Per-request timeout in seconds for HTTP/2 streams (0 = disabled).
     request_timeout: float = 0.0
@@ -336,10 +410,15 @@ class Settings:
     header_max_total: int = 65536
 
     #: Per-stream HTTP/2 flow-control window advertised in the server's SETTINGS.
-    h2_initial_window_size: int = 1048576  # 1 MiB
+    #: 65535 is the RFC 9113 §6.9.2 default.  Production deployments serving
+    #: large responses should raise this — see
+    #: docs/reference/env-vars.md "Performance recommendations".
+    h2_initial_window_size: int = 65535
 
     #: Connection-level HTTP/2 flow-control window advertised via WINDOW_UPDATE(stream_id=0).
-    h2_connection_window_size: int = 4194304  # 4 MiB
+    #: 65535 is the RFC 9113 §6.9.2 connection-window minimum.  Production
+    #: deployments should raise this — see env-vars.md recommendations.
+    h2_connection_window_size: int = 65535
 
     #: Maximum concurrent HTTP/2 streams per connection (SETTINGS_MAX_CONCURRENT_STREAMS).
     h2_max_concurrent_streams: int = 100
@@ -452,7 +531,7 @@ def get_settings() -> Settings:
         write_timeout=_float_env_nonneg('BB_WRITE_TIMEOUT', 30.0),
         header_max_line=_int_env_nonneg('BB_HEADER_MAX_LINE', 8192),
         header_max_total=_int_env_nonneg('BB_HEADER_MAX_TOTAL', 65536),
-        # RFC 7540 §6.9.2 default initial window size.  See
+        # RFC 9113 §6.9.2 default initial window size.  See
         # docs/reference/env-vars.md "Performance recommendations" for the
         # values commonly used on tuned production deployments.
         h2_initial_window_size=_int_env('BB_H2_INITIAL_WINDOW_SIZE', 65535),

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -31,9 +31,10 @@ _SERVER_PREFERENCE = ['br', 'zstd', 'gzip']  # server-side priority order
 # uncompressed font tables that DO benefit from gzip/brotli, so they stay
 # off this list and run through the codec like any other text-shaped
 # payload.  WOFF wraps zlib internally; WOFF2 wraps brotli internally —
-# re-compressing them is the worst case (high-entropy input at default
-# quality 11) and contributes a measurable per-request CPU tail in
-# Sprint 35's HttpArena static-rotate probe.
+# re-compressing them is the worst case (high-entropy input; under the
+# brotli library's bare-call default of quality 11 — BlackBull's own
+# default is q=4 via ``BB_BROTLI_QUALITY``) and contributes a measurable
+# per-request CPU tail in Sprint 35's HttpArena static-rotate probe.
 _SKIP_CONTENT_TYPES = (
     'image/',
     'audio/',

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -182,7 +182,7 @@ The actor hierarchy is the *control* side.  The *data* side is
 the protocol stack:
 
 - **HTTP/1.1 parser** — `blackbull/server/parser.py`.  Pure
-  Python; no `httptools` dependency.
+  Python.
 - **HTTP/2 frame layer** — `blackbull/protocol/` (frame types,
   flow-control windows, RFC 9218 `PRIORITY_UPDATE`).  Header
   compression delegates to the `hpack` library — the only
@@ -209,8 +209,8 @@ source of truth.
 
 `blackbull[speed]` adds `uvloop` as an optional dependency.
 The HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec
-are all BlackBull's own code — no `httptools`, no `h2` library
-for framing.  The one exception is HPACK header compression,
+are all BlackBull's own code in pure Python.  The one exception
+is HPACK header compression,
 which delegates to the [`hpack`](https://pypi.org/project/hpack/)
 library (pure Python, layered under the BlackBull-owned
 `hpack_fastpath.py`); re-implementing a conformant HPACK
@@ -224,7 +224,7 @@ pure Python:
   applies to `hpack` too — it is itself pure Python, so HPACK
   bugs remain debuggable in-process.
 - **Identity.**  BlackBull exists in part to demonstrate that
-  CPython is fast enough for a from-scratch ASGI implementation
+  CPython is fast enough for a pure-Python ASGI implementation
   when the framework itself stays out of the way.  Swapping in
   a C parser would make it a different project.
 

--- a/docs/getting-started/hello-world.md
+++ b/docs/getting-started/hello-world.md
@@ -30,8 +30,7 @@ Hello, world!
 
 That's a complete server: an HTTP/1.1 listener bound on
 `127.0.0.1:8000` with one route registered.  No external server
-process (no `uvicorn`, no `gunicorn`) and no separate framework
-package — `BlackBull` is both.
+process and no separate framework package — `BlackBull` is both.
 
 ## The ASGI triplet
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,10 +2,9 @@
 
 BlackBull is a Python web framework that speaks the
 [**ASGI 3.0**](https://asgi.readthedocs.io/en/latest/specs/main.html)
-interface[^asgi], with native implementations of HTTP/1.1, HTTP/2 (with
-ALPN), and WebSocket.  Pure-Python protocol stack, no required C
-extensions outside the standard library, one `pip install`, one
-deployable.
+interface[^asgi], with pure-Python implementations of HTTP/1.1, HTTP/2
+(with ALPN), and WebSocket.  No required C extensions outside the
+standard library, one `pip install`, one deployable.
 
 [^asgi]: ASGI is the async successor to WSGI — a single small interface
     that lets the same app object speak HTTP and WebSocket without

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -22,7 +22,7 @@ For the precedence order (CLI flags > env > TOML), see
 
 | Variable | Default | Controls |
 |---|---|---|
-| `BB_MAX_CONNECTIONS` | `1024` | Maximum simultaneous TCP connections **per worker**.  When the cap is reached, new connections receive HTTP/1.1 `503 Service Unavailable` with `Retry-After: 1` before close — a well-formed response so load-balancers / health-checks can interpret it correctly.  `0` disables the cap (rely on OS file-descriptor limit instead).  Multi-worker servers multiply the ceiling (`workers × max_connections`). |
+| `BB_MAX_CONNECTIONS` | `0` (uncapped) | Maximum simultaneous TCP connections **per worker**.  When the cap is reached, new connections receive HTTP/1.1 `503 Service Unavailable` with `Retry-After: 1` before close — a well-formed response so load-balancers / health-checks can interpret it correctly.  `0` disables the cap (rely on OS file-descriptor limit instead).  Multi-worker servers multiply the ceiling (`workers × max_connections`).  Production deployments on untrusted hosts should set this to a finite ceiling — 1024 is a typical single-loop value. |
 | `BB_REQUEST_TIMEOUT` | `0` (off) | Per-HTTP/2-stream deadline in seconds.  When the deadline elapses the stream is forcibly cancelled with `RST_STREAM CANCEL`.  Use a positive value (e.g. `30`) in production to evict stalled handlers from stream slots. |
 | `BB_HEADER_TIMEOUT` | `10.0` | Seconds an HTTP/1.1 client has to deliver the complete header block (request-line + headers + `CRLFCRLF`).  Primary slowloris defence — without it, an attacker can hold a connection open indefinitely by dripping bytes.  Server answers `408 Request Timeout` and closes.  `0` disables. |
 | `BB_BODY_TIMEOUT` | `30.0` | Per-chunk deadline for the request body once headers are parsed.  Slowloris body-half defence.  Each `await receive()` is bounded by this; exceed → the recipient surfaces `http.disconnect` and the connection tears down.  `0` disables. |
@@ -74,6 +74,7 @@ For the precedence order (CLI flags > env > TOML), see
 |---|---|---|
 | `BB_COMPRESSION_MIN_SIZE` | `100` | Minimum body size in bytes below which the `Compression` middleware skips compression entirely. |
 | `BB_COMPRESSION_EXECUTOR_THRESHOLD` | `65536` (64 KiB) | Body size above which compression is offloaded to a thread-pool executor so the event loop stays responsive during the (CPU-bound) compress call.  `0` always compresses on the event loop. |
+| `BB_COMPRESSION_MAX_INFLIGHT` | `os.cpu_count() * 2` | Maximum concurrent compression offloads to the asyncio default thread pool.  When at or above this cap, additional eligible responses are served **uncompressed** rather than queued — bounded fall-back rather than unbounded queue growth.  `0` disables the cap (unbounded queue, pre-0.29 behaviour). |
 | `BB_BROTLI_QUALITY` | `4` | Brotli quality level (0–11) for dynamic-response compression.  4 matches Google/Cloudflare's recommendation for dynamic content; 5 matches Apache `mod_brotli`; 6 matches nginx `ngx_brotli`.  11 is appropriate only for build-time / static pre-compression — far too expensive on the request path. |
 
 ## Sessions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "blackbull"
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
 version = "0.33.1"
-description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
+description = "Async ASGI 3.0 framework with pure-Python HTTP/1.1, HTTP/2 framing, and WebSocket implementations. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary

Two rounds of post-v0.33.1 doc cleanup. No behaviour change — pure docs + comments + module docstrings.

### Tone

- Drop "from-scratch" framing across README, `pyproject.toml`, `CLAUDE.md`, `docs/*`, `bench/httparena/meta.json`, `bench/CHARACTERIZATION.md`. BlackBull depends on `hpack`, `beartype`, and optional `brotli`/`zstandard` — "pure-Python" is accurate, "from-scratch" overclaims.
- Drop peer-framework comparisons ("no uvicorn", "no httptools", etc.) per the `public-docs-humble` convention.

### env-var docs stale-data fixes

- `Settings` dataclass field defaults synced to the effective defaults set by `get_settings()` (7 fields: `socket_*`, `h2_*_window_size`, `max_connections`, `tcp_user_timeout_ms`).
- `BB_H2_ACTIVE_STREAMS` docstring default `0` → `20` (actual).
- `BB_MAX_CONNECTIONS` docstring + dataclass + env-vars.md default `1024` → `0` (actual; uncapped, relies on OS FD limit).
- 12 env vars that were in `env-vars.md` but absent from the `env.py` module docstring are now in both (symmetry verified by grep diff).
- `BB_COMPRESSION_MAX_INFLIGHT` row added to `env-vars.md`.
- `KNOWN_LIMITATIONS.md` static cache description rewritten to lead with the default disk-read path (since 0.33); `cache=True` documented as the opt-in.
- `keep_alive_timeout` comment dropped the Caddy / Go-net/http peer comparison (factually wrong — Caddy default is 5 min, Go is 0).
- `ThreadPoolExecutor` default formula corrected to `min(32, os.cpu_count() + 4)` on Python ≤ 3.12 and `min(128, os.cpu_count() * 5)` on Python ≥ 3.13.
- RFC 7540 → RFC 9113 in `env.py` (6 hits). Broader 96-hit RFC refresh deferred to a separate follow-up.

## Test plan

- [x] Pre-commit hook green: 1273 unit tests pass, 196 skipped, 0 failures; \`mkdocs build --strict\` green.
- [x] env-vars.md ↔ env.py module-docstring symmetry verified by sort-diff (34 = 34 vars, identical sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)