### PR TITLE
release: v0.38.0 — Sprint 42 close: prove the extension surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,59 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.38.0] — 2026-06-14
+
+**Sprint 42 close: prove the extension surface.**
+
+The Sprint 40 `init_app(app)` convention now has a real second
+implementation living outside the BlackBull repo: the
+[`blackbull-session`](https://github.com/TOKUJI/blackbull-session)
+package on PyPI.  Packaging the existing in-tree `Session` middleware
+as a separate distribution was the proving exercise — the convention
+survived contact with a real cross-repo release cycle, OIDC trusted
+publishing, dependency floor selection, and a deprecation cycle, and
+no convention adjustments were needed.
+
+### Added
+
+- `docs/guide/extensions.md` gains a *Patterns and pitfalls from real
+  extractions* appendix, capturing concrete decisions from the
+  `blackbull-session` packaging (dependency floor, public middleware
+  helpers, eager+deferred construction, the `extension_key` class
+  attribute, `app` as first positional argument, the
+  `blackbull[testing]` dependency for downstream test suites, and the
+  recommended deprecation cycle).
+- `docs/guide/extensions.md` gains a *Common extension categories*
+  fair-treatment section, listing reasonable shapes for sessions,
+  authentication, authorisation, observability, rate limiting,
+  caching, database integration, background tasks, admin panels, CORS
+  / CSRF, WebSocket helpers, and static / template engines.  No
+  endorsements — the framework does not curate a "blessed extension"
+  registry.
+
+### Deprecated
+
+- `blackbull.middleware.Session` now emits `DeprecationWarning` on
+  construction and will be removed in BlackBull 0.40.  Migrate to
+  `pip install blackbull-session` and
+  `from blackbull_session import SessionExtension`.
+
+### Changed
+
+- `examples/ChatServer/chatserver.py` migrated from the in-tree
+  `Session` middleware to `SessionExtension`, demonstrating the
+  `pip install blackbull-session` adoption path.
+- `docs/guide/middleware.md` Session section rewritten to lead with
+  the `blackbull-session` extension; an admonition documents the
+  deprecation and removal target.
+
+### Internal
+
+- The audit of `OpenAPIExtension` against the documented convention
+  found a 1:1 match (`extension_key` class attribute, eager + deferred
+  construction, collision check with `is not self` idempotence, `app`
+  as first positional argument).  No back-port required.
+
 ## [0.37.0] — 2026-06-14
 
 **Sprint 41 close: OpenAPI as the reference implementation of the

--- a/blackbull/middleware/session.py
+++ b/blackbull/middleware/session.py
@@ -51,12 +51,21 @@ import json
 import logging
 import os
 import time
+import warnings
 from typing import Any
 
 from ..asgi import ASGIEvent
 from .utils import as_middleware
 
 logger = logging.getLogger(__name__)
+
+
+_DEPRECATION_MESSAGE = (
+    "blackbull.middleware.Session is deprecated and will be removed in "
+    "BlackBull 0.40.  Install the standalone 'blackbull-session' package "
+    "and use 'from blackbull_session import SessionExtension' instead.  "
+    "See https://github.com/TOKUJI/blackbull-session for details."
+)
 
 
 class _SessionDict(dict):
@@ -158,6 +167,7 @@ class Session:
         samesite: str | None = 'Lax',
         path: str = '/',
     ):
+        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning, stacklevel=2)
         if secret is None:
             secret = os.environ.get('BB_SESSION_SECRET')
         if not secret:

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -208,3 +208,159 @@ class RequestIdExtension:
 See [Middleware](middleware.md) for the full middleware
 contract, including how to short-circuit the chain and how to
 inspect responses via `intercepting_send`.
