### PR TITLE
docs: extend Session deprecation window per policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,9 +57,12 @@ no convention adjustments were needed.
 ### Deprecated
 
 - `blackbull.middleware.Session` now emits `DeprecationWarning` on
-  construction and will be removed in BlackBull 0.40.  Migrate to
-  `pip install blackbull-session` and
-  `from blackbull_session import SessionExtension`.
+  construction.  Migrate to `pip install blackbull-session` and
+  `from blackbull_session import SessionExtension`.  The in-tree
+  form will be removed no earlier than BlackBull v0.41 (and not
+  before 2026-07-14) — see the
+  [Patterns and pitfalls](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/extensions.md#deprecating-an-in-tree-class-youre-extracting)
+  section for the deprecation-window policy.
 
 ### Changed
 

--- a/blackbull/middleware/session.py
+++ b/blackbull/middleware/session.py
@@ -61,10 +61,11 @@ logger = logging.getLogger(__name__)
 
 
 _DEPRECATION_MESSAGE = (
-    "blackbull.middleware.Session is deprecated and will be removed in "
-    "BlackBull 0.40.  Install the standalone 'blackbull-session' package "
-    "and use 'from blackbull_session import SessionExtension' instead.  "
-    "See https://github.com/TOKUJI/blackbull-session for details."
+    "blackbull.middleware.Session is deprecated.  Install the standalone "
+    "'blackbull-session' package and use 'from blackbull_session import "
+    "SessionExtension' instead.  This in-tree form will be removed no "
+    "earlier than BlackBull v0.41 (and not before 2026-07-14).  See "
+    "https://github.com/TOKUJI/blackbull-session for details."
 )
 
 

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -312,7 +312,7 @@ surface BlackBull itself uses.  You don't have to re-declare those.
 
 If your extension replaces something that previously lived in
 BlackBull, the in-tree form should emit a `DeprecationWarning` on
-construction for at least one MINOR cycle:
+construction:
 
 ```python
 import warnings
@@ -321,17 +321,27 @@ class Session:           # in-tree, deprecated form
     def __init__(self, ...):
         warnings.warn(
             "blackbull.middleware.Session is deprecated; install "
-            "'blackbull-session' and use SessionExtension instead.",
+            "'blackbull-session' and use SessionExtension instead. "
+            "Will be removed no earlier than BlackBull v0.41 "
+            "(and not before 2026-07-14).",
             DeprecationWarning,
             stacklevel=2,
         )
         ...
 ```
 
-Schedule the removal explicitly — naming a target version
-(`"will be removed in BlackBull 0.40"`) anchors both authors and
-users.  Don't ship a deprecation without a removal plan; "deprecated
-forever" code accretes maintenance debt without any of the migration
+Schedule the removal with **two gates: at least three MINOR releases
+ahead AND at least one calendar month after the deprecation lands** —
+whichever boundary is later.  For a deprecation announced in v0.38.0
+on 2026-06-14, both gates put the earliest removal at v0.41.0 or
+later, and not before 2026-07-14.  Naming both gates in the warning
+text (rather than a single bare version target) anchors authors and
+users alike and forecloses cargo-cult removal at the release-count
+gate alone.  Early-alpha status does not shorten this window: users
+plan migrations against the announced removal target, and a
+too-short window forces emergency migrations.  At the same time,
+don't ship a deprecation without *some* removal plan — "deprecated
+forever" code accretes maintenance debt without the migration
 benefit.
 
 ## Common extension categories

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -188,7 +188,8 @@ revoke a session early without rotating the secret.
     package, following the [`init_app(app)`](extensions.md)
     extension convention.  The in-tree
     `blackbull.middleware.Session` emits a `DeprecationWarning` and
-    will be removed in BlackBull 0.40.
+    will be removed no earlier than BlackBull v0.41 (and not before
+    2026-07-14).
 
 ```python
 # pip install blackbull-session


### PR DESCRIPTION
## Summary

The deprecation language shipped in v0.38.0 named **BlackBull 0.40** as the removal target — too short a window (only two MINOR releases ahead, potentially well under a calendar month at the current sprint cadence).

New deprecation policy:

> A deprecated feature may not be removed until at least **three MINOR releases ahead AND at least one calendar month** has passed — whichever boundary is later.  Early-alpha status does not shorten this window.

Concrete impact on the in-tree `Session` deprecation announced in v0.38.0 (2026-06-14):

- earliest-by-releases = **v0.41.0**
- earliest-by-time = **2026-07-14**
- removal at v0.41.0 only if v0.41.0 lands on or after 2026-07-14

This PR updates four touchpoints to reflect the new policy:

1. `blackbull/middleware/session.py` — `DeprecationWarning` text
2. `docs/guide/middleware.md` — admonition
3. `docs/guide/extensions.md` — patterns-and-pitfalls appendix now states the **two-gate** deprecation policy as the recommendation for any in-tree → extracted-package extraction, not just Session
4. `CHANGELOG.md` — v0.38.0 Deprecated section

No code behaviour change.  v0.38.0 is still the target tag; once this PR merges I'll tag v0.38.0 at the post-fix commit so the published PyPI wheel + release notes carry the corrected language.

## Test plan

- [x] `tests/unit/test_session_middleware.py` — 41 passed (warning text update, no semantics change).
- [x] `mkdocs build --quiet` — clean, no new warnings.
- [x] Pre-commit hook (beartype-instrumented full suite + mkdocs) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)