### PR TITLE
release: v0.45.0 — Sprint 56 close (DX consolidation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,51 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+Sprint 56 close — **DX consolidation** (no new protocol; gRPC stays queued).
+A MINOR of additive developer-experience and perf items: `BLACKBULL_*` env-var /
+`.env` resolution for `run()`, `RedirectResponse`, `read_json` / `read_text`
+body helpers, HTTP/1.1 `Content-Length` body streaming, and two pay-for-what-you-use
+hot-path wins (cached request-listener check, lazy per-connection cap counter).
+
+### Added
+- **`BLACKBULL_*` environment-variable + `.env` resolution for `app.run()`.**
+  The deploy-time settings — `BLACKBULL_PORT` / `CERT` / `KEY` / `UNIX_PATH` /
+  `RELOAD` — now resolve with documented precedence: explicit `run(...)` argument
+  → `BLACKBULL_*` env var → `.env` file → bound `AppConfig` → built-in default
+  (see `blackbull.config.resolve_run_config`). `.env` loading is gated behind a
+  new optional extra `blackbull[dotenv]` (no new hard dependency); without it,
+  resolution from the real process environment still works. One INFO line per
+  non-default deploy setting is logged at startup on the `blackbull.config`
+  logger, naming each value's source (key paths are logged, never contents).
+  `BLACKBULL_*` is the deployment namespace; `BB_*` remains the tuning namespace.
+- **`RedirectResponse`** — `Response` convenience subclass that sets a `Location`
+  header and a 3xx status (default `302 Found`), completing the
+  `JSONResponse` / `StreamingResponse` family. Exported from `blackbull`.
+- **`read_json` / `read_text`** — request-body helpers wrapping `read_body`.
+  `read_json(receive)` returns the parsed JSON value or `None` on empty / invalid /
+  undecodable bodies; `read_text(receive, encoding='utf-8')` decodes with
+  `errors='replace'` so malformed bytes never raise. Both exported from `blackbull`.
+- **`BB_BODY_CHUNK_SIZE` — streamed HTTP/1.1 `Content-Length` request bodies.**
+  A `Content-Length` body is now delivered to the ASGI app as successive
+  `http.request` events of at most `BB_BODY_CHUNK_SIZE` bytes (default 64 KiB,
+  must be > 0; `more_body: True` until exhausted) instead of one
+  `readexactly(content_length)` allocation — capping per-connection buffering and
+  letting the app start work before the whole body arrives. The exact-bytes
+  contract is preserved (a short body still raises `IncompleteReadError`).
+
+### Changed
+- **Cached request-listener check on the request hot path.** `RequestActor.run()`'s
+  `has_any_request_listeners()` fast-path guard no longer re-scans the six
+  request-lifecycle events on every request; the result is cached against a new
+  `EventDispatcher.generation` counter (bumped on `on` / `intercept`) and
+  recomputed only when listeners change — effectively once, at startup. Behaviour
+  is identical, including for listeners registered after the first request.
+- **Lazy per-connection cap counter (`connection-accept` fast path).** The
+  `CapHitCounter` and its `os.urandom` connection id are now built only if a cap
+  actually fires (`_LazyCapHitCounter`). On the keep-alive / healthy path this
+  removes a `getrandom(2)` syscall, an allocation, and a flush from every accepted
+  connection; cross-task propagation and cap-hit logging are unchanged.
+
 ---
 
 ## [0.44.1] — 2026-06-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+---
+
+## [0.45.0] — 2026-06-27
+
 Sprint 56 close — **DX consolidation** (no new protocol; gRPC stays queued).
 A MINOR of additive developer-experience and perf items: `BLACKBULL_*` env-var /
 `.env` resolution for `run()`, `RedirectResponse`, `read_json` / `read_text`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
-| 0.43.x  | :white_check_mark: |
-| 0.42.x  | :white_check_mark: |
-| < 0.42  | :x:                |
+| 0.45.x  | :white_check_mark: |
+| 0.44.x  | :white_check_mark: |
+| < 0.44  | :x:                |
 
 This table updates with each minor release.
 

--- a/bench/aws/httparena_compare.sh
+++ b/bench/aws/httparena_compare.sh
@@ -85,7 +85,7 @@ _bench_aws_check_env
 # on one host with --network host).
 export TOPO=single
 
-PROFILES="${PROFILES:-baseline json json-tls static}"
+: "${PROFILES:?must be set explicitly, space-separated (e.g. 'baseline baseline-h2 echo-ws json json-comp json-tls limited-conn pipelined static static-h2 upload')}"
 FRAMEWORKS="${FRAMEWORKS:-blackbull fastapi}"
 KEEP_INSTANCE="${KEEP_INSTANCE:-0}"
 SKIP_VALIDATE="${SKIP_VALIDATE:-0}"
@@ -110,6 +110,13 @@ TS="$(date -u +%Y%m%d-%H%M%SZ)"
 SPRINT_TAG="${SPRINT_TAG:-sprint29}"
 LOCAL_DEST="$REPO_ROOT/bench/results/httparena/${SPRINT_TAG}-${TS}"
 mkdir -p "$LOCAL_DEST"
+
+# Self-document the run: capture the entire driver console — provisioning,
+# image builds, the watchdog heartbeats, and the streamed validate/benchmark
+# output — into the result directory itself, so the orchestration + remote
+# health trail lives alongside the artefacts instead of in an ad-hoc external
+# tee.  (The caller may still pipe to its own log; this is independent.)
+exec > >(tee -a "$LOCAL_DEST/driver.log") 2>&1
 
 echo "=== bench/aws/httparena_compare.sh ==="
 echo "  destination:   $LOCAL_DEST"
@@ -463,9 +470,47 @@ _FW_CSV=$(echo "$FRAMEWORKS" | tr ' ' ',')
 _PROF_CSV=$(echo "$PROFILES" | tr ' ' ',')
 
 echo ">>> HttpArena validate + benchmark ..."
+
+# --- remote-state watchdog ---------------------------------------------------
+# The validate+benchmark SSH below blocks for ~50 min.  A wedged docker daemon
+# (e.g. an instance reused after a killed run) emits NOTHING for the full 600s
+# validate gate, so a frozen log line is indistinguishable from slow progress.
+# This sidecar probes the server independently every WATCHDOG_INTERVAL seconds
+# and prints a one-line heartbeat (docker responsiveness, live containers,
+# :8080 listen state, loadavg) into the same streamed output.  It is strictly
+# observational — it never touches the benchmark commands, profiles, or
+# connection counts.  Every probe is `timeout`-wrapped so it can never itself
+# hang the run, and it is killed the moment the run SSH returns.  The probe is
+# 4 cheap syscalls every 30 s on a 32-vCPU box — far below the measurement
+# noise band.  Set WATCHDOG_INTERVAL=0 to disable.
+_REMOTE_PROBE='set +e; if names=$(timeout 5 sudo docker ps --format "{{.Names}}" 2>/dev/null); then c=$(printf "%s" "$names" | paste -sd, -); [ -n "$c" ] || c="(none)"; else c=HUNG; fi; p=$(ss -ltn 2>/dev/null | grep -qE ":8080|:8443" && echo up || echo down); printf "docker=%s port8080=%s load=%s\n" "$c" "$p" "$(cut -d" " -f1 /proc/loadavg)"'
+_watchdog() {
+    local interval="${WATCHDOG_INTERVAL:-30}" strikes=0 probe
+    [ "$interval" -gt 0 ] 2>/dev/null || return 0
+    while true; do
+        sleep "$interval"
+        if probe=$(timeout 12 ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "$_REMOTE_PROBE" 2>/dev/null) \
+           && [ -n "$probe" ] && [[ "$probe" != *docker=HUNG* ]]; then
+            strikes=0
+            echo "  [watchdog $(date +%H:%M:%S)] $probe"
+        else
+            strikes=$((strikes + 1))
+            echo "  [watchdog $(date +%H:%M:%S)] ⚠ remote unresponsive (strike ${strikes}) — ${probe:-probe ssh timed out}"
+            if [ "$strikes" -ge "${WATCHDOG_MAX_STRIKES:-4}" ]; then
+                echo "  [watchdog] ✗ docker/instance wedged for ${strikes} consecutive probes — abort manually (Ctrl-C) and re-provision; do not trust this run."
+                strikes=0
+            fi
+        fi
+    done
+}
+_watchdog & _WATCHDOG_PID=$!
+
 ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
     "bash ~/run_httparena.sh '${_FW_CSV}' '${_PROF_CSV}' '${SKIP_VALIDATE}' '${WRK_CPUS}'" \
     || echo "  (run_httparena.sh exited non-zero — kept going)"
+
+kill "$_WATCHDOG_PID" 2>/dev/null || true
+wait "$_WATCHDOG_PID" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # Step 8 — remove the shim and restore the real docker binary.

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -8,10 +8,12 @@ Public API exports:
 - `BlackBull`: the main application object; wraps routing, middleware, and lifespan hooks.
 - `AppConfig`: declarative, immutable holder for the startup settings ``run()`` accepts (port, TLS, workers, …).
 - `serve`: synchronous entry point that runs any ASGI 3.0 callable (also used by the ``blackbull`` console script).
-- `Response`, `JSONResponse`, `StreamingResponse`, `EventSourceResponse`, `WebSocketResponse`: response helpers.
+- `Response`, `JSONResponse`, `RedirectResponse`, `StreamingResponse`, `EventSourceResponse`, `WebSocketResponse`: response helpers.
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
 - `cookie_header`: builds a ``Set-Cookie`` header tuple.
 - `read_body`: reads and buffers the full request body from the ASGI receive channel.
+- `read_json`: reads the body and parses it as JSON (``None`` on empty/invalid).
+- `read_text`: reads the body and decodes it as text.
 - `parse_cookies`: parses the ``Cookie`` header into a plain ``dict``.
 - `CORS`: adds ``Access-Control-*`` headers; handles preflight OPTIONS requests.
 - `as_middleware`: decorator that marks an async function or class as middleware; normalises ``send`` so inner wrappers see only ASGI event dicts.
@@ -41,10 +43,10 @@ except PackageNotFoundError:
 from .app import BlackBull, serve
 from .config import AppConfig
 from .headers import Headers
-from .request import read_body, parse_cookies
+from .request import read_body, read_json, read_text, parse_cookies
 from .response import (
-    Response, JSONResponse, StreamingResponse, EventSourceResponse,
-    WebSocketResponse, cookie_header,
+    Response, JSONResponse, RedirectResponse, StreamingResponse,
+    EventSourceResponse, WebSocketResponse, cookie_header,
 )
 from .event import Event, EventHandler
 from .asgi import ResponseStart, ResponseBody, parse_response_event

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -756,15 +756,21 @@ class BlackBull:
         For ``workers > 1`` *or* ``reload=True`` the master pre-binds
         sockets, forks workers, and blocks until SIGTERM / SIGINT.
 
-        Each argument left unset (``None``) falls back to the value declared
-        on the bound :class:`~blackbull.AppConfig` (if the app was built with
-        ``BlackBull(config=...)``), then to :func:`blackbull.serve`'s own
-        default.  An explicit argument always wins::
+        Each argument left unset (``None``) is resolved, highest precedence
+        first: the explicit argument → a ``BLACKBULL_*`` environment variable
+        (``BLACKBULL_PORT`` / ``CERT`` / ``KEY`` / ``UNIX_PATH`` / ``RELOAD``)
+        → a ``.env`` file in the working directory (needs the ``[dotenv]``
+        extra) → the bound :class:`~blackbull.AppConfig` → :func:`blackbull.serve`'s
+        own default.  Server-tuning knobs (``workers``, ``max_connections``,
+        queue depths) keep their ``BB_*`` environment variables; ``BLACKBULL_*``
+        is the deployment namespace.  The provenance of each non-default deploy
+        setting is logged once at startup on the ``blackbull.config`` logger::
 
             app = BlackBull(config=AppConfig(port=8443, certfile='c.pem',
                                              keyfile='k.pem'))
             app.run()              # binds 8443 with TLS from the config
             app.run(port=9000)     # explicit arg overrides the config's 8443
+            # BLACKBULL_PORT=9000 python app.py   # env overrides the config too
 
         For embedded use under an existing event loop, or for pre-binding
         a socket before forking a test subprocess, instantiate
@@ -779,29 +785,24 @@ class BlackBull:
             app.run(port=8443, certfile='cert.pem', keyfile='key.pem', reload=True)
             app.run(unix_path='/run/blackbull.sock')
         """
-        cfg = self._config
+        from .config import resolve_run_config, log_config_sources  # noqa: PLC0415
 
-        def _pick(explicit, attr, fallback):
-            if explicit is not None:
-                return explicit
-            if cfg is not None:
-                return getattr(cfg, attr)
-            return fallback
-
-        serve(
-            self,
-            certfile=_pick(certfile, 'certfile', None),
-            keyfile=_pick(keyfile, 'keyfile', None),
-            port=_pick(port, 'port', 0),
-            unix_path=_pick(unix_path, 'unix_path', None),
-            inherited_fd=_pick(inherited_fd, 'inherited_fd', None),
-            workers=_pick(workers, 'workers', None),
-            max_connections=_pick(max_connections, 'max_connections', None),
-            stream_queue_depth=_pick(stream_queue_depth, 'stream_queue_depth', None),
-            ws_queue_depth=_pick(ws_queue_depth, 'ws_queue_depth', None),
-            reload=_pick(reload, 'reload', False),
-            reload_paths=_pick(reload_paths, 'reload_paths', None),
+        # Resolve each setting through: explicit arg → BLACKBULL_* env var →
+        # .env → AppConfig → default (see resolve_run_config), then surface the
+        # provenance of any non-default deploy setting at startup.
+        resolved, sources = resolve_run_config(
+            {
+                'certfile': certfile, 'keyfile': keyfile, 'port': port,
+                'unix_path': unix_path, 'inherited_fd': inherited_fd,
+                'workers': workers, 'max_connections': max_connections,
+                'stream_queue_depth': stream_queue_depth,
+                'ws_queue_depth': ws_queue_depth,
+                'reload': reload, 'reload_paths': reload_paths,
+            },
+            self._config,
         )
+        log_config_sources(resolved, sources)
+        serve(self, **resolved)
 
 
 def serve(app, *,

--- a/blackbull/config.py
+++ b/blackbull/config.py
@@ -17,18 +17,25 @@ settings once::
     if __name__ == '__main__':
         app.run()          # picks up the config; no flags to thread through
 
-Resolution precedence in :meth:`BlackBull.run` is, highest to lowest:
+Resolution precedence in :meth:`BlackBull.run` is, highest to lowest
+(see :func:`resolve_run_config`):
 
 1.  an explicit keyword argument to ``run(...)`` — ``app.run(port=9000)``
     always wins;
-2.  the value declared on the bound :class:`AppConfig` (if any);
-3.  the built-in default baked into :func:`blackbull.serve`.
+2.  a ``BLACKBULL_*`` environment variable, for the deploy-time settings
+    (``BLACKBULL_PORT`` / ``CERT`` / ``KEY`` / ``UNIX_PATH`` / ``RELOAD``);
+3.  the same ``BLACKBULL_*`` key in a ``.env`` file in the working directory
+    (requires the ``[dotenv]`` extra; absent it, only the real environment is
+    consulted);
+4.  the value declared on the bound :class:`AppConfig` (if any);
+5.  the built-in default baked into :func:`blackbull.serve`.
 
 ``AppConfig`` deliberately mirrors *only* the parameters ``serve`` already
 exposes — it is not a general-purpose settings store.  Per-request and
 server-tuning knobs (window sizes, timeouts, queue depths beyond the two
-listed here, …) continue to live in :mod:`blackbull.env` and are sourced
-from ``BB_*`` environment variables.
+listed here, ``workers``, ``max_connections``, …) continue to live in
+:mod:`blackbull.env` and are sourced from ``BB_*`` environment variables —
+``BLACKBULL_*`` is the deployment namespace, ``BB_*`` the tuning one.
 
 ``host`` is intentionally absent: BlackBull's socket layer binds dual-stack
 on all interfaces (see :meth:`blackbull.server.ASGIServer.open_socket`), so
@@ -38,6 +45,12 @@ or ``inherited_fd`` for non-TCP binds.
 from __future__ import annotations
 
 import dataclasses
+import logging
+import os
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger('blackbull.config')
 
 
 @dataclasses.dataclass(frozen=True)
@@ -88,3 +101,118 @@ class AppConfig:
     #: Directories / files to watch under auto-reload.  ``None`` watches the
     #: current working directory.
     reload_paths: list[str] | None = None
+
+
+def _parse_bool(value: str) -> bool:
+    """Parse a ``BLACKBULL_RELOAD``-style truthy string (``1/true/yes/on``)."""
+    return value.strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+# Deploy-time ``run()`` settings resolvable from ``BLACKBULL_*`` environment
+# variables: ``{field: (env var, coercer)}``.  Server-tuning knobs (``workers``,
+# ``max_connections``, the queue depths, timeouts, window sizes) are sourced
+# from ``BB_*`` in :mod:`blackbull.env` and are deliberately *not* duplicated
+# here — ``BLACKBULL_*`` is the deployment namespace, ``BB_*`` the tuning one.
+_ENV_VARS: dict[str, tuple[str, Callable[[str], Any]]] = {
+    'certfile':  ('BLACKBULL_CERT', str),
+    'keyfile':   ('BLACKBULL_KEY', str),
+    'port':      ('BLACKBULL_PORT', int),
+    'unix_path': ('BLACKBULL_UNIX_PATH', str),
+    'reload':    ('BLACKBULL_RELOAD', _parse_bool),
+}
+
+# Sentinel defaults for every ``run()`` parameter, mirroring ``serve``'s own
+# built-in defaults.  Used as the lowest-precedence fallback and to decide
+# whether an ``AppConfig`` field was actually declared (vs. left at its default).
+_DEFAULTS: dict[str, Any] = {
+    'certfile': None, 'keyfile': None, 'port': 0, 'unix_path': None,
+    'inherited_fd': None, 'workers': None, 'max_connections': None,
+    'stream_queue_depth': None, 'ws_queue_depth': None,
+    'reload': False, 'reload_paths': None,
+}
+
+
+def _load_dotenv_values() -> dict[str, str]:
+    """Return ``.env`` values from the working directory.
+
+    Reads the file without mutating ``os.environ`` so the real process
+    environment keeps precedence (``env`` > ``.env``).  Returns ``{}`` when
+    ``python-dotenv`` is not installed (the ``[dotenv]`` extra) or no ``.env``
+    file is present — ``BLACKBULL_*`` resolution from the real environment still
+    works either way.
+    """
+    try:
+        from dotenv import dotenv_values  # noqa: PLC0415
+    except ImportError:
+        return {}
+    return {k: v for k, v in dotenv_values('.env').items() if v is not None}
+
+
+def resolve_run_config(
+    explicit: dict[str, Any],
+    config: AppConfig | None,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Resolve every ``run()`` setting and record where each value came from.
+
+    Precedence, highest to lowest:
+
+    1. an explicit ``run(...)`` keyword argument (anything not ``None``);
+    2. a ``BLACKBULL_*`` environment variable (for the deploy-time settings in
+       :data:`_ENV_VARS`);
+    3. a ``BLACKBULL_*`` entry in a ``.env`` file (``[dotenv]`` extra);
+    4. the bound :class:`AppConfig` field, if declared (non-default);
+    5. the built-in default.
+
+    Returns ``(resolved, sources)`` where *resolved* maps each ``run()``
+    parameter to its final value and *sources* maps it to a short provenance
+    label (``argument`` / ``$BLACKBULL_PORT`` / ``.env`` / ``AppConfig`` /
+    ``default``) for startup logging.
+    """
+    dotenv = _load_dotenv_values()
+    resolved: dict[str, Any] = {}
+    sources: dict[str, str] = {}
+
+    for name, default in _DEFAULTS.items():
+        given = explicit.get(name)
+        if given is not None:
+            resolved[name], sources[name] = given, 'argument'
+            continue
+
+        if name in _ENV_VARS:
+            env_name, coerce = _ENV_VARS[name]
+            raw = os.environ.get(env_name)
+            if raw is not None:
+                resolved[name], sources[name] = coerce(raw), f'${env_name}'
+                continue
+            if env_name in dotenv:
+                resolved[name], sources[name] = coerce(dotenv[env_name]), '.env'
+                continue
+
+        if config is not None:
+            cfg_val = getattr(config, name)
+            if cfg_val != default:
+                resolved[name], sources[name] = cfg_val, 'AppConfig'
+                continue
+
+        resolved[name], sources[name] = default, 'default'
+
+    return resolved, sources
+
+
+def log_config_sources(resolved: dict[str, Any], sources: dict[str, str]) -> None:
+    """Log one INFO line per deploy setting that was configured non-trivially.
+
+    Only the ``BLACKBULL_*``-resolvable deploy settings whose value came from
+    an environment variable, ``.env``, or an :class:`AppConfig` are reported —
+    explicit call-site arguments (the author already knows them) and plain
+    defaults are left silent to keep startup quiet.  Paths are logged; secrets
+    are not (a ``keyfile`` path is configuration, its contents never touch the
+    log).
+    """
+    if not logger.isEnabledFor(logging.INFO):
+        return
+    for name in _ENV_VARS:
+        src = sources.get(name)
+        if src in (None, 'argument', 'default'):
+            continue
+        logger.info('config: %s=%r (from %s)', name, resolved[name], src)

--- a/blackbull/env.py
+++ b/blackbull/env.py
@@ -113,6 +113,11 @@ BB_HEADER_MAX_TOTAL
     Maximum total bytes in the entire HTTP/1.1 request header block
     (request-line + all headers + CRLFCRLF).  Default: ``65536``
     (matches typical reverse-proxy defaults).
+BB_BODY_CHUNK_SIZE
+    Slice size (bytes) for streaming an HTTP/1.1 ``Content-Length`` request
+    body to the ASGI app as successive ``http.request`` events instead of one
+    giant allocation.  Default: ``65536`` (asyncio's ``StreamReader`` buffer).
+    Must be ``> 0``.
 BB_H2_INITIAL_WINDOW_SIZE
     Per-stream flow-control window size (bytes) advertised to HTTP/2 peers in the
     server's initial SETTINGS frame.  Larger values allow peers to send more data
@@ -433,6 +438,15 @@ class Settings:
     #: typical reverse-proxy defaults.
     header_max_total: int = 65536
 
+    #: Chunk size (bytes) for streaming an HTTP/1.1 ``Content-Length`` request
+    #: body to the ASGI app.  Instead of one ``readexactly(content_length)``
+    #: giant allocation, the body is delivered in fixed-size ``http.request``
+    #: events (``more_body: True`` until exhausted) — capping per-connection
+    #: buffering at O(chunk × connections) and letting the app start work
+    #: before the whole body arrives.  64 KiB matches asyncio's default
+    #: ``StreamReader`` buffer limit.  Must be > 0.
+    body_chunk_size: int = 65536
+
     #: Per-stream HTTP/2 flow-control window advertised in the server's SETTINGS.
     #: 65535 is the RFC 9113 §6.9.2 default.  Production deployments serving
     #: large responses should raise this — see
@@ -569,6 +583,7 @@ def get_settings() -> Settings:
         write_timeout=_float_env_nonneg('BB_WRITE_TIMEOUT', 30.0),
         header_max_line=_int_env_nonneg('BB_HEADER_MAX_LINE', 8192),
         header_max_total=_int_env_nonneg('BB_HEADER_MAX_TOTAL', 65536),
+        body_chunk_size=_int_env('BB_BODY_CHUNK_SIZE', 65536),
         # RFC 9113 §6.9.2 default initial window size.  See
         # docs/reference/env-vars.md "Performance recommendations" for the
         # values commonly used on tuned production deployments.

--- a/blackbull/event.py
+++ b/blackbull/event.py
@@ -55,14 +55,22 @@ class EventDispatcher:
         self._interceptors: defaultdict[str, list[EventHandler]] = defaultdict(list)
         self._pending_tasks: set[asyncio.Task] = set()
         self._shutdown_timeout = shutdown_timeout
+        # Monotonic counter bumped on every registration.  Hot-path callers
+        # (e.g. EventAggregator.has_any_request_listeners) cache a derived
+        # boolean keyed on this value, recomputing only when it changes —
+        # listeners are almost always registered before serving, so the
+        # per-request cost collapses to one int read + compare.
+        self.generation: int = 0
 
     def on(self, event_name: str, handler: EventHandler) -> None:
         """Register an observation handler for ``event_name``."""
         self._observers[event_name].append(handler)
+        self.generation += 1
 
     def intercept(self, event_name: str, handler: EventHandler) -> None:
         """Register an interception handler for ``event_name``."""
         self._interceptors[event_name].append(handler)
+        self.generation += 1
 
     def has_listeners(self, event_name: str) -> bool:
         """Return True if any interceptor or observer is registered for ``event_name``.

--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -21,6 +21,11 @@ class EventAggregator:
 
     def __init__(self, dispatcher: EventDispatcher) -> None:
         self._dispatcher = dispatcher
+        # Cache for has_any_request_listeners(), keyed on the dispatcher's
+        # registration generation.  ``-1`` can never equal a real generation
+        # (which starts at 0), so the first call always computes.
+        self._listeners_cache_gen: int = -1
+        self._listeners_cache_val: bool = False
 
     # ------------------------------------------------------------------
     # Hot-path optimisation: skip the indirection when nothing is listening
@@ -42,9 +47,17 @@ class EventAggregator:
         ``RequestActor`` indirection when no Level B event handlers are
         registered — matching the pre-Sprint-53 direct ``self._app()``
         call path.
+
+        Result is cached against the dispatcher's registration generation, so
+        the 6-event scan runs only when listeners change (effectively once,
+        at startup) rather than on every request.
         """
-        has = self._dispatcher.has_listeners
-        return any(has(n) for n in self._REQUEST_EVENTS)
+        gen = self._dispatcher.generation
+        if gen != self._listeners_cache_gen:
+            has = self._dispatcher.has_listeners
+            self._listeners_cache_val = any(has(n) for n in self._REQUEST_EVENTS)
+            self._listeners_cache_gen = gen
+        return self._listeners_cache_val
 
     # ------------------------------------------------------------------
     # Server lifecycle

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -3,8 +3,12 @@
 Provides:
 
 - `read_body`: buffers all ASGI ``http.request`` chunks into a single ``bytes`` object.
+- `read_json`: buffers the body and parses it as JSON (``None`` on empty/invalid).
+- `read_text`: buffers the body and decodes it as text.
 - `parse_cookies`: parses the ``Cookie`` request header into a ``dict[str, str]``.
 """
+import json
+from typing import Any
 
 
 async def read_body(receive) -> bytes:
@@ -27,6 +31,43 @@ async def read_body(receive) -> bytes:
     if len(chunks) == 1:
         return chunks[0]
     return b''.join(chunks)
+
+
+async def read_json(receive) -> Any:
+    """Read the request body and parse it as JSON.
+
+    Returns the parsed JSON value (``dict``, ``list``, ``str``, ``int``,
+    ``float``, ``bool``), or ``None`` when the body is empty, not valid JSON,
+    or not decodable.  Callers should treat ``None`` as a client error and
+    respond ``400``::
+
+        data = await read_json(receive)
+        if data is None:
+            await send(JSONResponse({'error': 'invalid JSON'},
+                                    status=HTTPStatus.BAD_REQUEST))
+            return
+
+    Note that a literal JSON ``null`` body also parses to ``None``; if that
+    distinction matters, read the body yourself with :func:`read_body`.
+    """
+    body = await read_body(receive)
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+
+async def read_text(receive, encoding: str = 'utf-8') -> str:
+    """Read the request body and decode it as text.
+
+    Uses ``errors='replace'`` so undecodable bytes become U+FFFD rather than
+    raising — a malformed body never crashes the handler.  Override
+    *encoding* for non-UTF-8 payloads.
+    """
+    body = await read_body(receive)
+    return body.decode(encoding, errors='replace')
 
 
 def parse_cookies(scope) -> dict[str, str]:

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -4,6 +4,7 @@ Provides:
 
 - `Response`: plain HTTP response (HTML / plain text / binary).
 - `JSONResponse`: convenience subclass that serialises a Python object to JSON.
+- `RedirectResponse`: convenience subclass that sets a ``Location`` header + 3xx status.
 - `StreamingResponse`: pushes an async iterator to the client without buffering.
 - `EventSourceResponse`: WHATWG Server-Sent Events on top of StreamingResponse.
 - `WebSocketResponse`: wraps text, bytes, or dict data as a WebSocket send event.
@@ -82,6 +83,32 @@ class JSONResponse(Response):
                  status: HTTPStatus = HTTPStatus.OK,
                  headers: list | None = None):
         super().__init__(json.dumps(content).encode(), status, 'application/json', headers)
+
+
+class RedirectResponse(Response):
+    """HTTP redirect response carrying a ``Location`` header.
+
+    Completes the ``Response`` convenience family alongside ``JSONResponse``.
+    The body is empty; *url* becomes the ``Location`` header value and *status*
+    a 3xx redirect code (default ``302 Found`` — the safer general-purpose
+    default, since it does not force the client to preserve the request method).
+
+    Pass directly to the ASGI ``send`` callable, or return it from a handler::
+
+        await send(RedirectResponse('/new-url'))
+        return RedirectResponse('/permanent', status=HTTPStatus.MOVED_PERMANENTLY)
+
+    *url* must be ASCII (RFC 9110 §10.2.2 — the Location field value is a
+    URI-reference); percent-encode non-ASCII URLs before passing them in.
+    """
+
+    def __init__(self, url: str,
+                 status: HTTPStatus = HTTPStatus.FOUND,
+                 headers: list | None = None):
+        merged = [(b'location', url.encode('ascii'))]
+        if headers:
+            merged.extend(headers)
+        super().__init__(b'', status=status, headers=merged)
 
 
 def cookie_header(name: str, value: str, path: str = '/',

--- a/blackbull/server/cap_log.py
+++ b/blackbull/server/cap_log.py
@@ -286,16 +286,59 @@ class CapHitCounter:
         self._suppressed.clear()
 
 
+class _LazyCapHitCounter:
+    """Deferred :class:`CapHitCounter` bound once per connection.
+
+    The accept path runs once per TCP connection, but a cap is hit only on
+    abuse/misconfiguration — so the overwhelming majority of connections build
+    a counter (and draw its ``os.urandom`` connection id, a ``getrandom(2)``
+    syscall) that never records anything.  This holder makes that machinery
+    pay-for-what-you-use: nothing is constructed until the first cap actually
+    fires.
+
+    Bound on the ambient contextvar by :class:`ConnectionActor`; TaskGroup
+    children inherit the *same* holder by reference, so whichever task hits the
+    first cap materialises the real counter for all of them — identical
+    cross-task propagation to an eager counter.
+    """
+
+    __slots__ = ('_counter', '_kwargs')
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._counter: Optional[CapHitCounter] = None
+        self._kwargs = kwargs
+
+    def ensure(self) -> CapHitCounter:
+        """Return the real counter, constructing it (and its id) on first call."""
+        if self._counter is None:
+            self._counter = CapHitCounter(**self._kwargs)
+        return self._counter
+
+    @property
+    def counter(self) -> Optional[CapHitCounter]:
+        """The materialised counter, or ``None`` if no cap has fired yet."""
+        return self._counter
+
+    def bind(self) -> '_CapHitCounterScope':
+        """Install this holder as the ambient counter (mirrors ``CapHitCounter.bind``)."""
+        return _CapHitCounterScope(self)
+
+    def flush(self, **kwargs: Any) -> None:
+        """Flush the real counter if it was ever materialised; otherwise a no-op."""
+        if self._counter is not None:
+            self._counter.flush(**kwargs)
+
+
 class _CapHitCounterScope:
-    """Context manager bound to a single :class:`CapHitCounter`."""
+    """Context manager bound to a single :class:`CapHitCounter` or holder."""
 
     __slots__ = ('_counter', '_token')
 
-    def __init__(self, counter: CapHitCounter) -> None:
+    def __init__(self, counter: Union['CapHitCounter', '_LazyCapHitCounter']) -> None:
         self._counter = counter
         self._token = None
 
-    def __enter__(self) -> CapHitCounter:
+    def __enter__(self) -> Union['CapHitCounter', '_LazyCapHitCounter']:
         self._token = _current_counter.set(self._counter)
         return self._counter
 
@@ -352,6 +395,11 @@ def log_cap_hit(
     emits one summary per suppressed cap.
     """
     active = counter if counter is not None else _current_counter.get()
+    # A lazily-bound holder materialises its real counter (and its os.urandom
+    # connection id) here — the first cap hit is the first moment the id is
+    # actually needed.  Healthy connections never reach this branch.
+    if type(active) is _LazyCapHitCounter:
+        active = active.ensure()
     if active is not None and not active._first(cap):
         return
     if not _logger.isEnabledFor(logging.WARNING):

--- a/blackbull/server/connection_actor.py
+++ b/blackbull/server/connection_actor.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 
 from ..actor import Actor, Message
 from ..event_aggregator import EventAggregator
-from .cap_log import CapHitCounter
+from .cap_log import _LazyCapHitCounter
 from .deadline import ConnectionDeadline
 from .protocol_registry import (ConnectionView, ProtocolBinding,
                                 ProtocolRegistry)
@@ -76,7 +76,11 @@ class ConnectionActor(Actor):
         # senders) picks it up without constructor plumbing.  TaskGroup
         # children inherit the context automatically.
         import time  # noqa: PLC0415
-        counter = CapHitCounter()
+        # Lazy holder: the real CapHitCounter (and its os.urandom connection id)
+        # is built only if a cap actually fires.  On the keep-alive path this is
+        # a strict no-op; on connection-churn profiles it removes a getrandom(2)
+        # syscall + an allocation + a flush from every accepted connection.
+        counter = _LazyCapHitCounter()
         start = time.monotonic()
         with counter.bind():
             if self._aggregator is not None:

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -354,7 +354,8 @@ class HTTP1Recipient(BaseRecipient):
 
     def __init__(self, reader: AbstractReader, scope: dict,
                  *, body_timeout: float = 0.0,
-                 deadline: ConnectionDeadline | None = None):
+                 deadline: ConnectionDeadline | None = None,
+                 chunk_size: int | None = None):
         super().__init__(reader)
         self._scope = scope
         headers = scope['headers']
@@ -367,7 +368,16 @@ class HTTP1Recipient(BaseRecipient):
                 f'Transfer-Encoding "{te.decode()}" is not supported.'
             )
         self._chunked = (te == b'chunked')
