### PR TITLE
ci(http2): gate the H2 flow-control deadlock test on every PR

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -8,6 +8,9 @@ name: RFC conformance
 #   autobahn       — RFC 6455 (WebSocket)
 #   corpus-replay  — docker-free regression replay of the curated
 #                     fuzz/user-corpus/ diff entries
+#   h2-flow-control — docker-free RFC 9113 flow-control deadlock gate
+#                     (the three payload > 65535-byte deadlocks fixed
+#                     in v0.46.0), subprocess-isolated per scenario
 #
 # The workflow's pass/fail status becomes the badge linked from the
 # README.  An individual job failure surfaces in the badge as a red
@@ -207,3 +210,31 @@ jobs:
         run: |
           timeout 60 python -m pytest --timeout=30 -v \
               tests/conformance/http1/test_h1_user_corpus_replay.py
+
+  h2-flow-control:
+    name: H2 flow-control deadlock gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1   # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install BlackBull (with testing extras)
+        run: pip install -e '.[testing]'
+
+      - name: Run H2 flow-control deadlock regression gate
+        # Docker-free, subprocess-isolated regression gate for the three RFC
+        # 9113 flow-control deadlocks fixed in v0.46.0 (client crediting,
+        # sender lost-wakeup, WU-on-closed-stream).  Each scenario runs in a
+        # child interpreter (`sys.executable`) with an 8s per-step guard; the
+        # outer 90s bounds the whole job in case the subprocess guard itself
+        # wedges.  Runs on every push/PR so a reintroduced deadlock blocks
+        # merge instead of surfacing only in the weekly full tier.
+        run: |
+          timeout 90 python -m pytest --timeout=60 -v \
+              tests/conformance/http2/test_h2_flow_control_deadlock.py

--- a/tests/conformance/http2/test_h2_flow_control_deadlock.py
+++ b/tests/conformance/http2/test_h2_flow_control_deadlock.py
@@ -8,7 +8,7 @@ deadlocks survive ``CancelledError``, ``@pytest.mark.timeout``, and
 teardown).  **However, the scenario logic lives in plain async
 functions in this file — no embedded script strings.**
 
-Full analysis: ``.claude/planning/proposals/h2-flow-control-deadlock.md``
+Full analysis: ``.claude/planning/archives/h2-flow-control-deadlock.md``
 Sprint log: ``bench/sprint-logs/sprint-57.md``
 """
 from __future__ import annotations
@@ -21,7 +21,11 @@ import sys
 import pytest
 
 
-_VENV_PYTHON = str(pathlib.Path(__file__).parents[3] / '.venv' / 'bin' / 'python')
+# Reuse the interpreter running the test suite so the subprocess sees the same
+# installed BlackBull.  ``sys.executable`` is the local ``.venv`` when run from
+# there and the CI runner's system Python on GitHub Actions — no hardcoded
+# ``.venv`` path (which doesn't exist on the runner's ``pip install -e``).
+_SUBPROCESS_PYTHON = sys.executable
 _TIMEOUT = 8  # seconds per subprocess
 
 
@@ -158,7 +162,7 @@ def _run_scenario(name: str) -> tuple[bool, str]:
     """
     try:
         subprocess.run(
-            [_VENV_PYTHON, __file__, name],
+            [_SUBPROCESS_PYTHON, __file__, name],
             capture_output=True, timeout=_TIMEOUT,
             cwd=str(pathlib.Path(__file__).parents[3]),
         )


### PR DESCRIPTION
The three-bug flow-control deadlock regression test (payloads above the 65535-byte initial window, fixed in v0.46.0) only ran in the **weekly** full tier — so it never actually gated merges. This makes it a real per-PR gate.

## Changes
- **test**: run each scenario via `sys.executable` instead of a hardcoded `.venv/bin/python` path, which doesn't exist on a CI runner's `pip install -e`. Locally `sys.executable` *is* that same `.venv` interpreter, so behaviour is unchanged here.
- **ci**: add a docker-free `h2-flow-control` job to `conformance.yml` (runs on every push/PR to master), modeled on the `corpus-replay` job. Outer `timeout 90` bounds the job in case the per-step 8s subprocess guard itself wedges. setup-python pinned to v6.3.0 to match the other jobs.
- repoint the stale docstring analysis-doc reference from `proposals/` to its archived `archives/` location.

## Coverage
The gate reproduces (via subprocess-isolated timeout) the three RFC 9113 §6.9/§5.1 deadlocks:
1. client never crediting received DATA (REST 100 KB response),
2. sender lost-wakeup race (gRPC 65531-byte echo),
3. WINDOW_UPDATE on a CLOSED stream (30 rapid gRPC echoes).

Verified green locally (`1 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)