### PR TITLE
release: v0.43.0 — Sprint 49 close: AppConfig + blackbull serve CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.43.0] — 2026-06-20
+
+### Added
+- **`AppConfig` — declarative startup config.** A frozen dataclass holding
+  exactly the parameters `run()`/`serve()` accept (port, TLS, workers,
+  queue depths, reload, …).  `BlackBull(config=AppConfig(...))` declares the
+  server settings once; `app.run()` resolves each setting **explicit arg →
+  bound config → built-in default**.  Additive — existing programmatic
+  startup is unchanged.  Exported as `blackbull.AppConfig`.
+- **`blackbull serve` — zero-code static file server.** `blackbull serve
+  [DIR]` serves a directory over HTTP/1.1 (and HTTP/2 when `--certfile` /
+  `--keyfile` enable TLS) with ETag / `304` conditional requests, a
+  directory index, and precompressed-sibling negotiation — a drop-in
+  upgrade over `python -m http.server`.  The existing `blackbull
+  module:attr` runner is unchanged.
+- **`StaticFiles` directory index.** New opt-in `index=` parameter on
+  `StaticFiles` and `app.static()` (default off): a request resolving to a
+  directory serves the named file (e.g. `index.html`) when present, guarded
+  by the same realpath + traversal check.
+
 ### Docs
 - Added [`docs/about/rfc9113-implementation.md`](docs/about/rfc9113-implementation.md)
   — a section-by-section map of how BlackBull implements RFC 9113, ordered by the
@@ -32,6 +52,8 @@ so the editable install's metadata catches up.
 - Corrected RFC 7540→9113 section citations in `http2_actor.py` and
   `frame_types.py` comments/docstrings (server push §8.4, malformed messages
   §8.1.1/§8.2.1; no behaviour change).
+- Documented `AppConfig` and `blackbull serve` in the configuration,
+  static-files, and running guides.
 
 ## [0.42.3] — 2026-06-19
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -135,8 +135,10 @@ next request with no staleness window.  Default is `cache=False`;
 standalone deployments serving static traffic directly should opt
 in to keep prior performance.
 
-What's still missing across all paths: ETag-driven revalidation,
-byte-range-multipart, and CDN edge-cache invalidation glue.  For
+`StaticFiles` itself emits no `ETag`; pair it with the `Cache`
+middleware for ETag / `If-None-Match` revalidation (`blackbull serve`
+does this for you).  What's still missing across all paths:
+byte-range-multipart and CDN edge-cache invalidation glue.  For
 anything user-visible, front a real static-file server (nginx,
 S3 + CloudFront).
 
@@ -161,12 +163,17 @@ Out of scope.  Revisit if a real user need appears.
 
 Out of scope.
 
-### CLI ergonomics are minimal
+### CLI `--bind` host is advisory
 
-The `blackbull` console script covers the basic ASGI-runner
-shape (`blackbull app:app --bind ...`).  A few quality-of-life
-knobs (`--version`, helpful error on missing `app:module`,
-`--reload-dir`) are pending.
+The `blackbull` console script covers the ASGI-runner shape
+(`blackbull app:app --bind ...`), the zero-code static server
+(`blackbull serve ./dir`), `--version`, `--config`, `--reload`, and
+focused errors on a bad `module:attr`.  The one notable gap: the
+host portion of `--bind host:port` (and the absence of a `host`
+field on `AppConfig`) is advisory — the socket layer binds dual-stack
+on **all** interfaces, so `--bind 127.0.0.1:8000` still listens on
+every interface.  Use a `unix:` bind, `fd://` socket activation, or a
+fronting proxy when interface filtering matters.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Hello, world!
 
 ## Why BlackBull
 
-- **Zero ceremony.** `app.run()` is the entire deploy story.  No
-  separate ASGI runner, no YAML config, no `gunicorn` class path.
+- **Zero ceremony.** `app.run()` is the entire deploy story — or
+  `blackbull serve ./public` for a static site with ETag + HTTP/2 and
+  no code at all.  No separate ASGI runner, no YAML config, no
+  `gunicorn` class path.
 - **Readable stack.** Every byte on the wire passes through Python
   you can step through with `pdb`.  No C extensions to debug.
 - **Break things on purpose.** The same protocol code that serves

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.43.x  | :white_check_mark: |
 | 0.42.x  | :white_check_mark: |
-| 0.41.x  | :white_check_mark: |
-| < 0.41  | :x:                |
+| < 0.42  | :x:                |
 
 This table updates with each minor release.
 

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -6,6 +6,7 @@
 Public API exports:
 
 - `BlackBull`: the main application object; wraps routing, middleware, and lifespan hooks.
+- `AppConfig`: declarative, immutable holder for the startup settings ``run()`` accepts (port, TLS, workers, …).
 - `serve`: synchronous entry point that runs any ASGI 3.0 callable (also used by the ``blackbull`` console script).
 - `Response`, `JSONResponse`, `StreamingResponse`, `EventSourceResponse`, `WebSocketResponse`: response helpers.
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
@@ -38,6 +39,7 @@ except PackageNotFoundError:
     __version__ = '0.0.0+unknown'
 
 from .app import BlackBull, serve