+        # Remaining Content-Length bytes; counts down as the body streams.
         self._content_length = int(cl) if cl else None
+        # P4: deliver a Content-Length body in fixed-size chunks instead of one
+        # giant ``readexactly(content_length)`` allocation.  Falls back to the
+        # ``BB_BODY_CHUNK_SIZE`` setting when not injected (direct-instantiation
+        # tests pass it explicitly).
+        if chunk_size is None:
+            from ..env import get_settings as _get_settings  # noqa: PLC0415
+            chunk_size = _get_settings().body_chunk_size
+        self._chunk_size = chunk_size
         self._done = False
         # Sprint 17 Phase 3 — body-read deadline.  0 = disabled.  Applied
         # per ``_read_with_timeout`` call (i.e. per chunk for chunked
@@ -419,14 +429,23 @@ class HTTP1Recipient(BaseRecipient):
                     self._reader.readuntil(b'\r\n'))        # consume CRLF after chunk data
                 return {'type': ASGIEvent.HTTP_REQUEST, 'body': data, 'more_body': True}
             else:
-                self._done = True
+                # P4: stream the Content-Length body in ``chunk_size`` slices so
+                # a large upload is delivered as several ``http.request`` events
+                # (``more_body: True`` until exhausted) rather than one giant
+                # allocation.  ``readexactly`` keeps the exact-bytes contract —
+                # a short body still raises IncompleteReadError below.
                 if self._content_length:
