### PR TITLE
feat(events+dx): scope_completed terminal event, blocking observers, register_converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,28 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+- **`scope_completed` event** — a guaranteed, cross-protocol terminal event
+  emitted once per ASGI scope (HTTP request, WebSocket connection, or gRPC
+  call), on success or error, under any server. It is the application-level
+  completion event (distinct from the server-level `request_completed`
+  telemetry), and the home of the resource-cleanup hook.
+- **Blocking observers** — `@app.on(name, blocking=True)` adds a third event
+  delivery mode: awaited in registration order (so cleanup completes within the
+  event's lifetime) yet isolated (a failing handler cannot break the emitter or
+  siblings). Pair with `scope_completed` to close a per-request DB session or
+  delete a temp file.
+- **`app.register_converter(type, fn)`** — extend simplified-handler return
+  coercion so a handler can `return my_orm_object`; the registry is empty by
+  default so the common return paths pay nothing. Direct and decorator forms.
+
+### Changed
+- **`Response(headers=...)` accepts a `dict`** (matching the
+  FastAPI/Starlette/httpx convention) as well as a list of `(name, value)`
+  pairs; names/values may be `str` or `bytes`. Malformed shapes now raise
+  `TypeError` at construction instead of silently corrupting the response
+  (the old loop iterated a dict's *keys*).
+
 ## [0.46.0] — 2026-06-30
 
 Sprint 57 — **gRPC** (the next protocol after MQTT) plus three supporting

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -57,7 +57,7 @@ def _wrap_send(raw_send):
     ``middleware.utils._normalize_send``.  Response is a pure serialiser and
     ignores scope/receive, so ``None`` is passed for both.
     """
-    from .response import Response as _Response
+    from .response import Response as _Response, _emit_response
 
     async def _send(event, status=HTTPStatus.OK, headers=[]):
         if isinstance(event, _Response):
@@ -65,16 +65,8 @@ def _wrap_send(raw_send):
         elif isinstance(event, (bytes, bytearray, memoryview)):
             # ``send(body, status, headers)`` convenience form — used by
             # full-form handlers and custom error handlers.
-            await raw_send({
-                'type': 'http.response.start',
-                'status': int(status),
-                'headers': list(headers),
-            })
-            await raw_send({
-                'type': 'http.response.body',
-                'body': bytes(event) if not isinstance(event, bytes) else event,
-                'more_body': False,
-            })
+            body = bytes(event) if not isinstance(event, bytes) else event
+            await _emit_response(raw_send, body, status, headers)
         else:
             # ASGI dict (the common path) or any other shape — passed through
             # so the underlying sender's type checking decides what to do.
@@ -176,8 +168,8 @@ async def _default_error_handler(scope, receive, send):  # noqa: ARG001
         headers.append((b'content-type', b'text/plain; charset=utf-8'))
 
     headers.append((b'content-length', str(len(body)).encode()))
-    await send({'type': 'http.response.start', 'status': status, 'headers': headers})
-    await send({'type': 'http.response.body', 'body': body, 'more_body': False})
+    from .response import _emit_response
+    await _emit_response(send, body, status, headers)
 
 
 class RouteGroup:
@@ -338,15 +330,28 @@ class BlackBull:
         self._dispatcher.intercept('app_shutdown', _adapter)
         return fn
 
-    def on(self, event_name: str) -> Callable[[EventHandler], EventHandler]:
-        """Decorate a handler to observe ``event_name`` (fire-and-forget).
+    def on(self, event_name: str, *, blocking: bool = False
+           ) -> Callable[[EventHandler], EventHandler]:
+        """Decorate a handler to observe ``event_name``.
 
-        The handler is scheduled as an independent ``asyncio.Task`` each time
-        the event fires.  Exceptions raised by the handler are caught and
-        logged; they do not propagate to the emitter or affect other handlers.
+        With ``blocking=False`` (the default) the handler is scheduled as an
+        independent ``asyncio.Task`` each time the event fires — fire-and-forget,
+        never delaying the emitter.  Use it for telemetry that must not add
+        latency to the hot path.
+
+        With ``blocking=True`` the handler is *awaited* in registration order
+        before the emit completes, so a side effect is guaranteed to finish
+        within the event's lifetime.  Use it for resource cleanup keyed to an
+        event's completion — most notably ``scope_completed`` (close a
+        per-request DB session, delete a temp file).
+
+        Either way the handler's exceptions are isolated: they are caught and
+        logged and never propagate to the emitter or affect other handlers.
+        (For a hook that *may* affect the request, use :meth:`intercept`.)
 
         Args:
-            event_name: Name of the event to observe (e.g. ``'app_startup'``).
+            event_name: Name of the event to observe (e.g. ``'scope_completed'``).
+            blocking: Await the handler before emit returns (default ``False``).
 
         Returns:
             A decorator that registers the wrapped coroutine and returns it
@@ -354,13 +359,19 @@ class BlackBull:
 
         Example:
             ```python
-            @app.on('app_startup')
-            async def handler(event: Event):
-                print(event.detail)
+            @app.on('request_completed')            # detached telemetry
+            async def log_it(event: Event):
+                metrics.record(event.detail)
+
+            @app.on('scope_completed', blocking=True)   # awaited cleanup
+            async def close_session(event: Event):
+                session = event.detail['scope'].get('state', {}).get('db')
+                if session is not None:
+                    await session.close()
             ```
         """
         def decorator(handler):
-            self._dispatcher.on(event_name, handler)
+            self._dispatcher.on(event_name, handler, blocking=blocking)
             return handler
         return decorator
 
@@ -554,7 +565,38 @@ class BlackBull:
         if raw_headers is not None and not isinstance(raw_headers, Headers):
             scope['headers'] = Headers(raw_headers)
 
-        await self._chain(scope, receive, send)
+        # ``scope_completed`` — the guaranteed, cross-protocol terminal event.
+        # Emitted here, at the one point every scope (HTTP request, WebSocket
+        # connection, gRPC call) passes through exactly once, under *any* server
+        # (BlackBull's own actors, uvicorn, TestClient).  It is the application-
+        # level completion event (fires wherever the app runs), as distinct from
+        # the server-level telemetry events (``request_completed`` et al., which
+        # need wire data and fire only under BlackBull's server).  Register
+        # cleanup with ``@app.on('scope_completed', blocking=True)``.  Guarded so
+        # a request with no such listener pays only one dict lookup.
+        if not self._dispatcher.has_listeners('scope_completed'):
+            await self._chain(scope, receive, send)
+            return
+        exc: BaseException | None = None
+        try:
+            await self._chain(scope, receive, send)
+        except BaseException as e:
+            exc = e
+            raise
+        finally:
+            # ``exception`` reflects whether the scope encountered an error:
+            # either one that propagated out of the chain (exc), or a handler
+            # error that ``_dispatch`` already turned into a 500 and recorded in
+            # ``scope['state']['error_exception']``.  ``None`` for a clean
+            # request (including a 404, which is not an exception).
+            err = exc or scope.get('state', {}).get('error_exception')
+            await self._dispatcher.emit(Event('scope_completed', {
+                'scope':     scope,
+                'type':      scope.get('type', '-'),
+                'client_ip': str((scope.get('client') or ['-'])[0]),
+                'path':      scope.get('path', '-'),
+                'exception': err,
+            }))
 
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
@@ -573,6 +615,41 @@ class BlackBull:
     def group(self, middlewares=[]) -> 'RouteGroup':
         """Return a RouteGroup that prepends *middlewares* to every route."""
         return RouteGroup(self, middlewares)
+
+    def register_converter(self, type_: type, converter: Callable | None = None):
+        """Teach simplified handlers to return values of a custom *type_*.
+
+        A simplified handler may already return ``str``, ``bytes``, ``dict``,
+        ``list``, a dataclass, a ``Response``, or ``None``.  Register a
+        converter to extend that set — e.g. so a handler can
+        ``return my_orm_object`` and have it serialised automatically.  The
+        converter receives the returned value and must return a *natively
+        supported* sendable (a ``Response``, ``str``/``bytes``, ``None``, or a
+        JSON-able ``dict``/``list``/dataclass).
+
+        The registry is empty by default, so registering nothing costs nothing:
+        the coercion fast path never consults it for the built-in shapes.
+
+        Direct form::
+
+            app.register_converter(MyOrmObject, lambda o: o.to_dict())
+
+        Decorator form (omit *converter*)::
+
+            @app.register_converter(MyOrmObject)
+            def _(o):
+                return o.to_dict()
+
+        Converters registered after a route are still honoured — the registry
+        is shared with every adapted handler by reference.
+        """
+        if converter is None:
+            def _decorator(fn: Callable) -> Callable:
+                self._router.register_converter(type_, fn)
+                return fn
+            return _decorator
+        self._router.register_converter(type_, converter)
+        return converter
 
     def use(self, mw) -> None:
         """Register a global middleware applied to every non-lifespan request."""

--- a/blackbull/event.py
+++ b/blackbull/event.py
@@ -1,13 +1,24 @@
 """Event-driven dispatcher.
 
 Implements the minimal Pub/Sub dispatcher used by ``BlackBull.on`` /
-``BlackBull.intercept``.  Two delivery modes are supported:
+``BlackBull.intercept``.  Three delivery modes are supported:
 
 - **Interception** (``intercept``): handlers are awaited in registration order;
   exceptions propagate to the emitter and abort subsequent interceptors.
+- **Blocking observation** (``on(..., blocking=True)``): handlers are awaited in
+  registration order *before* ``emit`` returns, but their exceptions are caught
+  and logged — they never reach the emitter or abort siblings.  This is the
+  "observe but block" mode: use it when a side effect must *complete* within the
+  event's lifetime (resource cleanup on ``scope_completed``) yet must not be
+  able to break the thing that emitted it.
 - **Observation** (``on``): handlers are scheduled as independent
   ``asyncio.Task``s (fire-and-forget); exceptions are caught and logged and
   never reach the emitter or other observers.
+
+The two observation modes share isolation (a failing observer is contained);
+they differ only in whether ``emit`` waits for them.  Blocking is the right
+default for cleanup that must finish before the request context is gone;
+detached is right for telemetry that must not add latency to the hot path.
 """
 import asyncio
 import logging
@@ -52,6 +63,7 @@ class EventDispatcher:
 
     def __init__(self, shutdown_timeout: float = 5.0) -> None:
         self._observers: defaultdict[str, list[EventHandler]] = defaultdict(list)
+        self._blocking_observers: defaultdict[str, list[EventHandler]] = defaultdict(list)
         self._interceptors: defaultdict[str, list[EventHandler]] = defaultdict(list)
         self._pending_tasks: set[asyncio.Task] = set()
         self._shutdown_timeout = shutdown_timeout
@@ -62,9 +74,21 @@ class EventDispatcher:
         # per-request cost collapses to one int read + compare.
         self.generation: int = 0
 
-    def on(self, event_name: str, handler: EventHandler) -> None:
-        """Register an observation handler for ``event_name``."""
-        self._observers[event_name].append(handler)
+    def on(self, event_name: str, handler: EventHandler,
+           blocking: bool = False) -> None:
+        """Register an observation handler for ``event_name``.
+
+        With ``blocking=False`` (the default) the handler is scheduled as an
+        independent task when the event fires — it never delays the emitter.
+        With ``blocking=True`` the handler is awaited in registration order
+        before ``emit`` returns, so a side effect (e.g. resource cleanup) is
+        guaranteed to finish within the event's lifetime; its exceptions are
+        still isolated (logged, never propagated).
+        """
+        if blocking:
+            self._blocking_observers[event_name].append(handler)
+        else:
+            self._observers[event_name].append(handler)
         self.generation += 1
 
     def intercept(self, event_name: str, handler: EventHandler) -> None:
@@ -79,20 +103,29 @@ class EventDispatcher:
         when no one will receive the event.  ``defaultdict.get`` returns ``None``
         for missing keys without inserting an empty list.
         """
-        return bool(self._interceptors.get(event_name)) or bool(
-            self._observers.get(event_name))
+        return (bool(self._interceptors.get(event_name))
+                or bool(self._blocking_observers.get(event_name))
+                or bool(self._observers.get(event_name)))
 
     async def emit(self, event: Event) -> None:
         """Dispatch ``event`` to all registered handlers.
 
-        Interception handlers are awaited in registration order; their
-        exceptions propagate.  Observation handlers are scheduled as
-        independent tasks and their exceptions are isolated.
-        Tasks are tracked so they can be drained at shutdown via 
-        :meth:`aclose`.
+        Delivery order:
+
+        1. **Interceptors** — awaited in registration order; their exceptions
+           propagate (and abort the remaining interceptors).
+        2. **Blocking observers** — awaited in registration order; their
+           exceptions are caught and logged (isolated).  ``emit`` does not
+           return until they finish, so cleanup registered here is guaranteed
+           to complete within the event's lifetime.
+        3. **Detached observers** — scheduled as independent tasks (isolated),
+           tracked so they can be drained at shutdown via :meth:`aclose`.
         """
         for h in self._interceptors.get(event.name, []):
             await h(event)
+
+        for h in self._blocking_observers.get(event.name, []):
+            await self._safe_observe(h, event)
 
         for h in self._observers.get(event.name, []):
             task = asyncio.create_task(self._safe_observe(h, event))

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -19,6 +19,69 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _normalize_headers(headers) -> list[tuple[bytes, bytes]]:
+    """Coerce a user-supplied ``headers=`` argument to ASGI's wire shape.
+
+    Accepts either
+
+    * a :class:`~collections.abc.Mapping` (``dict``-like) — matching the
+      FastAPI / Starlette / httpx convention, iterated by ``.items()``; or
+    * an iterable of ``(name, value)`` pairs (BlackBull's original shape).
+
+    Names and values may be ``str`` (encoded ASCII per RFC 9110 §5.5, so
+    non-ASCII raises ``UnicodeEncodeError`` at construction rather than
+    letting obs-text bytes onto the wire) or ``bytes``.  Any other shape —
+    a bare string, an iterable of non-pairs, a non-bytes/str value — raises
+    ``TypeError`` here, at construction, instead of silently corrupting the
+    response (the old ``for k, v in headers`` loop iterated a ``dict``'s
+    *keys* and unpacked each key string into ``(k, v)``) or blowing up later
+    in the sender's ``b''.join``.
+    """
+    if not headers:
+        return []
+    items = headers.items() if isinstance(headers, Mapping) else headers
+    out: list[tuple[bytes, bytes]] = []
+    for pair in items:
+        if isinstance(pair, (str, bytes, bytearray)):
+            raise TypeError(
+                'Response headers must be a mapping or an iterable of '
+                f'(name, value) pairs; got a bare {type(pair).__name__} '
+                f'element {pair!r}')
+        try:
+            k, v = pair
+        except (TypeError, ValueError):
+            raise TypeError(
+                'each header must be a (name, value) pair; '
+                f'got {pair!r}') from None
+        if isinstance(k, str):
+            k = k.encode('ascii')
+        if isinstance(v, str):
+            v = v.encode('ascii')
+        if not isinstance(k, (bytes, bytearray)) or not isinstance(v, (bytes, bytearray)):
+            raise TypeError(
+                'header name and value must be str or bytes; got '
+                f'({type(k).__name__}, {type(v).__name__})')
+        out.append((bytes(k), bytes(v)))
+    return out
+
+
+async def _emit_response(send, body: bytes, status, headers) -> None:
+    """Send a complete non-streamed HTTP response as ASGI ``start`` + ``body``.
+
+    The single source of truth for the ``http.response.start`` /
+    ``http.response.body`` event pair used by every non-streaming response
+    path — :meth:`Response.__call__`, the app's ``send(body, status, headers)``
+    convenience form (``_wrap_send``), and the default error handler.  *status*
+    may be an ``int`` or an ``HTTPStatus`` (coerced to ``int`` for the wire);
+    *headers* is any iterable of ``(bytes, bytes)`` pairs (copied defensively).
+    """
+    await send({'type': 'http.response.start',
+                'status': int(status),
+                'headers': list(headers)})
+    await send({'type': 'http.response.body',
+                'body': body, 'more_body': False})
+
+
 class Response:
     """HTTP response object carrying body, status, and headers.
 
@@ -31,7 +94,7 @@ class Response:
     def __init__(self, content: Union[str, bytes],
                  status: HTTPStatus = HTTPStatus.OK,
                  content_type: str = 'text/html; charset=utf-8',
-                 headers: list | None = None):
+                 headers: Mapping | list | None = None):
         if isinstance(content, str):
             self.body = content.encode()
         elif isinstance(content, bytes):
@@ -39,19 +102,11 @@ class Response:
         else:
             raise TypeError(f'Response expects str or bytes, got {type(content)}')
         self.status = status
+        # A dict or a list of (name, value) pairs; str or bytes names/values.
+        # See _normalize_headers for the accepted shapes and the ASCII /
+        # RFC 9110 §5.5 coercion rules.
         self.headers = [(b'content-type', content_type.encode())]
-        if headers:
-            # ASGI requires headers as bytes/bytes tuples; coerce str on the
-            # way in so callers may pass either shape without crashing the
-            # sender's b''.join later.  ASCII per RFC 9110 §5.5 — non-ASCII
-            # input raises UnicodeEncodeError at construction rather than
-            # letting obs-text bytes onto the wire.
-            for k, v in headers:
-                if isinstance(k, str):
-                    k = k.encode('ascii')
-                if isinstance(v, str):
-                    v = v.encode('ascii')
-                self.headers.append((k, v))
+        self.headers.extend(_normalize_headers(headers))
 
     async def __call__(self, scope, receive, send) -> None:
         """Drive this response as an ASGI app: emit ``start`` then ``body``.
@@ -63,11 +118,7 @@ class Response:
         start/body serialisation here means there is a single source of truth
         for turning a Response into ASGI events.
         """
-        await send({'type': 'http.response.start',
-                    'status': int(self.status),
-                    'headers': list(self.headers)})
-        await send({'type': 'http.response.body',
-                    'body': self.body, 'more_body': False})
+        await _emit_response(send, self.body, self.status, self.headers)
 
 
 class JSONResponse(Response):
@@ -81,7 +132,7 @@ class JSONResponse(Response):
 
     def __init__(self, content,
                  status: HTTPStatus = HTTPStatus.OK,
-                 headers: list | None = None):
+                 headers: Mapping | list | None = None):
         super().__init__(json.dumps(content).encode(), status, 'application/json', headers)
 
 
