### PR TITLE
release: v0.36.0 — Sprint 40 close: slim extension surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ venv.bak/
 # private development notes (not for end users)
 CLAUDE_DEV.md
 .claude/design/
-.claude/phases/
+.claude/planning/
 .claude/patterns/
 # benchmark result files (keep directory + READMEs, ignore data)
 bench/results/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,24 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+- `BlackBull.extensions: dict[str, object]` — namespace for
+  third-party integrations following the `init_app(app)`
+  convention.  Empty at construction; extensions write themselves
+  into it under a documented key.
+- `app.on_error(int)` — accepts a plain `int` HTTP status code
+  in addition to `HTTPStatus` and exception classes.  Coerced to
+  `HTTPStatus` internally; ergonomic shortcut for extension code
+  that already uses raw status codes.
+
+### Docs
+- New guide page `docs/guide/extensions.md` covering the
+  `app.extensions` namespace, the `init_app(app)` convention,
+  the `blackbull-<name>` → `app.extensions['<name>']` key
+  convention with `RuntimeError` collision detection, and the
+  author-managed dependency-ordering pattern with the
+  prerequisite-check idiom.
+
 ## [0.35.0] — 2026-06-14
 
 **Sprint 39 close: RFC 8441 interop, default-on safety guards,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.36.0] — 2026-06-14
+
+**Sprint 40 close: slim extension surface.**
+
 ### Added
 - `BlackBull.extensions: dict[str, object]` — namespace for
   third-party integrations following the `init_app(app)`

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -228,6 +228,11 @@ class BlackBull:
         self._static_roots: list[tuple[str, Path]] = []
         self._chain = None  # cached global middleware chain; rebuilt on first request
 
+        # Extension namespace — name→object registry used by third-party
+        # integrations following the ``init_app(app)`` convention.  See
+        # docs/guide/extensions.md.
+        self.extensions: dict[str, object] = {}
+
         if trusted_proxies is not None:
             from .middleware.proxy import TrustedProxy  # noqa: PLC0415
             self.use(TrustedProxy(trusted_proxies))
@@ -567,9 +572,16 @@ class BlackBull:
     def on_error(self, key):
         """Register a custom error handler for an HTTPStatus or exception class.
 
+        ``key`` may be an :class:`HTTPStatus`, a plain ``int`` status code
+        (coerced to ``HTTPStatus``), or an exception class.
+
         Usage::
 
             @app.on_error(HTTPStatus.FORBIDDEN)
+            async def handle_403(scope, receive, send):
+                ...
+
+            @app.on_error(403)            # int shorthand
             async def handle_403(scope, receive, send):
                 ...
 
@@ -583,6 +595,8 @@ class BlackBull:
           - 'error_exception' : exception instance (when triggered by an exception)
           - 'allowed_methods' : allowed method names (for 405)
         """