+                    n = min(self._content_length, self._chunk_size)
                     body = await self._read_with_timeout(
-                        self._reader.readexactly(self._content_length))
-                else:
-                    body = b''
-                logger.debug('HTTP1Recipient body: %r', body)
-                return {'type': ASGIEvent.HTTP_REQUEST, 'body': body, 'more_body': False}
+                        self._reader.readexactly(n))
+                    self._content_length -= n
+                    more = self._content_length > 0
+                    if not more:
+                        self._done = True
+                    return {'type': ASGIEvent.HTTP_REQUEST, 'body': body,
+                            'more_body': more}
+                self._done = True
+                return {'type': ASGIEvent.HTTP_REQUEST, 'body': b'', 'more_body': False}
 
         except (asyncio.TimeoutError, TimeoutError):
             # body_timeout exceeded — distinguish from EOF mid-body so

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -159,8 +159,13 @@ Resolution order in `run()` is, highest to lowest:
 
 1. an explicit `run(...)` keyword argument — `app.run(port=9000)`
    always wins;
-2. the value declared on the bound `AppConfig`;
-3. `serve()`'s built-in default.
+2. a `BLACKBULL_*` environment variable, for the deploy-time
+   settings (`BLACKBULL_PORT`, `BLACKBULL_CERT`, `BLACKBULL_KEY`,
+   `BLACKBULL_UNIX_PATH`, `BLACKBULL_RELOAD`);
+3. the same `BLACKBULL_*` key in a `.env` file in the working
+   directory (needs the `[dotenv]` extra — see below);
+4. the value declared on the bound `AppConfig`;
+5. `serve()`'s built-in default.
 
 ```python
 app = BlackBull(config=AppConfig(port=8443, certfile='c.pem', keyfile='k.pem'))
@@ -168,9 +173,46 @@ app.run()              # binds 8443 with TLS from the config
 app.run(port=9000)     # explicit arg overrides the config's 8443
 ```
 
