### PR TITLE
fix(ws): re-raise CancelledError instead of swallowing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ so the editable install's metadata catches up.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **`WebSocketActor` no longer swallows `asyncio.CancelledError`.** `run()`
+  caught `BaseException` (to isolate the connection from app/protocol errors),
+  which also swallowed cancellation — so cancelling a WebSocket task completed it
+  *normally* and reported the cancellation through `on_error` instead of
+  propagating it. It now re-raises `CancelledError` before the generic handler
+  (mirroring `HTTP1Actor`); the disconnect/close cleanup still runs in `finally`.
+  (CodeQL `py/catch-base-exception`.)
+
+### Internal
+- CodeQL quality analysis is scoped to the shipped package (`blackbull/`) plus
+  `examples/`; `tests/`, `bench/`, `templates/`, and `docs/` are excluded via
+  `.github/codeql/codeql-config.yml`, removing ~196 style-lint alerts in
+  non-shipped code.
+
+---
+
 ## [0.44.0] — 2026-06-25
 
 Combined release of Sprint 50 through Sprint 54 (see the Versioning note above).

--- a/blackbull/server/websocket_actor.py
+++ b/blackbull/server/websocket_actor.py
@@ -1,4 +1,5 @@
 """WebSocket Actor — Phase 6 Step 5."""
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -81,6 +82,11 @@ class WebSocketActor(Actor):
     async def run(self) -> None:
         try:
             await self._app(self._scope, self._receive, self._send)
+        except asyncio.CancelledError:
+            # Cancellation is not an error: re-raise so the task actually
+            # cancels rather than completing normally.  (Mirrors HTTP1Actor;
+            # the finally below still runs the disconnect/close cleanup.)
+            raise
         except BaseException as exc:
             await self._aggregator.on_error(self._scope, exc)
         finally:

--- a/tests/architecture/test_websocket_actor.py
+++ b/tests/architecture/test_websocket_actor.py
@@ -194,4 +194,34 @@ async def test_protocol_violation_closes_writer(
     actor = WebSocketActor(fake_bad_frame_reader, fake_writer, scope, app, aggregator)
     await actor.run()
 
+
+@pytest.mark.asyncio
+async def test_cancellation_propagates_and_is_not_reported_as_error(
+        fake_writer) -> None:
+    """Cancelling the actor's task must raise CancelledError (the task really
+    cancels instead of completing normally) and must NOT be reported via
+    on_error — cancellation is not an error.  Regression: run() used to catch
+    BaseException, swallowing CancelledError."""
+    aggregator = AsyncMock(spec_set=EventAggregator)
+    scope = {'type': 'websocket', '_connection_id': 'test-id'}
+    accepted = asyncio.Event()
+
+    async def app(scope, receive, send):
+        await receive()  # websocket.connect
+        await send({'type': 'websocket.accept'})
+        accepted.set()
+        await asyncio.Event().wait()  # block until cancelled
+
+    actor = WebSocketActor(_FakeReader(b''), fake_writer, scope, app, aggregator)
+    task = asyncio.create_task(actor.run())
+    await accepted.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    aggregator.on_error.assert_not_called()
+    # The finally cleanup still fires on cancellation.
+    aggregator.on_websocket_disconnected.assert_called_once()
+
     assert fake_writer.closed, 'writer.close() must be called after protocol violation'


### PR DESCRIPTION
The one genuine bug from the Sprint 55 CodeQL backlog triage (G4).

## Problem
`WebSocketActor.run()` caught `BaseException` to isolate the connection from app/protocol errors — but that also swallowed `asyncio.CancelledError`. Cancelling a WebSocket task therefore completed it *normally* and reported the cancellation through `on_error`, instead of letting the cancellation propagate.

## Fix
Re-raise `CancelledError` before the generic `except Exception` (mirrors `HTTP1Actor.run` at `http1_actor.py:848`). The disconnect/close cleanup still runs in `finally`.

## Test
`test_cancellation_propagates_and_is_not_reported_as_error` cancels a blocked actor task and asserts `CancelledError` propagates and `on_error` is not called. (Fails without the fix: previously the task completed normally and `on_error` was called with the `CancelledError`.)

Resolves CodeQL `py/catch-base-exception` on `websocket_actor.py`. Full beartype suite green (2065 passed). Targets the **v0.44.1** release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)