+        if isinstance(key, int) and not isinstance(key, HTTPStatus):
+            key = HTTPStatus(key)
         return self._error_router(key)
 
     def url_path_for(self, name: str, /, **params) -> str:

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -1,0 +1,191 @@
+# Extensions
+
+BlackBull's core surface is intentionally narrow — protocols,
+routing, middleware, events, error handling.  Everything else
+(auth, admin dashboards, ORMs, template engines, ...) lives
+outside the core as **extensions**: small packages that wire
+themselves into an application using the existing public APIs
+(`app.use`, `app.route`, `app.on`, `app.on_error`).
+
+The extension surface is one attribute and one convention:
+
+- **`app.extensions`** — a `dict[str, object]` for extension
+  instances to register themselves under a stable key.
+- **`init_app(app)`** — a method extensions implement so the
+  application author can wire them in explicitly.
+
+There is no plugin registry, no auto-discovery, no dependency
+injection.  Composition is the application author's job.
+
+## The `app.extensions` namespace
+
+Every `BlackBull` instance carries an `extensions` dict, empty
+at construction:
+
+```python
+from blackbull import BlackBull
+
+app = BlackBull()
+assert app.extensions == {}
+```
+
+Extensions write themselves into it under a documented key:
+
+```python
+app.extensions['auth'] = my_auth_instance
+```
+
+Application code reads it back when one extension needs to
+look up another (for example a route handler needing the
+configured auth instance).
+
+## The `init_app(app)` convention
+
+An extension is any class with an `init_app(app)` method that
+registers its routes, middleware, events, and error handlers
+through the existing `app.*` APIs:
+
+```python
+from blackbull import BlackBull
+
+
+class HelloExtension:
+    def __init__(self, greeting: str = 'Hello'):
+        self._greeting = greeting
+
+    def init_app(self, app: BlackBull) -> None:
+        app.extensions['hello'] = self
+
+        @app.route(path='/hello')
+        async def hello():
+            return {'message': f'{self._greeting} from extension'}
+
+        # Keep a reference so the registered handler is not GC'd
+        # if the user does not retain it.
+        self._handler = hello
+
+
+app = BlackBull()
+HelloExtension(greeting='Howdy').init_app(app)
+```
+
+Optionally accept `app` in the constructor and call
+`init_app` for the user:
+
+```python
+class HelloExtension:
+    def __init__(self, app: BlackBull | None = None, *, greeting: str = 'Hello'):
+        self._greeting = greeting
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: BlackBull) -> None:
+        ...
+```
+
+Both styles are supported by convention; pick one per extension
+and document it.
+
+## Extension keys in `app.extensions`
+
+The `app.extensions` dict is a shared namespace.  Keys follow
+one rule:
+
+- **For published packages** named `blackbull-<name>` on PyPI,
+  the key MUST be `<name>` (the package name with the
+  `blackbull-` prefix stripped).  A package named
+  `blackbull-auth` registers itself at `app.extensions['auth']`;
+  `blackbull-session` at `app.extensions['session']`.
+- **For application-private extensions** (not published),
+  pick a key unlikely to collide with any published
+  `blackbull-*` package — prefix with an underscore or the
+  application name:
+
+  ```python
+  app.extensions['_myapp_cache'] = MyAppCache(...)
+  ```
+
+If a collision is detected at `init_app` time, the extension
+SHOULD raise `RuntimeError` rather than silently overwriting:
+
+```python
+def init_app(self, app: BlackBull) -> None:
+    if 'auth' in app.extensions:
+        existing = type(app.extensions['auth']).__module__
+        raise RuntimeError(
+            f"app.extensions['auth'] is already registered by "
+            f"{existing}. Cannot initialise {type(self).__module__}.")
+    app.extensions['auth'] = self
+```
+
+## Extension dependencies and `init_app` ordering
+
+When extension A depends on extension B (for example, an admin
+dashboard that needs an auth extension to protect its routes),
+the application author calls `init_app(app)` in dependency
+order — B before A:
+
+```python
+auth = AuthExtension(jwt_secret=os.environ['JWT_SECRET'])
+auth.init_app(app)
+
+admin = AdminExtension()
+admin.init_app(app)   # looks up app.extensions['auth']
+```
+
+BlackBull does NOT enforce ordering — that would require a
+dependency resolver inside the core.  Instead the dependent
+extension validates its prerequisites at `init_app` time and
+raises a clear error if they are missing:
+
+```python
+class AdminExtension:
+    def init_app(self, app: BlackBull) -> None:
+        if 'auth' not in app.extensions:
+            raise RuntimeError(
+                'AdminExtension requires an auth extension. '
+                'Initialise it first: auth.init_app(app)')
+        self._auth = app.extensions['auth']
+        app.extensions['admin'] = self
+```
+
+The application author owns the dependency graph; the
+extension author owns the prerequisite check.  The core stays
+free of resolution logic.
+
+## Extension vs library
+
+Not every reusable component needs to be an extension.
+
+| Use an extension when | Just import the library when |
+| --- | --- |
+| The component registers routes, middleware, events, or error handlers on the app | The component is a pure function or class used inside a handler |
+| The component needs configuration tied to the app's lifecycle | The component is configured at module import time |
+| Multiple parts of the app need to look the component up by name | One handler uses it and nobody else needs a reference |
+
+A database client, JSON serialiser, or password hasher is a
+library — import it directly.  An auth layer that adds login
+routes and a `scope['user']` middleware is an extension —
+wire it through `init_app`.
+
+## ASGI middleware via `app.use()`
+
+`app.use()` accepts any ASGI 3.0 middleware following the
+`(scope, receive, send, call_next)` shape, so an extension can
+simply pass a middleware callable through it:
+
+```python
+async def x_request_id_mw(scope, receive, send, call_next):
+    scope['x-request-id'] = generate_id()
+    await call_next(scope, receive, send)
+
+
+class RequestIdExtension:
+    def init_app(self, app: BlackBull) -> None:
+        app.use(x_request_id_mw)
+        app.extensions['request_id'] = self
+```
+
+See [Middleware](middleware.md) for the full middleware
+contract, including how to short-circuit the chain and how to
+inspect responses via `intercepting_send`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
     - Logging: guide/logging.md
     - Static files: guide/static-files.md
     - Configuration: guide/configuration.md
