### PR TITLE
fix(grpc): Trailers-Only framing so real gRPC clients decode error statuses

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,6 +11,10 @@ name: RFC conformance
 #   h2-flow-control — docker-free RFC 9113 flow-control deadlock gate
 #                     (the three payload > 65535-byte deadlocks fixed
 #                     in v0.46.0), subprocess-isolated per scenario
+#   grpc-interop   — docker-free real-client (grpcio) gRPC interop over
+#                     h2c: the only test that puts a spec-strict external
+#                     gRPC client on the wire (guards the Trailers-Only
+#                     framing regression fixed in Sprint 58)
 #
 # The workflow's pass/fail status becomes the badge linked from the
 # README.  An individual job failure surfaces in the badge as a red
@@ -238,3 +242,32 @@ jobs:
         run: |
           timeout 90 python -m pytest --timeout=60 -v \
               tests/conformance/http2/test_h2_flow_control_deadlock.py
+
+  grpc-interop:
+    name: gRPC real-client interop (h2c)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1   # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install BlackBull (with testing + grpcio interop client)
+        # grpc-interop pulls in grpcio — the spec-strict third-party client.
+        # Without it the interop module skips (pytest.importorskip), so the
+        # gate would silently pass on nothing; install it explicitly here.
+        run: pip install -e '.[testing,grpc-interop]'
+
+      - name: Run real-client gRPC interop conformance
+        # Docker-free interop gate: a real grpcio client drives BlackBull's
+        # unary gRPC over a real h2c socket.  Guards the Trailers-Only framing
+        # regression (Sprint 58) — the error path must land grpc-status in a
+        # trailing HEADERS frame or strict clients decode every error as
+        # UNKNOWN.  Runs on every push/PR, not just the weekly full tier.
+        run: |
+          timeout 90 python -m pytest --timeout=60 -v \
+              tests/conformance/grpc/test_grpc_real_client_h2c.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ so the editable install's metadata catches up.
 - **`app.register_converter(type, fn)`** — extend simplified-handler return
   coercion so a handler can `return my_orm_object`; the registry is empty by
   default so the common return paths pay nothing. Direct and decorator forms.