-There is no `host` field: BlackBull's socket layer binds dual-stack
-on all interfaces, so a per-interface `host` would silently do
-nothing.  Use `unix_path` or `inherited_fd` for non-TCP binds.
+```bash
+# Same app.py, no code change — the env var overrides the config's 8443:
+BLACKBULL_PORT=9000 BLACKBULL_CERT=/etc/ssl/c.pem BLACKBULL_KEY=/etc/ssl/k.pem \
+  python app.py
+```
+
+`BLACKBULL_*` is the **deployment** namespace (the handful of
+settings you change per environment); server-tuning knobs
+(`workers`, `max_connections`, queue depths, timeouts) keep their
+`BB_*` variables — they are not duplicated under `BLACKBULL_*`. The
+provenance of each non-default deploy setting is logged once at
+startup on the `blackbull.config` logger, e.g.
+`config: port=9000 (from $BLACKBULL_PORT)`.
+
+There is no `host` field / `BLACKBULL_HOST`: BlackBull's socket
+layer binds dual-stack on all interfaces, so a per-interface `host`
+would silently do nothing.  Use `unix_path` or `inherited_fd` for
+non-TCP binds.
+
+#### `.env` files
+
+Install the optional extra to let `app.run()` (and the `blackbull`
+CLI) read `BLACKBULL_*` values from a `.env` file in the working
+directory:
+
+```bash
+pip install 'blackbull[dotenv]'
+```
+
+```bash
+# .env
+BLACKBULL_PORT=8443
+BLACKBULL_CERT=/etc/ssl/cert.pem
+BLACKBULL_KEY=/etc/ssl/key.pem
+```
+
+The real process environment always wins over `.env` (so a
+`docker run -e BLACKBULL_PORT=9000` overrides the file). Without the
+extra, `.env` files are ignored and only the real environment is
+consulted — `BLACKBULL_*` resolution still works.
 
 ## Serving static files with `blackbull serve`
 

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -24,6 +24,36 @@ returns one chunk with `more_body=True` until the final chunk
 arrives with `more_body=False`.  `read_body` is a convenience
 wrapper that buffers all chunks before returning.
 