+
+## Patterns and pitfalls from real extractions
+
+The following notes come from packaging an in-tree middleware
+(`blackbull.middleware.Session`) as the standalone
+[`blackbull-session`](https://github.com/TOKUJI/blackbull-session)
+extension during the 0.38 cycle.  They are concrete decisions, not
+hypothetical advice.
+
+### Pick a `dependencies` floor that matches what you import
+
+`app.extensions` landed in BlackBull 0.36.0 (the Sprint 40 work).
+An extension that touches it must pin at least that floor:
+
+```toml
+dependencies = [
+    "blackbull >= 0.36.0",
+]
+```
+
+If your extension uses something newer — `intercepting_send`, a
+specific event name, a `scope` field — bump the floor to match.
+Don't pin an exact version; that fights with downstream apps that
+want a different patch level.
+
+### Reuse the framework's public middleware helpers
+
+Two BlackBull APIs are useful to extension authors and are
+guaranteed-stable public surface:
+
+- `from blackbull.middleware import as_middleware` — class
+  decorator that normalises `call_next` so any `send` wrapper your
+  middleware installs receives plain ASGI event dicts, not
+  `Response` objects.  Saves you from `isinstance` guards.
+- `from blackbull.asgi import ASGIEvent` — symbolic constants for
+  ASGI event type strings (`HTTP_RESPONSE_START`, etc.).  Prefer
+  these over hard-coded literals.
+
+If you find yourself reaching for `from blackbull._something_private`,
+stop and ask whether the symbol should be promoted to a public
+re-export.  Opening an issue is the right move; private imports
+will break across MINOR versions.
+
+### Eager + deferred construction
+
+Follow the same dual-construction shape as `OpenAPIExtension`:
+
+```python
+class MyExtension:
+    extension_key: str = 'myext'
+
+    def __init__(self, app=None, *, opt=...):
+        # validate/store config first
+        self._opt = opt
+        # then wire on-construction if eager
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        existing = app.extensions.get(self.extension_key)
+        if existing is not None and existing is not self:
+            raise RuntimeError(...)
+        app.use(self)                                # or app.route(...), etc.
+        app.extensions[self.extension_key] = self
+```
+
+The `existing is not self` guard makes `init_app` idempotent for the
+same instance — a defensive nicety for users who wire eagerly and
+then call `init_app` explicitly anyway.
+
+### Make `extension_key` a class attribute, not configurable
+
+A `__init__` kwarg like `extension_key='session-v2'` looks
+flexible but lets users sneak past the collision check (`if 'session'
+in app.extensions: raise` is bypassed when a second extension
+registers itself under a different key).  Pin the key as a class
+attribute and document it in your `README`.
+
+### Place `app` as the first positional argument
+
+`SessionExtension(app, secret=...)` reads cleanly only when `app`
+is positional-first.  If you place it after a `*` keyword separator
+you force `SessionExtension(secret=..., app=app)` — readable but
+inverts the convention every other extension already follows.
+
+### Tests: depend on `blackbull[testing]` for the parent framework
+
+```toml
+[project.optional-dependencies]
+testing = [
+    "pytest",
+    "pytest-asyncio",
+    "blackbull[testing] >= 0.36.0",
+]
+```
+
+This pulls in `pytest-asyncio`, `httpx[http2]`, `websockets`,
+`hypothesis`, and `openapi-spec-validator` — the same testing
+surface BlackBull itself uses.  You don't have to re-declare those.
+
+### Deprecating an in-tree class you're extracting
+
+If your extension replaces something that previously lived in
+BlackBull, the in-tree form should emit a `DeprecationWarning` on
+construction for at least one MINOR cycle:
+
+```python
+import warnings
+
+class Session:           # in-tree, deprecated form
+    def __init__(self, ...):
+        warnings.warn(
+            "blackbull.middleware.Session is deprecated; install "
+            "'blackbull-session' and use SessionExtension instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        ...
+```
+
+Schedule the removal explicitly — naming a target version
+(`"will be removed in BlackBull 0.40"`) anchors both authors and
+users.  Don't ship a deprecation without a removal plan; "deprecated
+forever" code accretes maintenance debt without any of the migration
+benefit.
+
+## Common extension categories
+
+BlackBull's core ships protocols, routing, middleware, events,
+error handling, and a minimal OpenAPI generator.  Almost everything
+else is deliberately *not* in the framework — partly to keep the
+core small and audited, partly because most of these categories
+have several reasonable shapes and BlackBull does not endorse one.
+The table below is informational, not a roadmap; ship one of these
+as `blackbull-<name>` on PyPI and it becomes a citizen of the
+extension ecosystem.
+
+| Category | Reasonable shapes (pick one per extension) | Notes |
+|---|---|---|
+| **Sessions** | signed cookie ([`blackbull-session`](https://github.com/TOKUJI/blackbull-session)), Redis-backed, SQL-backed | Signed cookies have no server state; backed stores allow revocation. |
+| **Authentication** | JWT bearer, OAuth2 PKCE, API keys, session-cookie auth, mutual TLS, HMAC-signed requests | BlackBull does not ship a blessed auth method.  Pick the one that matches your threat model and credential lifecycle. |
+| **Authorization / RBAC** | per-route decorators, policy objects (Casbin-style), scope-based | Often composes with an auth extension via `app.extensions['auth']`. |
+| **Observability** | Prometheus metrics, OpenTelemetry tracing, structured access logs, Sentry error reporting | The `blackbull.*` and `blackbull.access` loggers are the natural hook points; see [Logging](logging.md). |
+| **Rate limiting** | token bucket, leaky bucket, sliding window; in-process / Redis-backed | Best wired through `app.intercept('before_handler')`. |
+| **Caching** | response cache (already in tree as `Cache` middleware), fragment cache, full-page edge cache | Re-extraction of `Cache` is an option once user signal warrants. |
+| **Database integration** | SQLAlchemy async, Tortoise, raw `asyncpg`, SQLite via `aiosqlite` | Connection-pool lifecycle ties to `@app.on('lifespan_startup')` / `lifespan_shutdown`. |
+| **Background tasks** | in-process `asyncio.create_task` helpers, ARQ bridge, Celery bridge | Mind shutdown ordering: drain in `lifespan_shutdown` before pools close. |
+| **Admin / dashboards** | route-mount admin UIs, OpenAPI-driven CRUD | Most depend on an auth extension being already wired. |
+| **CORS / CSRF / security headers** | `CORS` (already in tree), CSP / HSTS injectors, double-submit CSRF | Single-touchpoint middlewares — straightforward to ship as extensions if your variant differs from the in-tree default. |
+| **WebSocket helpers** | room/channel managers, pub-sub bridges (Redis, NATS), broadcast routers | Build on the [`scheme=Scheme.websocket`](websockets.md) route form. |
+| **Static / templates** | static-file extras (already in tree), Jinja2 / Mako / minify-html bridges | Templates are usually a library, not an extension — call them from your handler. |
+
+The framework does not curate this list — there's no
+"blessed extension" registry.  If you want others to find your
+extension, the discovery path is PyPI search for `blackbull-` and
+linking to your project from your own documentation.

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -182,14 +182,23 @@ HMAC-signed by the server.  No server-side store, no database.
 Trade-off: cookies are capped at ~4 KiB by browsers and you can't
 revoke a session early without rotating the secret.
 
+!!! warning "Moved to a separate package"
+    Starting with BlackBull 0.38 the session layer lives in the
+    standalone [`blackbull-session`](https://github.com/TOKUJI/blackbull-session)
+    package, following the [`init_app(app)`](extensions.md)
+    extension convention.  The in-tree
+    `blackbull.middleware.Session` emits a `DeprecationWarning` and
+    will be removed in BlackBull 0.40.
+
 ```python
-from blackbull.middleware.session import Session
+# pip install blackbull-session
+from blackbull_session import SessionExtension
 
 # Operator sets BB_SESSION_SECRET=<32-byte random> in the deployment env
-app.use(Session())
+SessionExtension(app)
 
 # Or pass the secret explicitly (handy for tests):
-app.use(Session(secret=b'<long-random-bytes>'))
+SessionExtension(app, secret=b'<long-random-bytes>')
 
 @app.route(path='/')
 async def index(scope, receive, send):
@@ -200,6 +209,9 @@ async def index(scope, receive, send):
 async def whoami(scope, receive, send):
     await send(Response(scope['session'].get('user', 'anonymous')))
 ```
+
+After construction the live extension is reachable at
+`app.extensions['session']`.
 
 `scope['session']` is a `dict` subclass that tracks whether you
 mutated it.  The middleware only emits `Set-Cookie` when a request

--- a/examples/ChatServer/chatserver.py
+++ b/examples/ChatServer/chatserver.py
@@ -53,7 +53,8 @@ from blackbull import (
     cookie_header,
     read_body,
 )
-from blackbull.middleware import Compression, Session
+from blackbull.middleware import Compression
+from blackbull_session import SessionExtension
 from blackbull.utils import Scheme
 
 _TEMPLATES = pathlib.Path(__file__).parent / 'templates'
@@ -217,13 +218,14 @@ async def json_body_mw(scope, receive, send, call_next):
 
 app = BlackBull()
 app.use(Compression())          # gzips JSON / HTML responses when the client accepts it
-app.use(Session(
+SessionExtension(
+    app,
     # Demo secret — set BB_SESSION_SECRET in production.  DO NOT use this
     # inline default for anything real: anyone who can read the source can
     # forge a session.
     secret=os.environ.get('BB_SESSION_SECRET', 'chat-demo-secret-not-for-production'),
     secure=False,   # demo runs over plain HTTP unless --cert/--key are passed
-))
+)
 protected = app.group(middlewares=[auth_mw])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.37.0"
+version = "0.38.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 42 closes the proving exercise for the Sprint 40 `init_app(app)` extension convention.  The session middleware now lives in the standalone [`blackbull-session`](https://github.com/TOKUJI/blackbull-session) package on PyPI; the convention survived contact with a real cross-repo release cycle (OIDC trusted publishing, dependency floor selection, deprecation cycle) and no convention adjustments were needed.

- `blackbull.middleware.Session` deprecated → `blackbull_session.SessionExtension`; removal in 0.40.
- `examples/ChatServer` migrated to the new extension, demonstrating the adoption path.
- `docs/guide/extensions.md` gains two new sections: *Patterns and pitfalls from real extractions* (concrete decisions from the packaging work) and *Common extension categories* (fair-treatment landscape of session / auth / observability / rate-limit / etc. shapes, no endorsements).
- `OpenAPIExtension` audited against the now-documented convention — 1:1 match, no back-port needed.

## Test plan

- [x] `blackbull-session` 14 smoke tests pass against editable BlackBull.
- [x] Full BlackBull test suite green: 1347 passed, 225 skipped, 2 xfailed.
- [x] `mkdocs build` (quiet mode used by the pre-commit hook) passes with zero new warnings.
- [x] ChatServer imports cleanly; `app.extensions['session']` registered.
- [x] `blackbull-session==0.1.0a1` already live on PyPI, `pip install --pre` resolves.
- [x] `blackbull.__version__` reports `0.38.0` after editable refresh.
- [x] CodeQL + Audit dependencies green on the PR before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)