### PR TITLE
release: v0.43.1 — beartype forward-ref annotation crash fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ BlackBull uses [ZeroVer](https://0ver.org/) prior to a 1.0 commitment:
 
 - `0.MINOR.PATCH`
 - `MINOR` advances at each sprint close (one minor per closed sprint).
-  The number matches the sprint: `0.26.0` = Sprint 26 close.
+  The minor number does **not** equal the sprint number — patch releases
+  and combined-sprint releases have introduced an offset (Sprint 49
+  closed as `v0.43.0`).
+- **Exception (2026-06-21)**: Sprint 50 is not independently released —
+  it ships together with Sprint 51 and Sprint 52 as `v0.44.0` (the next
+  minor after `v0.43.0`).  Normal per-sprint versioning resumes at the
+  next sprint close as `v0.45.0`.
 - `PATCH` covers bug fixes / harness work between sprints.
 - No `1.0.0` until the framework's identity (pure-Python H1 parser,
   BlackBull-internal `ASGIServer`, per-process tick scanner deadline
@@ -23,6 +29,21 @@ so the editable install's metadata catches up.
 ---
 
 ## [Unreleased]
+
+## [0.43.1] — 2026-06-21
+
+### Fixed
+
+- **`Router.validate()` — forward-ref annotation crash on lifespan startup.**
+  Route handlers annotated with string types (`'str'`, `'int'`, etc.) or compiled
+  under `from __future__ import annotations` (PEP 563) caused a `SyntaxError`
+  inside beartype's code generator (`${FORWARDREF:str]?}` — mismatched bracket),
+  which surfaced as `RuntimeError: Lifespan startup failed` for all integration
+  tests and the production `app.run()` path.
+  Fix: resolve annotations via `typing.get_type_hints()` before passing to
+  `die_if_unbearable`, and catch `BeartypeException` (beartype's base error class)
+  as a defensive fallback for any other internal beartype code-gen failure.
+  Affected `beartype` ≥ 0.22.8; no beartype version change required.
 
 ## [0.43.0] — 2026-06-20
 

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -890,7 +890,7 @@ class Router(UserDict, BaseRouter):
         surface before the first request is served, not after.
         """
         from beartype.door import die_if_unbearable
-        from beartype.roar import BeartypeDoorHintViolation
+        from beartype.roar import BeartypeDoorHintViolation, BeartypeException
 
         errors: list[str] = []
 
@@ -908,18 +908,34 @@ class Router(UserDict, BaseRouter):
                     continue
 
                 p = sig.parameters.get(param_name)
-                if p is None or p.annotation is inspect.Parameter.empty:
+                if p is None:
+                    continue
+
+                # Resolve string annotations (forward refs / PEP 563) to real
+                # types before handing to beartype.  inspect.Parameter.annotation
+                # returns the raw string when __future__.annotations is active,
+                # and beartype's code generator cannot handle unresolved strings.
+                try:
+                    hints = typing.get_type_hints(info.handler)
+                except Exception:
+                    hints = {}
+                annotation = hints.get(param_name, inspect.Parameter.empty)
+                if annotation is inspect.Parameter.empty:
                     continue
 
                 _regex_str, converter_fn = _CONVERTERS[spec]
                 sample = converter_fn(_SAMPLE_INPUTS[spec])
                 try:
-                    die_if_unbearable(sample, p.annotation)
+                    die_if_unbearable(sample, annotation)
                 except BeartypeDoorHintViolation as exc:
                     errors.append(
                         f"Route {info.template!r} param {param_name!r}: "
                         f"converter {spec!r} yields {type(sample).__name__!r} "
-                        f"but annotation is {p.annotation!r}: {exc}")
+                        f"but annotation is {annotation!r}: {exc}")
+                except BeartypeException:
+                    # beartype internal error (e.g. code-gen bug with a
+                    # partially-resolved forward ref) — skip this check.
+                    pass
 
         if errors:
             raise ConfigurationError('\n'.join(errors))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.43.0"
+version = "0.43.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- **`Router.validate()` — forward-ref annotation crash on lifespan startup.**
  Route handlers annotated with string types (`'str'`, `'int'`, etc.) or compiled
  under `from __future__ import annotations` (PEP 563) caused a `SyntaxError`
  inside beartype's code generator (`${FORWARDREF:str]?}` — mismatched bracket),
  surfacing as `RuntimeError: Lifespan startup failed` and blocking all integration
  tests and the production `app.run()` path.

- Fix: resolve annotations via `typing.get_type_hints()` before passing to
  `die_if_unbearable`; also catch `BeartypeException` (beartype's base error class)
  as a defensive fallback. No beartype version change required (`beartype` ≥ 0.22.8
  affected).

## Test plan

- [x] Pre-commit hook ran full suite (1493 passed, 225 skipped, 2 xfailed) on both commits — green
- [x] MkDocs strict build passed on both commits
- [x] Smoke test: `Router.validate()` with `from __future__ import annotations` handlers passes
- [ ] `blackbull.__version__` == `"0.43.1"` after `pip install -e .`
- [ ] Wait for CodeQL / pip-audit CI checks to pass before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)