+### `read_json` and `read_text`
+
+For the two most common body shapes, `read_json` and `read_text`
+wrap `read_body` so the handler skips the parse/decode boilerplate:
+
+```python
+from http import HTTPStatus
+from blackbull import read_json, read_text, JSONResponse
+
+@app.route(path='/api/things', methods=[HTTPMethod.POST])
+async def create_thing(scope, receive, send):
+    data = await read_json(receive)        # dict | list | … | None
+    if data is None:
+        await send(JSONResponse({'error': 'invalid JSON'},
+                                status=HTTPStatus.BAD_REQUEST))
+        return
+    await send(JSONResponse({'created': data}))
+
+@app.route(path='/api/note', methods=[HTTPMethod.POST])
+async def note(scope, receive, send):
+    text = await read_text(receive)        # str (errors='replace')
+    await send(Response(text))
+```
+
+`read_json` returns `None` when the body is empty, not valid JSON, or
+not decodable — treat `None` as a client error.  `read_text` never
+raises on malformed bytes (undecodable bytes become U+FFFD); pass
+`encoding=` for non-UTF-8 payloads.  Both consume the stream, so call
+at most once per request, exactly like `read_body`.
+
 ### Recommended JSON-body middleware
 
 ```python
@@ -200,6 +230,22 @@ await send(JSONResponse({'id': 1, 'title': 'Buy milk'}, status=HTTPStatus.CREATE
 ```
 
 `Content-Type` is set to `application/json` automatically.
