### PR TITLE
release: v0.42.1 — Sprint 47 close: custom HTTP method support

### DIFF
--- a/.github/skills/add-event
+++ b/.github/skills/add-event
@@ -1,0 +1,1 @@
+../../.claude/skills/add-event

--- a/.github/skills/bench-compare
+++ b/.github/skills/bench-compare
@@ -1,0 +1,1 @@
+../../.claude/skills/bench-compare

--- a/.github/skills/new-http2-frame
+++ b/.github/skills/new-http2-frame
@@ -1,0 +1,1 @@
+../../.claude/skills/new-http2-frame

--- a/.github/skills/protocol-handler
+++ b/.github/skills/protocol-handler
@@ -1,0 +1,1 @@
+../../.claude/skills/protocol-handler

--- a/.github/skills/type-check
+++ b/.github/skills/type-check
@@ -1,0 +1,1 @@
+../../.claude/skills/type-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.42.1] — 2026-06-18
+
+**Sprint 47: Custom HTTP Method Support (Proposal 009 Phase 1).**
+
+Routes can now be registered and dispatched using non-IANA HTTP method
+strings such as `BREW`, `PROPFIND`, and `WHEN` from RFC 2324 / RFC 4918.
+Previously, any method not in `http.HTTPMethod` was rejected at dispatch
+time with an immediate 405; the router never had a chance to match.
+
+Key changes:
+
+- `app.py` dispatch: `HTTPMethod(scope['method'])` `ValueError` now keeps
+  the raw string and continues to the router instead of short-circuiting
+  to 405.  IANA methods still resolve to the `HTTPMethod` enum value.
+- `router.py`: `isinstance(x, HTTPMethod)` guard removed from `route_fn`;
+  `methods` annotation broadened to `str | HTTPMethod | Iterable[str | HTTPMethod]`
+  on all public registration surfaces (`RouteGroup.route`, `BlackBull.route`,
+  `Router.route_fn`, `Router.route`, `BaseRouter.route`).
+- RFC 9110 §5.6.2 token validation added at registration time: strings
+  that are not valid HTTP tokens (e.g. `'BREW METHOD'` with a space) raise
+  `ValueError` early.
+- `blackbull-htcpcp` extension unblocked: `BREW`, `PROPFIND`, and `WHEN`
+  routes now register and dispatch without the previous `try/except HTTPMethod`
+  workaround; the three `xfail(strict=True)` tests are promoted to passing.
+
 ## [0.42.0] — 2026-06-16
 
 **Sprint 46 close: deliberate-misbehaviour toolkit.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.42.x  | :white_check_mark: |
 | 0.41.x  | :white_check_mark: |
-| 0.40.x  | :white_check_mark: |
-| < 0.40  | :x:                |
+| < 0.41  | :x:                |
 
 This table updates with each minor release.
 

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -190,7 +190,7 @@ class RouteGroup:
         self._app = app
         self._group_mw = list(middlewares)
 
