### PR TITLE
feat: Non-ASGI protocol bridge + unified ProtocolRegistry (Sprint 50/51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,29 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+- **Non-ASGI protocol bridge (Sprint 50).** `app.raw_handler(name, *, port=…)`
+  / `app.register_protocol_handler(...)` register a raw-TCP protocol that speaks
+  the wire directly, alongside HTTP on other ports.  A `RawActor` drives the
+  byte stream; see `docs/guide/raw-protocols.md` and `examples/echo_tcp.py`.
+- **Unified `ProtocolRegistry` (Sprint 50).** Connection dispatch is now
+  registry-driven (`Http1Binding`, `Http2Binding`, `RawBinding`) instead of a
+  hardcoded `_dispatch()`; `ASGIServer` is reorganised and re-exported as
+  `Server`.  Non-disruptive — all HTTP/1.1, HTTP/2, and WebSocket paths behave
+  identically.
+- **Protocol-agnostic Level B events (Sprint 50).** `EventAggregator` gains
+  `on_connection_accepted(protocol=…)`, `on_connection_closed`,
+  `on_message_received`, and `on_message_sent`, so observers can hook raw
+  protocols, not just HTTP requests.
+- **`ProtocolDetector` shared-port dispatch (Sprint 51).** Raw bindings may
+  carry a detector consulted after the cleartext-HTTP chain, enabling a raw
+  protocol to share a port with HTTP (the foundation for Sprint 52 MQTT).
+
+### Internal
+- Raw protocol handlers are single-worker and cleartext-only for now; documented
+  in `KNOWN_LIMITATIONS.md` / `docs/guide/raw-protocols.md`.  Combined Sprint
+  50 + 51 + 52 work releases together as a future `v0.44.0`.
+
 ## [0.43.2] — 2026-06-22
 
 ### Fixed

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -98,6 +98,24 @@ appears.
 
 ## Deployment notes
 
+### Raw protocol handlers are single-worker and cleartext-only
+
+When a non-ASGI protocol handler is registered via `app.raw_handler()` or
+`app.register_protocol_handler()`, BlackBull enforces two constraints:
+
+**Single-worker only** — if `workers > 1` is requested at startup, the
+server silently forces `workers=1` for the entire process.  The root cause
+is that inherited-socket adoption (used for `--reload`) does not tag sockets
+by protocol; distributing raw protocol sockets across worker processes would
+require SO_REUSEPORT with protocol-tagged socket sets or a dispatcher-worker
+model.  Planned for resolution after Sprint 52.
+
+**Cleartext only** — raw protocol sockets are bound without TLS regardless
+of whether a TLS certificate is configured.  Adding TLS support for raw
+protocols requires `ssl_context` plumbing through `RawBinding` → `Server`.
+For MQTT-over-TLS or similar, put a TLS-terminating proxy in front of the
+raw socket.
+
 ### Multi-worker scaling tops out at physical core count
 
 Worker throughput scales roughly to the **physical core count**,

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -237,6 +237,12 @@ class BlackBull:
         # docs/guide/extensions.md.
         self.extensions: dict[str, object] = {}
 
+        # Non-ASGI protocol registry (Sprint 50) — lazily built on the first
+        # raw_handler / register_protocol_handler so importing BlackBull does
+        # not drag in the server package.  None means "HTTP-only" (the bridge
+        # is fully dormant).
+        self._protocol_registry = None
+
         if trusted_proxies is not None:
             from .middleware.proxy import TrustedProxy  # noqa: PLC0415
             self.use(TrustedProxy(trusted_proxies))
@@ -652,6 +658,51 @@ class BlackBull:
             docs_path=docs_path,
         )
 