+
+### `RedirectResponse`
+
+```python
+from blackbull import RedirectResponse
+
+await send(RedirectResponse('/new-url'))                                    # 302 Found
+await send(RedirectResponse('/permanent', status=HTTPStatus.MOVED_PERMANENTLY))  # 301
+return RedirectResponse('/login', status=HTTPStatus.SEE_OTHER)             # 303
+```
+
+Sets the `Location` header from the URL and an empty body. The default
+status is `302 Found` — the safer general-purpose default, since it does
+not ask the client to preserve the original request method. The URL must be
+ASCII (RFC 9110 §10.2.2 — `Location` is a URI-reference); percent-encode
+non-ASCII URLs before passing them in. Extra `headers=` are merged in.
 
 ### Custom response headers
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -39,6 +39,7 @@ first-hit-then-summary rate-limit model.
 | `BB_TCP_USER_TIMEOUT_MS` | `0` (off, kernel default) | `TCP_USER_TIMEOUT` socket option (Linux).  Per-connection upper bound on how long an unacknowledged sent segment can linger before the kernel kills the connection.  Useful to evict dead peers behind NATs without waiting for keepalives.  See "Performance recommendations" below for production tuning. |
 | `BB_HEADER_MAX_LINE` | `8192` | Maximum bytes in a single HTTP/1.1 request-line or header line.  Matches Apache `LimitRequestLine` / nginx `large_client_header_buffers`.  Exceeded → `431 Request Header Fields Too Large`. |
 | `BB_HEADER_MAX_TOTAL` | `65536` | Maximum total bytes in the entire HTTP/1.1 header block.  Exceeded → `431`. |
+| `BB_BODY_CHUNK_SIZE` | `65536` | Slice size (bytes) for streaming an HTTP/1.1 `Content-Length` request body to the ASGI app.  The body is delivered as successive `http.request` events (`more_body: True` until exhausted) instead of one giant `readexactly(content_length)` allocation — capping per-connection buffering at O(chunk × connections).  64 KiB matches asyncio's default `StreamReader` buffer.  Must be `> 0` (invalid values fall back to the default). |
 | `BB_STREAM_QUEUE_DEPTH` | `64` | `asyncio.Queue` depth for HTTP/2 per-stream request-body events.  Caps memory growth when an ASGI handler is slower than the client uploading data. |
 | `BB_WS_QUEUE_DEPTH` | `256` | `asyncio.Queue` depth for inbound WebSocket events per connection. |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.44.1"
+version = "0.45.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,8 @@ testing = [
     "httpx[http2]",
     "websockets",
     "hypothesis",
+    # Exercises the `.env` resolution path in app.run() (blackbull[dotenv]).
+    "python-dotenv",
     # Validates the generated OpenAPI 3.1 documents against the upstream
     # schema in tests/unit/test_openapi.py — proves the spec we emit is
     # consumable by the wider OpenAPI ecosystem.