+    - Extensions: guide/extensions.md
     - OpenAPI: guide/openapi.md
     - Testing: guide/testing.md
   - Deployment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.35.0"
+version = "0.36.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -19,9 +19,6 @@ Coverage:
 
 from __future__ import annotations
 
-import asyncio
-import re
-
 import pytest
 from http import HTTPMethod, HTTPStatus
 
@@ -56,7 +53,8 @@ class TestExtensionsAttribute:
         app = BlackBull()
         app.extensions['test'] = object()
         assert 'test' in app.extensions
-        assert app.extensions.pop('test') is not None
+        popped = app.extensions.pop('test')
+        assert popped is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -1,0 +1,511 @@
+"""Tests for ``BlackBull.extensions`` and the ``init_app(app)`` convention.
+
+The extension surface is intentionally minimal — one dict attribute
+(``app.extensions``) and a documented convention for third-party
+packages (``init_app(app)``).  These tests verify the mechanism and
+double as the worked examples for ``docs/guide/extensions.md``.
+
+Coverage:
+    * ``app.extensions`` exists and is a writable dict.
+    * An extension class following the ``init_app(app)`` pattern can
+      register middleware, routes, event handlers, and error handlers.
+    * Extension key collision raises ``RuntimeError`` (per the convention).
+    * Extension dependency ordering — an extension can look up another
+      extension in ``app.extensions`` at ``init_app`` time.
+    * Preserving ``init_app`` idempotency — calling it twice behaves
+      predictably.
+    * Representative ASGI middleware via ``app.use()`` — smoke test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+from http import HTTPMethod, HTTPStatus
+
+from blackbull import BlackBull, Response
+from blackbull.testing import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Task A — app.extensions exists
+# ---------------------------------------------------------------------------
+
+class TestExtensionsAttribute:
+    """``app.extensions`` must exist as a plain dict on every BlackBull
+    instance, initially empty."""
+
+    def test_extensions_exists_on_app(self):
+        """``app.extensions`` is a dict attribute on ``BlackBull``."""
+        app = BlackBull()
+        assert hasattr(app, 'extensions'), (
+            'BlackBull must expose app.extensions')
+        assert isinstance(app.extensions, dict), (
+            'app.extensions must be a dict')
+
+    def test_extensions_is_empty_by_default(self):
+        """A freshly-constructed app has an empty extensions dict."""
+        app = BlackBull()
+        assert app.extensions == {}, (
+            'app.extensions must be empty at construction time')
+
+    def test_extensions_is_writable(self):
+        """Third-party code can write into app.extensions."""
+        app = BlackBull()
+        app.extensions['test'] = object()
+        assert 'test' in app.extensions
+        assert app.extensions.pop('test') is not None
+
+
+# ---------------------------------------------------------------------------
+# Task A + B — init_app convention with middleware, events, routes, errors
+# ---------------------------------------------------------------------------
+
+class _FakeAuthExtension:
+    """A minimal extension following the ``init_app(app)`` convention.
+
+    Registers:
+        - An auth middleware that injects ``scope['user']``.
+        - A ``request_received`` event handler.
+        - A ``/whoami`` route.
+        - A custom 403 error handler.
+    """
+
+    def __init__(self, app: BlackBull | None = None):
+        self._middleware_called = False
+        self._event_fired = False
+        self._error_handler_called = False
+        self._whoami_called = False
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app: BlackBull) -> None:
+        app.extensions['auth'] = self
+        app.use(self._auth_middleware)
+        app.on('request_received')(self._on_request)
+        app.on_error(403)(self._on_403)
+
+        @app.route(path='/whoami')
+        async def whoami(scope):
+            self._whoami_called = True
+            user = scope.get('user', 'anonymous')
+            return {'user': user}
+
+        # Keep a reference so the route callback is collected properly
+        self._whoami_handler = whoami
+
+    async def _auth_middleware(self, scope, receive, send, call_next):
+        self._middleware_called = True
+        # Dummy auth — always sets 'testuser'
+        scope['user'] = 'testuser'
+        await call_next(scope, receive, send)
+
+    async def _on_request(self, event):
+        self._event_fired = True
+
+    async def _on_403(self, scope, receive, send):
+        self._error_handler_called = True
+        await send(Response(b'forbidden', status=HTTPStatus.FORBIDDEN))
+
+
+class TestInitAppConvention:
+    """The ``init_app(app)`` convention must work end-to-end with
+    BlackBull's existing middleware, event, route, and error APIs."""
+
+    def test_extension_registers_in_extensions_dict(self):
+        """After ``init_app(app)``, the extension must be stored under
+        its key in ``app.extensions``."""
+        app = BlackBull()
+        ext = _FakeAuthExtension()
+        ext.init_app(app)
+        assert app.extensions.get('auth') is ext, (
+            'extension must be stored at app.extensions["auth"]')
+
+    def test_extension_constructor_with_app_argument(self):
+        """Passing ``app`` to the constructor must call ``init_app``
+        immediately (Flask-compatible convenience pattern)."""
+        app = BlackBull()
+        ext = _FakeAuthExtension(app=app)
+        assert app.extensions.get('auth') is ext
+
+    def test_extension_middleware_is_called(self):
+        """Middleware registered by ``init_app`` must run and inject
+        ``scope['user']``."""
+        app = BlackBull()
+        ext = _FakeAuthExtension(app=app)
+
+        # Add a route that returns the injected user
+        @app.route(path='/me')
+        async def me(scope):
+            return {'user': scope.get('user', '?')}
+
+        with TestClient(app) as client:
+            resp = client.get('/me')
+            assert resp.status_code == 200
+            # The middleware should have injected 'testuser'
+            assert resp.json() == {'user': 'testuser'}
+            assert ext._middleware_called, (
+                'auth middleware must have been called')
+
+    def test_extension_route_is_served(self):
+        """Routes registered by ``init_app`` must be reachable."""
+        app = BlackBull()
+        ext = _FakeAuthExtension(app=app)
+
+        with TestClient(app) as client:
+            resp = client.get('/whoami')
+            assert resp.status_code == 200
+            assert resp.json() == {'user': 'testuser'}
+            assert ext._whoami_called
+
+    @pytest.mark.xfail(
+        reason="'request_received' is emitted from the HTTP1/HTTP2/WS actor "
+               "layer, not from BlackBull.__call__. TestClient goes through "
+               "httpx.ASGITransport → __call__, so this event does not fire "
+               "in TestClient-driven tests. Cross-layer event-emission "
+               "consistency is out of Sprint 40 scope; carry-forward.",
+        strict=True,
+    )
+    def test_extension_event_handler_is_fired(self):
+        """Event handlers registered by ``init_app`` must fire on
+        every request."""
+        app = BlackBull()
+        ext = _FakeAuthExtension(app=app)
+
+        @app.route(path='/ping')
+        async def ping():
+            return 'pong'
+
+        with TestClient(app) as client:
+            resp = client.get('/ping')
+            assert resp.status_code == 200
+            # Fire-and-forget events need a settle window — poll with
+            # a small sleep rather than spinning the GIL, so the
+            # dispatcher's background task can actually run.
+            import time
+            deadline = time.monotonic() + 2.0
+            while not ext._event_fired and time.monotonic() < deadline:
+                time.sleep(0.02)
+            assert ext._event_fired, (
+                'request_received event must have fired')
+
+    @pytest.mark.xfail(
+        reason="on_error(STATUS) handlers fire only when routing/dispatch "
+               "raises (MethodNotApplicable, PathNotRegistered, or an "
+               "exception that becomes 500). A handler that explicitly "
+               "returns Response(status=403) is an emission, not an error "
+               "event — wiring status-code matching to handler-returned "
+               "responses requires intercepting send and is out of Sprint 40 "
+               "scope.",
+        strict=True,
+    )
+    def test_extension_error_handler_is_called(self):
+        """Error handlers registered by ``init_app`` must handle
+        the appropriate status code."""
+        app = BlackBull()
+        ext = _FakeAuthExtension(app=app)
+
+        @app.route(path='/secret')
+        async def secret():
+            return Response(b'forbidden', status=HTTPStatus.FORBIDDEN)
+
+        with TestClient(app) as client:
+            resp = client.get('/secret')
+            assert resp.status_code == 403
+            assert ext._error_handler_called, (
+                '403 error handler must have been called')
+
+
+# ---------------------------------------------------------------------------
+# Task D §3 — Namespace collision detection
+# ---------------------------------------------------------------------------
+
+class _CollidingExtension:
+    """An extension that checks for key collision at ``init_app`` time."""
+    def __init__(self, key: str = 'auth'):
+        self._key = key
+
+    def init_app(self, app: BlackBull) -> None:
+        if self._key in app.extensions:
+            existing = type(app.extensions[self._key]).__module__
+            raise RuntimeError(
+                f"app.extensions[{self._key!r}] is already registered "
+                f"by {existing}. Cannot initialise "
+                f"{type(self).__module__}.")
+        app.extensions[self._key] = self
+
+
+class TestExtensionKeyCollision:
+    """If two extensions claim the same key in ``app.extensions``, the
+    second MUST raise ``RuntimeError`` (convention, not framework
+    enforced)."""
+
+    def test_collision_raises_runtime_error(self):
+        """Registering two extensions under the same key ('auth')
+        must raise RuntimeError from the second ``init_app``."""
+        app = BlackBull()
+        ext1 = _CollidingExtension(key='auth')
+        ext1.init_app(app)
+
+        ext2 = _CollidingExtension(key='auth')
+        with pytest.raises(RuntimeError, match='already registered'):
+            ext2.init_app(app)
+
+    def test_different_keys_no_collision(self):
+        """Two extensions using different keys must both succeed."""
+        app = BlackBull()
+        ext_auth = _CollidingExtension(key='auth')
+        ext_auth.init_app(app)
+        ext_admin = _CollidingExtension(key='admin')
+        ext_admin.init_app(app)
+
+        assert app.extensions['auth'] is ext_auth
+        assert app.extensions['admin'] is ext_admin
+
+
+# ---------------------------------------------------------------------------
+# Task D §4 — Extension dependency ordering
+# ---------------------------------------------------------------------------
+
+class _DependentExtension:
+    """An extension that requires another extension to be initialised first."""
+    def __init__(self, key: str = 'admin', requires: str = 'auth'):
+        self._key = key
+        self._requires = requires
+
+    def init_app(self, app: BlackBull) -> None:
+        if self._requires not in app.extensions:
+            dep_name = self._requires
+            raise RuntimeError(
+                f'{type(self).__name__} requires an extension at '
+                f"app.extensions[{dep_name!r}]. "
+                f'Initialise it first.')
+        app.extensions[self._key] = self
+
+
+class _PrerequisiteExtension:
+    """A simple extension that provides a prerequisite for others."""
+    def __init__(self, key: str = 'auth'):
+        self._key = key
+
+    def init_app(self, app: BlackBull) -> None:
+        app.extensions[self._key] = self
+
+
+class TestExtensionDependencyOrdering:
+    """Extensions must be initialised in dependency order — prerequisites
+    first, dependents second.  BlackBull does not resolve this; the
+    application author controls it via ``init_app`` call order."""
+
+    def test_dependent_after_prerequisite_succeeds(self):
+        """Prerequisite first, dependent second → both succeed."""
+        app = BlackBull()
+        auth = _PrerequisiteExtension(key='auth')
+        auth.init_app(app)
+        admin = _DependentExtension(key='admin', requires='auth')
+        admin.init_app(app)
+
+        assert 'auth' in app.extensions
+        assert 'admin' in app.extensions
+
+    def test_dependent_before_prerequisite_raises(self):
+        """Dependent first, prerequisite missing → RuntimeError."""
+        app = BlackBull()
+        admin = _DependentExtension(key='admin', requires='auth')
+        with pytest.raises(RuntimeError, match='requires an extension'):
+            admin.init_app(app)
+
+    def test_dependency_lookup_in_init_app(self):
+        """An extension that successfully looks up its dependency can
+        use it — end-to-end with two real-ish extensions."""
+        app = BlackBull()
+
+        class _AuthProvider:
+            def init_app(self, a):
+                a.extensions['auth'] = self
+                self.secret = 's3cret'
+
+        class _AdminDashboard:
+            def init_app(self, a):
+                if 'auth' not in a.extensions:
+                    raise RuntimeError('auth required')
+                self._auth = a.extensions['auth']
+                a.extensions['admin'] = self
+
+        auth = _AuthProvider()
+        auth.init_app(app)
+        admin = _AdminDashboard()
+        admin.init_app(app)
+
+        assert admin._auth is auth
+        assert admin._auth.secret == 's3cret'
+
+
+# ---------------------------------------------------------------------------
+# Task D §2 — init_app idempotency
+# ---------------------------------------------------------------------------
+
+class TestInitAppIdempotency:
+    """Calling ``init_app(app)`` twice on the same extension instance
+    should be predictable — the second call should either be a no-op
+    or raise a clear error."""
+
+    def test_init_app_called_twice_raises_or_noops(self):
+        """If the convention detects double-init, it should raise
+        RuntimeError rather than double-register routes/middleware."""
+        app = BlackBull()
+
+        class _OnceOnlyExtension:
+            def __init__(self):
+                self._initialised = False
+
+            def init_app(self, a):
+                if self._initialised:
+                    raise RuntimeError(
+                        f'{type(self).__name__} is already initialised')
+                self._initialised = True
+                a.extensions['once'] = self
+
+        ext = _OnceOnlyExtension()
+        ext.init_app(app)
+        with pytest.raises(RuntimeError, match='already initialised'):
+            ext.init_app(app)
+
+
+# ---------------------------------------------------------------------------
+# Task D §6 — Representative ASGI middleware via app.use()
+# ---------------------------------------------------------------------------
+
+class TestASGIMiddlewareCompat:
+    """Arbitrary ASGI 3.0 middleware that follows the ``(scope, receive,
+    send, call_next)`` convention must work when passed to ``app.use()``."""
+
+    def test_asgi_middleware_via_app_use(self):
+        """A hand-written ASGI middleware must be callable via ``app.use()``
+        and must see every request."""
+        app = BlackBull()
+        calls: list[str] = []
+
+        async def _x_request_id(scope, receive, send, call_next):
+            calls.append('mw_enter')
+            scope['x-request-id'] = 'test-001'
+            await call_next(scope, receive, send)
+            calls.append('mw_exit')
+
+        app.use(_x_request_id)
+
+        @app.route(path='/mw-test')
+        async def mw_test(scope):
+            return {'request_id': scope.get('x-request-id', '?')}
+
+        with TestClient(app) as client:
+            resp = client.get('/mw-test')
+            assert resp.status_code == 200
+            assert resp.json() == {'request_id': 'test-001'}
+            assert calls == ['mw_enter', 'mw_exit'], (
+                f'middleware call sequence wrong: {calls!r}')
+
+    def test_asgi_middleware_can_short_circuit(self):
+        """An ASGI middleware that does NOT call ``call_next`` must
+        short-circuit the request — the route handler must never run."""
+        app = BlackBull()
+        handler_called = False
+
+        async def _block_mw(scope, receive, send, call_next):
+            # Short-circuit without calling call_next
+            await send({
+                'type': 'http.response.start',
+                'status': 403,
+                'headers': [(b'content-type', b'text/plain')],
+            })
+            await send({
+                'type': 'http.response.body',
+                'body': b'blocked',
+            })
+
+        app.use(_block_mw)
+
+        @app.route(path='/secret')
+        async def secret():
+            nonlocal handler_called
+            handler_called = True
+            return 'you should not see this'
+
+        with TestClient(app) as client:
+            resp = client.get('/secret')
+            assert resp.status_code == 403
+            assert resp.text == 'blocked'
+            assert not handler_called, (
+                'handler must not run when middleware short-circuits')
+
+
+# ---------------------------------------------------------------------------
+# Extension + TestClient together (dogfooding)
+# ---------------------------------------------------------------------------
+
+class TestExtensionWithTestClient:
+    """Full dogfooding: an ``init_app``-style extension exercised
+    end-to-end through ``TestClient``."""
+
+    def test_extension_registers_route_reachable_via_testclient(self):
+        """A third-party package's extension registers a route; the
+        route is reachable through TestClient."""
+        app = BlackBull()
+
+        class _HelloExtension:
+            def init_app(self, a):
+                a.extensions['hello'] = self
+
+                @a.route(path='/hello-ext')
+                async def hello():
+                    return {'msg': 'hello from extension'}
+
+                self._handler = hello
+
+        _HelloExtension().init_app(app)
+
+        with TestClient(app) as client:
+            resp = client.get('/hello-ext')
+            assert resp.status_code == 200
+            assert resp.json() == {'msg': 'hello from extension'}
+
+    def test_multiple_extensions_coexist(self):
+        """Two extensions registering routes, middleware, and events
+        must coexist without interference."""
+        app = BlackBull()
+
+        class _ExtA:
+            def init_app(self, a):
+                a.extensions['a'] = self
+                a.use(self._mw)
+
+                @a.route(path='/a')
+                async def a_route():
+                    return 'a'
+
+                self._handler = a_route
+
+            async def _mw(self, scope, receive, send, call_next):
+                scope['x-ext-a'] = 'yes'
+                await call_next(scope, receive, send)
+
+        class _ExtB:
+            def init_app(self, a):
+                a.extensions['b'] = self
+
+                @a.route(path='/b')
+                async def b_route(scope):
+                    return {'ext_a': scope.get('x-ext-a', 'no')}
+
+                self._handler = b_route
+
+        _ExtA().init_app(app)
+        _ExtB().init_app(app)
+
+        with TestClient(app) as client:
+            assert client.get('/a').text == 'a'
+            resp = client.get('/b')
+            assert resp.json() == {'ext_a': 'yes'}, (
+                '_ExtA middleware must inject x-ext-a before _ExtB route runs')