@@ -104,10 +155,8 @@ class RedirectResponse(Response):
 
     def __init__(self, url: str,
                  status: HTTPStatus = HTTPStatus.FOUND,
-                 headers: list | None = None):
-        merged = [(b'location', url.encode('ascii'))]
-        if headers:
-            merged.extend(headers)
+                 headers: Mapping | list | None = None):
+        merged = [(b'location', url.encode('ascii')), *_normalize_headers(headers)]
         super().__init__(b'', status=status, headers=merged)
 
 
@@ -136,11 +185,11 @@ class StreamingResponse:
     def __init__(self, content: AsyncIterator,
                  *,
                  status: int = 200,
-                 headers: list | None = None,
+                 headers: Mapping | list | None = None,
                  media_type: str = 'text/plain'):
         self._content = content
         self._status = status
-        self._headers = list(headers or [])
+        self._headers = _normalize_headers(headers)
         self._media_type = media_type
 
     async def __call__(self, scope, receive, send) -> None:
@@ -241,9 +290,9 @@ class EventSourceResponse(StreamingResponse):
     def __init__(self, content: AsyncIterator,
                  *,
                  status: int = 200,
-                 headers: list | None = None):
+                 headers: Mapping | list | None = None):
         # Caller-provided Cache-Control / Content-Type wins (case-insensitive).