@@ -116,6 +118,14 @@ speed = [
 
 reload = [
     "watchfiles",
+]
+
+# `.env` file resolution for app.run() / the blackbull CLI.  Without this extra,
+# app.run() still resolves BLACKBULL_* from the real process environment; the
+# extra only adds support for loading a `.env` file from the working directory.
+# Install with `pip install 'blackbull[dotenv]'`.
+dotenv = [
+    "python-dotenv",
 ]
 
 # Deliberate-misbehaviour toolkit (blackbull.fault_injection).  The

--- a/tests/architecture/test_event_aggregator.py
+++ b/tests/architecture/test_event_aggregator.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 from blackbull.event import Event, EventDispatcher
 from blackbull.event_aggregator import EventAggregator
 
@@ -138,3 +138,37 @@ def test_has_any_request_listeners_ignores_non_request_events(event) -> None:
     d = EventDispatcher()
     d.on(event, AsyncMock())
     assert EventAggregator(d).has_any_request_listeners() is False
+
+
+# ---------------------------------------------------------------------------
+# Caching — the per-request guard must not recompute the 6-event scan every call
+# ---------------------------------------------------------------------------
+
+def test_has_any_request_listeners_invalidates_when_listener_added_late() -> None:
+    """A listener registered AFTER the first (cached) call must still flip the
+    result — the cache is keyed on the dispatcher's listener generation."""
+    d = EventDispatcher()
+    agg = EventAggregator(d)
+    assert agg.has_any_request_listeners() is False   # caches False
+    d.on('before_handler', AsyncMock())               # bumps generation
+    assert agg.has_any_request_listeners() is True     # recomputed, not stale
+
+
+def test_has_any_request_listeners_is_cached_between_calls() -> None:
+    """Repeat calls with no registration change must not re-scan the dispatcher."""
+    d = EventDispatcher()
+    agg = EventAggregator(d)
+    agg.has_any_request_listeners()                   # prime the cache
+    d.has_listeners = Mock(side_effect=AssertionError(
+        'has_listeners must not be called again while the generation is unchanged'))
+    assert agg.has_any_request_listeners() is False   # served from cache, no scan
+
+
+def test_dispatcher_generation_bumps_on_registration() -> None:
+    d = EventDispatcher()
+    g0 = d.generation
+    d.on('before_handler', AsyncMock())
+    g1 = d.generation
+    d.intercept('error', AsyncMock())
+    g2 = d.generation
+    assert g0 != g1 != g2 and len({g0, g1, g2}) == 3

--- a/tests/conformance/http1/test_http1_dispatch.py
+++ b/tests/conformance/http1/test_http1_dispatch.py
@@ -640,6 +640,89 @@ class TestHTTP1Recipient:
         second = await r()
         assert second == {'type': 'http.disconnect'}
 
+    # -- P4: Content-Length body streaming (chunk_size slices) --------------
+
+    @pytest.mark.asyncio
+    async def test_content_length_streams_in_chunks(self):
+        """A body larger than chunk_size arrives as several http.request events."""
+        from blackbull.server.recipient import HTTP1Recipient
+        scope = {'headers': [(b'content-length', b'10')]}
+        reader = self._make_reader(b'0123456789')
+        r = HTTP1Recipient(reader, scope, chunk_size=4)
+        events = []
+        while True:
+            e = await r()
+            events.append(e)
+            if not e.get('more_body', False):
+                break
+        assert [e['body'] for e in events] == [b'0123', b'4567', b'89']
+        assert [e['more_body'] for e in events] == [True, True, False]
+        assert b''.join(e['body'] for e in events) == b'0123456789'
+
+    @pytest.mark.asyncio
+    async def test_single_chunk_more_body_false(self):
+        from blackbull.server.recipient import HTTP1Recipient
+        scope = {'headers': [(b'content-length', b'5')]}
+        reader = self._make_reader(b'hello')
+        r = HTTP1Recipient(reader, scope, chunk_size=65536)
+        event = await r()
+        assert event == {'type': 'http.request', 'body': b'hello', 'more_body': False}
+
+    @pytest.mark.asyncio
+    async def test_exact_multiple_of_chunk_size(self):
+        """No spurious empty trailing event when the body divides evenly."""
+        from blackbull.server.recipient import HTTP1Recipient
+        scope = {'headers': [(b'content-length', b'8')]}
+        reader = self._make_reader(b'abcdefgh')
+        r = HTTP1Recipient(reader, scope, chunk_size=4)
+        events = []
+        while True:
+            e = await r()
+            events.append(e)
+            if not e.get('more_body', False):
+                break
+        assert [e['body'] for e in events] == [b'abcd', b'efgh']
+        assert events[-1]['more_body'] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_content_length_one_event(self):
+        from blackbull.server.recipient import HTTP1Recipient
+        scope = {'headers': [(b'content-length', b'0')]}
+        reader = self._make_reader(b'')
+        r = HTTP1Recipient(reader, scope, chunk_size=4)
+        event = await r()
+        assert event == {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    @pytest.mark.asyncio
+    async def test_no_body_headers_one_empty_event(self):
+        from blackbull.server.recipient import HTTP1Recipient
+        scope = {'headers': []}
+        reader = self._make_reader(b'')
+        r = HTTP1Recipient(reader, scope, chunk_size=4)
+        event = await r()
+        assert event == {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    @pytest.mark.asyncio
+    async def test_body_chunk_size_from_env(self, monkeypatch):
+        """When chunk_size is not injected, BB_BODY_CHUNK_SIZE drives slicing."""
+        import blackbull.env as env
+        from blackbull.server.recipient import HTTP1Recipient
+        monkeypatch.setenv('BB_BODY_CHUNK_SIZE', '3')
+        env.get_settings.cache_clear()
+        try:
+            scope = {'headers': [(b'content-length', b'7')]}
+            reader = self._make_reader(b'abcdefg')
+            r = HTTP1Recipient(reader, scope)        # no chunk_size → env
+            sizes = []
+            while True:
+                e = await r()
+                sizes.append(len(e['body']))
+                if not e.get('more_body', False):
+                    break
+            assert sizes == [3, 3, 1]
+        finally:
+            env.get_settings.cache_clear()
+
 
 class TestHTTP2Recipient:
     @pytest.mark.asyncio

--- a/tests/unit/test_cap_log.py
+++ b/tests/unit/test_cap_log.py
@@ -16,7 +16,9 @@ import logging
 
 import pytest
 
-from blackbull.server.cap_log import log_cap_hit, CapHitCounter
+from blackbull.server.cap_log import (
+    log_cap_hit, CapHitCounter, _LazyCapHitCounter,
+)
 
 
 # ----------------------------------------------------------------------
@@ -359,3 +361,86 @@ async def test_flush_cancels_pending_interval_timer(cap_log_caplog):
     await _asyncio.sleep(0.2)
     records = [r for r in cap_log_caplog.records if r.name == 'blackbull.caps']
     assert records == []
+
+
+# ----------------------------------------------------------------------
+# _LazyCapHitCounter — defer construction (and os.urandom id) to first hit
+# ----------------------------------------------------------------------
+
+def test_lazy_holder_starts_unmaterialised():
+    holder = _LazyCapHitCounter()
+    assert holder.counter is None
+
+
+def test_lazy_holder_no_urandom_until_first_hit(monkeypatch, cap_log_caplog):
+    """A healthy (no-cap) connection draws no os.urandom connection id."""
+    import blackbull.server.cap_log as cap_log
+    calls = 0
+    real = cap_log._gen_connection_id
+
+    def counted():
+        nonlocal calls
+        calls += 1
+        return real()
+
+    monkeypatch.setattr(cap_log, '_gen_connection_id', counted)
+
+    holder = _LazyCapHitCounter()
+    with holder.bind():
+        pass                      # no log_cap_hit → no cap fired
+    holder.flush(peer=('127.0.0.1', 1234))
+
+    assert calls == 0
+    assert holder.counter is None
+
+
+def test_lazy_holder_materialises_on_first_hit(cap_log_caplog):
+    holder = _LazyCapHitCounter()
+    with holder.bind():
+        log_cap_hit('ws_max_frame_payload', 1, 2)
+    assert holder.counter is not None
+    records = [r for r in cap_log_caplog.records if r.name == 'blackbull.caps']
+    assert len(records) == 1
+    # The materialised counter minted a connection id for the emitted record.
+    assert records[0].connection_id == holder.counter.connection_id
+
+
+def test_lazy_holder_flush_is_noop_when_unmaterialised(cap_log_caplog):
+    holder = _LazyCapHitCounter()
+    holder.flush(peer=('127.0.0.1', 1234))   # must not raise
+    records = [r for r in cap_log_caplog.records if r.name == 'blackbull.caps']
+    assert records == []
+
+
+def test_lazy_holder_rate_limits_and_summarises_like_eager(cap_log_caplog):
+    """First hit emits; later hits suppress; flush summarises — same as eager."""
+    holder = _LazyCapHitCounter(flush_threshold=0, flush_interval=0)
+    with holder.bind():
+        for _ in range(4):       # 1 first-hit + 3 suppressed
+            log_cap_hit('ws_max_frame_payload', 1, 2)
+    holder.flush(peer=('127.0.0.1', 1234))
+
+    records = [r for r in cap_log_caplog.records if r.name == 'blackbull.caps']
+    first = [r for r in records if getattr(r, 'suppressed', None) is None]
+    summaries = [r for r in records if getattr(r, 'suppressed', None) is not None]
+    assert len(first) == 1
+    assert len(summaries) == 1
+    assert summaries[0].suppressed == 3
+
+
+def test_lazy_holder_shared_across_tasks(cap_log_caplog):
+    """A child task hitting the cap materialises the holder the parent flushes."""
+    import asyncio as _asyncio
+
+    async def main():
+        holder = _LazyCapHitCounter()
+        with holder.bind():
+            async with _asyncio.TaskGroup() as tg:
+                async def child():
+                    log_cap_hit('ws_max_frame_payload', 1, 2)
+                tg.create_task(child())
+            # Parent sees the counter the child materialised.
+            assert holder.counter is not None
+        holder.flush(peer=('127.0.0.1', 1234))
+
+    _asyncio.run(main())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -14,6 +14,7 @@ import pytest
 
 import blackbull.app as app_module
 from blackbull import AppConfig, BlackBull
+from blackbull.config import resolve_run_config
 
 
 @pytest.fixture()
@@ -105,3 +106,108 @@ def test_config_unix_path_and_queue_depths_flow_through(captured_serve):
     assert captured_serve['stream_queue_depth'] == 128
     assert captured_serve['ws_queue_depth'] == 512
     assert captured_serve['max_connections'] == 1024
+
+
+# ---------------------------------------------------------------------------
+# BLACKBULL_* environment variable resolution
+# ---------------------------------------------------------------------------
+
+def test_env_port_resolved_and_coerced_to_int(captured_serve, monkeypatch):
+    monkeypatch.setenv('BLACKBULL_PORT', '9001')
+    BlackBull().run()
+    assert captured_serve['port'] == 9001          # str → int
+
+
+def test_env_overrides_appconfig(captured_serve, monkeypatch):
+    monkeypatch.setenv('BLACKBULL_PORT', '9001')
+    BlackBull(config=AppConfig(port=8443)).run()
+    assert captured_serve['port'] == 9001          # env beats config
+
+
+def test_explicit_arg_overrides_env(captured_serve, monkeypatch):
+    monkeypatch.setenv('BLACKBULL_PORT', '9001')
+    BlackBull().run(port=7000)
+    assert captured_serve['port'] == 7000          # explicit beats env
+
+
+def test_env_cert_and_key(captured_serve, monkeypatch):
+    monkeypatch.setenv('BLACKBULL_CERT', '/etc/ssl/cert.pem')
+    monkeypatch.setenv('BLACKBULL_KEY', '/etc/ssl/key.pem')
+    BlackBull().run()
+    assert captured_serve['certfile'] == '/etc/ssl/cert.pem'
+    assert captured_serve['keyfile'] == '/etc/ssl/key.pem'
+
+
+@pytest.mark.parametrize('raw,expected', [
+    ('1', True), ('true', True), ('TRUE', True), ('yes', True), ('on', True),
+    ('0', False), ('false', False), ('no', False), ('', False),
+])
+def test_env_reload_bool_parsing(captured_serve, monkeypatch, raw, expected):
+    monkeypatch.setenv('BLACKBULL_RELOAD', raw)
+    BlackBull().run()
+    assert captured_serve['reload'] is expected
+
+
+def test_tuning_knob_not_resolved_from_blackbull_namespace(captured_serve, monkeypatch):
+    # workers is a BB_* tuning knob, not a BLACKBULL_* deploy setting: a
+    # BLACKBULL_WORKERS var must NOT be picked up (no double-sourcing).
+    monkeypatch.setenv('BLACKBULL_WORKERS', '8')
+    BlackBull().run()
+    assert captured_serve['workers'] is None        # serve() applies BB_WORKERS
+
+
+# ---------------------------------------------------------------------------
+# .env file resolution (lowest of the env tiers)
+# ---------------------------------------------------------------------------
+
+def test_dotenv_file_resolved(captured_serve, monkeypatch, tmp_path):
+    monkeypatch.delenv('BLACKBULL_PORT', raising=False)
+    (tmp_path / '.env').write_text('BLACKBULL_PORT=9100\n')
+    monkeypatch.chdir(tmp_path)
+    BlackBull().run()
+    assert captured_serve['port'] == 9100
+
+
+def test_real_env_beats_dotenv(captured_serve, monkeypatch, tmp_path):
+    (tmp_path / '.env').write_text('BLACKBULL_PORT=9100\n')
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv('BLACKBULL_PORT', '9200')
+    BlackBull().run()
+    assert captured_serve['port'] == 9200           # process env wins over .env
+
+
+# ---------------------------------------------------------------------------
+# resolve_run_config — source attribution
+# ---------------------------------------------------------------------------
+
+def test_sources_label_argument_env_config_default(monkeypatch):
+    monkeypatch.setenv('BLACKBULL_CERT', '/c.pem')
+    monkeypatch.delenv('BLACKBULL_PORT', raising=False)
+    resolved, sources = resolve_run_config(
+        {'keyfile': '/explicit.key'},
+        AppConfig(port=8443),
+    )
+    assert sources['keyfile'] == 'argument'
+    assert sources['certfile'] == '$BLACKBULL_CERT'
+    assert sources['port'] == 'AppConfig'
+    assert sources['reload'] == 'default'
+    assert resolved['port'] == 8443
+    assert resolved['certfile'] == '/c.pem'
+
+
+def test_startup_logging_reports_non_default_sources(monkeypatch, caplog):
+    import logging
+    monkeypatch.setenv('BLACKBULL_PORT', '9001')
+
+    def _fake_serve(app, **kwargs):
+        pass
+
+    monkeypatch.setattr(app_module, 'serve', _fake_serve)
+    with caplog.at_level(logging.INFO, logger='blackbull.config'):
+        BlackBull().run(certfile='/explicit.pem')
+
+    msgs = [r.getMessage() for r in caplog.records if r.name == 'blackbull.config']
+    # env-sourced port is reported; explicit certfile and default keyfile are not.
+    assert any('port=9001' in m and 'BLACKBULL_PORT' in m for m in msgs)
+    assert not any('certfile' in m for m in msgs)
+    assert not any('keyfile' in m for m in msgs)

--- a/tests/unit/test_request.py
+++ b/tests/unit/test_request.py
@@ -1,7 +1,90 @@
 import pytest
 
-from blackbull.request import read_body, parse_cookies
+from blackbull.request import read_body, read_json, read_text, parse_cookies
 from blackbull.headers import Headers
+
+
+def _receive_from(*chunks):
+    """Build an ASGI receive() that yields the given (body, more_body) events.
+
+    A single bytes argument is wrapped as one final chunk.
+    """
+    if len(chunks) == 1 and isinstance(chunks[0], (bytes, bytearray)):
+        events = [{'body': bytes(chunks[0]), 'more_body': False}]
+    else:
+        events = list(chunks)
+    it = iter(events)
+
+    async def receive():
+        return next(it)
+
+    return receive
+
+
+# ---------------------------------------------------------------------------
+# read_json
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_json_object():
+    assert await read_json(_receive_from(b'{"a": 1, "b": [2, 3]}')) == {'a': 1, 'b': [2, 3]}
+
+
+@pytest.mark.asyncio
+async def test_read_json_array():
+    assert await read_json(_receive_from(b'[1, 2, 3]')) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_read_json_empty_body_returns_none():
+    assert await read_json(_receive_from(b'')) is None
+
+
+@pytest.mark.asyncio
+async def test_read_json_invalid_returns_none():
+    assert await read_json(_receive_from(b'{not json')) is None
+
+
+@pytest.mark.asyncio
+async def test_read_json_invalid_utf8_returns_none():
+    # Lone continuation byte — not decodable as UTF-8, must not raise.
+    assert await read_json(_receive_from(b'\xff\xfe')) is None
+
+
+@pytest.mark.asyncio
+async def test_read_json_reassembles_multiple_chunks():
+    received = await read_json(_receive_from(
+        {'body': b'{"x":', 'more_body': True},
+        {'body': b' 42}', 'more_body': False},
+    ))
+    assert received == {'x': 42}
+
+
+# ---------------------------------------------------------------------------
+# read_text
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_read_text_decodes_utf8():
+    assert await read_text(_receive_from('héllo'.encode())) == 'héllo'
+
+
+@pytest.mark.asyncio
+async def test_read_text_empty_body():
+    assert await read_text(_receive_from(b'')) == ''
+
+
+@pytest.mark.asyncio
+async def test_read_text_invalid_utf8_uses_replacement():
+    # errors='replace' → never raises; undecodable bytes become U+FFFD.
+    result = await read_text(_receive_from(b'a\xffb'))
+    assert result == 'a�b'
+
+
+@pytest.mark.asyncio
+async def test_read_text_honours_encoding_argument():
+    assert await read_text(_receive_from('café'.encode('latin-1')),
+                           encoding='latin-1') == 'café'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -5,7 +5,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from blackbull import Response, JSONResponse, WebSocketResponse
+from blackbull import Response, JSONResponse, RedirectResponse, WebSocketResponse
 from blackbull.response import cookie_header
 from blackbull.app import _wrap_send
 
@@ -97,6 +97,57 @@ def test_jsonresponse_extra_headers():
     extra = [(b'set-cookie', b'sid=abc')]
     r = JSONResponse({}, headers=extra)
     assert (b'set-cookie', b'sid=abc') in r.headers
+
+
+# ---------------------------------------------------------------------------
+# RedirectResponse
+# ---------------------------------------------------------------------------
+
+def test_redirectresponse_default_status_is_302():
+    assert RedirectResponse('/new').status == HTTPStatus.FOUND
+
+
+def test_redirectresponse_custom_status():
+    r = RedirectResponse('/perm', status=HTTPStatus.MOVED_PERMANENTLY)
+    assert r.status == HTTPStatus.MOVED_PERMANENTLY
+
+
+def test_redirectresponse_sets_location_header():
+    assert (b'location', b'/static/favicon.svg') in \
+        RedirectResponse('/static/favicon.svg').headers
+
+
+def test_redirectresponse_empty_body():
+    assert RedirectResponse('/new').body == b''
+
+
+def test_redirectresponse_merges_extra_headers():
+    r = RedirectResponse('/new', headers=[(b'set-cookie', b'sid=abc')])
+    assert (b'location', b'/new') in r.headers
+    assert (b'set-cookie', b'sid=abc') in r.headers
+
+
+def test_redirectresponse_rejects_non_ascii_url():
+    # RFC 9110 §10.2.2 — Location is a URI-reference (ASCII); callers
+    # percent-encode non-ASCII URLs before passing them in.
+    with pytest.raises(UnicodeEncodeError):
+        RedirectResponse('/café')
+
+
+@pytest.mark.asyncio
+async def test_wrap_send_unpacks_redirectresponse():
+    calls = []
+
+    async def raw(event):
+        calls.append(event)
+
+    r = RedirectResponse('/login', status=HTTPStatus.SEE_OTHER)
+    await _wrap_send(raw)(r)
+    assert len(calls) == 2
+    start, body = calls
+    assert start['status'] == int(HTTPStatus.SEE_OTHER)
+    assert (b'location', b'/login') in start['headers']
+    assert body == {'type': 'http.response.body', 'body': b'', 'more_body': False}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sprint 56 — **DX consolidation**. Additive DX + perf; no new protocol (gRPC stays queued for v0.46.0).

## Added
- **`BLACKBULL_*` env-var + `.env` resolution for `app.run()`** — `BLACKBULL_PORT`/`CERT`/`KEY`/`UNIX_PATH`/`RELOAD`, precedence arg > env > `.env` > `AppConfig` > default (`config.resolve_run_config`); `.env` behind a new `blackbull[dotenv]` extra; one INFO line per non-default deploy setting naming its source.
- **`RedirectResponse`** — `Response` subclass setting `Location` + 3xx (default 302).
- **`read_json` / `read_text`** — request-body helpers over `read_body` (`read_json` → parsed value or `None`; `read_text` → `errors='replace'`).
- **`BB_BODY_CHUNK_SIZE`** — HTTP/1.1 `Content-Length` bodies stream as `http.request` chunks (default 64 KiB) instead of one `readexactly()`; exact-bytes contract preserved.

## Changed (behaviour-preserving perf)
- **Cached request-listener check** — `RequestActor.run()`'s `has_any_request_listeners()` guard cached against a new `EventDispatcher.generation` counter instead of re-scanning six events per request. (Found via an EC2 py-spy A/B of Sprint 55.)
- **Lazy per-connection cap counter** (`_LazyCapHitCounter`) — defers the `os.urandom` connection id until a cap fires; keep-alive path is a no-op.

## Release housekeeping
- Version `0.44.1` → `0.45.0`; CHANGELOG `[Unreleased]` → `[0.45.0]`.
- `SECURITY.md` supported-versions table → `0.45.x` + `0.44.x` (was 2 releases stale).
- Plus a bench-tooling chore (self-tee `driver.log` + remote-state watchdog in `httparena_compare.sh`).

Full suite green with beartype on (`--beartype-packages=blackbull`); pre-commit ran it on each commit.

> ⚠️ **Do not tag/publish yet** — opened for review; the maintainer triggers the `v0.45.0` tag → PyPI publish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)