### PR TITLE
test(sse): await the backpressure task to clear CodeQL py/unused-local-variable

### DIFF
--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -239,21 +239,27 @@ async def test_http2_sender_blocks_when_window_closed():
         write_done.set()
 
     task = asyncio.create_task(do_write())
-    # Give the loop a couple of ticks so the writer enters its credit-wait
-    # loop without producing any DATA bytes.
-    for _ in range(5):
-        await asyncio.sleep(0)
-    assert not write_done.is_set(), 'expected _write_data to block on credit'
-    assert writer.chunks == b'', 'expected no DATA bytes before credit grant'
+    try:
+        # Give the loop a couple of ticks so the writer enters its
+        # credit-wait loop without producing any DATA bytes.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not write_done.is_set(), 'expected _write_data to block on credit'
+        assert writer.chunks == b'', 'expected no DATA bytes before credit grant'
 
-    # Reopen the window and signal the waiter — the write should now run
-    # to completion and put the full payload on the wire.
-    sender.connection_window_size = 100
-    sender.stream_window_size[1] = 100
-    assert sender._window_open is not None
-    sender._window_open.set()
-    await asyncio.wait_for(write_done.wait(), timeout=1.0)
-    assert b'xxxx' in bytes(writer.chunks)
+        # Reopen the window and signal the waiter — the write should now
+        # run to completion and put the full payload on the wire.
+        sender.connection_window_size = 100
+        sender.stream_window_size[1] = 100
+        assert sender._window_open is not None
+        sender._window_open.set()
+        await asyncio.wait_for(write_done.wait(), timeout=1.0)
+        assert b'xxxx' in bytes(writer.chunks)
+    finally:
+        # Awaiting the task drains its result and surfaces any exception
+        # the writer raised — without this, an exception inside do_write
+        # would be lost and CodeQL flags ``task`` as unused.
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to the v0.41.0 merge (#73).  CodeQL flagged ``py/unused-local-variable`` on [`tests/unit/test_sse.py:241`](tests/unit/test_sse.py#L241) — the HTTP/2 backpressure test assigned `asyncio.create_task(do_write())` to `task` and never awaited it.  Beyond the lint, the original shape would have silently swallowed any exception raised inside `_write_data` and risked GC of the pending task before completion.

Fix: wrap the assertion block in `try / finally` and `await task` in the `finally`.  Happy path is functionally identical; failure path now propagates errors instead of dropping them.

Test-only change — no source or docs touched.  Tagging v0.41.0 from the post-fix SHA so PyPI artefacts carry the clean test (the wheel itself excludes `tests/` per `pyproject.toml`, but git history stays tidy).

## Test plan

- [x] Targeted: `pytest tests/unit/test_sse.py` — 15 passed.
- [x] Pre-commit hook (beartype-instrumented full suite + mkdocs build) green.
- [ ] CodeQL re-run on this PR clears the `py/unused-local-variable` alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)