+- **Real-client gRPC interop conformance** — a new
+  `tests/conformance/grpc/test_grpc_real_client_h2c.py` suite drives BlackBull's
+  unary gRPC over a real h2c socket with an actual `grpcio` client (success,
+  every error status, large-response flow control, and concurrent multiplexed
+  calls). It is the only test that puts a spec-strict external gRPC client on
+  the wire; a dedicated docker-free `grpc-interop` CI job runs it on every
+  push/PR (install with `pip install 'blackbull[grpc-interop]'`).
 
 ### Changed
 - **`Response(headers=...)` accepts a `dict`** (matching the
@@ -52,6 +59,18 @@ so the editable install's metadata catches up.
   pairs; names/values may be `str` or `bytes`. Malformed shapes now raise
   `TypeError` at construction instead of silently corrupting the response
   (the old loop iterated a dict's *keys*).
+
+### Fixed
+- **gRPC Trailers-Only framing (real-client interop)** — unary gRPC error
+  responses now carry `grpc-status` in a *trailing* HEADERS frame instead of a
+  non-terminal HEADERS frame followed by an empty `END_STREAM` DATA frame. A
+  spec-strict third-party client (grpcio, grpc-go) reads the status only from a
+  HEADERS frame with `END_STREAM` or a trailing HEADERS frame, so the old shape
+  decoded **every** error — `INTERNAL`, `PERMISSION_DENIED`, `UNIMPLEMENTED`, …
+  — as `UNKNOWN` ("Stream removed (Data frame with END_STREAM flag received)").
+  BlackBull's own `HTTP2Client` was lenient about the framing, which hid the bug
+  until a real gRPC client (`ghz`/grpcio) exercised the wire path. The success
+  path was already correct; only the error/Trailers-Only path changed.
 
 ## [0.46.0] — 2026-06-30
 

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -144,14 +144,28 @@ def _status_trailers(status: GrpcStatus, details: str,
 
 async def _send_trailers_only(send, status: GrpcStatus, details: str,
                               content_type: bytes = _GRPC_CONTENT_TYPE) -> None:
-    """Emit a Trailers-Only-style error: HTTP 200 + grpc-status in the
-    response headers and an empty, end-of-stream body (no message)."""
-    headers = [(b'content-type', content_type),
-               (b'grpc-accept-encoding', _GRPC_ACCEPT_ENCODING)]
-    headers.extend(_status_trailers(status, details))
+    """Emit a gRPC error response: HTTP 200, no message, ``grpc-status`` in
+    a *trailing* HEADERS frame.
+
+    A strict gRPC client (grpcio, grpc-go) reads ``grpc-status`` only from a
+    HEADERS frame carrying END_STREAM (true Trailers-Only) or from a trailing
+    HEADERS frame — never from a non-terminal HEADERS frame.  The earlier
+    implementation put ``grpc-status`` in the initial HEADERS and then sent an
+    empty END_STREAM DATA frame; the client read the HEADERS as ordinary
+    initial metadata, found no trailing status, and surfaced UNKNOWN
+    ("Stream removed (Data frame with END_STREAM flag received)").  BlackBull's
+    own ``HTTP2Client`` is lenient about this, which hid the bug.
+
+    Routing through ``http.response.start(trailers=True)`` + ``…trailers`` emits
+    Response-Headers followed by a trailing HEADERS frame (END_STREAM) with the
+    status — the same trailers machinery the success path uses, minus the DATA
+    frame — which every conformant gRPC client accepts."""
     await send({'type': 'http.response.start', 'status': 200,
-                'headers': headers})
-    await send({'type': 'http.response.body', 'body': b'', 'more_body': False})
+                'headers': [(b'content-type', content_type),
+                            (b'grpc-accept-encoding', _GRPC_ACCEPT_ENCODING)],
+                'trailers': True})
+    await send({'type': 'http.response.trailers',
+                'headers': _status_trailers(status, details)})
 
 
 async def serve_grpc(registry: GrpcServiceRegistry, scope, receive, send) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,16 @@ mqtt = []
 # `protoc`-generated message classes.  Install with `pip install 'blackbull[grpc]'`.
 grpc = []
 
+# Real-client gRPC interop testing.  ``grpcio`` is a spec-strict, third-party
+# gRPC client used by tests/conformance/grpc/test_grpc_real_client_h2c.py to
+# drive BlackBull over a real h2c socket — the only test that puts an external
+# gRPC client on the wire.  Not needed to *use* BlackBull's gRPC (that layer is
+# pure-Python); only to run the interop conformance suite (the grpc-interop CI
+# job installs it).  Install with `pip install 'blackbull[grpc-interop]'`.
+grpc-interop = [
+    "grpcio",
+]
+
 testing = [
     "pytest",
     "pytest-asyncio",

--- a/tests/conformance/grpc/test_grpc_real_client_h2c.py
+++ b/tests/conformance/grpc/test_grpc_real_client_h2c.py
@@ -1,0 +1,192 @@
+"""Interop conformance: a **real third-party gRPC client** (grpcio) driving
+BlackBull's unary gRPC over a real h2c socket (Sprint 58).
+
+Every other gRPC test in the suite drives the server with BlackBull's own
+``HTTP2Client`` or the in-process ``serve_grpc`` harness — both of which are
+lenient about the exact HEADERS/DATA/TRAILERS framing.  This module is the only
+one that puts an *external, spec-strict* client (``grpcio``) on the wire, so it
+is what catches interop bugs BlackBull's own client tolerates.
+
+It caught the Trailers-Only framing bug (Sprint 58): the error path emitted
+``grpc-status`` in a non-terminal HEADERS frame followed by an empty
+END_STREAM DATA frame, which grpcio decoded as UNKNOWN /
+"Stream removed (Data frame with END_STREAM flag received)".  The fix routes
+errors through Response-Headers + trailers so the status rides a *trailing*
+HEADERS frame.
+
+``grpcio`` is not a BlackBull dependency (the framework's gRPC layer is
+pure-Python — handlers exchange raw message bytes), so the whole module is
+skipped when it is not importable.  The dedicated ``grpc-interop`` CI job
+installs ``grpcio`` so this actually runs on every push/PR.
+
+The grpcio client is blocking and manages its own threads, so client calls run
+via ``asyncio.to_thread`` while the BlackBull server runs in the test's event
+loop.  Generic ``(bytes) -> bytes`` (de)serializers are used so no ``.proto``
+compilation is needed — the raw message bytes are the body.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+grpc = pytest.importorskip(
+    'grpc', reason='grpcio (real gRPC client) not installed; '
+                   'install the grpc-interop extra to run this suite')
+
+from blackbull import BlackBull
+from blackbull.grpc import GrpcServiceRegistry, GrpcStatus, GrpcError
+from blackbull.server.server import ASGIServer
+
+
+_SERVER_STARTUP_WAIT_SECONDS = 0.15
+_EPHEMERAL_PORT = 0
+_CALL_TIMEOUT = 5.0
+
+
+def _make_grpc_app() -> BlackBull:
+    """A gRPC app exercising the success path and each error class."""
+    app = BlackBull()
+    reg = GrpcServiceRegistry()
+
+    @reg.method('/echo.Echo/Echo')
+    async def echo(request, context):
+        return request[::-1]
+
+    @reg.method('/echo.Echo/Big')
+    async def big(request, context):
+        # Response > the 65535-byte initial window: exercises flow control
+        # under a real client on the success path.
+        return b'Z' * 100_000
+
+    @reg.method('/err.Err/Explode')
+    async def explode(request, context):
+        raise RuntimeError('kaboom')
+
+    @reg.method('/err.Err/Denied')
+    async def denied(request, context):
+        raise GrpcError(GrpcStatus.PERMISSION_DENIED, 'access denied')
+
+    @reg.method('/err.Err/Abort')
+    async def abort_handler(request, context):
+        context.abort(GrpcStatus.NOT_FOUND, 'item not found')
+        return b''  # unreachable
+
+    app.enable_grpc(reg)
+    return app
+
+
+@pytest_asyncio.fixture
+async def grpc_server_port():
+    """Start a gRPC-enabled BlackBull app on an ephemeral h2c port."""
+    app = _make_grpc_app()
+    server = ASGIServer(app)
+    server.open_socket(port=_EPHEMERAL_PORT)
+    port = server.port
+
+    task = asyncio.create_task(server.run())
+    await asyncio.sleep(_SERVER_STARTUP_WAIT_SECONDS)
+    try:
+        yield port
+    finally:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+def _blocking_unary(port: int, method: str, payload: bytes):
+    """Issue one blocking unary call with a real grpcio channel.
+
+    Returns ``(ok, value_or_error)`` — ``(True, response_bytes)`` on success,
+    ``(False, grpc.RpcError)`` on a non-OK status.  Runs entirely inside the
+    worker thread ``asyncio.to_thread`` hands it, so grpcio's own IO threads
+    never touch the server's event loop.
+    """
+    with grpc.insecure_channel(f'127.0.0.1:{port}') as channel:
+        grpc.channel_ready_future(channel).result(timeout=_CALL_TIMEOUT)
+        call = channel.unary_unary(
+            method,
+            request_serializer=lambda b: b,
+            response_deserializer=lambda b: b,
+        )
+        try:
+            return (True, call(payload, timeout=_CALL_TIMEOUT))
+        except grpc.RpcError as exc:  # noqa: BLE001 — surface the status to the test
+            return (False, exc)
+
+
+async def _unary(port: int, method: str, payload: bytes = b''):
+    return await asyncio.to_thread(_blocking_unary, port, method, payload)
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+class TestRealClientSuccess:
+    @pytest.mark.asyncio
+    async def test_echo_round_trip(self, grpc_server_port):
+        ok, value = await _unary(grpc_server_port, '/echo.Echo/Echo', b'blackbull')
+        assert ok, f'unexpected error: {value}'
+        assert value == b'llubkcalb'
+
+    @pytest.mark.asyncio
+    async def test_large_response_flow_control(self, grpc_server_port):
+        # 100 KB response forces cross-window DATA framing to a strict client.
+        ok, value = await _unary(grpc_server_port, '/echo.Echo/Big', b'x')
+        assert ok, f'unexpected error: {value}'
+        assert value == b'Z' * 100_000
+
+
+# ---------------------------------------------------------------------------
+# Error path — the Trailers-Only regression this suite exists to guard.
+# ---------------------------------------------------------------------------
+
+class TestRealClientErrorStatus:
+    """A strict client must decode every error class as its gRPC status —
+    not UNKNOWN.  This is the regression the Sprint 58 Trailers-Only fix closes."""
+
+    @pytest.mark.asyncio
+    async def test_handler_crash_is_internal(self, grpc_server_port):
+        ok, exc = await _unary(grpc_server_port, '/err.Err/Explode')
+        assert not ok, 'expected an RpcError from a crashing handler'
+        assert exc.code() == grpc.StatusCode.INTERNAL, exc
+
+    @pytest.mark.asyncio
+    async def test_grpc_error_status_and_message(self, grpc_server_port):
+        ok, exc = await _unary(grpc_server_port, '/err.Err/Denied')
+        assert not ok
+        assert exc.code() == grpc.StatusCode.PERMISSION_DENIED, exc
+        assert exc.details() == 'access denied'
+
+    @pytest.mark.asyncio
+    async def test_context_abort_status(self, grpc_server_port):
+        ok, exc = await _unary(grpc_server_port, '/err.Err/Abort')
+        assert not ok
+        assert exc.code() == grpc.StatusCode.NOT_FOUND, exc
+        assert exc.details() == 'item not found'
+
+    @pytest.mark.asyncio
+    async def test_unknown_method_is_unimplemented(self, grpc_server_port):
+        ok, exc = await _unary(grpc_server_port, '/nope.No/Method')
+        assert not ok
+        assert exc.code() == grpc.StatusCode.UNIMPLEMENTED, exc
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — the ghz load shape (many multiplexed streams / one channel).
+# ---------------------------------------------------------------------------
+
+class TestRealClientConcurrency:
+    @pytest.mark.asyncio
+    async def test_many_concurrent_calls_one_channel(self, grpc_server_port):
+        async def one(i: int):
+            payload = f'msg{i}'.encode()
+            ok, value = await _unary(grpc_server_port, '/echo.Echo/Echo', payload)
+            assert ok, f'call {i} failed: {value}'
+            assert value == payload[::-1]
+
+        await asyncio.gather(*(one(i) for i in range(50)))

--- a/tests/conformance/grpc/test_grpc_security.py
+++ b/tests/conformance/grpc/test_grpc_security.py
@@ -581,9 +581,17 @@ class TestResponseShape:
         ], f'unexpected event sequence: {types}'
 
     @pytest.mark.asyncio
-    async def test_trailers_only_error_has_start_only(self):
-        """Error responses should be 'Trailers-Only': a single HEADERS frame
-        with END_STREAM, containing grpc-status, and no DATA frame."""
+    async def test_error_response_carries_status_in_trailers(self):
+        """Error responses must carry ``grpc-status`` in a *trailing* HEADERS
+        frame, not the initial (non-terminal) HEADERS.
+
+        gRPC-over-HTTP2 requires the status to arrive either as true
+        Trailers-Only (initial HEADERS *with* END_STREAM) or in a trailing
+        HEADERS frame.  BlackBull emits Response-Headers → trailers (no
+        message), so the ASGI shape is ``start(trailers=True) → trailers`` with
+        no body event.  A strict client (grpcio/grpc-go) reads status from the
+        trailers; the earlier ``start + empty-DATA`` shape put grpc-status in
+        the non-terminal HEADERS and real clients reported UNKNOWN."""
         reg = GrpcServiceRegistry()
 
         @reg.method('/svc/Err')
@@ -594,16 +602,17 @@ class TestResponseShape:
         await serve_grpc(reg, _grpc_scope('/svc/Err'),
                          _receive_with(encode_message(b'')), send)
         types = [e['type'] for e in events]
-        assert types == ['http.response.start', 'http.response.body'], (
-            f'trailers-only should be start + body(empty,more_body=False), got {types}')
-        # The body must be empty
-        assert events[1]['body'] == b''
-        assert events[1]['more_body'] is False
+        assert types == ['http.response.start', 'http.response.trailers'], (
+            f'error path should be start(trailers=True) + trailers, got {types}')
+        # The start must announce trailers and carry no grpc-status itself.
+        start_headers = dict(events[0]['headers'])
+        assert events[0].get('trailers') is True
+        assert b'grpc-status' not in start_headers
 
     @pytest.mark.asyncio
-    async def test_trailers_only_includes_grpc_status_in_headers(self):
-        """For trailers-only response, grpc-status must appear in the
-        response start headers (not in a separate trailers event)."""
+    async def test_error_status_appears_in_trailers_event(self):
+        """``grpc-status`` (and ``grpc-message``) must appear in the trailers
+        event, not the response start headers."""
         reg = GrpcServiceRegistry()
 
         @reg.method('/svc/Err')
@@ -615,10 +624,11 @@ class TestResponseShape:
                          _receive_with(encode_message(b'')), send)
         start = events[0]
         assert start['type'] == 'http.response.start'
-        start_headers = dict(start['headers'])
-        assert start_headers.get(b'grpc-status') == \
-            str(int(GrpcStatus.PERMISSION_DENIED)).encode()
         assert start['status'] == 200  # gRPC errors still use HTTP 200
+        trailers = dict(events[-1]['headers'])
+        assert events[-1]['type'] == 'http.response.trailers'
+        assert trailers.get(b'grpc-status') == \
+            str(int(GrpcStatus.PERMISSION_DENIED)).encode()
 
     @pytest.mark.asyncio
     async def test_response_has_correct_content_type(self):


### PR DESCRIPTION
## Summary

Root-causes and fixes the **gRPC h2c-over-real-socket core bug** (Sprint 58 deferred item). It was **not** a wire-path bug — the h2c transport is solid (verified single, 500-way concurrent, and 100 KB unary calls with a real `grpcio` client). The **success path always worked**; **every error path was broken**.

`serve_grpc._send_trailers_only()` emitted `grpc-status` in a **non-terminal HEADERS frame** followed by an empty `END_STREAM` DATA frame. A spec-strict client (grpcio / grpc-go) reads status only from a HEADERS frame *with* END_STREAM or a *trailing* HEADERS frame — so it decoded `INTERNAL`, `PERMISSION_DENIED`, `UNIMPLEMENTED`, … **all as `UNKNOWN`** (`"Stream removed (Data frame with END_STREAM flag received)"`). BlackBull's own lenient `HTTP2Client` tolerated the framing, which is exactly why nothing caught it before a real gRPC client hit the wire.

## The fix

- **`blackbull/grpc/asgi.py`** — route errors through `http.response.start(trailers=True)` + `http.response.trailers`, so `grpc-status` rides a **trailing** HEADERS frame. Reuses the already-working success-path trailers machinery; **no sender change**.

Verified with a real grpcio client — before: all `UNKNOWN`; after: `INTERNAL` / `PERMISSION_DENIED` / `NOT_FOUND` / `UNIMPLEMENTED` all correct.

## Supporting changes

- **`test_grpc_security.py`** — two `TestResponseShape` tests had codified the *buggy* shape (one's own docstring described the correct spec while its assertion checked the wrong thing). Corrected both to the conformant shape.
- **`tests/conformance/grpc/test_grpc_real_client_h2c.py`** (new) — the only test that puts a real, spec-strict `grpcio` client on the wire: success, every error status, large-response flow control, and concurrent multiplexed calls (the ghz load shape). Gated by `pytest.importorskip('grpc')`.
- **`pyproject.toml`** — new `grpc-interop` extra (`grpcio`).
- **`conformance.yml`** — new docker-free `grpc-interop` CI job runs the interop suite on every push/PR (same per-PR-gate philosophy as the H2 deadlock gate).
- **CHANGELOG** — Fixed + Added entries.

## Tests

All 246 gRPC tests pass (238 in-tree + 7 real-client interop, minus skips). The pre-commit full-suite run flaked only on the unrelated timing-based `test_reload.py::test_auto_reload_picks_up_new_code` (passes in isolation; 2512 other tests passed).

## Not in scope

ghz's HttpArena `stream-grpc` profiles use **server-streaming** (`StreamSum`), which BlackBull (unary-only) can't serve — a separate feature gap, tracked in a follow-up proposal, not this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)