+from .config import AppConfig
 from .headers import Headers
 from .request import read_body, parse_cookies
 from .response import (

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -30,6 +30,7 @@ from .event import Event, EventDispatcher, EventHandler
 from .headers import Headers
 from .utils import Scheme
 from .router import Router, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, has_middleware_param
+from .config import AppConfig
 logger = logging.getLogger(__name__)
 
 
@@ -207,7 +208,9 @@ class BlackBull:
                  loop=None,
                  observer_shutdown_timeout: float = 5.0,
                  trusted_proxies: list[str] | str | None = None,
+                 config: AppConfig | None = None,
                  ):
+        self._config = config
         self._router = Router()
         self._logger = logger
         self._error_router = ErrorRouter()
@@ -545,7 +548,7 @@ class BlackBull:
         self._chain = None  # invalidate cached chain
 
     def static(self, url_prefix: str, root_dir: str | Path, *,
-               cache: bool = False) -> None:
+               cache: bool = False, index: str | None = None) -> None:
         """Serve static files from *root_dir* under *url_prefix* via global middleware.
 
         ``cache`` (default ``False``): when ``True``, file bodies are
@@ -556,12 +559,15 @@ class BlackBull:
         need the in-process cache; the default off is calibrated to
         that majority.  See ``docs/guide/static-files.md`` for the
         full discussion.
+
+        ``index`` (default ``None`` — off): a filename (e.g.
+        ``'index.html'``) served when a request resolves to a directory.
         """
         from blackbull.middleware.static import StaticFiles
         root = Path(root_dir).resolve()
         self._static_roots.append((url_prefix, root))
         self._global_middlewares.append(
-            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache))
+            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache, index=index))
         self._chain = None  # invalidate cached chain
 
     def on_error(self, key):
@@ -638,14 +644,14 @@ class BlackBull:
             docs_path=docs_path,
         )
 
