### PR TITLE
chore(ci): scope CodeQL quality analysis to the shipped package

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+# CodeQL configuration.
+#
+# The analysis runs the `security-extended,security-and-quality` suites (see
+# codeql.yml).  The quality suite lints style across *all* Python, which floods
+# the alert list with unused-import / empty-except / ineffectual-statement hits
+# in code we never ship: the test suite, micro-benchmarks, and the generated
+# template dummy modules.  Scope quality analysis to the shipped package
+# (`blackbull/`) and the user-facing `examples/` (teaching code we want kept
+# clean) by ignoring the rest.
+#
+# Note: this also stops scanning the test-only self-signed-TLS setups that
+# tripped `py/request-without-cert-validation` in tests/integration — those are
+# intended for the local h2 fault-injection server, not real findings.  The
+# acceptance is recorded in .claude/planning/drafts/codeql-backlog-triage.md.
+
+paths-ignore:
+  - tests
+  - bench
+  - templates
+  - docs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
+          # Scope quality lint to shipped code (blackbull/ + examples/);
+          # ignore tests/bench/templates/docs.  See the config file header.
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e   # v4.36.2


### PR DESCRIPTION
First step of the Sprint 55 CodeQL backlog triage (G4).

## What
- Add `.github/codeql/codeql-config.yml` with `paths-ignore: [tests, bench, templates, docs]`.
- Reference it from `codeql.yml`'s `Initialize CodeQL` step via `config-file:`.

## Why
The `security-and-quality` suite lints style across **all** Python. Of the 313 open alerts on `master`, ~196 are quality-lint hits (unused-import, empty-except, ineffectual-statement) in code we never ship — the test suite, micro-benchmarks, and generated template dummy modules. Scoping quality analysis to the shipped package (`blackbull/`) plus the user-facing `examples/` (teaching code we want kept clean) removes that noise and leaves a triageable backlog (~117).

## Note
This also stops scanning the test-only self-signed-TLS setups that tripped `py/request-without-cert-validation` in `tests/integration/test_http2*.py` — those are intended for the local h2 fault-injection server, not real findings. The acceptance is recorded in `.claude/planning/drafts/codeql-backlog-triage.md`.

Security coverage for the shipped package is unchanged (`security-extended` still runs over `blackbull/` + `examples/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)