### PR TITLE
docs: post-v0.44.1 audit fixes (SECURITY supported versions + README AsyncAPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,11 @@ parameters.  Dataclass-typed bodies are also deserialized at runtime
 — `async def h(body: CreateTask): ...` receives a constructed
 instance, no manual `json.loads`.
 
+For the MQTT broker there is a messaging counterpart: `AsyncAPIExtension`
+publishes an AsyncAPI 3.0 document for your `@mqtt.on_message` taps at
+`/asyncapi.json` (with an HTML viewer at `/asyncapi`).  See
+[`docs/guide/mqtt.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/mqtt.md).
+
 ## Fault injection
 
 BlackBull's single most distinctive feature: a programmable

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.44.x  | :white_check_mark: |
 | 0.43.x  | :white_check_mark: |
-| 0.42.x  | :white_check_mark: |
-| < 0.42  | :x:                |
+| < 0.43  | :x:                |
 
 This table updates with each minor release.
 


### PR DESCRIPTION
Documentation drift surfaced by the pre-release docs audit during the Sprint 55 close. No code changes.

### SECURITY.md
The supported-versions table had lagged a full minor — still `0.43.x` / `0.42.x` after `v0.44.0` shipped (2026-06-25). Policy is "latest released minor + the preceding one", so it now reads:

| Version | Supported |
|---|---|
| 0.44.x | ✅ |
| 0.43.x | ✅ |
| < 0.43 | ❌ |

A prospective adopter reading the file on master today would otherwise see the wrong set of maintained releases.

### README.md
`AsyncAPIExtension` (AsyncAPI 3.0 docs for `@mqtt.on_message` taps at `/asyncapi.json` + `/asyncapi`) shipped in `v0.44.1` (#96) but the README never mentioned it. Added a short pointer in the OpenAPI section, linking to `docs/guide/mqtt.md` (where it was already documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)