-    def route(self, methods: HTTPMethod | Iterable[HTTPMethod] = [HTTPMethod.GET],
+    def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               middlewares: list = [], name: str | None = None):
         return self._app.route(
@@ -427,18 +427,13 @@ class BlackBull:
             return
 
         try:
-            # RFC 9110 §9.1 — methods are case-sensitive.  Looking up
-            # ``scope['method'].upper()`` would silently fold a lowercase
-            # ``get`` to ``GET`` and dispatch to the wrong handler.  Use
-            # the value verbatim; HTTPMethod() rejects non-uppercase forms.
+            # RFC 9110 §9.1 — methods are case-sensitive tokens.  Prefer the
+            # HTTPMethod enum for IANA-registered methods; for non-IANA methods
+            # (BREW, PROPFIND, WHEN, …) keep the raw str so the router can
+            # still match a registered route and return the correct Allow header.
             method = HTTPMethod(scope['method'])
         except ValueError:
-            self._logger.debug("Unknown HTTP method: %r", scope['method'])
-            scope.setdefault('state', {})['error_status'] = HTTPStatus.METHOD_NOT_ALLOWED
-            handler = self._error_router[HTTPStatus.METHOD_NOT_ALLOWED]
-            if handler is not None:
-                await handler(scope, receive, send)
-            return
+            method = scope['method']
 
         path = scope['path']
         self._logger.debug((path, scheme))
@@ -526,7 +521,7 @@ class BlackBull:
 
         await self._chain(scope, receive, _wrap_send(send))
 
-    def route(self, methods: HTTPMethod | Iterable[HTTPMethod] = [HTTPMethod.GET],
+    def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               functions: list = [], middlewares: list = [],
               name: str | None = None):

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -501,6 +501,18 @@ def _adapt_handler(fn, path: str):
     return _wrapper
 
 
+# RFC 9110 §5.6.2: token = 1*tchar (visible US-ASCII, no separators)
+_HTTP_TOKEN_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+
+
+def _validate_method_token(method: str) -> None:
+    if not _HTTP_TOKEN_RE.match(method):
+        raise ValueError(
+            f"Invalid HTTP method token {method!r}: RFC 9110 §5.6.2 requires "
+            "a non-empty sequence of visible ASCII tchar characters."
+        )
+
+
 def _to_tuple(value: Any) -> tuple:
     """
     Normalise a value into a tuple.
@@ -522,7 +534,7 @@ class BaseRouter:
     def __contains__(self, item):
         raise NotImplementedError()
 
-    def route(self, methods: HTTPMethod | Iterable[HTTPMethod] = [HTTPMethod.GET],
+    def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               functions: list = []):
         raise NotImplementedError()
@@ -556,8 +568,8 @@ class Router(UserDict, BaseRouter):
 
     def __setitem__(
         self,
-        key: (Tuple[str | re.Pattern, HTTPMethod | Iterable[HTTPMethod]]
-              | Tuple[str | re.Pattern, HTTPMethod | Iterable[HTTPMethod],
+        key: (Tuple[str | re.Pattern, str | HTTPMethod | Iterable[str | HTTPMethod]]
+              | Tuple[str | re.Pattern, str | HTTPMethod | Iterable[str | HTTPMethod],
                       Scheme | Iterable[Scheme] | None]),
         value: Any,
     ):
@@ -593,6 +605,9 @@ class Router(UserDict, BaseRouter):
 
         # Normalise methods / scheme to tuples
         methods = _to_tuple(methods)
+        for m in methods:
+            if isinstance(m, str):
+                _validate_method_token(m)
         scheme  = _ANY_SCHEME if scheme is None or isinstance(scheme, _AnyScheme) \
                   else _to_tuple(scheme)
 
@@ -638,10 +653,10 @@ class Router(UserDict, BaseRouter):
 
     def __getitem__(
         self,
-        key: Tuple[str, HTTPMethod, Scheme],
+        key: Tuple[str, str | HTTPMethod, Scheme],
     ):
         """
-        key: (path: str, method: HTTPMethod, scheme: Scheme)
+        key: (path: str, method: str | HTTPMethod, scheme: Scheme)
 
         Uses the routing trie for O(path-depth) lookup of string-path routes,
         then falls back to a linear scan of raw re.Pattern routes.
@@ -664,7 +679,7 @@ class Router(UserDict, BaseRouter):
 
     def _resolve(
         self,
-        key: Tuple[str, HTTPMethod, Scheme],
+        key: Tuple[str, str | HTTPMethod, Scheme],
     ):
         """Core route lookup — trie first, regex fallback.  Raises on miss."""
         key_path, key_method, key_scheme = key
@@ -764,16 +779,16 @@ class Router(UserDict, BaseRouter):
         return key_scheme in registered_scheme
 
     def route_fn(self,
-                 methods: HTTPMethod | Iterable[HTTPMethod] = [HTTPMethod.GET],
+                 methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
                  path: str = '/',
                  scheme: Scheme | Iterable[Scheme] = Scheme.http,
                  name: str | None = None):
 
         logger.debug('Router.route_fn() is called.')
         methods = _to_tuple(methods)
-
-        if [x for x in methods if not isinstance(x, HTTPMethod)]:
-            raise ValueError('methods must be HTTPMethod.')
+        for m in methods:
+            if isinstance(m, str):
+                _validate_method_token(m)
 
         def register(fn):
             logger.debug(f'Router.route_fn.register() is called. {fn}')
@@ -911,7 +926,7 @@ class Router(UserDict, BaseRouter):
 
         self._frozen = True
 
-    def route(self, methods: HTTPMethod | Iterable[HTTPMethod] = [HTTPMethod.GET],
+    def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               functions: list = [], middlewares: list = [],
               name: str | None = None):

--- a/docs/draft-devto-htcpcp.md
+++ b/docs/draft-devto-htcpcp.md
@@ -1,0 +1,194 @@
+# Brewing Coffee Over HTTP: A Python Implementation of RFC 2324 (HTCPCP)
+
+**Five lines of Python. That's all it takes to turn your ASGI server into a fully RFC-compliant, HTTP-controlled coffee pot — custom methods, status 418, and all.**
+
+---
+
+```python
+from blackbull import BlackBull
+from blackbull_htcpcp import HtcpcpExtension
+
+app = BlackBull()
+HtcpcpExtension(app=app, pot_type='coffee')
+```
+
+This isn't a mock — and no, there's no USB coffee pot. It's a pure software implementation of the protocol: `BREW /pot` starts brewing (a virtual brew cycle, not a physical one). `PROPFIND /pot` inspects the pot. `WHEN /pot` asks when it'll be ready. Ask a teapot to brew coffee? You get `418 I'm a teapot` — with `Content-Type: message/coffeepot`. Every method, status code, and header behaves exactly as the RFC specifies. The only thing missing is the actual caffeine. All from a single constructor call, all through the framework's public extension API. No core modifications.
+
+[`blackbull-htcpcp`](https://pypi.org/project/blackbull-htcpcp/) is the first Python package on PyPI to implement the full Hyper Text Coffee Pot Control Protocol — both [RFC 2324](https://datatracker.ietf.org/doc/html/rfc2324) (coffee pots, 1998) and [RFC 7168](https://datatracker.ietf.org/doc/html/rfc7168) (teapots, 2014). Both were published on April 1st. Both were jokes. But implementing a joke protocol turns out to be a remarkably effective way to answer a real question: **can you ship a non-trivial application protocol — custom HTTP methods, custom status codes, custom content types, custom error semantics — purely on top of an ASGI framework's public extension surface, without modifying the framework?**
+
+Spoiler: yes. Here's how, and why it matters.
+
+---
+
+### Why a joke RFC is worth implementing
+
+In 2017, the IETF HTTP Working Group proposed removing status code 418 from Node.js, Go, and Python. A 15-year-old developer started the [\#save418](https://save418.com/) movement — and won. Python 3.9 shipped with `HTTPStatus.IM_A_TEAPOT`. Google serves [google.com/teapot](https://www.google.com/teapot). The Russian military briefly used 418 as DDoS protection. The teapot endures.
+
+**But nobody had published a Python package that actually implements the full protocol.** Until now.
+
+---
+
+## What `blackbull-htcpcp` Implements
+
+[`blackbull-htcpcp`](https://pypi.org/project/blackbull-htcpcp/) is a Python package that implements the complete HTCPCP specification — both RFC 2324 (coffee pots) and RFC 7168 (teapots) — as an extension for the [BlackBull](https://github.com/TOKUJI/BlackBull) ASGI framework.
+
+| Feature | RFC | Implementation |
+|---|---|---|
+| `BREW` method | 2324 §2.2 | Start brewing. POST fallback for environments where the stdlib rejects non-IANA HTTP methods. |
+| `PROPFIND` method | 2324 §2.2 | Inspect the pot (type, state, capacity, supported additions). |
+| `WHEN` method | 2324 §2.2 | Ask when the coffee will be ready. |
+| `GET /pot` | — | Browser-friendly pot state. |
+| Status `418 I'm a teapot` | 2324 §2.2.2 | Returned when a teapot is asked to brew coffee, or vice versa. |
+| `Accept-Additions` header | 2324 §2.2.3 | Coffee: cream, sugar, vanilla, whisky, aquavit… Tea: milk, lemon, honey, ginger, bergamot… |
+| `message/coffeepot` content type | 2324 §2.2.1 | All `/pot` responses carry the official HTCPCP media type. |
+| Teapot discrimination | 7168 §2.1 | Teapots brew tea (200); coffee additions on a teapot → 418. |
+
+---
+
+## Five Lines of Code
+
+```python
+from blackbull import BlackBull
+from blackbull_htcpcp import HtcpcpExtension
+
+app = BlackBull()
+HtcpcpExtension(app=app, pot_type='coffee')
+```
+
+That's it. Four routes on `/pot`, an `app.on_error(418)` handler, and the extension registers itself in `app.extensions['htcpcp']` — all from a single constructor call.
+
+```bash
+$ pip install blackbull-htcpcp
+$ python -c "
+from blackbull import BlackBull
+from blackbull_htcpcp import HtcpcpExtension
+BlackBull().run(HtcpcpExtension(app=BlackBull(), pot_type='coffee'))
+"
+# Then:
+$ curl -X BREW -H 'Accept-Additions: cream; sugar' http://localhost:8000/pot
+{"pot-type": "coffee", "state": "ready", "message": "Brewing complete", "additions": ["cream", "sugar"]}
+
+$ curl -X BREW http://localhost:8000/pot   # teapot mode
+{"error": "I'm a teapot", "pot-type": "teapot"}
+```
+
+### Deferred Wiring
+
+Prefer explicit initialization? The extension supports deferred wiring:
+
+```python
+ext = HtcpcpExtension(pot_type='teapot')
+# ... configure app ...
+ext.init_app(app)
+```
+
+Both eager and deferred styles follow BlackBull's documented [`init_app(app)` convention](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/extensions.md) — the same pattern used by `blackbull-session`, the framework's session-management extension.
+
+---
+
+## Why This Is Interesting Beyond the Joke
+
+HTCPCP is funny. But `blackbull-htcpcp` exists for a serious reason: **it validates that a non-trivial application protocol — custom HTTP methods, custom status codes, custom content types, custom error semantics — can be layered onto an ASGI framework purely through its public extension surface, without modifying the framework itself.**
+
+The extension registers:
+
+- **Routes with non-standard HTTP methods** (`BREW`, `PROPFIND`, `WHEN`). Because Python's `http.HTTPMethod` enum rejects non-IANA verbs, the extension keeps a `POST` fallback for clients that can't send custom methods — and registers the real verbs directly now that BlackBull 0.42.1 accepts any RFC 9110 §5.6.2 token as an HTTP method.
+- **A custom error handler** via `app.on_error(418)` that returns `message/coffeepot` JSON — any code path in the application that emits 418 gets the same teapot response body.
+- **Custom header parsing** for `Accept-Additions` with full security hardening.
+- **Self-registration** into `app.extensions['htcpcp']` so other extensions can discover it.
+
+No changes to BlackBull's core. No plugin registry. No dependency injection framework. Just `app.route`, `app.on_error`, and `app.extensions` — all public, stable APIs.
+
+This is the second external `blackbull-*` package (after `blackbull-session`), and it compounds the story: **BlackBull's extension surface can carry real protocols.**
+
+---
+
+## Security: The Threat Model Behind a Joke Protocol
+
+Because HTCPCP extends HTTP with custom headers, it inherits all of HTTP's attack surface. The `Accept-Additions` parser was designed with a threat model — documented in the test suite as test cases S001 through S015:
+
+| Category | Threat | Mitigation |
+|---|---|---|
+| **Header injection** | CRLF / bare LF in addition tokens | Rejected at parse time (S001–S002) |
+| **Header injection** | NULL bytes in addition tokens | Rejected at parse time (S003) |
+| **DoS — oversized tokens** | Addition tokens > 256 characters | Rejected (S004) |
+| **DoS — too many additions** | More than 64 addition tokens | Rejected (S005) |
+| **DoS — concurrent BREW** | Brewing while already brewing | 409 Conflict (S006) |
+| **DoS — oversized body** | BREW body > 1 MiB | 413 Request Entity Too Large (S007) |
+| **Control characters** | Non-printable chars (except HTAB) | Rejected (S008) |
+| **418 abuse — cache poisoning** | 418 responses carrying cache headers | No permissive cache headers on 418 (S010) |
+
+Every rejection returns `message/coffeepot` content type — consistent error formatting even on security responses.
+
+This is the point where the joke RFC meets real engineering. The protocol is absurd; the implementation is not.
+
+---
+
+## The Cultural Precedent: IPoAC
+
+In 1990, [RFC 1149](https://datatracker.ietf.org/doc/html/rfc1149) specified IP datagram transmission via avian carrier (homing pigeons). In 2001, the Bergen Linux User Group [actually implemented it](https://en.wikipedia.org/wiki/IP_over_Avian_Carriers#Real-world_implementation), sending 9 packets over 5 km with a 55% packet loss rate — mostly due to avian interference.
+
+HTCPCP follows the same arc: a joke RFC, a real implementation, a crowd that *gets it*. The cultural through-line from IPoAC (2001) through \#save418 (2017) to `blackbull-htcpcp` (2026) is that **implementing joke protocols is a form of protocol literacy**. If you can implement HTCPCP correctly, you understand HTTP's extension points well enough to implement a real one.
+
+---
+
+## Comparison With Existing Implementations
+
+There are about 105 HTCPCP repositories on GitHub across all languages. The landscape is sparse:
+
+| Implementation | Language | Stars | Last Updated | RFC 7168 |
+|---|---|---|---|---|
+| [HyperTextCoffeePot](https://github.com/HyperTextCoffeePot/HyperTextCoffeePot) | Python (Flask) | 78 | 2015 (archived) | ❌ |
+| [madmaze/HTCPCP](https://github.com/madmaze/HTCPCP) | C | 49 | 2011 | ❌ |
+| [node-htcpcp](https://github.com/stephen/node-htcpcp) | Node.js | 36 | 2013 | ❌ |
+| [htcpcp-delonghi](https://github.com/dkundel/htcpcp-delonghi) | JS (Tessel 2) | 29 | 2023 (archived) | ❌ |
+| [Go teapot](https://godoc.org/github.com/davsk/teapot) | Go | — | — | ✅ |
+
+`blackbull-htcpcp` is:
+
+- **The first Python package on PyPI** implementing HTCPCP (zero prior PyPI packages).
+- **One of two known implementations** covering both RFC 2324 + RFC 7168 (alongside Go's `teapot`).
+- **The only ASGI-native implementation** — all prior implementations are standalone servers or framework-specific hacks.
+- **Actively maintained** — the top 5 GitHub implementations by stars are all dead or archived.
+
+---
+
+## Getting Started
+
+```bash
+pip install blackbull-htcpcp
+```
+
+Minimal application:
+
+```python
+from blackbull import BlackBull
+from blackbull_htcpcp import HtcpcpExtension
+
+app = BlackBull()
+HtcpcpExtension(app=app, pot_type='coffee', capacity_ml=1500)
+app.run()
+```
+
+Then:
+
+```bash
+# Brew coffee with additions
+curl -X BREW -H 'Accept-Additions: cream; sugar; vanilla' http://localhost:8000/pot
+
+# Inspect the pot
+curl http://localhost:8000/pot
+
+# Ask when it's ready
+curl http://localhost:8000/pot/when
+
+# Teapot mode — ask a teapot to brew coffee
+curl -X BREW -H 'Accept-Additions: cream' http://localhost:8000/pot
+# → 418 I'm a teapot
+```
+
+---
+
+---
+
+*`blackbull-htcpcp` is on [PyPI](https://pypi.org/project/blackbull-htcpcp/) and [GitHub](https://github.com/TOKUJI/blackbull-htcpcp), licensed under Apache 2.0. The [BlackBull framework](https://github.com/TOKUJI/BlackBull) is a pure-Python ASGI server with HTTP/1.1, HTTP/2, and WebSocket at the protocol level — a personal learning project where correctness over the wire matters more than API stability.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.42.0"
+version = "0.42.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1089,18 +1089,16 @@ class TestRouterEdgeCases:
         assert isinstance(r, str)
         assert 'Router' in r
 
-    def test_route_fn_invalid_method_type_raises(self):
-        """``methods=['GET']`` is wrong — items must be HTTPMethod values.
+    def test_route_fn_invalid_method_token_raises(self):
+        """Method strings must be valid RFC 9110 §5.6.2 tokens.
 
-        Under the test-time beartype hook the wrong element type is
-        caught at function entry (raises a TypeError subclass) before
-        ``route_fn``'s own ValueError check fires.  Both outcomes mean
-        the misuse was rejected, which is what the test exists to
-        guarantee.
+        Valid str methods like 'BREW' are accepted (Sprint 47).
+        Strings containing spaces, control characters, or separator
+        characters are not valid tokens and must raise ValueError.
         """
         router = Router()
-        with pytest.raises(_TYPE_ERRORS + (ValueError,)):
-            router.route_fn(methods=['GET'], path='/x')
+        with pytest.raises(ValueError):
+            router.route_fn(methods=['BREW METHOD'], path='/x')  # space is not tchar
 
     def test_register_chain_non_middleware_in_middle_raises(self):
         router = Router()
@@ -1356,3 +1354,59 @@ class TestFrozenRouter:
         with pytest.raises(RuntimeError, match="frozen"):
             @router.route(path='/y', methods=HTTPMethod.GET)
             async def fn(scope, receive, send): pass
+
+
+class TestCustomMethods:
+    """RFC 9110 §9.1 — any token is a valid HTTP method; non-IANA methods
+    (BREW, PROPFIND, WHEN, …) must be registerable and dispatchable."""
+
+    def test_register_single_str_method(self, router):
+        @router.route(path='/pot', methods='BREW')
+        def fn(scope, receive, send): pass
+
+        result = router[('/pot', 'BREW', Scheme.http)]
+        assert result is fn
+
+    def test_register_list_of_str_methods(self, router):
+        @router.route(path='/pot', methods=['BREW', 'PROPFIND'])
+        def fn(scope, receive, send): pass
+
+        assert router[('/pot', 'BREW', Scheme.http)] is fn
+        assert router[('/pot', 'PROPFIND', Scheme.http)] is fn
+
+    def test_custom_method_dispatches_correctly(self, router):
+        @router.route(path='/pot', methods='BREW')
+        def brew_fn(scope, receive, send): pass
+
+        result = router[('/pot', 'BREW', Scheme.http)]
+        assert result is brew_fn
+
+    def test_wrong_custom_method_raises_method_not_applicable(self, router):
+        @router.route(path='/pot', methods='BREW')
+        def fn(scope, receive, send): pass
+
+        with pytest.raises(MethodNotApplicable) as exc_info:
+            router[('/pot', 'FROBNICATE', Scheme.http)]
+        assert 'BREW' in exc_info.value.allowed_methods
+
+    def test_case_sensitivity_custom_method(self, router):
+        @router.route(path='/pot', methods='BREW')
+        def fn(scope, receive, send): pass
+
+        with pytest.raises((MethodNotApplicable, PathNotRegistered)):
+            router[('/pot', 'brew', Scheme.http)]
+
+    def test_iana_and_custom_method_coexist(self, router):
+        @router.route(path='/pot', methods=[HTTPMethod.GET, 'BREW'])
+        def fn(scope, receive, send): pass
+
+        assert router[('/pot', HTTPMethod.GET, Scheme.http)] is fn
+        assert router[('/pot', 'BREW', Scheme.http)] is fn
+
+    def test_custom_method_allow_header_populated(self, router):
+        @router.route(path='/pot', methods='BREW')
+        def fn(scope, receive, send): pass
+
+        with pytest.raises(MethodNotApplicable) as exc_info:
+            router[('/pot', 'WHEN', Scheme.http)]
+        assert 'BREW' in exc_info.value.allowed_methods


### PR DESCRIPTION
## Summary

- Bump version to `0.42.1` in `pyproject.toml` and update `CHANGELOG.md` with the Sprint 47 close notes.
- Routes can now be registered and dispatched using non-IANA HTTP method strings (`BREW`, `PROPFIND`, `WHEN`, etc.) — any RFC 9110 §5.6.2 token is accepted at registration time; invalid tokens (e.g. tokens with embedded spaces) raise `ValueError` eagerly.
- `SECURITY.md` supported-versions table updated to `0.42.x / 0.41.x`.

## Test plan

- [x] All 1455 tests pass, 225 skipped, 2 xfailed (pre-commit hook confirms)
- [x] `python -c "import blackbull; print(blackbull.__version__)"` → `0.42.1` after `pip install -e .`
- [x] CodeQL passes
- [x] `pip-audit` passes
- [x] After squash-merge: tag `v0.42.1` and push — `publish.yml` builds + publishes to PyPI via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
