### PR TITLE
release: v0.44.1 — Sprint 55 close (HTTP multi-worker + AsyncAPI docs + hot-path perf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+---
+
+## [0.44.1] — 2026-06-26
+
+Sprint 55 close. A PATCH on top of `v0.44.0`: HTTP now scales across workers
+while a stateful single-owner protocol (the MQTT 5 broker) runs alongside,
+AsyncAPI 3.0 docs for the broker taps, and behaviour-preserving hot-path perf.
+Measured **+8.7% FA-normalized mean HTTP/1.1 throughput** vs `v0.44.0` across the
+HttpArena suite (c7i.8xlarge, FastAPI reference; validation 47/0 + WS 7/0), with
+the largest gains on the connection-churn / pipelining lanes.
+
 ### Changed
 - **Hot-path copy + logging reduction (no behaviour change).** Three low-risk
   perf wins on the HTTP/1.1 and HTTP/2 hot paths: `read_body()` collects chunks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.44.0"
+version = "0.44.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## v0.44.1 — Sprint 55 close

PATCH on top of `v0.44.0`. Version bump `0.44.0 → 0.44.1` + CHANGELOG `[Unreleased]` → `[0.44.1] — 2026-06-26`. All feature/fix PRs already merged to master (#93–#98); this is the release-cut commit only.

### What's in it
- **HTTP scales across workers alongside a stateful single-owner protocol** (MQTT 5 broker bound on worker 0 only) — #95.
- **`AsyncAPIExtension`** — AsyncAPI 3.0 docs for `@mqtt.on_message` taps at `/asyncapi.json` + `/asyncapi` — #96.
- **Behaviour-preserving hot-path perf** — RequestActor fast-path (no-listener), `PrefixReader.readuntil` short-circuit, header/body copy reduction, lazy H2 frame logging — #97/#98.
- **Fixes** — `BB_SOCKET_REUSEPORT` plumbed through the HTTP listener; `WebSocketActor` re-raises `asyncio.CancelledError` (CodeQL `py/catch-base-exception`) — #93.

### Performance
**+8.7% FA-normalized mean HTTP/1.1 throughput** vs `v0.44.0` across the full 11-profile HttpArena suite (c7i.8xlarge, FastAPI fluctuation reference). Validation clean: **47 passed / 0 failed + WS 7 passed / 0 failed** on both base and head. Largest gains on connection-churn / pipelining lanes (pipelined +23.5%, limited-conn +18.6%, baseline +16.4%); `upload` flat-to-slightly-down. H2/WS not FA-normalizable (no FastAPI reference). Full table: `bench/results/httparena/compare-head-98-full-20260625-220039Z/AB-vs-base-cd39703-full11.md`.

### Release mechanics
On merge, tagging `v0.44.1` triggers `publish.yml` (PyPI publish + GitHub Release from the CHANGELOG `[0.44.1]` section). No manual `gh release create`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)