### PR TITLE
chore: remove dead imports in server.py (review R1)

### DIFF
--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -17,8 +17,6 @@ from ..protocol.rsock import (
     create_dual_stack_sockets, create_unix_socket,
     adopt_inherited_sockets, adopt_listening_fd,
 )
-from ..protocol.frame import FrameFactory
-from ..protocol.frame_types import ErrorCodes, FrameTypes, FrameBase
 from .response import ResponderFactory
 from .parser import ParserFactory
 from .sender import SenderFactory, AbstractWriter
@@ -28,7 +26,6 @@ from .access_log import AccessLogRecord, _make_capturing_send, emit_access_log a
 from .cap_log import log_cap_hit
 from ..asgi import ASGIEvent
 from ..headers import Headers
-from .http2_actor import HTTP2Actor
 logger = logging.getLogger(__name__)
 
 async def _run_with_log(coro, record: AccessLogRecord,


### PR DESCRIPTION
Closes review item **R1** from `sprint-50-post-review.md`.

`FrameFactory`, `ErrorCodes` / `FrameTypes` / `FrameBase`, and `HTTP2Actor` were left unused in `blackbull/server/server.py` after the Sprint 50 `ProtocolRegistry` refactor moved frame dispatch into `protocol_registry.py` and `HTTP2Actor` construction into `Http2Binding`. All five symbols were import-only; this removes the three dead import lines.

## Test plan
- [x] `import blackbull.server.server` + `from blackbull.server import ASGIServer, Server` OK
- [x] 0 remaining references to the removed symbols in `server.py`
- [x] Pre-commit full beartype suite + mkdocs build green
- [x] architecture + protocol-registry + non-http-bridge tests: 194 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)