-        h = list(headers or [])
+        h = _normalize_headers(headers)
         if not any(k.lower() == b'cache-control' for k, _ in h):
             h.append((b'cache-control', b'no-cache'))
         super().__init__(

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -386,8 +386,97 @@ def _instantiate_dataclass(cls: Any, data: dict) -> Any:
     return cls(**kwargs)
 
 
-def _adapt_handler(fn, path: str):
+def _lookup_converter(converters: dict, result_type: type):
+    """Find a registered converter for *result_type* (exact match, then MRO).
+
+    Only reached on the cold path — after a handler returns a value that is
+    none of the natively supported shapes — so the MRO walk costs nothing on
+    the common path.  Returns the converter callable or ``None``.
+    """
+    fn = converters.get(result_type)
+    if fn is not None:
+        return fn
+    for base in result_type.__mro__[1:]:
+        fn = converters.get(base)
+        if fn is not None:
+            return fn
+    return None
+
+
+async def _send_native(result, scope, receive, send) -> bool:
+    """Serialise a *natively supported* handler/converter return value to ASGI.
+
+    The single source of truth for return-value → ASGI mapping, shared by the
+    simplified-handler wrapper and the converter path.  Handles the shapes
+    BlackBull sends without an app-registered converter:
+
+    * ``None`` — send nothing;
+    * an existing ``StreamingResponse`` / ``EventSourceResponse`` instance, or a
+      bare async generator — driven directly so it owns its own start event;
+    * a ``Response`` (sent as-is);
+    * ``bytes`` / ``str`` (wrapped in a default ``Response``);
+    * a JSON-able ``dict`` / ``list`` / dataclass instance (``JSONResponse``).
+
+    Returns ``True`` when *result* matched one of those shapes (and has been
+    sent), ``False`` otherwise — leaving the caller to apply its own fallback
+    (the handler wrapper tries a registered converter, then raises;
+    ``_send_converted`` raises, since a converter must itself return a native
+    shape).
+    """
+    from .response import (
+        Response as _Response, JSONResponse as _JSONResponse,
+        StreamingResponse as _StreamingResponse,
+    )
+    if result is None:
+        return True
+    if isinstance(result, _StreamingResponse):
+        # Existing StreamingResponse / EventSourceResponse instance — let it
+        # drive scope/receive/send directly so subclasses keep control over
+        # the start event.
+        await result(scope, receive, send)
+    elif inspect.isasyncgen(result):
+        # ``async def stream(): yield ...`` shape — wrap in a default-typed
+        # StreamingResponse.  Backpressure flows naturally because each
+        # ``await send()`` on a body event blocks on flow-control credit
+        # (HTTP/2) or drain (HTTP/1).
+        await _StreamingResponse(result)(scope, receive, send)
+    elif isinstance(result, _Response):
+        await send(result)
+    elif isinstance(result, bytes):
+        await send(_Response(result))
+    elif isinstance(result, str):
+        await send(_Response(result.encode()))
+    elif dataclasses.is_dataclass(result) and not isinstance(result, type):
+        # Dataclass instance → recurse so nested dataclasses serialise too.
+        await send(_JSONResponse(_to_jsonable(result)))
+    elif isinstance(result, (dict, list)):
+        await send(_JSONResponse(_to_jsonable(result)))
+    else:
+        return False
+    return True
+
+
+async def _send_converted(value, scope, receive, send) -> None:
+    """Serialise a converter's output and send it.
+
+    A converter must return a *natively supported* sendable (see
+    :func:`_send_native`).  Anything else raises here — the intended loud
+    failure — rather than silently dropping the response.
+    """
+    if await _send_native(value, scope, receive, send):
+        return
+    raise TypeError(
+        'a registered converter must return a Response, StreamingResponse, '
+        f'bytes, str, dict, list, dataclass, or None; got {type(value).__name__!r}')
+
+
+def _adapt_handler(fn, path: str, converters: dict | None = None):
     """Wrap a simplified handler in an ASGI (scope, receive, send) coroutine.
+
+    *converters* is the app's ``type → callable`` registry (shared by
+    reference so converters registered after this route are still visible).
+    When a handler returns a value that is none of the natively supported
+    shapes, a matching converter — if any — maps it to a sendable.
 
     Parameter resolution:
     - Name matches a {param} in the path pattern → scope['path_params'][name],
@@ -404,10 +493,6 @@ def _adapt_handler(fn, path: str):
     None → no send; other → TypeError at call time.
     """
     from .request import read_body as _read_body
-    from .response import (
-        Response as _Response, JSONResponse as _JSONResponse,
-        StreamingResponse as _StreamingResponse,
-    )
 
     path_param_names: set[str] = {m.group(1) for m in Router._param_pattern.finditer(path)}
     params = inspect.signature(fn).parameters
@@ -485,35 +570,20 @@ def _adapt_handler(fn, path: str):
 
         result = (await fn(**kwargs)) if is_async else fn(**kwargs)
 
-        if result is None:
+        if await _send_native(result, scope, receive, send):
             return
-        elif isinstance(result, _StreamingResponse):
-            # Sprint 45: existing StreamingResponse / EventSourceResponse
-            # instance — let it drive scope/receive/send directly so
-            # subclasses keep control over the start event.
-            await result(scope, receive, send)
-        elif inspect.isasyncgen(result):
-            # Sprint 45: ``async def stream(): yield ...`` shape — wrap
-            # in a default-typed StreamingResponse.  Backpressure flows
-            # naturally because each ``await send()`` on a body event
-            # blocks on flow-control credit (HTTP/2) or drain (HTTP/1).
-            await _StreamingResponse(result)(scope, receive, send)
-        elif isinstance(result, _Response):
-            await send(result)
-        elif isinstance(result, bytes):
-            await send(_Response(result))
-        elif isinstance(result, str):
-            await send(_Response(result.encode()))
-        elif dataclasses.is_dataclass(result) and not isinstance(result, type):
-            # Dataclass instance → recurse so nested dataclasses serialise too.
-            await send(_JSONResponse(_to_jsonable(result)))
-        elif isinstance(result, (dict, list)):
-            await send(_JSONResponse(_to_jsonable(result)))
-        else:
-            raise TypeError(
-                f"Simplified handler {fn.__name__!r} returned unsupported type "
-                f"{type(result).__name__!r}."
-            )
+        if converters and (conv := _lookup_converter(converters, type(result))) is not None:
+            # Cold path: an app-registered type→sendable converter.  Guarded by
+            # ``converters`` truthiness so an empty registry costs nothing here
+            # and the common shapes above never reach this branch at all.
+            await _send_converted(conv(result), scope, receive, send)
+            return
+        raise TypeError(
+            f"Simplified handler {fn.__name__!r} returned unsupported type "
+            f"{type(result).__name__!r}.  Return a Response, str, bytes, "
+            f"dict, list, or None, or register a converter with "
+            f"app.register_converter({type(result).__name__}, ...)."
+        )
 
     return _wrapper
 
@@ -582,6 +652,16 @@ class Router(UserDict, BaseRouter):
         self._trie = _RouteTrie()
         self._raw_regex: dict = {}  # raw re.Pattern routes (not compiled from string paths)
         self._lookup_cache: OrderedDict = OrderedDict()
+        # type → callable registry for simplified-handler return coercion.
+        # Empty by default (falsy) so the common return paths never consult it.
+        # Shared by reference with every adapted handler, so a converter
+        # registered after a route is still honoured.
+        self._converters: dict[type, Callable] = {}
+
+    def register_converter(self, type_: type, converter: Callable) -> None:
+        """Register *converter* to turn a handler that returns *type_* into a
+        sendable (a Response, str/bytes, or JSON-able)."""
+        self._converters[type_] = converter
 
     def __setitem__(
         self,
@@ -812,7 +892,7 @@ class Router(UserDict, BaseRouter):
 
             original = fn
             if _is_simplified_handler(fn):
-                fn = _adapt_handler(fn, path)
+                fn = _adapt_handler(fn, path, self._converters)
 
             @wraps(fn)
             def wrapper(*args, **kwds):
@@ -1005,14 +1085,14 @@ class Router(UserDict, BaseRouter):
             fns = list(functions)
             original = fns[-1]
             if _is_simplified_handler(fns[-1]):
-                fns[-1] = _adapt_handler(fns[-1], path)
+                fns[-1] = _adapt_handler(fns[-1], path, self._converters)
             self._register_chain(fns, path, methods, scheme,
                                  name=name, original_handler=original)
             return lambda fn: fn
 
         if middlewares:
             def decorator(fn):
-                adapted = _adapt_handler(fn, path) if _is_simplified_handler(fn) else fn
+                adapted = _adapt_handler(fn, path, self._converters) if _is_simplified_handler(fn) else fn
                 self._register_chain(list(middlewares) + [adapted], path, methods, scheme,
                                      name=name, original_handler=fn)
                 return fn

--- a/docs/guide/events.md
+++ b/docs/guide/events.md
@@ -5,26 +5,36 @@ request lifecycle.  Application code registers handlers with one
 of two decorators and the framework dispatches events at well-
 defined points in the application's lifetime.
 
-## Two hook kinds
+## Three hook kinds
 
-| Property | `@app.intercept(name)` | `@app.on(name)` |
-| --- | --- | --- |
-| Execution | Synchronous (awaited inline) | Asynchronous (fire-and-forget) |
-| Order | Registration order, serial | Independent, no inter-handler order |
-| Exceptions | Propagate to the emitter | Isolated, logged, never propagate |
-| Can short-circuit / modify flow | Yes | No |
-| Typical use | Auth, validation, rewriting | Logging, metrics, tracing |
+| Property | `@app.intercept(name)` | `@app.on(name, blocking=True)` | `@app.on(name)` |
+| --- | --- | --- | --- |
+| Execution | Awaited inline | Awaited inline | Fire-and-forget task |
+| Order | Registration order, serial | Registration order, serial | Independent, no order |
+| Exceptions | Propagate to the emitter | Isolated, logged | Isolated, logged |
+| Can short-circuit / modify flow | Yes | No | No |
+| Blocks the emitter? | Yes | Yes | No |
+| Typical use | Auth, validation, rewriting | Resource cleanup (`scope_completed`) | Logging, metrics, tracing |
 
-The split is a deliberate defence.  Writing an authentication
-check as an observer would silently let unauthorized requests
-through — the request proceeds before the observer has finished,
-and an observer cannot signal failure to the emitter.  Conversely,
-putting slow telemetry into an interceptor blocks the request
-path on every emission.
+Two axes are in play: **does the hook block the emitter** (is it
+awaited before `emit` returns?) and **can its failure affect the
+emitter** (does the exception propagate?).
 
-There is no third mode that "observes but blocks" or "intercepts
-but is fire-and-forget" — pick one based on whether the hook is
-allowed to affect the request.
+- `intercept` blocks *and* propagates — it participates in the
+  request and may abort it. Writing an authentication check as a
+  plain observer would silently let unauthorized requests through:
+  the request proceeds before the observer finishes, and an
+  observer cannot signal failure. Auth belongs here.
+- `on` (the default) neither blocks nor propagates — fire-and-forget
+  observation. Putting slow telemetry in an interceptor would add
+  latency to every request; put it here instead.
+- `on(..., blocking=True)` blocks but does **not** propagate — the
+  "observe but block" mode. Use it when a side effect must *complete*
+  within the event's lifetime yet must not be able to break what
+  emitted it. The canonical case is releasing a per-request resource
+  on `scope_completed` (close a DB session, delete a temp file): the
+  cleanup has to finish before the scope is gone, but a failing
+  cleanup must not corrupt a response that is already sent.
 
 ## `@app.intercept` — synchronous interception
 
@@ -68,6 +78,27 @@ to the emitter or to other observers.
 
 Use observers for telemetry, audit logging, cache warming, and
 other side-effects that the request path should not depend on.
+
+### `blocking=True` — awaited observation
+
+Pass `blocking=True` to await the observer in registration order
+*before* the emit returns, while keeping the isolation of `on`
+(exceptions logged, never propagated):
+
+```python
+@app.on('scope_completed', blocking=True)
+async def close_session(event: Event):
+    session = event.detail['scope'].get('state', {}).get('db_session')
+    if session is not None:
+        await session.close()
+```
+
+This is the right mode for cleanup keyed to an event's completion:
+the work is guaranteed to finish within the event's lifetime (unlike
+a detached observer, which may outlive the scope), but a failure in
+one cleanup handler neither aborts the others nor breaks the emitter.
+Blocking observers run after any interceptors and before any detached
+observers for the same event.
 
 ## The `Event` object
 
@@ -124,6 +155,7 @@ you want the consistency of writing every hook as
 | `before_handler` | Route matched, before handler dispatch | `scope`, `client_ip`, `method`, `path`, `http_version`, `headers` | `@app.on` and `@app.intercept`; raise to abort |
 | `after_handler` | Handler returned normally | `scope`, `client_ip`, `method`, `path`, `http_version` | Observation only |
 | `request_completed` | HTTP request finished — response fully sent (or failed before that) | `scope`, `client_ip`, `method`, `path`, `http_version`, `status`, `response_bytes`, `duration_ms` | Observation only; not fired if client disconnected or for WebSocket |
+| `scope_completed` | Any ASGI scope finished — HTTP request, WebSocket connection, or gRPC call | `scope`, `type`, `client_ip`, `path`, `exception` | Guaranteed once per scope, every protocol, on success or error; the cleanup hook. Pair with `@app.on(..., blocking=True)` |
 | `request_disconnected` | HTTP client closed connection before response complete | `scope`, `client_ip`, `method`, `path`, `http_version` | Observation only; mutually exclusive with `request_completed` |
 | `websocket_message` | WebSocket message fully received and reassembled, before the handler reads it | `scope`, `text`, `bytes` | Observation only |
 | `websocket_connected` | `websocket.accept` sent | `connection_id`, `path`, `client_ip`, `subprotocol` | Observation only |
@@ -132,10 +164,14 @@ you want the consistency of writing every hook as
 Request flow:
 
 ```
-request_received → routing → before_handler → handler → after_handler → request_completed
-                                                            ↑
-                                                         (or) request_disconnected
+request_received → routing → before_handler → handler → after_handler → request_completed → scope_completed
+                                                            ↑                                      ↑
+                                                         (or) request_disconnected ───────────────┘
 ```
+
+`scope_completed` is the terminal event on *every* path (including
+WebSocket and gRPC, which do not fire the HTTP-specific events
+above) — it always fires last, exactly once.
 
 ### `request_received` — earliest gate
 
@@ -187,6 +223,49 @@ async def log_request(event: Event):
 **Observation only.**  The response has already been sent by the
 time this fires; nothing an interceptor does can change what the
 client received.
+
+### `scope_completed` — the guaranteed terminal event
+
+Fires **exactly once for every ASGI scope** — every HTTP request,
+every WebSocket connection, and every gRPC call — when the
+application has finished handling it, whether it completed normally,
+returned an error, or was a 404. It is emitted from `BlackBull`'s
+entry point (the one place every scope passes through), so it fires
+under BlackBull's own server *and* under external ASGI servers
+(uvicorn, `httpx.ASGITransport`).
+
+This is the distinction from `request_completed`: that event is
+*server-level* telemetry (HTTP-only, carries wire data like status
+and byte counts, fires only under BlackBull's server).
+`scope_completed` is *application-level* — cross-protocol, fires
+wherever the app runs, and is meant for **resource cleanup**.
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `scope` | `dict` | The ASGI scope dict |
+| `type` | `str` | Scope type: `'http'` (also gRPC) or `'websocket'` |
+| `client_ip` | `str` | Remote address (`'-'` when unavailable) |
+| `path` | `str` | Request / connection path |
+| `exception` | `BaseException` \| `None` | The error that occurred while handling the scope (whether it propagated or was turned into a 500), or `None` |
+
+Pair it with `blocking=True` so cleanup completes before the scope
+is gone:
+
+```python
+@app.on('scope_completed', blocking=True)
+async def cleanup(event: Event):
+    scope = event.detail['scope']
+    tmp = scope.get('state', {}).get('tempfile')
+    if tmp is not None:
+        os.unlink(tmp)
+    if event.detail['exception'] is not None:
+        metrics.increment('requests.failed')
+```
+
+Use plain `@app.on('scope_completed')` (detached) only for
+observation that need not finish before the scope ends; use
+`blocking=True` for anything that releases a resource the scope
+owns.
 
 ### `request_disconnected` — client gave up
 
@@ -265,9 +344,12 @@ Restated:
   do not run; the exception propagates to the emitter (the
   framework code that called `emit`).  For lifespan events, this
   typically aborts startup or shutdown.
-- **Observer raises** → the exception is caught and logged at
-  `ERROR` on the `blackbull` logger; other observers for the same
-  event continue to run; the emitter never sees the exception.
+- **Observer raises** (detached or `blocking=True`) → the exception
+  is caught and logged at `ERROR` on the `blackbull` logger; other
+  observers for the same event continue to run; the emitter never
+  sees the exception.  A blocking observer is awaited but still
+  isolated, so a failing cleanup on `scope_completed` cannot break a
+  response that has already been sent.
 
 There is no built-in re-emission of failures as a separate
 `error` event.  If you want one, register a wrapper observer

--- a/tests/properties/test_handler_return_types.py
+++ b/tests/properties/test_handler_return_types.py
@@ -37,8 +37,8 @@ def _make_send():
     return _wrap_send(raw_send), body_parts
 
 
-def _run_handler(fn, path='/'):
-    wrapped = _adapt_handler(fn, path)
+def _run_handler(fn, path='/', converters=None):
+    wrapped = _adapt_handler(fn, path, converters)
 
     async def _go():
         send, body_parts = _make_send()
@@ -99,6 +99,61 @@ def test_none_return_sends_nothing():
 
     parts = _run_handler(handler)
     assert parts == []
+
+
+# ---------------------------------------------------------------------------
+# register_converter — custom return types via the type→callable registry
+# ---------------------------------------------------------------------------
+
+class _Widget:
+    def __init__(self, n):
+        self.n = n
+
+
+class _WidgetSub(_Widget):
+    pass
+
+
+@pytest.mark.properties
+@given(n=st.integers())
+def test_converter_maps_custom_type_to_json(n):
+    def to_dict(w):
+        return {'n': w.n}
+
+    async def handler():
+        return _Widget(n)
+
+    parts = _run_handler(handler, converters={_Widget: to_dict})
+    assert json.loads(b''.join(parts)) == {'n': n}
+
+
+@pytest.mark.properties
+@given(s=st.text())
+def test_converter_may_return_str(s):
+    async def handler():
+        return _Widget(s)
+
+    parts = _run_handler(handler, converters={_Widget: lambda w: str(w.n)})
+    assert b''.join(parts) == s.encode()
+
+
+@pytest.mark.properties
+def test_converter_matches_via_mro():
+    """A subclass with no exact registration uses the base-class converter."""
+    async def handler():
+        return _WidgetSub(7)
+
+    parts = _run_handler(handler, converters={_Widget: lambda w: {'n': w.n}})
+    assert json.loads(b''.join(parts)) == {'n': 7}
+
+
+@pytest.mark.properties
+def test_empty_converter_registry_still_raises_on_unknown_type():
+    async def handler():
+        return _Widget(1)
+
+    with pytest.raises(TypeError):
+        _run_handler(handler, converters={})
 
 
 @pytest.mark.properties

--- a/tests/unit/test_dispatch_hooks.py
+++ b/tests/unit/test_dispatch_hooks.py
@@ -1,0 +1,94 @@
+"""End-to-end tests for ``@app.register_converter`` — custom handler return
+types, driven through the real router + ``_dispatch`` via TestClient.
+
+Cleanup-on-completion is tested separately via the ``scope_completed`` event
+(see ``test_scope_completed.py``); it is no longer a dedicated hook.
+"""
+
+from blackbull import BlackBull
+from blackbull.testing import TestClient
+
+
+# ---------------------------------------------------------------------------
+# register_converter (end-to-end through _dispatch)
+# ---------------------------------------------------------------------------
+
+class Widget:
+    def __init__(self, name: str):
+        self.name = name
+
+
+def test_register_converter_direct_form() -> None:
+    app = BlackBull()
+    app.register_converter(Widget, lambda w: {'widget': w.name})
+
+    @app.route(path='/w')
+    async def get_widget():
+        return Widget('gizmo')
+
+    with TestClient(app) as client:
+        r = client.get('/w')
+    assert r.status_code == 200
+    assert r.json() == {'widget': 'gizmo'}
+
+
+def test_register_converter_decorator_form() -> None:
+    app = BlackBull()
+
+    @app.register_converter(Widget)
+    def _to_dict(w):
+        return {'widget': w.name}
+
+    @app.route(path='/w')
+    async def get_widget():
+        return Widget('sprocket')
+
+    with TestClient(app) as client:
+        r = client.get('/w')
+    assert r.json() == {'widget': 'sprocket'}
+
+
+def test_register_converter_after_route_registration() -> None:
+    """The registry is shared by reference, so late registration still works."""
+    app = BlackBull()
+
+    @app.route(path='/w')
+    async def get_widget():
+        return Widget('late')
+
+    # Registered *after* the route was adapted.
+    app.register_converter(Widget, lambda w: {'widget': w.name})
+
+    with TestClient(app) as client:
+        r = client.get('/w')
+    assert r.json() == {'widget': 'late'}
+
+
+def test_converter_may_return_a_response() -> None:
+    from http import HTTPStatus
+    from blackbull import Response
+    app = BlackBull()
+    app.register_converter(
+        Widget, lambda w: Response(w.name.encode(), status=HTTPStatus.CREATED))
+
+    @app.route(path='/w')
+    async def get_widget():
+        return Widget('body')
+
+    with TestClient(app) as client:
+        r = client.get('/w')
+    assert r.status_code == 201
+    assert r.text == 'body'
+
+
+def test_unregistered_type_is_a_server_error() -> None:
+    app = BlackBull()
+
+    @app.route(path='/w')
+    async def get_widget():
+        return Widget('no-converter')
+
+    with TestClient(app) as client:
+        r = client.get('/w')
+    assert r.status_code == 500
+

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -179,3 +179,97 @@ async def test_pending_tasks_are_removed_when_completed():
     d.on('test', quick)
     await d.emit(Event('test'))
     await asyncio.wait_for(d.aclose(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Blocking observers — the third delivery mode (awaited + isolated)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_blocking_observer_is_awaited_before_emit_returns():
+    """Unlike a detached observer, a blocking one completes before emit() returns."""
+    d = EventDispatcher()
+    done = []
+
+    async def cleanup(event):
+        await asyncio.sleep(0)  # yield, then finish
+        done.append('done')
+
+    d.on('test', cleanup, blocking=True)
+    await d.emit(Event('test'))
+    # No sleep / no aclose needed — it already ran to completion inside emit.
+    assert done == ['done']
+
+
+@pytest.mark.asyncio
+async def test_blocking_observers_run_in_registration_order():
+    d = EventDispatcher()
+    order = []
+
+    async def first(event):
+        await asyncio.sleep(0)
+        order.append('first')
+
+    async def second(event):
+        order.append('second')
+
+    d.on('test', first, blocking=True)
+    d.on('test', second, blocking=True)
+    await d.emit(Event('test'))
+    assert order == ['first', 'second']
+
+
+@pytest.mark.asyncio
+async def test_blocking_observer_exception_is_isolated():
+    """A blocking observer's exception is logged, not propagated, and does not
+    abort sibling blocking observers."""
+    d = EventDispatcher()
+    ran = []
+
+    async def boom(event):
+        raise RuntimeError('cleanup failed')
+
+    async def survivor(event):
+        ran.append('survivor')
+
+    d.on('test', boom, blocking=True)
+    d.on('test', survivor, blocking=True)
+    await d.emit(Event('test'))  # must NOT raise
+    assert ran == ['survivor']
+
+
+@pytest.mark.asyncio
+async def test_emit_order_interceptors_then_blocking_then_detached():
+    d = EventDispatcher()
+    order = []
+
+    async def interceptor(event):
+        order.append('intercept')
+
+    async def blocking(event):
+        order.append('blocking')
+
+    async def detached(event):
+        order.append('detached')
+
+    d.intercept('test', interceptor)
+    d.on('test', detached)               # detached
+    d.on('test', blocking, blocking=True)
+    await d.emit(Event('test'))
+    # Interceptor and blocking observer have run synchronously and in that
+    # order; the detached observer has not necessarily run yet.
+    assert order[:2] == ['intercept', 'blocking']
+    await asyncio.wait_for(d.aclose(), timeout=1.0)
+    assert 'detached' in order
+
+
+@pytest.mark.asyncio
+async def test_blocking_observer_counts_as_a_listener():
+    d = EventDispatcher()
+
+    async def cleanup(event):
+        pass
+
+    assert d.has_listeners('test') is False
+    d.on('test', cleanup, blocking=True)
+    assert d.has_listeners('test') is True

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -65,6 +65,60 @@ def test_response_str_headers_reject_non_ascii():
 
 
 # ---------------------------------------------------------------------------
+# headers=dict  (FastAPI/Starlette/httpx convention)
+# ---------------------------------------------------------------------------
+
+def test_response_accepts_dict_headers():
+    # Regression: passing a dict used to iterate the dict's *keys* and unpack
+    # each key string into (k, v) — silent corruption.  A dict now maps to
+    # (name, value) tuples via .items(), coerced to bytes.
+    r = Response(b'', headers={'X-Foo': 'bar', 'X-Baz': 'qux'})
+    assert (b'X-Foo', b'bar') in r.headers
+    assert (b'X-Baz', b'qux') in r.headers
+    for k, v in r.headers:
+        assert isinstance(k, bytes) and isinstance(v, bytes)
+
+
+def test_jsonresponse_accepts_dict_headers():
+    r = JSONResponse({'ok': True}, headers={'X-Trace': 'abc123'})
+    assert (b'content-type', b'application/json') in r.headers
+    assert (b'X-Trace', b'abc123') in r.headers
+
+
+def test_redirectresponse_accepts_dict_headers():
+    r = RedirectResponse('/new', headers={b'set-cookie': b'sid=abc'})
+    assert (b'location', b'/new') in r.headers
+    assert (b'set-cookie', b'sid=abc') in r.headers
+
+
+def test_response_dict_headers_bytes_keys_and_values():
+    r = Response(b'', headers={b'X-A': b'1'})
+    assert (b'X-A', b'1') in r.headers
+
+
+def test_response_rejects_bare_string_headers():
+    # A bare string is iterable; the old loop would silently mangle it.
+    # Asserted on _normalize_headers directly: under beartype instrumentation
+    # the str is rejected earlier still, by Response's ``headers`` annotation
+    # (a BeartypeCallHintParamViolation) — so both layers reject it loudly.
+    from blackbull.response import _normalize_headers
+    with pytest.raises(TypeError):
+        _normalize_headers('X-Foo: bar')
+
+
+def test_response_rejects_non_pair_headers():
+    with pytest.raises(TypeError):
+        Response(b'', headers=[('only-one-element',)])
+    with pytest.raises(TypeError):
+        Response(b'', headers=[('a', 'b', 'c')])
+
+
+def test_response_rejects_non_str_bytes_header_value():
+    with pytest.raises(TypeError):
+        Response(b'', headers={'X-Count': 5})
+
+
+# ---------------------------------------------------------------------------
 # JSONResponse
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_scope_completed.py
+++ b/tests/unit/test_scope_completed.py
@@ -1,0 +1,213 @@
+"""Tests for the ``scope_completed`` event — the guaranteed, cross-protocol
+terminal event emitted once per ASGI scope from ``BlackBull.__call__``.
+
+Unlike ``request_completed`` (HTTP-only, server-level) this fires for HTTP,
+WebSocket, and gRPC, on success and on error, under any server — here driven
+through TestClient (HTTP/WS) and a direct ``app(...)`` call (gRPC).  It is the
+home of the awaited-isolated ``@app.on(..., blocking=True)`` cleanup hook.
+"""
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.router import Scheme
+from blackbull.testing import TestClient
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+def test_fires_once_for_successful_request() -> None:
+    app = BlackBull()
+    seen = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        seen.append(event.detail)
+
+    @app.route(path='/ok')
+    async def ok():
+        return 'hi'
+
+    with TestClient(app) as client:
+        r = client.get('/ok')
+    assert r.status_code == 200
+    assert len(seen) == 1
+    assert seen[0]['type'] == 'http'
+    assert seen[0]['path'] == '/ok'
+    assert seen[0]['exception'] is None
+
+
+def test_fires_with_exception_on_handler_error() -> None:
+    app = BlackBull()
+    seen = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        seen.append(event.detail['exception'])
+
+    @app.route(path='/boom')
+    async def boom():
+        raise ValueError('handler failed')
+
+    with TestClient(app) as client:
+        r = client.get('/boom')
+    # The framework turned the error into a 500, and the cleanup hook can see it.
+    assert r.status_code == 500
+    assert len(seen) == 1
+    assert isinstance(seen[0], ValueError)
+
+
+def test_fires_for_404_without_exception() -> None:
+    app = BlackBull()
+    seen = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        seen.append(event.detail)
+
+    with TestClient(app) as client:
+        r = client.get('/nope')
+    assert r.status_code == 404
+    assert len(seen) == 1
+    assert seen[0]['path'] == '/nope'
+    assert seen[0]['exception'] is None  # a 404 is not an exception
+
+
+def test_fires_exactly_once_per_request_in_sequence() -> None:
+    app = BlackBull()
+    count = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        count.append(event.detail['path'])
+
+    @app.route(path='/r')
+    async def r():
+        return 'r'
+
+    with TestClient(app) as client:
+        for _ in range(3):
+            client.get('/r')
+    assert count == ['/r', '/r', '/r']
+
+
+# ---------------------------------------------------------------------------
+# Blocking-cleanup semantics through the real dispatch path
+# ---------------------------------------------------------------------------
+
+def test_blocking_cleanup_completes_and_isolates() -> None:
+    app = BlackBull()
+    order = []
+
+    @app.on('scope_completed', blocking=True)
+    async def first(event):
+        raise RuntimeError('cleanup boom')  # isolated
+
+    @app.on('scope_completed', blocking=True)
+    async def second(event):
+        order.append('second')
+
+    @app.route(path='/ok')
+    async def ok():
+        return 'ok'
+
+    with TestClient(app) as client:
+        r = client.get('/ok')
+    # Response unaffected by a failing cleanup hook; siblings still run.
+    assert r.status_code == 200
+    assert r.text == 'ok'
+    assert order == ['second']
+
+
+# ---------------------------------------------------------------------------
+# WebSocket
+# ---------------------------------------------------------------------------
+
+def test_fires_for_websocket_connection() -> None:
+    app = BlackBull()
+    seen = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        seen.append((event.detail['type'], event.detail['path']))
+
+    @app.route(path='/ws', scheme=Scheme.websocket)
+    async def ws(scope, receive, send):
+        await receive()
+        await send({'type': 'websocket.accept'})
+        while True:
+            ev = await receive()
+            if ev['type'] == 'websocket.disconnect':
+                return
+            if ev['type'] == 'websocket.receive':
+                await send({'type': 'websocket.send', 'text': ev['text']})
+
+    with TestClient(app) as client:
+        with client.websocket_connect('/ws') as wsconn:
+            wsconn.send_text('ping')
+            assert wsconn.receive_text() == 'ping'
+    assert seen == [('websocket', '/ws')]
+
+
+# ---------------------------------------------------------------------------
+# gRPC (application/grpc rides the HTTP scope through __call__ → _dispatch)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fires_for_grpc_call() -> None:
+    from blackbull.grpc import GrpcServiceRegistry
+    from blackbull.grpc.asgi import encode_message
+
+    reg = GrpcServiceRegistry()
+
+    @reg.method('/echo.Echo/Echo')
+    async def echo(request, context):
+        return request[::-1]
+
+    app = BlackBull()
+    app.enable_grpc(reg)
+    seen = []
+
+    @app.on('scope_completed', blocking=True)
+    async def cleanup(event):
+        seen.append((event.detail['type'], event.detail['path']))
+
+    scope = {
+        'type': 'http', 'path': '/echo.Echo/Echo', 'method': 'POST',
+        'headers': [(b'content-type', b'application/grpc'), (b':method', b'POST')],
+        'client': ('127.0.0.1', 9),
+    }
+    sent = [False]
+
+    async def receive():
+        if not sent[0]:
+            sent[0] = True
+            return {'type': 'http.request', 'body': encode_message(b'abc'),
+                    'more_body': False}
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    async def send(event):
+        pass
+
+    await app(scope, receive, send)
+    assert seen == [('http', '/echo.Echo/Echo')]
+
+
+# ---------------------------------------------------------------------------
+# Fast path: no listener → no overhead, app still works
+# ---------------------------------------------------------------------------
+
+def test_no_listener_is_a_noop() -> None:
+    app = BlackBull()
+
+    @app.route(path='/ok')
+    async def ok():
+        return 'ok'
+
+    assert app._dispatcher.has_listeners('scope_completed') is False
+    with TestClient(app) as client:
+        r = client.get('/ok')
+    assert r.status_code == 200
+    assert r.text == 'ok'


### PR DESCRIPTION
Sprint 58 DX consolidation — make BlackBull event-native for completion/cleanup instead of grafting on a Flask-style teardown hook.

## Added
- **`scope_completed` event** — a guaranteed, cross-protocol terminal event emitted exactly once per ASGI scope (HTTP request, WebSocket connection, or gRPC call), on success / handled-500 / 404, under any server. Emitted from the single choke point `BlackBull.__call__`. The application-level completion event, distinct from the server-level `request_completed` telemetry, and the home of the resource-cleanup hook.
- **Blocking observers** — `@app.on(name, blocking=True)` adds a third delivery mode: awaited in registration order (cleanup completes within the event's lifetime) yet isolated (a failing handler can't break the emitter or siblings). Emit order is interceptors → blocking observers → detached observers. Pair with `scope_completed` to close a per-request DB session or delete a temp file.
- **`app.register_converter(type, fn)`** — extend simplified-handler return coercion so a handler can `return my_orm_object`; registry empty by default so common return paths pay nothing. Direct and decorator forms.

## Changed
- **`Response(headers=...)` accepts a `dict`** (FastAPI/Starlette/httpx convention) as well as a list of `(name, value)` pairs; names/values may be `str` or `bytes`. Malformed shapes now raise `TypeError` at construction instead of silently corrupting the response.

## Refactors (behavior-preserving — 2506 passed unchanged)
- **router**: extract `_send_native()` as the single source of return-value → ASGI mapping, shared by the handler wrapper and the converter path.
- **response**: extract `_emit_response()` as the single source of the `start`+`body` event pair, shared by `Response.__call__`, `_wrap_send`, and the default error handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)