### PR TITLE
perf(access-log): defer format() off the event loop (~28–30% less per-emit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,16 @@ so the editable install's metadata catches up.
   pairs; names/values may be `str` or `bytes`. Malformed shapes now raise
   `TypeError` at construction instead of silently corrupting the response
   (the old loop iterated a dict's *keys*).
+- **Access-log hot-path cost cut (~28–30% less event-loop work per emit** in a
+  200k-emit producer microbenchmark, ~9.3µs → ~6.6µs). The access record is now
+  self-formatting and handed to the logger *as the message*, so the `format()`
+  string build (and the stdlib `QueueHandler`'s eager format + record copy)
+  moves off the event loop to the logging listener thread via a new
+  deferred-format `QueueHandler`. The request duration is snapshotted at emit so
+  the deferred format still reports real request duration, not duration + queue
+  latency. Structured `extra` fields (the documented access-log API) stay eager
+  and unchanged; ordinary debug/warning logs keep the stdlib's eager,
+  mutation-safe formatting.
 
 ### Fixed
 - **gRPC Trailers-Only framing (real-client interop)** — unary gRPC error

--- a/blackbull/logger.py
+++ b/blackbull/logger.py
@@ -71,6 +71,32 @@ class ColoredFormatter(logging.Formatter):
         return logging.Formatter.format(self, colored_record)
 
 
+class _DeferredFormatQueueHandler(logging.handlers.QueueHandler):
+    """QueueHandler that defers formatting of self-formatting records.
+
+    The stdlib :class:`~logging.handlers.QueueHandler.prepare` eagerly calls
+    ``self.format(record)`` on the *producer* thread (here, the event loop) so
+    the record is safe to hand across a process boundary.  For BlackBull's
+    access log that means the expensive ``AccessLogRecord.format()`` string
+    build runs on the hot path even though the actual write happens on the
+    listener thread.
+
+    Records whose message object is marked ``_bb_deferred_format`` (the
+    :class:`AccessLogRecord`) are enqueued *without* formatting or copying, so
+    the string build moves to the listener thread.  This is safe because the
+    queue is in-process (``SimpleQueue`` — no pickling) and an access record is
+    created fresh per request and never mutated after emit (its duration is
+    snapshotted by ``finalize()``).  Every other record keeps the stdlib's
+    eager-format, copy-and-sanitize behaviour, so mutable ``%``-args in
+    debug/warning logs still render their value-at-log-time.
+    """
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        if getattr(record.msg, '_bb_deferred_format', False):
+            return record
+        return super().prepare(record)
+
+
 _listener: logging.handlers.QueueListener | None = None
 
 
@@ -103,7 +129,7 @@ def setup_async_logging(handlers: list[logging.Handler] | None = None) -> None:
         handlers = existing if existing else [logging.StreamHandler()]
 
     log_queue: _queue_mod.SimpleQueue = _queue_mod.SimpleQueue()
-    queue_handler = logging.handlers.QueueHandler(log_queue)  # type: ignore[arg-type]
+    queue_handler = _DeferredFormatQueueHandler(log_queue)  # type: ignore[arg-type]
 
     for h in list(bb_logger.handlers):
         bb_logger.removeHandler(h)

--- a/blackbull/server/access_log.py
+++ b/blackbull/server/access_log.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 from ..asgi import ASGIEvent
 # Imported at runtime (not under TYPE_CHECKING) so beartype can resolve
@@ -26,15 +27,25 @@ PHASE_TRACE: bool = os.environ.get('BB_PHASE_TRACE', '0') == '1'
 def emit_access_log(record: 'AccessLogRecord') -> None:
     """Emit *record* on the access logger if INFO is enabled.
 
-    The isEnabledFor gate matters: ``record.format()`` and
-    ``record.as_extra()`` are evaluated before ``logger.info`` decides to
+    The isEnabledFor gate matters: ``record.as_extra()`` and (formerly)
+    ``record.format()`` are evaluated before ``logger.info`` decides to
     discard the call.  Profiling at -R 5000 with BB_ACCESS_LOG=0 showed
-    these two calls still costing ~1.2% of CPU.  Peers (uvicorn / granian /
+    these calls still costing ~1.2% of CPU.  Peers (uvicorn / granian /
     daphne) skip the work entirely when access logging is disabled; gating
     here matches that behaviour.
+
+    The *record itself* is handed to ``logger.info`` as the message (it is
+    self-formatting via ``__str__``), so the expensive ``format()`` string
+    build is deferred to the logging listener thread by the deferred-format
+    QueueHandler (``blackbull.logger``) instead of running on the event loop.
+    ``finalize()`` snapshots the duration first so that deferred format still
+    reports the request's real duration, not duration + queue latency.  The
+    structured ``extra`` fields stay eager — they are the documented public
+    access-log API (guide.md §14; ``tests/integration/test_access_log.py``).
     """
     if _access_logger.isEnabledFor(logging.INFO):
-        _access_logger.info(record.format(), extra=record.as_extra())
+        record.finalize()
+        _access_logger.info(record, extra=record.as_extra())
 
 
 @dataclass
@@ -66,6 +77,18 @@ class AccessLogRecord:
     # name → (perf_counter_seconds, process_time_seconds).  Only written
     # when PHASE_TRACE is on; empty otherwise.
     phases: dict[str, tuple[float, float]] = field(default_factory=dict, repr=False)
+    # Duration snapshot taken by finalize() at emit time so a format() run
+    # later on the logging listener thread reports the real request duration
+    # (not duration + queue latency).  None until finalize()/emit.
+    _duration_ms_snapshot: float | None = field(default=None, repr=False)
+    # Cached format() output — filled on first str() (listener thread).  Cached
+    # because several sink handlers may each format the same record.
+    _formatted: str | None = field(default=None, repr=False)
+
+    # Marker read by the deferred-format QueueHandler (blackbull.logger) to
+    # move this record's format() off the event-loop thread.  A ClassVar, not
+    # a dataclass field, so it is not part of __init__/eq/repr.
+    _bb_deferred_format: ClassVar[bool] = True
 
     def mark(self, name: str) -> None:
         """Capture wall + CPU clocks for *name*.  No-op when phase
@@ -110,7 +133,29 @@ class AccessLogRecord:
         )
 
     def duration_ms(self) -> float:
+        # Return the finalize() snapshot when present so the value is stable
+        # across the emit → enqueue → listener-format hop; fall back to a live
+        # reading for records that were never finalized (e.g. direct callers).
+        if self._duration_ms_snapshot is not None:
+            return self._duration_ms_snapshot
         return (time.monotonic() - self._started_at) * 1000
+
+    def finalize(self) -> 'AccessLogRecord':
+        """Snapshot the duration at completion so a later (deferred) format()
+        reports the request's real duration rather than duration + the time the
+        record waited in the logging queue.  Idempotent; returns ``self``."""
+        if self._duration_ms_snapshot is None:
+            self._duration_ms_snapshot = (time.monotonic() - self._started_at) * 1000
+        return self
+
+    def __str__(self) -> str:
+        """Self-formatting message body.  ``emit_access_log`` hands the record
+        to ``logger.info`` as the message so this — and the ``format()`` string
+        build it wraps — runs on the logging listener thread, not the event
+        loop.  Cached because several sink handlers may format the same record."""
+        if self._formatted is None:
+            self._formatted = self.format()
+        return self._formatted
 
     def format(self) -> str:
         if self.close_code is not None:

--- a/tests/unit/test_access_log_perf.py
+++ b/tests/unit/test_access_log_perf.py
@@ -1,0 +1,157 @@
+"""Unit tests for the deferred-format access-log fast path.
+
+Covers the O1 hot-path optimization: the access record is self-formatting and
+handed to ``logger.info`` as the message so its ``format()`` string build runs
+on the logging *listener* thread (via ``_DeferredFormatQueueHandler``) rather
+than the event loop, while structured ``extra`` fields stay eager and the
+logged duration is snapshotted at emit.
+"""
+from __future__ import annotations
+
+import logging
+import logging.handlers
+import queue
+import time
+
+import pytest
+
+from blackbull.logger import (
+    _DeferredFormatQueueHandler, setup_async_logging, teardown_async_logging,
+)
+from blackbull.server.access_log import AccessLogRecord, emit_access_log
+
+
+def _record(**kw) -> AccessLogRecord:
+    base = dict(client_ip='127.0.0.1', method='GET', path='/x',
+                http_version='1.1', status=200, response_bytes=3)
+    base.update(kw)
+    return AccessLogRecord(**base)
+
+
+# ---------------------------------------------------------------------------
+# finalize() / duration snapshot
+# ---------------------------------------------------------------------------
+
+def test_finalize_snapshots_duration_stable_across_delay():
+    rec = _record()
+    rec.finalize()
+    snap = rec.duration_ms()
+    time.sleep(0.02)
+    # Deferred format on the listener thread happens *after* the record waited
+    # in the queue; duration must not grow to include that wait.
+    assert rec.duration_ms() == snap
+
+
+def test_finalize_is_idempotent():
+    rec = _record()
+    rec.finalize()
+    first = rec.duration_ms()
+    rec.finalize()
+    assert rec.duration_ms() == first
+
+
+def test_duration_live_without_finalize():
+    rec = _record()
+    d1 = rec.duration_ms()
+    time.sleep(0.02)
+    # No finalize() → live reading, so it advances.
+    assert rec.duration_ms() > d1
+
+
+# ---------------------------------------------------------------------------
+# self-formatting message
+# ---------------------------------------------------------------------------
+
+def test_str_equals_format_and_is_cached():
+    rec = _record()
+    s1 = str(rec)
+    assert s1 == rec.format()
+    # Cached: second str() returns the same object (no re-build).
+    assert str(rec) is s1
+
+
+def test_str_reflects_snapshot_duration():
+    rec = _record()
+    rec.finalize()
+    time.sleep(0.02)
+    # The formatted line must use the snapshot, not a fresh (larger) reading.
+    assert f'{rec.duration_ms():.0f}ms' in str(rec)
+
+
+# ---------------------------------------------------------------------------
+# _DeferredFormatQueueHandler.prepare
+# ---------------------------------------------------------------------------
+
+def _logrecord(msg) -> logging.LogRecord:
+    return logging.LogRecord('blackbull.access', logging.INFO,
+                             __file__, 1, msg, (), None)
+
+
+def test_prepare_defers_access_records():
+    handler = _DeferredFormatQueueHandler(queue.SimpleQueue())
+    rec = _record()
+    lr = _logrecord(rec)
+    prepared = handler.prepare(lr)
+    # Returned unchanged (no eager format, no copy): message object preserved,
+    # so the listener thread does the format().
+    assert prepared is lr
+    assert prepared.msg is rec
+
+
+def test_prepare_eager_formats_normal_records():
+    handler = _DeferredFormatQueueHandler(queue.SimpleQueue())
+    lr = _logrecord('plain %s')
+    lr.args = ('value',)
+    prepared = handler.prepare(lr)
+    # Stdlib behaviour for non-access records: formatted + args cleared.
+    assert prepared.message == 'plain value'
+    assert prepared.args is None
+
+
+# ---------------------------------------------------------------------------
+# end-to-end through the async listener
+# ---------------------------------------------------------------------------
+
+class _Capture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record):
+        # Force formatting (what a real sink does) so we exercise the deferred
+        # path on the listener thread.
+        record.getMessage()
+        self.records.append(record)
+
+
+@pytest.fixture
+def _cleanup():
+    yield
+    teardown_async_logging()
+
+
+def test_emit_reaches_listener_with_structured_fields(_cleanup):
+    cap = _Capture()
+    cap.setLevel(logging.INFO)
+    setup_async_logging(handlers=[cap])
+
+    acc = logging.getLogger('blackbull.access')
+    acc.setLevel(logging.INFO)
+
+    rec = _record(path='/deferred', status=201)
+    emit_access_log(rec)
+
+    deadline = time.monotonic() + 2.0
+    while time.monotonic() < deadline and not cap.records:
+        time.sleep(0.01)
+
+    assert cap.records, 'access record never reached the listener'
+    lr = cap.records[-1]
+    # Deferred format produced the right line on the listener thread...
+    assert '/deferred' in lr.getMessage()
+    assert '201' in lr.getMessage()
+    # ...and the structured extra fields survived (public API contract).
+    assert lr.path == '/deferred'
+    assert lr.status == 201
+    assert lr.client_ip == '127.0.0.1'
+    assert isinstance(lr.duration_ms, float)


### PR DESCRIPTION
## Summary

Makes the per-request access-log emit minimal on the event-loop thread by moving the expensive work to the logging listener thread.

**What was slow:** `emit_access_log` built the full `format()` string *and* the `as_extra()` dict on the event loop, then the stdlib `QueueHandler` re-formatted + `copy.copy`'d the record — again on the event loop — before enqueueing. The `format()` string build was the dominant per-request cost.

## The change

- **`AccessLogRecord` is self-formatting** — `__str__` → cached `format()`. `emit_access_log` hands the *record itself* to `logger.info` as the message, so the string build is deferred.
- **New `_DeferredFormatQueueHandler`** (`blackbull/logger.py`) — for records marked `_bb_deferred_format` (the access record), `prepare()` skips the eager format + copy and enqueues as-is, so `format()` runs on the **listener thread**. Every other log (debug/warning) keeps the stdlib's eager, mutation-safe path.
- **`finalize()` snapshots duration at emit** — so the deferred format reports real request duration, not duration + queue latency.
- **Structured `extra` fields stay eager** — documented public access-log API (guide.md §14; `tests/integration/test_access_log.py` reads `record.status`/`path`/…), so that contract is untouched.

## Measured

Producer-thread microbenchmark (200k emits): **~9.3µs → ~6.6µs per emit, ~28–30% reduction** in event-loop time, run twice for stability.

## Tests

- New `tests/unit/test_access_log_perf.py` (8): duration-snapshot stability, `__str__`/caching, `prepare()` deferral vs. eager-format, and end-to-end delivery with structured fields intact.
- Green: 1511 unit+architecture, plus the logging/access/event suites under beartype (67), including the integration test that asserts the structured-field contract.

## Scope

Lands **O1 (deferred formatting)** from `.claude/planning/proposals/logging-performance-optimization.md` (updated to mark it done). O2–O4 (batch writes, lock-free queue, zero-copy record) and the full AWS throughput re-measure against the ≤5% target remain open — the ~28–30% figure is a local producer-thread microbenchmark, not the end-to-end profile number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)