+    def register_protocol_handler(
+        self,
+        name: str,
+        handler: Callable[..., Awaitable[None]],
+        *,
+        detector: object | None = None,
+        port: int | None = None,
+    ) -> None:
+        """Register a handler for a non-ASGI (raw) protocol (Sprint 50).
+
+        The handler is an async callable ``(reader, writer, ctx) -> None`` that
+        owns the connection for its whole lifetime.  When *port* is set, the
+        server binds an additional listening socket on it; connections there
+        skip HTTP detection and go straight to *handler*.
+
+        Args:
+            name: Protocol name (e.g. ``'echo'``, ``'mqtt'``); must be unique.
+            handler: Async ``(reader, writer, ctx)`` coroutine.
+            detector: Reserved for first-byte sniffing on shared ports
+                (Sprint 51); unused today.
+            port: Dedicated listening port for this protocol.
+        """
+        if self._protocol_registry is None:
+            from .server.protocol_registry import ProtocolRegistry  # noqa: PLC0415
+            self._protocol_registry = ProtocolRegistry()
+        self._protocol_registry.register(name, handler,
+                                         detector=detector, port=port)
+
+    def raw_handler(self, name: str, *, port: int | None = None,
+                    detector: object | None = None):
+        """Decorator form of :meth:`register_protocol_handler`.
+
+        ::
+
+            @app.raw_handler('echo', port=9000)
+            async def echo(reader, writer, ctx):
+                while data := await reader.read(1024):
+                    await writer.write(data)
+        """
+        def decorator(handler):
+            self.register_protocol_handler(name, handler,
+                                           detector=detector, port=port)
+            return handler
+        return decorator
+
     def run(self, certfile=None, keyfile=None, port: int | None = None,
             unix_path: str | None = None,
             inherited_fd: int | None = None,
@@ -749,6 +800,17 @@ def serve(app, *,
     _cfg = _get_settings()
     workers = workers if workers is not None else _cfg.workers
     workers = workers or (_os.cpu_count() or 1)
+
+    # Sprint 50: port-bound non-ASGI protocols are bound only in the
+    # single-worker path (inherited-socket adoption does not tag sockets by
+    # protocol, so multi-worker raw ports are a carry-forward).  Force
+    # workers=1 so ``app.run(port=8000)`` with a raw_handler "just works".
+    if (isinstance(app, BlackBull) and app._protocol_registry is not None
+            and app._protocol_registry.has_port_bindings() and workers > 1):
+        logger.warning(
+            'Non-ASGI protocol handlers are single-worker only; '
+            'forcing workers=1 (was %d).', workers)
+        workers = 1
     max_connections = max_connections if max_connections is not None else _cfg.max_connections
     stream_queue_depth = (stream_queue_depth if stream_queue_depth is not None
                           else _cfg.stream_queue_depth)

--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -157,5 +157,52 @@ class EventAggregator:
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def on_connection_accepted(self, peername) -> None:
-        """Level A notification — no Level B event fires yet."""
+    async def on_connection_accepted(self, peername, protocol: str = 'http') -> None:
+        """Fire Level B ``connection_accepted``.
+
+        *protocol* is ``'http'`` for the shared HTTP listener (the h1/h2 split is
+        not yet known at accept time) and the registered protocol name (e.g.
+        ``'echo'``) for a port-bound non-ASGI connection.
+        """
+        if not self._dispatcher.has_listeners('connection_accepted'):
+            return
+        await self._dispatcher.emit(Event('connection_accepted', {
+            'peername': peername,
+            'protocol': protocol,
+        }))
+
+    async def on_connection_closed(
+        self, peername, protocol: str, duration_ms: float
+    ) -> None:
+        """Fire Level B ``connection_closed``."""
+        if not self._dispatcher.has_listeners('connection_closed'):
+            return
+        await self._dispatcher.emit(Event('connection_closed', {
+            'peername': peername,
+            'protocol': protocol,
+            'duration_ms': duration_ms,
+        }))
+
+    async def on_message_received(
+        self, protocol: str, message_type: str, payload_size: int
+    ) -> None:
+        """Fire Level B ``message_received`` (application-level message in)."""
+        if not self._dispatcher.has_listeners('message_received'):
+            return
+        await self._dispatcher.emit(Event('message_received', {
+            'protocol': protocol,
+            'message_type': message_type,
+            'payload_size': payload_size,
+        }))
+
+    async def on_message_sent(
+        self, protocol: str, message_type: str, payload_size: int
+    ) -> None:
+        """Fire Level B ``message_sent`` (application-level message out)."""
+        if not self._dispatcher.has_listeners('message_sent'):
+            return
+        await self._dispatcher.emit(Event('message_sent', {
+            'protocol': protocol,
+            'message_type': message_type,
+            'payload_size': payload_size,
+        }))

--- a/blackbull/server/__init__.py
+++ b/blackbull/server/__init__.py
@@ -1,1 +1,3 @@
-from .server import ASGIServer
+from .server import ASGIServer, Server
+
+__all__ = ['Server', 'ASGIServer']

--- a/blackbull/server/connection_actor.py
+++ b/blackbull/server/connection_actor.py
@@ -8,14 +8,13 @@ from ..actor import Actor, Message
 from ..event_aggregator import EventAggregator
 from .cap_log import CapHitCounter
 from .deadline import ConnectionDeadline
-from .recipient import (AbstractReader, IncompleteReadError,
+from .protocol_registry import (ConnectionView, ProtocolBinding,
+                                ProtocolRegistry)
+from .recipient import (AbstractReader,
                         _HTTP2_STREAM_QUEUE_DEPTH, _WS_EVENT_QUEUE_DEPTH)
 from .sender import AbstractWriter
 
 logger = logging.getLogger(__name__)
-
-_HTTP2_PREFACE_FIRST_LINE = b'PRI * HTTP/2.0\r\n'
-_HTTP2_PREFACE_REMAINDER  = b'\r\nSM\r\n\r\n'
 
 
 class ConnectionActor(Actor):
@@ -42,6 +41,9 @@ class ConnectionActor(Actor):
         alpn: str | None = None,
         stream_queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH,
         ws_queue_depth: int = _WS_EVENT_QUEUE_DEPTH,
+        registry: ProtocolRegistry | None = None,
+        bound_binding: ProtocolBinding | None = None,
+        connection_id: str = '',
     ) -> None:
         super().__init__()
         self._reader = reader
@@ -54,6 +56,13 @@ class ConnectionActor(Actor):
         self._alpn = alpn
         self._stream_queue_depth = stream_queue_depth
         self._ws_queue_depth = ws_queue_depth
+        # A registry is always available: tests construct ConnectionActor with
+        # positional (reader, writer, app, aggregator) and no registry, so fall
+        # back to a default holding only the built-in http1/http2 bindings.
+        self._registry = registry if registry is not None else ProtocolRegistry()
+        # When set (port-bound raw protocol), detection is skipped entirely.
+        self._bound_binding = bound_binding
+        self._connection_id = connection_id
 
     async def run(self) -> None:
         # Per-connection cap-hit rate-limit state — bound on the
@@ -64,7 +73,10 @@ class ConnectionActor(Actor):
         counter = CapHitCounter()
         with counter.bind():
             if self._aggregator is not None:
-                await self._aggregator.on_connection_accepted(self._peername)
+                protocol = (self._bound_binding.name
+                            if self._bound_binding is not None else 'http')
+                await self._aggregator.on_connection_accepted(
+                    self._peername, protocol=protocol)
             try:
                 await self._dispatch()
             except Exception as exc:
@@ -98,13 +110,33 @@ class ConnectionActor(Actor):
         # just re-arms the same handle.
         dl = ConnectionDeadline()
 
-        # ALPN-negotiated HTTP/2: the peer is committed to HTTP/2, so the
-        # first 24 bytes MUST be the connection preface (RFC 9113 §3.4).
-        # Read exactly 24 bytes rather than scanning for CRLF so an invalid
-        # preface is detected and rejected promptly instead of hanging the
-        # reader (h2spec §3.5 #2 exercises this with a non-preface byte
-        # sequence and times out otherwise).
-        if self._alpn == 'h2':
+        conn = ConnectionView(
+            reader=self._reader, writer=self._writer, app=self._app,
+            aggregator=self._aggregator,
+            peername=self._peername, sockname=self._sockname, ssl=self._ssl,
+            alpn=self._alpn, deadline=dl, connection_id=self._connection_id,
+            stream_queue_depth=self._stream_queue_depth,
+            ws_queue_depth=self._ws_queue_depth,
+        )
+
+        # Port-bound non-ASGI protocol (Sprint 50): the listening socket already
+        # identifies the protocol, so skip detection and the deadline machinery
+        # entirely — the handler owns the connection lifetime.
+        if self._bound_binding is not None:
+            await self._bound_binding.serve_raw(conn)
+            return
+
+        # Sprint 50: dispatch is registry-driven.  ``http1``/``http2`` are
+        # built-in bindings; the deadline-guarded reads + slowloris handling
+        # stay here so the hot HTTP path is unchanged — only protocol selection
+        # and Actor construction move into the bindings.
+
+        # ALPN-negotiated protocol: the peer is committed.  For HTTP/2 the first
+        # 24 bytes MUST be the connection preface (RFC 9113 §3.4).  Read exactly
+        # 24 bytes rather than scanning for CRLF so an invalid preface is
+        # rejected promptly instead of hanging the reader (h2spec §3.5 #2).
+        alpn_binding = self._registry.by_alpn(self._alpn)
+        if alpn_binding is not None:
             try:
                 if deadline is not None:
                     with dl.guard(deadline):
@@ -112,40 +144,19 @@ class ConnectionActor(Actor):
                 else:
                     preface = await self._reader.readexactly(24)
             except (asyncio.TimeoutError, TimeoutError):
-                # Peer connected via ALPN h2 but never sent the preface.
+                # Peer connected via ALPN but never sent the preface.
                 # Close — no GOAWAY since we don't have a SETTINGS exchange.
-                logger.warning('slowloris: ALPN-h2 peer sent no preface within %.1fs', deadline)
+                logger.warning('slowloris: ALPN-%s peer sent no preface within %.1fs',
+                               self._alpn, deadline)
                 from .cap_log import log_cap_hit  # noqa: PLC0415
                 log_cap_hit('header_timeout',
                             requested=deadline, limit=deadline,
                             peer=self._peername, protocol='h2')
                 return
-            expected = _HTTP2_PREFACE_FIRST_LINE + _HTTP2_PREFACE_REMAINDER
-            if preface != expected:
-                # Best-effort: send GOAWAY before closing so a peer that did
-                # implement HTTP/2 gets a clean diagnosis.  We do not bother
-                # framing the goaway via the factory — the connection is
-                # already doomed and we want to close before timing out.
-                from ..protocol.frame_types import ErrorCodes  # noqa: PLC0415
-                goaway = (b'\x00\x00\x08\x07\x00\x00\x00\x00\x00'
-                          + b'\x00\x00\x00\x00'
-                          + int(ErrorCodes.PROTOCOL_ERROR).to_bytes(4, 'big'))
-                try:
-                    await self._writer.write(goaway)
-                except Exception:
-                    pass
-                raise ValueError(f'Invalid HTTP/2 preface: {preface!r}')
-            from .http2_actor import HTTP2Actor  # noqa: PLC0415
-            actor = HTTP2Actor(
-                self._reader, self._writer, self._app, self._aggregator,
-                peername=self._peername, sockname=self._sockname,
-                ssl=self._ssl,
-                stream_queue_depth=self._stream_queue_depth,
-            )
-            await actor.run()
+            await alpn_binding.serve_alpn(conn, preface)
             return
 
-        # No ALPN (cleartext) or ALPN didn't pick h2 — sniff the first line.
+        # No ALPN (cleartext) or ALPN didn't match a binding — sniff the first line.
         try:
             if deadline is not None:
                 with dl.guard(deadline):
@@ -172,29 +183,26 @@ class ConnectionActor(Actor):
                 pass
             return
 
-        if first_line == _HTTP2_PREFACE_FIRST_LINE:
-            remainder = await self._reader.readexactly(8)
-            if first_line + remainder != _HTTP2_PREFACE_FIRST_LINE + _HTTP2_PREFACE_REMAINDER:
-                raise ValueError(
-                    f'Invalid HTTP/2 preface continuation: {remainder!r}')
-            from .http2_actor import HTTP2Actor  # noqa: PLC0415
-            actor = HTTP2Actor(
-                self._reader, self._writer, self._app, self._aggregator,
-                peername=self._peername, sockname=self._sockname,
-                ssl=self._ssl,
-                stream_queue_depth=self._stream_queue_depth,
-            )
-        else:
-            from .http1_actor import HTTP1Actor  # noqa: PLC0415
-            actor = HTTP1Actor(
-                self._reader, self._writer, self._app, self._aggregator,
-                request=first_line,
-                peername=self._peername, sockname=self._sockname,
-                ssl=self._ssl,
-                ws_queue_depth=self._ws_queue_depth,
-                deadline=dl,
-            )
-        await actor.run()
+        # Shared-port protocol detection (Sprint 51): raw bindings with a
+        # ProtocolDetector get a chance to claim the connection before the
+        # http1 fallback — enabling e.g. MQTT+HTTP on one port.  Iteration is
+        # registration order (``raw_bindings`` is insertion-ordered), so when
+        # multiple detectors match overlapping byte signatures the
+        # first-registered binding wins.  Not exercised in Sprint 52 (a single
+        # MQTT detector); revisit this ordering guarantee if multi-detector
+        # ports arrive.
+        for raw_binding in self._registry.raw_bindings.values():
+            if (raw_binding.detector is not None
+                    and raw_binding.detector.detect(first_line, self._alpn)):
+                await raw_binding.serve_raw(conn)
+                return
+
+        # First cleartext binding to claim the line wins (http2 preface, then
+        # the http1 fallback which matches any line and is registered last).
+        for binding in self._registry.cleartext_bindings:
+            if binding.matches_cleartext(first_line):
+                await binding.serve_cleartext(conn, first_line)
+                return
 
     async def _handle(self, msg: Message) -> None:
         raise NotImplementedError

--- a/blackbull/server/protocol_registry.py
+++ b/blackbull/server/protocol_registry.py
@@ -1,0 +1,308 @@
+"""Unified protocol registry — Sprint 50.
+
+BlackBull dispatches every accepted connection through a single
+:class:`ProtocolRegistry`.  ``http1`` and ``http2`` are built-in *bindings*;
+non-HTTP protocols (raw TCP, and later MQTT/Redis) register their own bindings
+via :meth:`BlackBull.raw_handler` / :meth:`BlackBull.register_protocol_handler`.
+
+A *binding* owns protocol selection and Actor construction; the deadline-guarded
+byte I/O (the 24-byte HTTP/2 preface read, the first-line read, the slowloris
+408 / GOAWAY handling) stays in :class:`~blackbull.server.connection_actor.ConnectionActor`
+so the hot HTTP path is unchanged.
+
+Two dispatch routes:
+
+* **Detection** (the shared HTTP listener): ``ConnectionActor`` reads the first
+  bytes and asks each :class:`ProtocolBinding` in turn — ALPN first, then the
+  ordered cleartext chain (``http2`` preface, ``http1`` fallback).
+* **Port-bound** (raw protocols): a binding registered with ``port=`` gets its
+  own listening socket; connections there skip detection entirely.
+
+Note:
+    Do not export the internal classes from ``blackbull/__init__.py``; the
+    public surface is :meth:`BlackBull.raw_handler` and
+    :meth:`BlackBull.register_protocol_handler`.
+"""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..event_aggregator import EventAggregator
+from .deadline import ConnectionDeadline
+from .recipient import AbstractReader, _HTTP2_STREAM_QUEUE_DEPTH, _WS_EVENT_QUEUE_DEPTH
+from .sender import AbstractWriter
+
+logger = logging.getLogger(__name__)
+
+_HTTP2_PREFACE_FIRST_LINE = b'PRI * HTTP/2.0\r\n'
+_HTTP2_PREFACE_REMAINDER = b'\r\nSM\r\n\r\n'
+_HTTP2_PREFACE = _HTTP2_PREFACE_FIRST_LINE + _HTTP2_PREFACE_REMAINDER
+
+
+# ---------------------------------------------------------------------------
+# Handler contract
+# ---------------------------------------------------------------------------
+
+RawProtocolHandler = Callable[
+    ['AbstractReader', 'AbstractWriter', 'ProtocolContext'],
+    Awaitable[None],
+]
+"""Async ``(reader, writer, ctx) -> None`` — owns one connection's lifetime."""
+
+
+@dataclass
+class ProtocolContext:
+    """Context passed to a non-ASGI protocol handler.
+
+    Carries connection metadata and the shared :class:`EventAggregator`
+    without exposing any ASGI concept (no ``scope`` / ``receive`` / ``send``).
+    """
+    peername: tuple[str, int] | None
+    sockname: tuple[str, int] | None
+    ssl: bool
+    aggregator: EventAggregator | None
+    connection_id: str
+    protocol: str
+    # Protocol Actors may attach arbitrary state here before calling the handler.
+    protocol_state: dict[str, Any] | None = None
+
+
+@dataclass
+class ConnectionView:
+    """Everything a :class:`ProtocolBinding` needs to build its Actor.
+
+    Assembled once per connection by :class:`ConnectionActor` and handed to the
+    selected binding's ``serve_*`` method.  Keeps the binding API narrow and
+    decouples bindings from ``ConnectionActor``'s internals.
+    """
+    reader: AbstractReader
+    writer: AbstractWriter
+    app: Callable[..., Awaitable[None]]
+    aggregator: EventAggregator | None
+    peername: tuple[str, int] | None
+    sockname: tuple[str, int] | None
+    ssl: bool
+    alpn: str | None
+    deadline: ConnectionDeadline
+    connection_id: str
+    stream_queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH
+    ws_queue_depth: int = _WS_EVENT_QUEUE_DEPTH
+
+
+# ---------------------------------------------------------------------------
+# Detection (Sprint 51 — wired into ConnectionActor._dispatch())
+# ---------------------------------------------------------------------------
+
+class ProtocolDetector(ABC):
+    """Inspects the first bytes of a connection to identify the protocol.
+
+    Stateless — one instance is shared across all connections.  Used for
+    first-byte sniffing on *shared* ports (e.g. MQTT + HTTP on one port);
+    consulted by ``ConnectionActor._dispatch()`` after ALPN detection and
+    before the http1 cleartext fallback.
+    """
+
+    @abstractmethod
+    def detect(self, first_bytes: bytes, alpn: str | None) -> bool:
+        """Return True if *first_bytes* matches this protocol."""
+        ...
+
+    @property
+    @abstractmethod
+    def protocol_name(self) -> str:
+        """Human-readable protocol name for logging."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Bindings
+# ---------------------------------------------------------------------------
+
+class ProtocolBinding:
+    """One connection-level protocol.
+
+    Subclasses implement only the route(s) they support: ``serve_alpn`` for
+    ALPN-negotiated protocols, ``matches_cleartext`` + ``serve_cleartext`` for
+    cleartext-detected protocols, ``serve_raw`` for port-bound protocols.
+    """
+
+    name: str = ''
+    alpn_token: str | None = None
+    port: int | None = None
+
+    def matches_cleartext(self, first_line: bytes) -> bool:
+        """Return True if this binding owns a cleartext connection whose first
+        line is *first_line*.  Default: no match."""
+        return False
+
+    async def serve_alpn(self, conn: ConnectionView, preface: bytes) -> None:
+        raise NotImplementedError
+
+    async def serve_cleartext(self, conn: ConnectionView, first_line: bytes) -> None:
+        raise NotImplementedError
+
+    async def serve_raw(self, conn: ConnectionView) -> None:
+        raise NotImplementedError
+
+
+class Http2Binding(ProtocolBinding):
+    """HTTP/2 — ALPN ``h2`` or the cleartext connection preface (RFC 9113 §3.4)."""
+
+    name = 'http2'
+    alpn_token = 'h2'
+
+    def matches_cleartext(self, first_line: bytes) -> bool:
+        return first_line == _HTTP2_PREFACE_FIRST_LINE
+
+    async def serve_alpn(self, conn: ConnectionView, preface: bytes) -> None:
+        if preface != _HTTP2_PREFACE:
+            # Best-effort GOAWAY(PROTOCOL_ERROR) before closing so a peer that
+            # did implement HTTP/2 gets a clean diagnosis.  Frame it by hand —
+            # the connection is doomed and we want to close before timing out.
+            from ..protocol.frame_types import ErrorCodes  # noqa: PLC0415
+            goaway = (b'\x00\x00\x08\x07\x00\x00\x00\x00\x00'
+                      + b'\x00\x00\x00\x00'
+                      + int(ErrorCodes.PROTOCOL_ERROR).to_bytes(4, 'big'))
+            try:
+                await conn.writer.write(goaway)
+            except Exception:
+                pass
+            raise ValueError(f'Invalid HTTP/2 preface: {preface!r}')
+        await self._run(conn)
+
+    async def serve_cleartext(self, conn: ConnectionView, first_line: bytes) -> None:
+        # ``readexactly`` (not ``read``) so a byte-by-byte peer still yields the
+        # full 8-byte remainder (regression: test_connection_actor fragmented preface).
+        remainder = await conn.reader.readexactly(8)
+        if first_line + remainder != _HTTP2_PREFACE:
+            raise ValueError(f'Invalid HTTP/2 preface continuation: {remainder!r}')
+        await self._run(conn)
+
+    async def _run(self, conn: ConnectionView) -> None:
+        from .http2_actor import HTTP2Actor  # noqa: PLC0415
+        actor = HTTP2Actor(
+            conn.reader, conn.writer, conn.app, conn.aggregator,
+            peername=conn.peername, sockname=conn.sockname, ssl=conn.ssl,
+            stream_queue_depth=conn.stream_queue_depth,
+        )
+        await actor.run()
+
+
+class Http1Binding(ProtocolBinding):
+    """HTTP/1.1 — the cleartext fallback (matches any first line)."""
+
+    name = 'http1'
+
+    def matches_cleartext(self, first_line: bytes) -> bool:
+        return True
+
+    async def serve_cleartext(self, conn: ConnectionView, first_line: bytes) -> None:
+        from .http1_actor import HTTP1Actor  # noqa: PLC0415
+        actor = HTTP1Actor(
+            conn.reader, conn.writer, conn.app, conn.aggregator,
+            request=first_line,
+            peername=conn.peername, sockname=conn.sockname, ssl=conn.ssl,
+            ws_queue_depth=conn.ws_queue_depth,
+            deadline=conn.deadline,
+        )
+        await actor.run()
+
+
+class RawBinding(ProtocolBinding):
+    """A user-registered non-ASGI protocol, bound to its own listening port."""
+
+    def __init__(
+        self,
+        name: str,
+        handler: RawProtocolHandler,
+        *,
+        detector: ProtocolDetector | None = None,
+        port: int | None = None,
+    ) -> None:
+        self.name = name
+        self.handler = handler
+        self.detector = detector
+        self.port = port
+
+    async def serve_raw(self, conn: ConnectionView) -> None:
+        from .raw_actor import RawProtocolActor  # noqa: PLC0415
+        ctx = ProtocolContext(
+            peername=conn.peername, sockname=conn.sockname, ssl=conn.ssl,
+            aggregator=conn.aggregator, connection_id=conn.connection_id,
+            protocol=self.name,
+        )
+        actor = RawProtocolActor(conn.reader, conn.writer, self.handler, ctx)
+        await actor.run()
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+class ProtocolRegistry:
+    """Single source of truth for all connection-level protocols.
+
+    Pre-populated with the built-in HTTP bindings; one instance per app.  The
+    cleartext-detection order is fixed: ``http2`` (preface) before ``http1``
+    (fallback) — ``http1`` must be last because it matches any first line.
+    """
+
+    def __init__(self) -> None:
+        self._cleartext: list[ProtocolBinding] = [Http2Binding(), Http1Binding()]
+        self._alpn: dict[str, ProtocolBinding] = {
+            b.alpn_token: b for b in self._cleartext if b.alpn_token
+        }
+        self._ports: dict[str, RawBinding] = {}
+
+    def register(
+        self,
+        name: str,
+        handler: RawProtocolHandler,
+        *,
+        detector: ProtocolDetector | None = None,
+        port: int | None = None,
+    ) -> RawBinding:
+        """Register a non-ASGI protocol handler.  Raises on duplicate name.
+
+        A ``detector`` enables shared-port sniffing (see
+        :class:`ProtocolDetector`).  When several registered detectors could
+        match the same first bytes, dispatch picks the **first registered**
+        one — ``raw_bindings`` preserves insertion order.
+        """
+        if name in self._ports or name in {b.name for b in self._cleartext}:
+            raise ValueError(f'Protocol {name!r} already registered')
+        binding = RawBinding(name, handler, detector=detector, port=port)
+        self._ports[name] = binding
+        return binding
+
+    def by_alpn(self, token: str | None) -> ProtocolBinding | None:
+        return self._alpn.get(token) if token else None
+
+    @property
+    def cleartext_bindings(self) -> list[ProtocolBinding]:
+        """Ordered cleartext-detection chain (``http2`` then ``http1``)."""
+        return self._cleartext
+
+    @property
+    def port_bindings(self) -> dict[int, RawBinding]:
+        """Raw bindings that need their own listening socket, keyed by port."""
+        return {b.port: b for b in self._ports.values() if b.port is not None}
+
+    @property
+    def raw_bindings(self) -> dict[str, RawBinding]:
+        return dict(self._ports)
+
+    @property
+    def ports(self) -> list[int]:
+        return [b.port for b in self._ports.values() if b.port is not None]
+
+    def has_port_bindings(self) -> bool:
+        return any(b.port is not None for b in self._ports.values())
+
+    def __bool__(self) -> bool:
+        """Truthy once a non-HTTP protocol is registered (HTTP is always present)."""
+        return bool(self._ports)

--- a/blackbull/server/raw_actor.py
+++ b/blackbull/server/raw_actor.py
@@ -1,0 +1,62 @@
+"""Raw protocol Actor — Sprint 50 (Non-ASGI bridge).
+
+:class:`RawProtocolActor` is the Layer-2 Actor for non-HTTP protocols.  It wraps
+a :data:`RawProtocolHandler` with connection-lifetime timing, error isolation,
+and the ``connection_closed`` lifecycle event — the generic 80%-case host for a
+protocol that speaks the wire directly (raw TCP here; MQTT in Sprint 51).
+
+The handler owns the connection for its whole lifetime: it decides when to
+close.  This is deliberately unlike HTTP's request/response-per-connection
+model — raw protocols are typically long-lived and stateful.
+"""
+import logging
+import time
+
+from ..actor import Actor, Message
+from .protocol_registry import ProtocolContext, RawProtocolHandler
+from .recipient import AbstractReader
+from .sender import AbstractWriter
+
+logger = logging.getLogger(__name__)
+
+
+class RawProtocolActor(Actor):
+    """One per accepted non-HTTP connection.
+
+    Error contract (design §7.4): if the handler raises, the exception is
+    emitted via ``aggregator.on_error`` and swallowed here — ``ConnectionActor``
+    has its own ``on_error`` path, so re-raising would double-emit.  Either way
+    the connection is closed by ``ConnectionActor``'s ``finally`` and
+    ``connection_closed`` fires from this Actor's ``finally``.
+    """
+
+    def __init__(
+        self,
+        reader: AbstractReader,
+        writer: AbstractWriter,
+        handler: RawProtocolHandler,
+        ctx: ProtocolContext,
+    ) -> None:
+        super().__init__()
+        self._reader = reader
+        self._writer = writer
+        self._handler = handler
+        self._ctx = ctx
+
+    async def run(self) -> None:
+        start = time.monotonic()
+        try:
+            await self._handler(self._reader, self._writer, self._ctx)
+        except Exception as exc:
+            logger.debug('raw protocol %r handler raised: %r',
+                         self._ctx.protocol, exc)
+            if self._ctx.aggregator is not None:
+                await self._ctx.aggregator.on_error({}, exc)
+        finally:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            if self._ctx.aggregator is not None:
+                await self._ctx.aggregator.on_connection_closed(
+                    self._ctx.peername, self._ctx.protocol, elapsed_ms)
+
+    async def _handle(self, msg: Message) -> None:  # never reached — run() overridden
+        raise NotImplementedError

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -119,10 +119,15 @@ class LifespanManager:
 
 
 @asynccontextmanager
-async def SocketManager(cb, raw_sockets, ssl_context):
+async def SocketManager(socket_cb_pairs, ssl_context):
     """Async context manager that creates asyncio servers from already-bound sockets.
 
-    On enter: wraps each raw socket in asyncio.start_server (TCP) or
+    *socket_cb_pairs* is an iterable of ``(sock, callback)`` — each socket is
+    served by its own accept callback.  The shared HTTP listener uses
+    :meth:`Server.client_connected_cb`; port-bound non-ASGI protocols (Sprint 50)
+    use a per-binding raw callback.
+
+    On enter: wraps each socket in asyncio.start_server (TCP) or
     asyncio.start_unix_server (AF_UNIX) and yields the list.
     On exit: closes all asyncio servers.
 
@@ -140,7 +145,7 @@ async def SocketManager(cb, raw_sockets, ssl_context):
     # Use a sentinel so the family comparison never raises AttributeError.
     _af_unix = getattr(_socket, 'AF_UNIX', None)
     servers = []
-    for sock in raw_sockets:
+    for sock, cb in socket_cb_pairs:
         # ssl_handshake_timeout is meaningful only when SSL is enabled.
         kwargs = {'sock': sock, 'ssl': ssl_context, 'backlog': _backlog}
         if ssl_context is not None:
@@ -160,22 +165,41 @@ async def SocketManager(cb, raw_sockets, ssl_context):
             srv.close()
 
 
-class ASGIServer:
-    """ An asyncio socket server with which reads first several bytes and dispatches
-    transactions to HTTP2/HTTP1.1/WebSocket server.
-    When ssl_context or certfile is set, this server runs as a HTTPS server.
+class Server:
+    """An asyncio socket server that dispatches each connection through the
+    app's :class:`~blackbull.server.protocol_registry.ProtocolRegistry`.
+
+    The shared HTTP listener detects HTTP/1.1 vs HTTP/2 (and upgrades to
+    WebSocket); port-bound non-ASGI protocols registered via
+    :meth:`BlackBull.raw_handler` get their own listening socket (Sprint 50).
+    When ssl_context or certfile is set, the HTTP listener runs as HTTPS.
+
+    Formerly ``ASGIServer`` — that name remains as a backward-compat alias.
     """
     def __init__(self, app, *,
                  ssl_context=None, certfile=None, keyfile=None, password=None,
                  max_connections: int = 0,
                  stream_queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH,
                  ws_queue_depth: int = _WS_EVENT_QUEUE_DEPTH,
+                 protocol_registry=None,
                  **kwds):
         self.app = app
         self._max_connections = max_connections
         self._stream_queue_depth = stream_queue_depth
         self._ws_queue_depth = ws_queue_depth
         self._active_connections = 0
+
+        # Protocol registry: explicit arg wins, else the app's (a BlackBull
+        # carries one once a raw_handler is registered), else a default holding
+        # only the built-in http1/http2 bindings.
+        from .protocol_registry import ProtocolRegistry as _PR  # noqa: PLC0415
+        self._protocol_registry = (protocol_registry
+                                   or getattr(app, '_protocol_registry', None)
+                                   or _PR())
+        # name -> bound port, populated by open_socket for port-bound protocols.
+        self.protocol_ports: dict[str, int] = {}
+        # list of (raw_sockets, binding) bound for non-ASGI protocols.
+        self._protocol_sockets: list = []
         # Cache the dispatcher + aggregator pair once — both are
         # process-wide singletons.  Looking them up per accept is wasted
         # work on the hot connection-burst path.
@@ -251,7 +275,23 @@ class ASGIServer:
         self.ssl_context.load_verify_locations(cafile=ca_cert)
 
     async def client_connected_cb(self, reader, writer):
-        """Called when the server receives a new TCP connection."""
+        """Accept callback for the shared HTTP listener."""
+        await self._serve_connection(reader, writer)
+
+    def _raw_connected_cb(self, binding):
+        """Build an accept callback for a port-bound non-ASGI protocol."""
+        async def _cb(reader, writer):
+            await self._serve_connection(reader, writer, bound_binding=binding)
+        return _cb
+
+    async def _serve_connection(self, reader, writer, *, bound_binding=None):
+        """Wrap the transport and run one :class:`ConnectionActor`.
+
+        *bound_binding* is set for port-bound non-ASGI protocols (Sprint 50) —
+        the connection skips HTTP detection and is handed straight to the
+        binding's raw handler.
+        """
+        import uuid  # noqa: PLC0415
         from .connection_actor import ConnectionActor  # noqa: PLC0415
         from .sender import AsyncioWriter  # noqa: PLC0415
         from .recipient import AsyncioReader  # noqa: PLC0415
@@ -313,11 +353,12 @@ class ASGIServer:
                         requested=self._active_connections + 1,
                         limit=self._max_connections,
                         peer=peername, protocol='tcp')
-            if alpn != 'h2':
+            if bound_binding is None and alpn != 'h2':
                 # HTTP/1.1 (or undetected cleartext — h1 is the safe
                 # default since the client hasn't spoken yet).  Minimal
                 # response: no body, content-length: 0, connection:
-                # close.  Retry-After in seconds.
+                # close.  Retry-After in seconds.  A port-bound non-ASGI
+                # protocol gets a plain close — we don't know its framing.
                 try:
                     await wrapped_writer.write(
                         b'HTTP/1.1 503 Service Unavailable\r\n'
@@ -342,6 +383,9 @@ class ASGIServer:
                 alpn=alpn,
                 stream_queue_depth=self._stream_queue_depth,
                 ws_queue_depth=self._ws_queue_depth,
+                registry=self._protocol_registry,
+                bound_binding=bound_binding,
+                connection_id=uuid.uuid4().hex,
             )
             await actor.run()
         finally:
@@ -441,9 +485,39 @@ class ASGIServer:
         # Pre-wrapping with ssl_context.wrap_socket() causes a double-TLS
         # layer and breaks the handshake.
 
+        self._bind_protocol_sockets(_cfg)
+
+    def _bind_protocol_sockets(self, _cfg):
+        """Bind a listening socket per port-bound non-ASGI protocol (Sprint 50).
+
+        Each :class:`RawBinding` registered with a ``port`` gets its own
+        dual-stack socket set.  ``port=0`` lets the OS pick a free port (used by
+        tests); the bound port is recorded in :attr:`protocol_ports`.  Cleartext
+        only — TLS for raw protocols is out of scope for the PoC.
+        """
+        for port, binding in self._protocol_registry.port_bindings.items():
+            socks = create_dual_stack_sockets(
+                port,
+                backlog=_cfg.socket_backlog,
+                sndbuf=_cfg.socket_sndbuf,
+                rcvbuf=_cfg.socket_rcvbuf,
+                user_timeout_ms=_cfg.tcp_user_timeout_ms,
+                keepalive=False,
+            )
+            if not socks:
+                logger.error('Failed to bind %s on port %d.', binding.name, port)
+                continue
+            bound_port = socks[0].getsockname()[1]
+            self.protocol_ports[binding.name] = bound_port
+            self._protocol_sockets.append((socks, binding))
+            logger.info('Protocol %r listening on port %d', binding.name, bound_port)
+
     def close_socket(self):
         for s in getattr(self, 'raw_sockets', []):
             s.close()
+        for socks, _ in self._protocol_sockets:
+            for s in socks:
+                s.close()
 
     async def startup(self):
         """Drive the ASGI lifespan startup handshake.
@@ -465,13 +539,20 @@ class ASGIServer:
         if not hasattr(self, 'raw_sockets') or not self.raw_sockets:
             self.open_socket(port)
 
-        # SocketManager wraps each raw socket in asyncio.start_server and
-        # closes all servers on exit.  LifespanManager drives the ASGI
-        # lifespan protocol; nesting it inside SocketManager guarantees:
-        #   startup completes before serve_forever() is called, and
-        #   shutdown completes before sockets are closed.
-        async with SocketManager(self.client_connected_cb,
-                                 self.raw_sockets, self.ssl_context) as servers:
+        # SocketManager wraps each socket in asyncio.start_server and closes all
+        # servers on exit.  The shared HTTP listener uses client_connected_cb;
+        # each port-bound non-ASGI protocol uses its own raw callback.  Raw
+        # sockets are cleartext (no TLS) for the Sprint 50 PoC.
+        # LifespanManager drives the ASGI lifespan protocol; nesting it inside
+        # SocketManager guarantees: startup completes before serve_forever() is
+        # called, and shutdown completes before sockets are closed.
+        pairs = [(s, self.client_connected_cb) for s in self.raw_sockets]
+        async with SocketManager(pairs, self.ssl_context) as servers, \
+                SocketManager(
+                    [(s, self._raw_connected_cb(binding))
+                     for socks, binding in self._protocol_sockets for s in socks],
+                    None) as raw_servers:
+            servers = servers + raw_servers
             async with LifespanManager(self.app):
                 logger.info(f'Server(s) created: {servers}')
                 try:
@@ -520,6 +601,12 @@ class ASGIServer:
                 time.sleep(poll_interval)
 
     def close(self):
-        logger.info('ASGIServer.close() is called.')
+        logger.info('Server.close() is called.')
         logger.info(self.__dict__)
         self.close_socket()
+
+
+# Backward-compat alias — ``ASGIServer`` was renamed to ``Server`` in Sprint 50
+# when the class gained non-ASGI (raw protocol) listeners.  Existing imports
+# (``from blackbull.server import ASGIServer``) keep working.
+ASGIServer = Server

--- a/docs/guide/raw-protocols.md
+++ b/docs/guide/raw-protocols.md
@@ -1,0 +1,106 @@
+# Non-ASGI protocols (raw TCP)
+
+Most BlackBull traffic is HTTP/1.1, HTTP/2, or WebSocket — protocols that map
+cleanly onto the ASGI `(scope, receive, send)` contract. Some protocols do not:
+MQTT, Redis RESP, a raw line protocol, the PostgreSQL wire protocol. They have no
+method, path, status, or headers, so forcing them through ASGI would be a leaky
+abstraction.
+
+The **Non-ASGI bridge** lets such a protocol run inside the same BlackBull
+process, sharing the connection machinery and the event system, while speaking
+the socket directly. You register an async handler with `raw_handler` and give it
+a port:
+
+```python
+from blackbull import BlackBull
+
+app = BlackBull()
+
+@app.route(path='/')
+async def index():
+    return "HTTP here; raw TCP echo on :9000."
+
+@app.raw_handler('echo', port=9000)
+async def echo(reader, writer, ctx):
+    while True:
+        data = await reader.read(1024)
+        if not data:
+            break
+        await writer.write(data)
+
+app.run(port=8000)   # HTTP on 8000, echo on 9000
+```
+
+A full runnable version is in `examples/echo_tcp.py`.
+
+## The handler contract
+
+A raw handler is an async callable `(reader, writer, ctx)` that **owns the
+connection for its entire lifetime** — it decides when to stop. This is
+deliberately unlike HTTP's request-per-connection model; raw protocols are
+typically long-lived and stateful.
+
+- `reader` is an `AbstractReader`: `await reader.read(n)`,
+  `await reader.readexactly(n)`, `await reader.readuntil(sep)`.
+- `writer` is an `AbstractWriter`: `await writer.write(data)`,
+  `await writer.close()`.
+- `ctx` is a `ProtocolContext` carrying `peername`, `sockname`, `ssl`,
+  `connection_id` (a uuid4 hex for log correlation), `protocol` (the registered
+  name), and `aggregator` (for emitting events — see below).
+
+When the handler returns, or raises, BlackBull closes the connection. A raised
+exception is reported through the `error` event and otherwise isolated — one bad
+connection never affects another.
+
+`register_protocol_handler(name, handler, *, port=...)` is the non-decorator
+form of `raw_handler` and behaves identically.
+
+## How dispatch works
+
+BlackBull routes every accepted connection through a single **protocol
+registry**. `http1` and `http2` are built-in registry bindings on the shared
+HTTP listener; a `raw_handler` adds a binding on its own dedicated port.
+Connections arriving on a raw protocol's port skip HTTP detection entirely and
+go straight to the handler. WebSocket is unaffected — it is still reached through
+an HTTP `Upgrade` on the HTTP listener, not as a top-level protocol.
+
+The bridge is **dormant by default**: an app with no `raw_handler` binds only the
+HTTP port and runs no raw code paths.
+
+## Events
+
+Raw protocols emit the protocol-agnostic Level B events (subscribe with
+`@app.on`):
+
+| Event | Fires when | Detail |
+|-------|-----------|--------|
+| `connection_accepted` | a connection is accepted | `peername`, `protocol` |
+| `connection_closed` | the connection closes | `peername`, `protocol`, `duration_ms` |
+| `message_received` | the handler reports an inbound message | `protocol`, `message_type`, `payload_size` |
+| `message_sent` | the handler reports an outbound message | `protocol`, `message_type`, `payload_size` |
+| `error` | the handler raises | `scope`, `exception` |
+
+`message_received` / `message_sent` are emitted by the handler itself when it has
+parsed an application-level message, via the aggregator on `ctx`:
+
+```python
+if ctx.aggregator is not None:
+    await ctx.aggregator.on_message_received('echo', 'data', len(data))
+```
+
+`connection_accepted` and `connection_closed` fire automatically.
+
+## Limitations (Sprint 50)
+
+- **Cleartext only.** TLS termination for raw protocols is not yet wired up.
+- **Single worker.** Port-bound protocols are served only when `workers=1`;
+  `app.run()` with a `raw_handler` forces single-worker automatically.
+- **Port-based routing only.** Sharing one port between HTTP and a raw protocol
+  (first-byte sniffing) is planned for a later release.
+
+## A note on the server class
+
+The server class that drives all this is `blackbull.server.Server` (it serves
+both ASGI and non-ASGI listeners). Its previous name, `ASGIServer`, remains as a
+backward-compatible alias, so existing
+`from blackbull.server import ASGIServer` imports keep working.

--- a/examples/echo_tcp.py
+++ b/examples/echo_tcp.py
@@ -1,0 +1,43 @@
+"""Raw TCP echo server riding BlackBull's Non-ASGI bridge (Sprint 50).
+
+One BlackBull process serves HTTP on :8000 *and* a raw TCP echo protocol on
+:9000 — the echo handler bypasses ASGI entirely and speaks the socket directly.
+
+Run it::
+
+    python examples/echo_tcp.py
+
+Then, in another shell::
+
+    curl http://127.0.0.1:8000/          # normal HTTP route
+    printf 'hello\\n' | nc 127.0.0.1 9000  # raw TCP echo
+
+A non-ASGI handler is an async ``(reader, writer, ctx)`` callable that owns the
+connection for its whole lifetime.  ``ctx`` (a ``ProtocolContext``) carries the
+peer address, a ``connection_id`` for log correlation, and the shared event
+aggregator for protocol-agnostic Level B events.
+"""
+from blackbull import BlackBull
+
+app = BlackBull()
+
+
+@app.route(path='/')
+async def index():
+    return "BlackBull is serving HTTP here, and raw TCP echo on :9000."
+
+
+@app.raw_handler('echo', port=9000)
+async def echo(reader, writer, ctx):
+    """Echo every chunk back until the peer closes the connection."""
+    while True:
+        data = await reader.read(1024)
+        if not data:
+            break
+        await writer.write(data)
+        if ctx.aggregator is not None:
+            await ctx.aggregator.on_message_received('echo', 'data', len(data))
+
+
+if __name__ == '__main__':
+    app.run(port=8000)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - Requests and responses: guide/requests-and-responses.md
     - WebSockets: guide/websockets.md
     - HTTP/2: guide/http2.md
+    - Non-ASGI protocols: guide/raw-protocols.md
     - Streaming: guide/streaming.md
     - Events: guide/events.md
     - Logging: guide/logging.md

--- a/tests/architecture/test_event_aggregator.py
+++ b/tests/architecture/test_event_aggregator.py
@@ -84,7 +84,8 @@ def test_all_level_b_events_covered() -> None:
         "on_request_completed", "on_request_disconnected", "on_error",
         "on_websocket_connected", "on_websocket_message",
         "on_websocket_disconnected",
-        "on_connection_accepted",
+        "on_connection_accepted", "on_connection_closed",
+        "on_message_received", "on_message_sent",
     }
     from blackbull.event_aggregator import EventAggregator
     actual = {name for name in dir(EventAggregator) if name.startswith("on_")}

--- a/tests/conformance/http1/fuzz/user-corpus/diff_58ecfff070ba7f58.meta.json
+++ b/tests/conformance/http1/fuzz/user-corpus/diff_58ecfff070ba7f58.meta.json
@@ -1,6 +1,6 @@
 {
   "category": "STATUS_DIFFER",
-  "captured_at_unix": 1780063794,
+  "captured_at_unix": 1781972509,
   "wire_request_latin1": "GET  http://localhost/x HTTP/1.0\r\nHost: localhost\r\n\r\n",
   "nginx_exception": null,
   "nginx_status": 200,

--- a/tests/integration/test_non_http_bridge.py
+++ b/tests/integration/test_non_http_bridge.py
@@ -1,0 +1,93 @@
+"""Integration test for the Non-ASGI bridge — Raw TCP echo (Sprint 50).
+
+Spins up a single BlackBull ``Server`` that serves HTTP on one port and a raw
+TCP echo protocol on another, then exercises both to prove coexistence
+(non-disruption) and that the bridge round-trips bytes end to end.
+"""
+import asyncio
+import http.client
+import socket
+import time
+from multiprocessing import Process
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.server import Server
+
+
+def _make_app():
+    app = BlackBull()
+
+    @app.route(path='/')
+    async def index():
+        return "http-ok"
+
+    @app.raw_handler('echo', port=0)
+    async def echo(reader, writer, ctx):
+        while True:
+            data = await reader.read(1024)
+            if not data:
+                break
+            await writer.write(data)
+
+    return app
+
+
+@pytest.fixture
+def live_bridge():
+    """Bind HTTP + echo on ephemeral ports, fork a worker, yield (http, echo)."""
+    app = _make_app()
+    server = Server(app)
+    server.open_socket(0)  # binds HTTP + the echo port; populates protocol_ports
+    http_port = server.port
+    echo_port = server.protocol_ports['echo']
+    p = Process(target=lambda: asyncio.run(server.run()))
+    p.start()
+    try:
+        server.wait_for_port(timeout=10.0)
+        yield http_port, echo_port
+    finally:
+        server.close()
+        p.terminate()
+        p.join(timeout=5)
+
+
+def _connect_echo(port, timeout=5.0):
+    """Connect to the echo port, retrying until the worker is serving it."""
+    deadline = time.time() + timeout
+    while True:
+        try:
+            return socket.create_connection(('127.0.0.1', port), timeout=1)
+        except OSError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+def test_raw_echo_round_trips(live_bridge):
+    _http_port, echo_port = live_bridge
+    with _connect_echo(echo_port) as sock:
+        sock.sendall(b'hello bridge\n')
+        received = sock.recv(1024)
+    assert received == b'hello bridge\n'
+
+
+def test_raw_echo_multiple_chunks(live_bridge):
+    _http_port, echo_port = live_bridge
+    with _connect_echo(echo_port) as sock:
+        for chunk in (b'one', b'two', b'three'):
+            sock.sendall(chunk)
+            assert sock.recv(1024) == chunk
+
+
+def test_http_still_served_alongside_raw(live_bridge):
+    """Non-disruption: the HTTP listener works while a raw protocol is bound."""
+    http_port, _echo_port = live_bridge
+    conn = http.client.HTTPConnection('127.0.0.1', http_port, timeout=5)
+    conn.request('GET', '/')
+    resp = conn.getresponse()
+    body = resp.read()
+    conn.close()
+    assert resp.status == 200
+    assert body == b'http-ok'

--- a/tests/unit/test_protocol_events.py
+++ b/tests/unit/test_protocol_events.py
@@ -1,0 +1,81 @@
+"""Protocol-agnostic Level B events (Sprint 50).
+
+Uses a real EventDispatcher with *interceptor* handlers (awaited inline by
+emit) so emission is deterministic without draining fire-and-forget tasks.
+"""
+import pytest
+
+from blackbull.event import EventDispatcher
+from blackbull.event_aggregator import EventAggregator
+
+
+@pytest.fixture
+def dispatcher():
+    return EventDispatcher()
+
+
+@pytest.fixture
+def aggregator(dispatcher):
+    return EventAggregator(dispatcher)
+
+
+def _capture(dispatcher, event_name):
+    seen = []
+    dispatcher.intercept(event_name, lambda e: seen.append(e) or _noop())
+    return seen
+
+
+async def _noop():
+    return None
+
+
+@pytest.mark.asyncio
+async def test_connection_accepted_carries_protocol(aggregator, dispatcher):
+    seen = _capture(dispatcher, 'connection_accepted')
+    await aggregator.on_connection_accepted(('1.2.3.4', 5555), protocol='echo')
+    assert len(seen) == 1
+    assert seen[0].detail == {'peername': ('1.2.3.4', 5555), 'protocol': 'echo'}
+
+
+@pytest.mark.asyncio
+async def test_connection_accepted_defaults_to_http(aggregator, dispatcher):
+    seen = _capture(dispatcher, 'connection_accepted')
+    await aggregator.on_connection_accepted(('1.2.3.4', 5555))
+    assert seen[0].detail['protocol'] == 'http'
+
+
+@pytest.mark.asyncio
+async def test_connection_closed(aggregator, dispatcher):
+    seen = _capture(dispatcher, 'connection_closed')
+    await aggregator.on_connection_closed(('1.2.3.4', 5555), 'echo', 12.5)
+    assert seen[0].detail == {
+        'peername': ('1.2.3.4', 5555), 'protocol': 'echo', 'duration_ms': 12.5}
+
+
+@pytest.mark.asyncio
+async def test_message_received_and_sent(aggregator, dispatcher):
+    rx = _capture(dispatcher, 'message_received')
+    tx = _capture(dispatcher, 'message_sent')
+    await aggregator.on_message_received('mqtt', 'PUBLISH', 42)
+    await aggregator.on_message_sent('mqtt', 'PUBACK', 4)
+    assert rx[0].detail == {'protocol': 'mqtt', 'message_type': 'PUBLISH', 'payload_size': 42}
+    assert tx[0].detail == {'protocol': 'mqtt', 'message_type': 'PUBACK', 'payload_size': 4}
+
+
+@pytest.mark.asyncio
+async def test_no_emit_without_listeners(aggregator, dispatcher):
+    # No interceptor/observer registered → has_listeners() short-circuits, so
+    # emit is never called.  We assert this by spying on emit.
+    calls = []
+    orig_emit = dispatcher.emit
+
+    async def _spy(event):
+        calls.append(event)
+        await orig_emit(event)
+
+    dispatcher.emit = _spy
+    await aggregator.on_connection_accepted(('1.2.3.4', 5555), protocol='echo')
+    await aggregator.on_connection_closed(('1.2.3.4', 5555), 'echo', 1.0)
+    await aggregator.on_message_received('echo', 'data', 1)
+    await aggregator.on_message_sent('echo', 'data', 1)
+    assert calls == []

--- a/tests/unit/test_protocol_registry.py
+++ b/tests/unit/test_protocol_registry.py
@@ -1,0 +1,208 @@
+"""Unit tests for the unified protocol registry (Sprint 50/51)."""
+import pytest
+
+from blackbull.server.protocol_registry import (
+    Http1Binding, Http2Binding, ProtocolDetector, ProtocolRegistry, RawBinding,
+    _HTTP2_PREFACE_FIRST_LINE,
+)
+from blackbull.server.recipient import AbstractReader
+from blackbull.server.sender import AbstractWriter
+
+
+async def _noop(reader, writer, ctx):  # pragma: no cover - never invoked here
+    pass
+
+
+async def _noop_app(scope, receive, send):  # pragma: no cover - never invoked
+    pass
+
+
+class _StubReader(AbstractReader):
+    """Concrete AbstractReader so ConnectionActor's beartyped __init__ accepts
+    it.  Records whether the byte-sniffing reads were called and returns a
+    configurable first line from readuntil."""
+
+    def __init__(self, first_line: bytes = b''):
+        self._first_line = first_line
+        self.readuntil_called = False
+        self.readexactly_called = False
+
+    async def read(self, n: int) -> bytes:
+        return b''
+
+    async def readuntil(self, sep: bytes) -> bytes:
+        self.readuntil_called = True
+        return self._first_line
+
+    async def readexactly(self, n: int) -> bytes:
+        self.readexactly_called = True
+        return b''
+
+
+class _StubWriter(AbstractWriter):
+    async def write(self, data: bytes) -> None:
+        pass
+
+
+def test_builtin_http_bindings_present_and_ordered():
+    r = ProtocolRegistry()
+    names = [b.name for b in r.cleartext_bindings]
+    # http2 (preface) must precede http1; http1 is the catch-all fallback.
+    assert names == ['http2', 'http1']
+    assert isinstance(r.cleartext_bindings[0], Http2Binding)
+    assert isinstance(r.cleartext_bindings[-1], Http1Binding)
+
+
+def test_http1_is_fallback_http2_matches_only_preface():
+    r = ProtocolRegistry()
+    http2, http1 = r.cleartext_bindings
+    assert http2.matches_cleartext(_HTTP2_PREFACE_FIRST_LINE) is True
+    assert http2.matches_cleartext(b'GET / HTTP/1.1\r\n') is False
+    # http1 claims any first line.
+    assert http1.matches_cleartext(b'GET / HTTP/1.1\r\n') is True
+    assert http1.matches_cleartext(b'anything') is True
+
+
+def test_by_alpn():
+    r = ProtocolRegistry()
+    assert r.by_alpn('h2').name == 'http2'
+    assert r.by_alpn('http/1.1') is None
+    assert r.by_alpn(None) is None
+
+
+def test_register_raw_binding():
+    r = ProtocolRegistry()
+    binding = r.register('echo', _noop, port=9000)
+    assert isinstance(binding, RawBinding)
+    assert r.port_bindings == {9000: binding}
+    assert r.ports == [9000]
+    assert r.has_port_bindings() is True
+    assert bool(r) is True
+    assert 'echo' in r.raw_bindings
+
+
+def test_register_duplicate_name_raises():
+    r = ProtocolRegistry()
+    r.register('echo', _noop, port=9000)
+    with pytest.raises(ValueError, match='already registered'):
+        r.register('echo', _noop, port=9001)
+    # A name colliding with a built-in HTTP binding is also rejected.
+    with pytest.raises(ValueError, match='already registered'):
+        r.register('http1', _noop, port=9002)
+
+
+def test_empty_registry_is_dormant():
+    r = ProtocolRegistry()
+    assert bool(r) is False
+    assert r.has_port_bindings() is False
+    assert r.ports == []
+    assert r.port_bindings == {}
+
+
+def test_raw_binding_without_port_is_not_a_port_binding():
+    r = ProtocolRegistry()
+    r.register('detect-only', _noop)  # no port
+    assert r.ports == []
+    assert r.has_port_bindings() is False
+    # Still truthy: a non-HTTP protocol is registered.
+    assert bool(r) is True
+
+
+# ---------------------------------------------------------------------------
+# ConnectionActor dispatch — bound-binding and ProtocolDetector paths (R7)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_bound_binding_calls_serve_raw_skips_detection():
+    """ConnectionActor(bound_binding=…) hands the connection to serve_raw
+    without touching the reader — no byte sniffing, no ALPN check."""
+    from blackbull.server.connection_actor import ConnectionActor
+
+    reader = _StubReader()
+    writer = _StubWriter()
+
+    served = []
+
+    async def _serve_raw(conn):
+        served.append(conn)
+
+    binding = RawBinding('echo', _noop, port=9000)
+    binding.serve_raw = _serve_raw
+
+    actor = ConnectionActor(reader, writer, app=_noop_app, aggregator=None,
+                            bound_binding=binding)
+    await actor._dispatch()
+
+    assert len(served) == 1
+    assert reader.readexactly_called is False
+    assert reader.readuntil_called is False
+
+
+@pytest.mark.asyncio
+async def test_protocol_detector_claims_connection_before_http1():
+    """A RawBinding whose ProtocolDetector matches the first bytes takes the
+    connection before the http1 fallback runs."""
+    from blackbull.server.connection_actor import ConnectionActor
+
+    class _EchoDetector(ProtocolDetector):
+        def detect(self, first_bytes, alpn):
+            return first_bytes.startswith(b'ECHO')
+
+        @property
+        def protocol_name(self):
+            return 'echo'
+
+    reader = _StubReader(first_line=b'ECHO hello\r\n')
+    writer = _StubWriter()
+
+    served = []
+
+    async def _serve_raw(conn):
+        served.append(conn)
+
+    registry = ProtocolRegistry()
+    binding = registry.register('echo', _noop, detector=_EchoDetector())
+    binding.serve_raw = _serve_raw
+
+    actor = ConnectionActor(reader, writer, app=_noop_app, aggregator=None,
+                            registry=registry)
+    await actor._dispatch()
+
+    assert len(served) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_matching_detector_falls_through_to_http1():
+    """A RawBinding whose ProtocolDetector returns False does not intercept;
+    the http1 fallback still handles the connection."""
+    from unittest.mock import AsyncMock, patch
+    from blackbull.server.connection_actor import ConnectionActor
+
+    class _NeverMatches(ProtocolDetector):
+        def detect(self, first_bytes, alpn):
+            return False
+
+        @property
+        def protocol_name(self):
+            return 'none'
+
+    reader = _StubReader(first_line=b'GET / HTTP/1.1\r\n')
+    writer = _StubWriter()
+
+    http1_served = []
+
+    registry = ProtocolRegistry()
+    binding = registry.register('none', _noop, detector=_NeverMatches())
+
+    async def _record(conn, first_line):
+        http1_served.append(first_line)
+
+    with patch(
+        'blackbull.server.protocol_registry.Http1Binding.serve_cleartext',
+        new=AsyncMock(side_effect=_record),
+    ):
+        actor = ConnectionActor(reader, writer, app=_noop_app, aggregator=None,
+                                registry=registry)
+        await actor._dispatch()
+
+    assert http1_served == [b'GET / HTTP/1.1\r\n']

--- a/tests/unit/test_socket_manager_af_unix.py
+++ b/tests/unit/test_socket_manager_af_unix.py
@@ -28,7 +28,7 @@ async def test_socket_manager_handles_missing_af_unix(monkeypatch):
         writer.close()
 
     try:
-        async with SocketManager(_cb, [tcp_sock], ssl_context=None) as servers:
+        async with SocketManager([(tcp_sock, _cb)], ssl_context=None) as servers:
             assert len(servers) == 1
             await asyncio.sleep(0)
     finally:


### PR DESCRIPTION
Merges the **Sprint 50/51** work to master. **Not a release** — no version bump, no tag; Sprint 50 + 51 + 52 ship together later as `v0.44.0`.

## Sprint 50 — Non-ASGI bridge + registry-driven dispatch
- `app.raw_handler(name, *, port=…)` / `register_protocol_handler()` register a raw-TCP protocol served alongside HTTP; `RawActor` drives the byte stream.
- Unified `ProtocolRegistry` (`Http1Binding` / `Http2Binding` / `RawBinding`) replaces the hardcoded `ConnectionActor._dispatch()`; `ASGIServer` reorganised and re-exported as `Server`. Non-disruptive to HTTP/1.1, HTTP/2, WebSocket.
- `EventAggregator` protocol-agnostic Level B events: `on_connection_accepted(protocol=…)`, `on_connection_closed`, `on_message_received`, `on_message_sent`.

## Sprint 51 — forward-compat + process hygiene
- `ProtocolDetector` consulted after the cleartext-HTTP chain so a raw protocol can share a port with HTTP (foundation for Sprint 52 MQTT); dead-import cleanup.
- Two-tier pytest CI (`.github/workflows/test.yml`): fast beartype tier per PR, weekly full tier.
- Raw protocols are single-worker + cleartext-only for now; documented in `KNOWN_LIMITATIONS.md` and `docs/guide/raw-protocols.md`.

## Notes
- CHANGELOG entries added under `## [Unreleased]` (not a versioned section).
- Reconstructed from git dangling objects after the Sprint 50/51 working tree was lost to a `reset --hard` during the v0.43.1 release (preserved on branch `recover/sprint-50`).

## Test plan
- [x] Full beartype-instrumented suite: **1494 passed**, 225 skipped, 2 xfailed — 0 failures
- [x] All 18 protocol tests pass (registry, events, raw-TCP bridge integration)
- [x] Pre-commit hook (full suite + mkdocs build) green
- [ ] New `test.yml` fast tier runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)