### PR TITLE
release: v0.43.2 — middleware send-dict fix + Response serialisation unification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,36 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.43.2] — 2026-06-22
+
+### Fixed
+
+- **Middleware `send` wrappers received `Response` objects instead of ASGI
+  dicts.**  The `_wrap_send` adapter was installed at the outermost layer
+  (`BlackBull.__call__`), but `send` flows handler→outward, so it normalised
+  *last* — after every middleware had already seen the raw object.  A
+  middleware that wrapped `send` and inspected `msg['type']` therefore crashed
+  with `TypeError: 'Response' object is not subscriptable` whenever a handler
+  returned a `dict`/`str` (auto-`Response`) or called `send(Response(...))`.
+  Fix: install `_wrap_send` at the *handler boundary* in `_dispatch`, so
+  everything above the route handler observes plain ASGI dicts.  (The defect
+  shipped in 0.43.0; it surfaced only in 0.43.1 once the lifespan-startup crash
+  it hid behind — the beartype forward-ref bug — was fixed.)
+
+### Internal
+
+- **Unified the Response→ASGI serialisation onto a single source of truth.**
+  `Response` is now ASGI-callable (`Response.__call__(scope, receive, send)`),
+  mirroring `StreamingResponse`, so every response type shares one protocol.
+  `app._wrap_send` and `middleware.utils._normalize_send` both delegate to it
+  instead of carrying their own (and previously divergent) copies of the
+  `http.response.start` + `http.response.body` event construction.  No wire
+  behaviour change; terminal body events now consistently carry
+  `more_body: False`.
+- Added a regression test (`test_middleware_decorator.py`) asserting that a
+  plain, undecorated middleware's `send` wrapper receives ASGI dicts through
+  the full app stack.
+
 ## [0.43.1] — 2026-06-21
 
 ### Fixed

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -35,37 +35,37 @@ logger = logging.getLogger(__name__)
 
 
 def _wrap_send(raw_send):
-    """Wrap an ASGI send callable to also accept Response objects.
+    """Adapt the handler-facing ``send`` to accept BlackBull convenience shapes.
 