-    def run(self, certfile=None, keyfile=None, port=0,
+    def run(self, certfile=None, keyfile=None, port: int | None = None,
             unix_path: str | None = None,
             inherited_fd: int | None = None,
             workers: int | None = None,
             max_connections: int | None = None,
             stream_queue_depth: int | None = None,
             ws_queue_depth: int | None = None,
-            reload: bool = False,
+            reload: bool | None = None,
             reload_paths: list | None = None) -> None:
         """Run the app under BlackBull's own server (single- or multi-worker).
 
@@ -653,6 +659,16 @@ class BlackBull:
         write ``app.run(port=8000)``, not ``asyncio.run(app.run(...))``.
         For ``workers > 1`` *or* ``reload=True`` the master pre-binds
         sockets, forks workers, and blocks until SIGTERM / SIGINT.
+
+        Each argument left unset (``None``) falls back to the value declared
+        on the bound :class:`~blackbull.AppConfig` (if the app was built with
+        ``BlackBull(config=...)``), then to :func:`blackbull.serve`'s own
+        default.  An explicit argument always wins::
+
+            app = BlackBull(config=AppConfig(port=8443, certfile='c.pem',
+                                             keyfile='k.pem'))
+            app.run()              # binds 8443 with TLS from the config
+            app.run(port=9000)     # explicit arg overrides the config's 8443
 
         For embedded use under an existing event loop, or for pre-binding
         a socket before forking a test subprocess, instantiate
@@ -667,17 +683,28 @@ class BlackBull:
             app.run(port=8443, certfile='cert.pem', keyfile='key.pem', reload=True)
             app.run(unix_path='/run/blackbull.sock')
         """
+        cfg = self._config
+
+        def _pick(explicit, attr, fallback):
+            if explicit is not None:
+                return explicit
+            if cfg is not None:
+                return getattr(cfg, attr)
+            return fallback
+
         serve(
             self,
-            certfile=certfile, keyfile=keyfile, port=port,
-            unix_path=unix_path,
-            inherited_fd=inherited_fd,
-            workers=workers,
-            max_connections=max_connections,
-            stream_queue_depth=stream_queue_depth,
-            ws_queue_depth=ws_queue_depth,
-            reload=reload,
-            reload_paths=reload_paths,
+            certfile=_pick(certfile, 'certfile', None),
+            keyfile=_pick(keyfile, 'keyfile', None),
+            port=_pick(port, 'port', 0),
+            unix_path=_pick(unix_path, 'unix_path', None),
+            inherited_fd=_pick(inherited_fd, 'inherited_fd', None),
+            workers=_pick(workers, 'workers', None),
+            max_connections=_pick(max_connections, 'max_connections', None),
+            stream_queue_depth=_pick(stream_queue_depth, 'stream_queue_depth', None),
+            ws_queue_depth=_pick(ws_queue_depth, 'ws_queue_depth', None),
+            reload=_pick(reload, 'reload', False),
+            reload_paths=_pick(reload_paths, 'reload_paths', None),
         )
 
 

--- a/blackbull/cli.py
+++ b/blackbull/cli.py
@@ -296,13 +296,154 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+# ---------------------------------------------------------------------------
+# ``blackbull serve`` — zero-code static file server (Sprint 49, B4)
+# ---------------------------------------------------------------------------
+
+def _build_serve_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='blackbull serve',
+        description='Serve a directory of static files over HTTP/1.1 — and '
+                    'HTTP/2 when TLS is supplied — with ETag / conditional '
+                    'requests out of the box.  No application code required; '
+                    'a drop-in upgrade over "python -m http.server".',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        'directory', nargs='?', default='.', metavar='DIR',
+        help='Directory to serve.  Defaults to the current directory.',
+    )
+    p.add_argument(
+        '--bind', default=_DEFAULT_BIND, metavar='SPEC',
+        help='Address to bind: host:port (TCP) or unix:/abs/path (AF_UNIX).',
+    )
+    p.add_argument(
+        '--certfile', default=None, metavar='PATH',
+        help='TLS certificate file.  Supplying --certfile and --keyfile '
+             'enables HTTPS and HTTP/2 (via ALPN).',
+    )
+    p.add_argument(
+        '--keyfile', default=None, metavar='PATH',
+        help='TLS private key file.  Required alongside --certfile.',
+    )
+    p.add_argument(
+        '--index', default='index.html', metavar='NAME',
+        help="Filename served for directory requests.  Pass '' to disable.",
+    )
+    p.add_argument(
+        '--no-etag', dest='etag', action='store_false',
+        help='Disable ETag / If-None-Match (304) conditional responses.',
+    )
+    p.add_argument(
+        '--cache', action='store_true',
+        help='Hold file bodies in an in-memory LRU (faster, but does not '
+             'pick up on-disk edits until the per-entry stat TTL expires).',
+    )
+    p.add_argument(
+        '--workers', type=int, default=None, metavar='N',
+        help='Number of worker processes.  0 = os.cpu_count().',
+    )
+    return p
+
+
+def _build_static_app(directory: str, *, etag: bool, cache: bool,
+                      index: str | None):
+    """Build a :class:`blackbull.BlackBull` app that serves *directory*.
+
+    Raises :class:`FileNotFoundError` / :class:`NotADirectoryError` when
+    *directory* is not a usable directory so the caller can report a
+    focused error rather than starting a server that 404s everything.
+    """
+    if not os.path.isdir(directory):
+        if os.path.exists(directory):
+            raise NotADirectoryError(f'not a directory: {directory!r}')
+        raise FileNotFoundError(f'directory not found: {directory!r}')
+
+    from . import BlackBull  # noqa: PLC0415
+
+    app = BlackBull()
+    if etag:
+        # Cache is the outermost middleware (registered first) so a matching
+        # If-None-Match short-circuits to 304 before StaticFiles touches the
+        # disk; it also injects the generated ETag on the storing pass.
+        from .middleware.cache import Cache  # noqa: PLC0415
+        app.use(Cache())
+    app.static('/', directory, cache=cache, index=index or None)
+    return app
+
+
+def _serve_static(argv: list[str]) -> int:
+    parser = _build_serve_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        addr = _split_bind(args.bind)
+    except ValueError as exc:
+        print(f'blackbull: {exc}', file=sys.stderr)
+        return 1
+
+    port = 0
+    unix_path: str | None = None
+    if addr[0] == 'tcp':
+        _, host, port = addr
+        if host not in ('', '0.0.0.0', '::', '127.0.0.1', 'localhost'):
+            print(
+                f'blackbull: --bind host {host!r} is advisory in v1; '
+                f'binding dual-stack on port {port} for now.',
+                file=sys.stderr,
+            )
+    elif addr[0] == 'unix':
+        _, unix_path = addr
+    else:  # fd:// makes no sense for the zero-code static server
+        print('blackbull: serve does not support fd:// binds; use host:port '
+              'or unix:/path.', file=sys.stderr)
+        return 1
+
+    try:
+        app = _build_static_app(
+            args.directory, etag=args.etag, cache=args.cache, index=args.index)
+    except (FileNotFoundError, NotADirectoryError) as exc:
+        print(f'blackbull: {exc}', file=sys.stderr)
+        return 1
+
+    scheme = 'https' if args.certfile else 'http'
+    where = unix_path if unix_path else f'{scheme}://127.0.0.1:{port}'
+    print(f'blackbull: serving {os.path.abspath(args.directory)} on {where}',
+          file=sys.stderr)
+
+    try:
+        _serve(
+            app,
+            certfile=args.certfile,
+            keyfile=args.keyfile,
+            port=port,
+            unix_path=unix_path,
+            workers=args.workers,
+        )
+    except RuntimeError as exc:
+        print(f'blackbull: {exc}', file=sys.stderr)
+        return 1
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Entry point invoked by the ``blackbull`` console script.
+
+    Two forms are dispatched here:
+
+    * ``blackbull serve [DIR] …`` — the zero-code static file server
+      (see :func:`_serve_static`);
+    * ``blackbull module:attr …`` — run an ASGI 3.0 application.
 
     Returns a process exit code.  argparse handles ``--help`` and
     invalid-flag exits itself (status 2); application-level errors
     (bad import path, bind syntax) print to stderr and exit 1.
     """
+    if argv is None:
+        argv = sys.argv[1:]
+    if argv and argv[0] == 'serve':
+        return _serve_static(argv[1:])
+
     parser = _build_parser()
     args = parser.parse_args(argv)
 

--- a/blackbull/config.py
+++ b/blackbull/config.py
@@ -1,0 +1,90 @@
+"""Declarative application configuration — :class:`AppConfig`.
+
+``AppConfig`` is a small, typed, immutable holder for the server-facing
+settings that :meth:`blackbull.BlackBull.run` (and :func:`blackbull.serve`)
+already accept as keyword arguments.  It lets an application declare those
+settings once::
+
+    from blackbull import BlackBull, AppConfig
+
+    app = BlackBull(config=AppConfig(
+        port=8443,
+        certfile='cert.pem',
+        keyfile='key.pem',
+        workers=4,
+    ))
+
+    if __name__ == '__main__':
+        app.run()          # picks up the config; no flags to thread through
+
+Resolution precedence in :meth:`BlackBull.run` is, highest to lowest:
+
+1.  an explicit keyword argument to ``run(...)`` — ``app.run(port=9000)``
+    always wins;
+2.  the value declared on the bound :class:`AppConfig` (if any);
+3.  the built-in default baked into :func:`blackbull.serve`.
+
+``AppConfig`` deliberately mirrors *only* the parameters ``serve`` already
+exposes — it is not a general-purpose settings store.  Per-request and
+server-tuning knobs (window sizes, timeouts, queue depths beyond the two
+listed here, …) continue to live in :mod:`blackbull.env` and are sourced
+from ``BB_*`` environment variables.
+
+``host`` is intentionally absent: BlackBull's socket layer binds dual-stack
+on all interfaces (see :meth:`blackbull.server.ASGIServer.open_socket`), so
+a per-interface ``host`` field would silently do nothing.  Use ``unix_path``
+or ``inherited_fd`` for non-TCP binds.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass(frozen=True)
+class AppConfig:
+    """Immutable, declarative startup configuration for a BlackBull app.
+
+    Every field corresponds one-to-one with a keyword argument of
+    :func:`blackbull.serve` / :meth:`blackbull.BlackBull.run`.  Fields left
+    at their sentinel default (``None``, or ``0`` for ``port``, or ``False``
+    for ``reload``) defer to ``serve``'s own built-in default unless an
+    explicit ``run(...)`` argument overrides them.
+    """
+
+    #: TLS certificate file.  Enables HTTPS — and therefore HTTP/2 via ALPN —
+    #: when paired with ``keyfile``.
+    certfile: str | None = None
+
+    #: TLS private key file.  Required alongside ``certfile`` for HTTPS / HTTP/2.
+    keyfile: str | None = None
+
+    #: TCP port to bind.  ``0`` lets the OS pick a free ephemeral port.
+    port: int = 0
+
+    #: AF_UNIX socket path.  Mutually exclusive with a TCP ``port`` bind.
+    unix_path: str | None = None
+
+    #: Inherited listening socket fd (systemd-style socket activation).
+    inherited_fd: int | None = None
+
+    #: Number of worker processes.  ``None`` defers to ``BB_WORKERS``;
+    #: ``0`` resolves to ``os.cpu_count()``.
+    workers: int | None = None
+
+    #: Per-worker connection cap.  ``None`` defers to ``BB_MAX_CONNECTIONS``.
+    max_connections: int | None = None
+
+    #: ``asyncio.Queue`` depth for HTTP/2 per-stream events.  ``None`` defers
+    #: to ``BB_STREAM_QUEUE_DEPTH``.
+    stream_queue_depth: int | None = None
+
+    #: ``asyncio.Queue`` depth for inbound WebSocket events per connection.
+    #: ``None`` defers to ``BB_WS_QUEUE_DEPTH``.
+    ws_queue_depth: int | None = None
+
+    #: Enable auto-reload (requires the ``[reload]`` extra).
+    reload: bool = False
+
+    #: Directories / files to watch under auto-reload.  ``None`` watches the
+    #: current working directory.
+    reload_paths: list[str] | None = None

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -64,8 +64,15 @@ class StaticFiles:
 
     def __init__(self, directory: str | None = None, *,
                  url_prefix: str = '', root_dir: str | Path | None = None,
-                 cache: bool = False):
+                 cache: bool = False, index: str | None = None):
         """Serve files from ``directory`` (or ``root_dir``).
+
+        ``index`` (default ``None`` — off): when set to a filename (e.g.
+        ``'index.html'``), a request that resolves to a *directory* is
+        served that file from inside the directory if it exists.  Off by
+        default so existing exact-path serving is unchanged; the
+        ``blackbull serve`` CLI turns it on to match ``python -m
+        http.server``'s directory-index behaviour.
 
         ``cache`` (default ``False``): when ``True``, file bodies up to
         ``_CACHE_MAX_BYTES_PER_FILE`` are held in an in-memory
@@ -94,6 +101,7 @@ class StaticFiles:
         self._root_sep: str = self._root_str + os.sep
         self._url_prefix = url_prefix.rstrip('/')
         self._cache_enabled: bool = cache
+        self._index: str | None = index
         # cache key = the actual filesystem path served (original or
         # sibling), held as a ``str`` so the hash is cheap and the
         # key matches the value returned by ``os.path.realpath``.
@@ -162,6 +170,17 @@ class StaticFiles:
             return
 
         if not os.path.isfile(target):
+            # Directory request → serve the configured index file when one
+            # is set (off by default, so ``app.static()`` callers keep the
+            # exact-file-only behaviour).  The index candidate is run
+            # through the same realpath + traversal guard as any other
+            # target so a crafted ``index`` can't escape the root.
+            if self._index and os.path.isdir(target):
+                candidate = os.path.realpath(os.path.join(target, self._index))
+                if ((candidate == self._root_str or candidate.startswith(self._root_sep))
+                        and os.path.isfile(candidate)):
+                    await self._serve(scope, send, candidate)
+                    return
             if call_next:
                 await call_next(scope, receive, send)
             else:

--- a/docs/deployment/running.md
+++ b/docs/deployment/running.md
@@ -31,11 +31,26 @@ around the worker pool).
 Full signature:
 
 ```python
-def run(port=0, certfile=None, keyfile=None,
+def run(port=None, certfile=None, keyfile=None,
         workers=None, unix_path=None, inherited_fd=None,
         max_connections=None, stream_queue_depth=None,
-        ws_queue_depth=None, reload=False, reload_paths=None):
+        ws_queue_depth=None, reload=None, reload_paths=None):
     ...
+```
+
+Each argument left unset (`None`) falls back to the value declared
+on the bound [`AppConfig`](../guide/configuration.md#declarative-startup-with-appconfig)
+(if any), then to `serve()`'s built-in default.  Declaring the
+settings once keeps `__main__` to a single line:
+
+```python
+from blackbull import BlackBull, AppConfig
+
+app = BlackBull(config=AppConfig(port=8443, certfile='cert.pem',
+                                 keyfile='key.pem', workers=4))
+
+if __name__ == '__main__':
+    app.run()
 ```
 
 ## 2. `blackbull` CLI — useful for systemd, Docker, PaaS
@@ -56,6 +71,20 @@ attribute may be a `BlackBull` instance *or* a plain ASGI
 callable.  See `blackbull --help` for the full flag list and
 [Configuration](../guide/configuration.md) for how flags compose
 with environment variables and TOML config files.
+
+### `blackbull serve` — zero-code static files
+
+To serve a directory of static files without writing any
+application code — a drop-in upgrade over `python -m
+http.server`, with ETag, HTTP/2 (under TLS), and a directory
+index built in:
+
+```bash
+blackbull serve ./public --bind :8080
+blackbull serve ./public --certfile cert.pem --keyfile key.pem  # HTTPS + HTTP/2
+```
+
+See [Static files → blackbull serve](../guide/static-files.md#zero-code-static-server-blackbull-serve).
 
 ## 3. Any external ASGI 3.0 server
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -129,6 +129,81 @@ app.run(
 Keyword arguments take precedence over environment variables in
 the same way the CLI flags do.
 
+### Declarative startup with `AppConfig`
+
+To declare the startup settings once — rather than threading them
+through every `run()` call site — build the app with an
+`AppConfig`:
+
+```python
+from blackbull import BlackBull, AppConfig
+
+app = BlackBull(config=AppConfig(
+    port=8443,
+    certfile='cert.pem', keyfile='key.pem',
+    workers=4,
+))
+
+if __name__ == '__main__':
+    app.run()                 # picks up the bound config
+```
+
+`AppConfig` is a frozen dataclass holding exactly the parameters
+`run()` accepts (`port`, `certfile`, `keyfile`, `unix_path`,
+`inherited_fd`, `workers`, `max_connections`, `stream_queue_depth`,
+`ws_queue_depth`, `reload`, `reload_paths`).  It is not a
+general-purpose settings store — server-tuning knobs stay in the
+`BB_*` environment variables.
+
+Resolution order in `run()` is, highest to lowest:
+
+1. an explicit `run(...)` keyword argument — `app.run(port=9000)`
+   always wins;
+2. the value declared on the bound `AppConfig`;
+3. `serve()`'s built-in default.
+
+```python
+app = BlackBull(config=AppConfig(port=8443, certfile='c.pem', keyfile='k.pem'))
+app.run()              # binds 8443 with TLS from the config
+app.run(port=9000)     # explicit arg overrides the config's 8443
+```
+
+There is no `host` field: BlackBull's socket layer binds dual-stack
+on all interfaces, so a per-interface `host` would silently do
+nothing.  Use `unix_path` or `inherited_fd` for non-TCP binds.
+
+## Serving static files with `blackbull serve`
+
+For a quick static file server — a drop-in upgrade over
+`python -m http.server` — point the `serve` subcommand at a
+directory:
+
+```bash
+blackbull serve                       # serve ./ on http://127.0.0.1:8000
+blackbull serve ./public --bind :8080
+blackbull serve ./public --certfile cert.pem --keyfile key.pem  # HTTPS + HTTP/2
+```
+
+Unlike `python -m http.server`, it ships:
+
+- **ETag / conditional requests** — repeat fetches get a `304 Not
+  Modified` (disable with `--no-etag`);
+- **HTTP/2** automatically once `--certfile` / `--keyfile` make it
+  HTTPS;
+- a **directory index** (`index.html` by default; change with
+  `--index NAME`, disable with `--index ''`);
+- precompressed-sibling negotiation (`.br` / `.zst` / `.gz`).
+
+No application code is required.  `--cache` holds file bodies in an
+in-memory LRU for higher throughput at the cost of picking up
+on-disk edits only after the per-entry `stat` TTL.
+
+!!! note
+    `blackbull serve` is a development / standalone convenience.
+    `StaticFiles` does not serve files when `BLACKBULL_ENV=production`
+    (the expectation is a reverse proxy or CDN fronts static traffic
+    there) — see [Static files](static-files.md).
+
 ## Operational defaults to think about
 
 The default values are tuned for development.  For production,

--- a/docs/guide/static-files.md
+++ b/docs/guide/static-files.md
@@ -36,6 +36,35 @@ app = StaticFiles(directory='public')
 # app(scope, receive, send)  — 3-argument ASGI
 ```
 
+## Directory index
+
+By default `StaticFiles` serves files by their exact path only.
+Pass `index` to serve a named file when a request resolves to a
+directory:
+
+```python
+app.static('/', 'public', index='index.html')   # GET / → public/index.html
+```
+
+The index candidate is run through the same realpath + traversal
+guard as any other target, so it can't escape the root.  The
+`blackbull serve` CLI (below) turns this on by default.
+
+## Zero-code static server: `blackbull serve`
+
+For an ad-hoc static server with no application code — a drop-in
+upgrade over `python -m http.server` — use the `serve` subcommand:
+
+```bash
+blackbull serve ./public --bind :8080
+blackbull serve ./public --certfile cert.pem --keyfile key.pem  # HTTPS + HTTP/2
+```
+
+It wires `StaticFiles` with `index='index.html'` plus the
+[`Cache`](middleware.md) middleware for ETag / `304` conditional
+responses.  See [Configuration → blackbull serve](configuration.md#serving-static-files-with-blackbull-serve)
+for the full flag list.
+
 ## Environment gate
 
 The `BLACKBULL_ENV` environment variable controls serving

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.42.3"
+version = "0.43.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -30,9 +30,11 @@ from pathlib import Path
 import pytest
 
 
-# Smaller payload than the unit-test debounce wait — picked so the test
-# is responsive without becoming flaky on a loaded laptop.
-_RELOAD_DEADLINE_SEC = 20.0
+# Generous deadline: polling-mode watchfiles (see env setup below) detects
+# the change reliably, but the re-exec + re-import + re-fork cycle can still
+# run slow under the CPU/IO contention of the full pre-commit suite.  30 s
+# gives headroom there while staying well under the 90 s hard timeout.
+_RELOAD_DEADLINE_SEC = 30.0
 _REQ_TIMEOUT_SEC = 2.0
 
 
@@ -89,7 +91,7 @@ def _write_app(script: Path, port: int, version: str) -> None:
     ''').lstrip())
 
 
-@pytest.mark.timeout(60)
+@pytest.mark.timeout(90)
 def test_auto_reload_picks_up_new_code(tmp_path: Path):
     port = _free_port()
     script = tmp_path / 'reload_app.py'
@@ -101,6 +103,16 @@ def test_auto_reload_picks_up_new_code(tmp_path: Path):
     env = os.environ.copy()
     env['PYTHONUNBUFFERED'] = '1'
     env['BB_ACCESS_LOG'] = '0'   # quieter test output
+    # Force watchfiles into polling mode for the subprocess's watcher.
+    # watchfiles' default inotify backend silently drops the rewrite event
+    # on WSL2's drvfs/9p filesystem and under the CPU/IO contention of the
+    # full pre-commit suite (which forks through the multiworker tests just
+    # before this one) — the observed flake was ``last_seen='v1'`` with zero
+    # connect failures, i.e. the change was never detected.  Polling is
+    # backend-agnostic and reliable across filesystems; the reload re-exec
+    # logic under test is identical either way.
+    env['WATCHFILES_FORCE_POLLING'] = '1'
+    env['WATCHFILES_POLL_DELAY_MS'] = '100'
 
     # Capture to a file rather than a pipe: an unread PIPE eventually
     # blocks the subprocess on writes once the kernel buffer (~64 KiB)

--- a/tests/unit/test_cli_serve.py
+++ b/tests/unit/test_cli_serve.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import pytest
 
 import blackbull.cli as cli
-from blackbull.cli import _build_static_app
 from blackbull.testing import TestClient
 
 
@@ -26,15 +25,15 @@ def site(tmp_path):
 
 def test_build_static_app_missing_dir_raises(tmp_path):
     with pytest.raises(FileNotFoundError):
-        _build_static_app(str(tmp_path / 'nope'), etag=True, cache=False,
-                          index='index.html')
+        cli._build_static_app(str(tmp_path / 'nope'), etag=True, cache=False,
+                              index='index.html')
 
 
 def test_build_static_app_file_not_dir_raises(tmp_path):
     f = tmp_path / 'a_file'
     f.write_text('x')
     with pytest.raises(NotADirectoryError):
-        _build_static_app(str(f), etag=True, cache=False, index='index.html')
+        cli._build_static_app(str(f), etag=True, cache=False, index='index.html')
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +41,7 @@ def test_build_static_app_file_not_dir_raises(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_serves_a_file(site):
-    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    app = cli._build_static_app(str(site), etag=True, cache=False, index='index.html')
     with TestClient(app) as c:
         r = c.get('/a.txt')
     assert r.status_code == 200
@@ -50,7 +49,7 @@ def test_serves_a_file(site):
 
 
 def test_directory_index_served_on_root(site):
-    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    app = cli._build_static_app(str(site), etag=True, cache=False, index='index.html')
     with TestClient(app) as c:
         r = c.get('/')
     assert r.status_code == 200
@@ -58,21 +57,21 @@ def test_directory_index_served_on_root(site):
 
 
 def test_index_disabled_means_root_404(site):
-    app = _build_static_app(str(site), etag=True, cache=False, index=None)
+    app = cli._build_static_app(str(site), etag=True, cache=False, index=None)
     with TestClient(app) as c:
         r = c.get('/')
     assert r.status_code == 404
 
 
 def test_missing_file_is_404(site):
-    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    app = cli._build_static_app(str(site), etag=True, cache=False, index='index.html')
     with TestClient(app) as c:
         r = c.get('/does-not-exist.txt')
     assert r.status_code == 404
 
 
 def test_etag_and_conditional_304(site):
-    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    app = cli._build_static_app(str(site), etag=True, cache=False, index='index.html')
     with TestClient(app) as c:
         r = c.get('/a.txt')
         etag = r.headers.get('etag')
@@ -82,7 +81,7 @@ def test_etag_and_conditional_304(site):
 
 
 def test_no_etag_omits_etag_header(site):
-    app = _build_static_app(str(site), etag=False, cache=False, index='index.html')
+    app = cli._build_static_app(str(site), etag=False, cache=False, index='index.html')
     with TestClient(app) as c:
         r = c.get('/a.txt')
     assert r.status_code == 200

--- a/tests/unit/test_cli_serve.py
+++ b/tests/unit/test_cli_serve.py
@@ -1,0 +1,127 @@
+"""Tests for ``blackbull serve`` — the zero-code static file server (B4).
+
+Covers the CLI surface (argument parsing, dispatch, error exit codes) and
+the behaviour of the app built by :func:`blackbull.cli._build_static_app`
+(file serving, directory index, ETag / 304 conditional requests).
+"""
+from __future__ import annotations
+
+import pytest
+
+import blackbull.cli as cli
+from blackbull.cli import _build_static_app
+from blackbull.testing import TestClient
+
+
+@pytest.fixture()
+def site(tmp_path):
+    (tmp_path / 'index.html').write_text('<h1>home</h1>')
+    (tmp_path / 'a.txt').write_text('alpha')
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _build_static_app — directory validation
+# ---------------------------------------------------------------------------
+
+def test_build_static_app_missing_dir_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        _build_static_app(str(tmp_path / 'nope'), etag=True, cache=False,
+                          index='index.html')
+
+
+def test_build_static_app_file_not_dir_raises(tmp_path):
+    f = tmp_path / 'a_file'
+    f.write_text('x')
+    with pytest.raises(NotADirectoryError):
+        _build_static_app(str(f), etag=True, cache=False, index='index.html')
+
+
+# ---------------------------------------------------------------------------
+# Serving behaviour
+# ---------------------------------------------------------------------------
+
+def test_serves_a_file(site):
+    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    with TestClient(app) as c:
+        r = c.get('/a.txt')
+    assert r.status_code == 200
+    assert r.text == 'alpha'
+
+
+def test_directory_index_served_on_root(site):
+    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    with TestClient(app) as c:
+        r = c.get('/')
+    assert r.status_code == 200
+    assert '<h1>home</h1>' in r.text
+
+
+def test_index_disabled_means_root_404(site):
+    app = _build_static_app(str(site), etag=True, cache=False, index=None)
+    with TestClient(app) as c:
+        r = c.get('/')
+    assert r.status_code == 404
+
+
+def test_missing_file_is_404(site):
+    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    with TestClient(app) as c:
+        r = c.get('/does-not-exist.txt')
+    assert r.status_code == 404
+
+
+def test_etag_and_conditional_304(site):
+    app = _build_static_app(str(site), etag=True, cache=False, index='index.html')
+    with TestClient(app) as c:
+        r = c.get('/a.txt')
+        etag = r.headers.get('etag')
+        assert etag is not None
+        r2 = c.get('/a.txt', headers={'if-none-match': etag})
+    assert r2.status_code == 304
+
+
+def test_no_etag_omits_etag_header(site):
+    app = _build_static_app(str(site), etag=False, cache=False, index='index.html')
+    with TestClient(app) as c:
+        r = c.get('/a.txt')
+    assert r.status_code == 200
+    assert 'etag' not in {k.lower() for k in r.headers}
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch + exit codes
+# ---------------------------------------------------------------------------
+
+def test_main_dispatches_serve_to_static(site, monkeypatch):
+    captured: dict = {}
+
+    def _fake_serve(app, **kwargs):
+        captured['app'] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr(cli, '_serve', _fake_serve)
+    rc = cli.main(['serve', str(site), '--bind', '127.0.0.1:8123'])
+    assert rc == 0
+    assert captured['port'] == 8123
+    # The dispatched app is a BlackBull instance serving the directory.
+    from blackbull import BlackBull
+    assert isinstance(captured['app'], BlackBull)
+
+
+def test_main_serve_missing_dir_returns_1(tmp_path, capsys):
+    rc = cli.main(['serve', str(tmp_path / 'absent')])
+    assert rc == 1
+    assert 'not found' in capsys.readouterr().err
+
+
+def test_main_serve_bad_bind_returns_1(site, capsys):
+    rc = cli.main(['serve', str(site), '--bind', '0.0.0.0'])  # no port
+    assert rc == 1
+    assert 'blackbull:' in capsys.readouterr().err
+
+
+def test_main_serve_rejects_fd_bind(site, capsys):
+    rc = cli.main(['serve', str(site), '--bind', 'fd://3'])
+    assert rc == 1
+    assert 'fd://' in capsys.readouterr().err

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,107 @@
+"""Unit tests for :class:`blackbull.AppConfig` and its resolution in
+:meth:`blackbull.BlackBull.run`.
+
+These cover the precedence chain only — explicit ``run()`` arg beats the
+bound ``AppConfig`` beats ``serve``'s built-in default — without actually
+binding a socket: ``blackbull.app.serve`` is monkeypatched to capture the
+keyword arguments it would have been called with.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import blackbull.app as app_module
+from blackbull import AppConfig, BlackBull
+
+
+@pytest.fixture()
+def captured_serve(monkeypatch):
+    """Replace the module-level ``serve`` so ``run()`` records its kwargs
+    instead of binding a real socket."""
+    captured: dict = {}
+
+    def _fake_serve(app, **kwargs):
+        captured.clear()
+        captured.update(kwargs)
+
+    monkeypatch.setattr(app_module, 'serve', _fake_serve)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# AppConfig dataclass surface
+# ---------------------------------------------------------------------------
+
+def test_appconfig_defaults_are_sentinels():
+    cfg = AppConfig()
+    assert cfg.certfile is None
+    assert cfg.keyfile is None
+    assert cfg.port == 0
+    assert cfg.unix_path is None
+    assert cfg.inherited_fd is None
+    assert cfg.workers is None
+    assert cfg.max_connections is None
+    assert cfg.stream_queue_depth is None
+    assert cfg.ws_queue_depth is None
+    assert cfg.reload is False
+    assert cfg.reload_paths is None
+
+
+def test_appconfig_is_frozen():
+    cfg = AppConfig(port=8000)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.port = 9000  # type: ignore[misc]
+
+
+def test_appconfig_has_no_host_field():
+    # host binding is dual-stack-only at the socket layer; a host field
+    # would silently do nothing, so it is deliberately absent.
+    assert 'host' not in {f.name for f in dataclasses.fields(AppConfig)}
+
+
+# ---------------------------------------------------------------------------
+# run() resolution
+# ---------------------------------------------------------------------------
+
+def test_run_without_config_uses_serve_defaults(captured_serve):
+    BlackBull().run()
+    assert captured_serve['port'] == 0
+    assert captured_serve['certfile'] is None
+    assert captured_serve['keyfile'] is None
+    assert captured_serve['workers'] is None
+    assert captured_serve['reload'] is False
+
+
+def test_run_resolves_from_bound_config(captured_serve):
+    cfg = AppConfig(port=8443, certfile='c.pem', keyfile='k.pem', workers=4)
+    BlackBull(config=cfg).run()
+    assert captured_serve['port'] == 8443
+    assert captured_serve['certfile'] == 'c.pem'
+    assert captured_serve['keyfile'] == 'k.pem'
+    assert captured_serve['workers'] == 4
+
+
+def test_explicit_arg_overrides_config(captured_serve):
+    cfg = AppConfig(port=8443, certfile='c.pem', keyfile='k.pem')
+    app = BlackBull(config=cfg)
+    app.run(port=9000)
+    assert captured_serve['port'] == 9000          # explicit wins
+    assert captured_serve['certfile'] == 'c.pem'   # config still supplies TLS
+
+
+def test_explicit_reload_true_overrides_config_false(captured_serve):
+    cfg = AppConfig(reload=False)
+    BlackBull(config=cfg).run(reload=True)
+    assert captured_serve['reload'] is True
+
+
+def test_config_unix_path_and_queue_depths_flow_through(captured_serve):
+    cfg = AppConfig(unix_path='/run/bb.sock', stream_queue_depth=128,
+                    ws_queue_depth=512, max_connections=1024)
+    BlackBull(config=cfg).run()
+    assert captured_serve['unix_path'] == '/run/bb.sock'
+    assert captured_serve['stream_queue_depth'] == 128
+    assert captured_serve['ws_queue_depth'] == 512
+    assert captured_serve['max_connections'] == 1024


