### PR TITLE
docs(readme): add HttpArena participation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ third-party C extensions in the protocol stack.
 [![PyPI](https://img.shields.io/pypi/v/blackbull.svg)](https://pypi.org/project/blackbull/)
 [![Python](https://img.shields.io/pypi/pyversions/blackbull.svg)](https://pypi.org/project/blackbull/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Benchmarked by HttpArena](https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/wordmark.svg)](https://www.http-arena.com/leaderboard/)
 
 ## Why BlackBull
 


### PR DESCRIPTION
## Summary

- Add the `Benchmarked by HttpArena` wordmark badge to the README, next to the existing PyPI / Python / License badges.
- Follows BlackBull's acceptance into the HttpArena harness — [MDA2AV/HttpArena#861](https://github.com/MDA2AV/HttpArena/pull/861), merged 2026-06-14.
- Wordmark variant only — no protocol-specific or rank-ordered links — to keep the README consistent with the humble-docs convention. The badge declares participation in an external measurement venue, not a comparison claim.
- README-only; no changes to `docs/` (the humble-docs convention's strongest force is on the teaching surface).

## Test plan

- [ ] CI status checks pass (CodeQL, Audit dependencies).
- [ ] Badge image renders on the GitHub README preview after merge.
- [ ] Badge link resolves to https://www.http-arena.com/leaderboard/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)