-    Normalises every form a BlackBull handler may produce — Response
-    object, ASGI event dict, or raw ``bytes`` body — into the standard
-    ASGI 3.0 ``http.response.start`` + ``http.response.body`` event
-    pair forwarded to ``raw_send`` one event at a time.  This keeps
-    ``BlackBull.__call__`` truly ASGI 3.0 compliant so the app runs
-    unchanged under external ASGI servers (uvicorn, hypercorn,
-    httpx.ASGITransport, …) while BlackBull's own ``HTTP1Sender`` /
-    ``HTTP2Sender`` (which also accept dict events natively) handle
-    the same canonical sequence.
+    BlackBull lets a handler emit more than bare ASGI dicts: a ``Response``
+    object, or the ``send(body_bytes, status, headers)`` 3-arg form.  This
+    wrapper normalises those into standard ASGI ``http.response.start`` +
+    ``http.response.body`` events before they reach ``raw_send`` (the access
+    log + wire sender, which also accept dict events natively), so the app
+    stays ASGI 3.0 compliant under external servers (uvicorn, hypercorn,
+    httpx.ASGITransport, …).
+
+    **Altitude matters.**  This adapter is installed at the *handler boundary*
+    inside :meth:`_dispatch` — never at :meth:`__call__` around the whole
+    middleware chain.  Wrapping outward leaks ``Response`` objects into
+    middleware ``send`` wrappers, which reasonably assume ASGI dicts and
+    crash on ``msg['type']`` (the 0.43.2 regression; locked by
+    ``tests/unit/test_middleware_decorator.py``).  Keep it innermost so
+    everything above the route handler observes plain ASGI dicts.
+
+    The Response case delegates to :meth:`Response.__call__` — the single
+    source of truth for Response→ASGI serialisation, shared with
+    ``middleware.utils._normalize_send``.  Response is a pure serialiser and
+    ignores scope/receive, so ``None`` is passed for both.
     """
     from .response import Response as _Response
 
     async def _send(event, status=HTTPStatus.OK, headers=[]):
         if isinstance(event, _Response):
-            await raw_send({
-                'type': 'http.response.start',
-                'status': int(event.status),
-                'headers': list(event.headers),
-            })
-            await raw_send({
-                'type': 'http.response.body',
-                'body': event.body,
-            })
-        elif isinstance(event, dict):
-            # Standard ASGI event from full-form handlers or middleware.
-            await raw_send(event)
+            await event(None, None, raw_send)
         elif isinstance(event, (bytes, bytearray, memoryview)):
-            # Legacy "bytes body + status + headers" form used by simplified
-            # handlers when they pass through the wrap from inside BlackBull.
+            # ``send(body, status, headers)`` convenience form — used by
+            # full-form handlers and custom error handlers.
             await raw_send({
                 'type': 'http.response.start',
                 'status': int(status),
@@ -74,10 +74,11 @@ def _wrap_send(raw_send):
             await raw_send({
                 'type': 'http.response.body',
                 'body': bytes(event) if not isinstance(event, bytes) else event,
+                'more_body': False,
             })
         else:
-            # Unknown shapes are passed through; the underlying sender's
-            # type checking decides what to do with them.
+            # ASGI dict (the common path) or any other shape — passed through
+            # so the underlying sender's type checking decides what to do.
             await raw_send(event)
 
     return _send
@@ -429,6 +430,13 @@ class BlackBull:
             await function(scope, receive, send)
             return
 
+        # Normalise send for the HTTP path: handlers may emit Response objects
+        # or the (bytes, status, headers) 3-arg form.  Apply _wrap_send here —
+        # at the handler boundary, after the WebSocket branch — so middleware
+        # (which sees send before _dispatch is entered) always receives plain
+        # ASGI dicts.  See _wrap_send for why outward placement is a bug.
+        send = _wrap_send(send)
+
         try:
             # RFC 9110 §9.1 — methods are case-sensitive tokens.  Prefer the
             # HTTPMethod enum for IANA-registered methods; for non-IANA methods
@@ -522,7 +530,7 @@ class BlackBull:
         if raw_headers is not None and not isinstance(raw_headers, Headers):
             scope['headers'] = Headers(raw_headers)
 
-        await self._chain(scope, receive, _wrap_send(send))
+        await self._chain(scope, receive, send)
 
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -9,7 +9,6 @@ Public API:
 from functools import wraps
 
 from ..response import Response
-from ..asgi import ASGIEvent
 
 
 def _normalize_send(inner_send):
@@ -26,19 +25,17 @@ def _normalize_send(inner_send):
     ``*args/**kwargs`` form needs to be preserved here, and dropping it
     shaves a per-event call-frame setup that showed in the Sprint 33
     py-spy profile on the static path.
+
+    The Response→ASGI expansion is delegated to :meth:`Response.__call__` so
+    there is a single source of truth for the start/body event shape (shared
+    with ``app._wrap_send`` and the simplified-handler dispatch).
     """
     async def normalized(event):
         if isinstance(event, Response):
-            await inner_send({
-                'type': ASGIEvent.HTTP_RESPONSE_START,
-                'status': event.status,
-                'headers': list(event.headers),
-            })
-            await inner_send({
-                'type': ASGIEvent.HTTP_RESPONSE_BODY,
-                'body': event.body,
-                'more_body': False,
-            })
+            # Response is ASGI-callable and ignores scope/receive (it is a pure
+            # serialiser wearing the ASGI-app signature), so drive it with the
+            # inner send to reuse the one Response→ASGI path.
+            await event(None, None, inner_send)
         else:
             await inner_send(event)
 

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -52,6 +52,22 @@ class Response:
                     v = v.encode('ascii')
                 self.headers.append((k, v))
 