### PR DESCRIPTION
## Summary

Sprint 40 close.  Ships the minimum-viable extension surface:

- **`BlackBull.extensions: dict[str, object]`** — name→object namespace, empty at construction.
- **`init_app(app)` convention** — documented in [`docs/guide/extensions.md`](https://github.com/TOKUJI/BlackBull/blob/release/v0.36.0/docs/guide/extensions.md) with the six contract points (namespace, init convention, key naming, dependency ordering, extension-vs-library boundary, ASGI middleware via `app.use()`).
- **`app.on_error(int)`** — accepts a raw status code in addition to `HTTPStatus` and exception classes.  Ergonomics loosening.

No plugin registry, no auto-discovery, no DI machinery.  Composition stays the application author's job.

## Out of scope (recorded as candidates for follow-up sprints)

Two cross-layer gaps surfaced as `xfail` tests in `tests/unit/test_extensions.py`:

1. `request_received` is emitted from the HTTP/1/HTTP/2/WS actor layer, not from `BlackBull.__call__`.  TestClient never observes it.
2. `on_error(STATUS)` fires only on routing/dispatch raises, not on handler-returned `Response(status=STATUS)`.

Both recorded with promotion criteria in `.claude/planning/candidates/sprint-40-xfail-followups.md`.

## Test plan

- [x] `tests/unit/test_extensions.py` — 17 pass + 2 xfail
- [x] Full unit suite (1339 passed, 225 skipped, 2 xfailed)
- [x] Pre-commit hook (full suite + `mkdocs build --strict`) green on both commits
- [x] Pre-flight: `pip install -e . --quiet && python -c "import blackbull; print(blackbull.__version__)"` → `0.36.0`
- [ ] CodeQL green on this PR
- [ ] Squash-merge → tag `v0.36.0` → PyPI + GitHub Release auto-publish via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)