### PR DESCRIPTION
## Summary

Sprint 49 — DX bundle that cuts first-touch friction for new users.

- **`AppConfig` — declarative startup config.** Frozen dataclass holding exactly the params `run()`/`serve()` accept (port, TLS, workers, queue depths, reload). `BlackBull(config=AppConfig(...))` declares settings once; `run()` resolves each setting **explicit arg → bound config → built-in default** (sentinel-aware). Additive — existing programmatic startup is unchanged. Exported as `blackbull.AppConfig`.
- **`blackbull serve [DIR]` — zero-code static file server.** ETag / `304` conditional requests (via the `Cache` middleware), HTTP/2 automatically under TLS, directory index, and precompressed-sibling negotiation — a drop-in upgrade over `python -m http.server`. The existing `blackbull module:attr` runner is untouched; `fd://` binds are rejected.
- **`StaticFiles` directory index.** Opt-in `index=` on `StaticFiles` / `app.static()` (default off), guarded by the same realpath + traversal check.

The in-tree `Session` middleware removal planned for this sprint is **held** — calendar floor **2026-07-14** (today 2026-06-20) — and carries forward.

## Test plan

- [x] `tests/unit/test_config.py` (8) — AppConfig defaults, frozen, no-`host`-field, `run()` precedence
- [x] `tests/unit/test_cli_serve.py` (11) — dir validation, file/index/404 serving, ETag→304, `--no-etag`, `main()` dispatch + exit codes
- [x] Full beartype suite green via pre-commit hook
- [x] Real end-to-end `blackbull serve` smoke test: 200 + index, ETag, 304
- [x] Pre-release docs audit (README / SECURITY / CHANGELOG / KNOWN_LIMITATIONS); doc edits add no new `mkdocs --strict` warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)