+    async def __call__(self, scope, receive, send) -> None:
+        """Drive this response as an ASGI app: emit ``start`` then ``body``.
+
+        Mirrors :class:`StreamingResponse` so every BlackBull response type
+        shares one protocol — ``await response(scope, receive, send)`` —
+        whether returned from a simplified handler, invoked explicitly by a
+        full-form handler, or normalised by ``app._wrap_send``.  Keeping the
+        start/body serialisation here means there is a single source of truth
+        for turning a Response into ASGI events.
+        """
+        await send({'type': 'http.response.start',
+                    'status': int(self.status),
+                    'headers': list(self.headers)})
+        await send({'type': 'http.response.body',
+                    'body': self.body, 'more_body': False})
+
 
 class JSONResponse(Response):
     """HTTP response with JSON-serialised body and ``application/json`` content-type.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.43.1"
+version = "0.43.2"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_middleware_decorator.py
+++ b/tests/unit/test_middleware_decorator.py
@@ -207,3 +207,55 @@ async def test_startup_accepts_undecorated_valid_middleware():
     await app._handle_lifespan({'type': 'lifespan'}, mock_receive, mock_send)
 
     assert not failed
+
+
+# ---------------------------------------------------------------------------
+# Regression (0.43.2): plain (undecorated) middleware send wrappers must see
+# ASGI dicts, never Response objects, when driven through the full app stack.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_plain_middleware_send_wrapper_sees_asgi_dicts():
+    """An undecorated middleware that wraps ``send`` and subscripts
+    ``msg['type']`` must receive ASGI dicts.
+
+    Before 0.43.2 ``_wrap_send`` was applied at ``BlackBull.__call__``
+    (outermost), so a simplified handler returning a dict (auto-JSONResponse)
+    reached the middleware's send wrapper as a ``Response`` object →
+    ``TypeError: 'Response' object is not subscriptable``.  The adapter now
+    sits at the handler boundary in ``_dispatch`` so middleware always sees
+    plain dicts.
+    """
+    from blackbull import BlackBull
+
+    app = BlackBull()
+    seen_status = []
+
+    async def stats_mw(scope, receive, send, call_next):
+        async def capture(msg):
+            if msg['type'] == 'http.response.start':   # subscripts the dict
+                seen_status.append(msg['status'])
+            await send(msg)
+        await call_next(scope, receive, capture)
+
+    app.use(stats_mw)
+
+    @app.route(path='/health')
+    async def health():
+        return {'status': 'ok'}          # auto JSONResponse
+
+    sent = []
+    scope = {'type': 'http', 'method': 'GET', 'path': '/health',
+             'headers': [], 'client': ('127.0.0.1', 1)}
+
+    async def receive():
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    async def send(event):
+        sent.append(event)
+
+    await app(scope, receive, send)
+
+    assert seen_status == [200]
+    assert all(isinstance(e, dict) for e in sent)
+    assert sent[0]['type'] == 'http.response.start'

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -148,7 +148,7 @@ async def test_wrap_send_unpacks_response():
     assert start['type'] == 'http.response.start'
     assert start['status'] == int(HTTPStatus.CREATED)
     assert (b'content-type', b'text/html; charset=utf-8') in start['headers']
-    assert body == {'type': 'http.response.body', 'body': b'hi'}
+    assert body == {'type': 'http.response.body', 'body': b'hi', 'more_body': False}
 
 
 @pytest.mark.asyncio
@@ -191,7 +191,7 @@ async def test_wrap_send_passes_bytes_through():
     await _wrap_send(raw)(b'raw bytes')
     assert len(calls) == 2
     assert calls[0]['type'] == 'http.response.start'
-    assert calls[1] == {'type': 'http.response.body', 'body': b'raw bytes'}
+    assert calls[1] == {'type': 'http.response.body', 'body': b'raw bytes', 'more_body': False}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug fix:** Middleware `send` wrappers received `Response` objects instead of ASGI dicts, crashing any middleware that inspected `msg['type']` with `TypeError: 'Response' object is not subscriptable`. The `_wrap_send` adapter was installed at the outermost layer (`BlackBull.__call__`); since `send` flows handler→outward, it normalised *last* — after every middleware had already seen the raw object. Fix installs it at the **handler boundary** in `_dispatch`, so everything above the route handler observes plain ASGI dicts.

- **Causal note:** the defect shipped in **0.43.0**, not 0.43.1. It was masked until 0.43.1 because the beartype forward-ref lifespan-startup crash aborted before any request reached middleware; fixing that crash unmasked this one.

- **Refactor — one Response→ASGI serialiser:** `Response` is now ASGI-callable (`Response.__call__`), mirroring `StreamingResponse`. `app._wrap_send` and `middleware.utils._normalize_send` both delegate to it instead of carrying their own (previously divergent) copies of the `start`+`body` event construction. No wire behaviour change; terminal body events now consistently carry `more_body: False`.

## Test plan

- [x] Pre-commit hook ran the full beartype-instrumented suite on both commits — green
- [x] Full suite: **1483 passed**, 225 skipped, 2 xfailed (the only failures are pre-existing untracked Sprint 50 WIP files, proven identical with changes stashed)
- [x] New regression test: a plain undecorated middleware's `send` wrapper receives ASGI dicts through the full app stack
- [x] Real-wire `TestClient` smoke: plain middleware + `@as_middleware` + `send(Response)` + dict/str handlers all see ASGI dicts
- [x] Wait for CodeQL / pip-audit CI before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)