### PR TITLE
test(ci): stabilize reload watcher tests + large-bidirectional H2 deadlock gate

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -10,7 +10,8 @@ name: RFC conformance
 #                     fuzz/user-corpus/ diff entries
 #   h2-flow-control — docker-free RFC 9113 flow-control deadlock gate
 #                     (the three payload > 65535-byte deadlocks fixed
-#                     in v0.46.0), subprocess-isolated per scenario
+#                     in v0.46.0, plus a large 128 KiB bidirectional
+#                     stress), subprocess-isolated per scenario
 #   grpc-interop   — docker-free real-client (grpcio) gRPC interop over
 #                     h2c: the only test that puts a spec-strict external
 #                     gRPC client on the wire (guards the Trailers-Only
@@ -234,11 +235,13 @@ jobs:
       - name: Run H2 flow-control deadlock regression gate
         # Docker-free, subprocess-isolated regression gate for the three RFC
         # 9113 flow-control deadlocks fixed in v0.46.0 (client crediting,
-        # sender lost-wakeup, WU-on-closed-stream).  Each scenario runs in a
-        # child interpreter (`sys.executable`) with an 8s per-step guard; the
-        # outer 90s bounds the whole job in case the subprocess guard itself
-        # wedges.  Runs on every push/PR so a reintroduced deadlock blocks
-        # merge instead of surfacing only in the weekly full tier.
+        # sender lost-wakeup, WU-on-closed-stream) plus a large 128 KiB
+        # bidirectional payload that forces multiple WINDOW_UPDATE refills in
+        # both directions.  Each scenario runs in a child interpreter
+        # (`sys.executable`) with an 8s per-step guard; the outer 90s bounds
+        # the whole job in case the subprocess guard itself wedges.  Runs on
+        # every push/PR so a reintroduced deadlock blocks merge instead of
+        # surfacing only in the weekly full tier.
         run: |
           timeout 90 python -m pytest --timeout=60 -v \
               tests/conformance/http2/test_h2_flow_control_deadlock.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ so the editable install's metadata catches up.
   until a real gRPC client (`ghz`/grpcio) exercised the wire path. The success
   path was already correct; only the error/Trailers-Only path changed.
 
+### Internal
+- **Reload watcher unit tests pinned to polling** — `test_watcher_fires_callback_on_py_change`
+  / `test_watcher_ignores_non_py` now force watchfiles into polling mode (as the
+  reload *integration* test already did in its subprocess), removing the inotify
+  startup-race flake where the first `.py` write was silently dropped under
+  suite contention. These run in the fast tier on every PR, so the flake blocked
+  merges; the watcher logic under test is identical either way.
+- **H2 flow-control deadlock gate now covers a large bidirectional payload** — a
+  4th subprocess-isolated scenario echoes 128 KiB of gRPC (up *and* down),
+  forcing multiple `WINDOW_UPDATE` refills in both directions at once rather than
+  the single-refill window boundary of the existing steps. A regression in
+  client crediting or sender resume that survives the boundary cases deadlocks
+  here. Rides the existing `h2-flow-control` conformance CI job (every push/PR).
+
 ## [0.46.0] — 2026-06-30
 
 Sprint 57 — **gRPC** (the next protocol after MQTT) plus three supporting

--- a/tests/conformance/http2/test_h2_flow_control_deadlock.py
+++ b/tests/conformance/http2/test_h2_flow_control_deadlock.py
@@ -1,8 +1,11 @@
 """Conformance test: H2 flow-control for payloads above the 65535-byte
 initial window (Sprint 57).
 
-Three sequential RFC-compliance checks in one test function — each
-step gates the next.  Subprocess isolation is required because the
+Four sequential RFC-compliance checks in one test function — each
+step gates the next.  Steps 1-3 pin the three fixed bugs at the window
+boundary; step 4 adds a large *bidirectional* payload that forces
+multiple WINDOW_UPDATE refills in both directions at once.  Subprocess
+isolation is required because the
 deadlocks survive ``CancelledError``, ``@pytest.mark.timeout``, and
 ``asyncio.wait_for`` (they block at the C-level socket / event-loop
 teardown).  **However, the scenario logic lives in plain async
@@ -111,6 +114,49 @@ async def _scenario_step2_grpc_65531b():
         assert r.status == 200
 
 
+async def _scenario_step4_grpc_128kb_bidir():
+    """Large *bidirectional* payload: gRPC Echo of 128 KiB.
+
+    Steps 1-3 hit the deadlocks at the window boundary (step 2 is 65536
+    bytes — a single WINDOW_UPDATE refill).  This step sends *and* receives
+    128 KiB, forcing ~2 full window refills in **each** direction at once:
+    the client must credit received DATA (bug #1) *while* the server's
+    sender resumes on incoming WINDOW_UPDATEs (bug #2), with neither side
+    able to drain the other in one window.  A regression in either
+    direction's flow control wedges here even if the boundary cases pass.
+    """
+    from blackbull import BlackBull
+    from blackbull.grpc import GrpcServiceRegistry, encode_message, decode_messages
+    from blackbull.client.http2 import HTTP2Client
+    from blackbull.server.server import ASGIServer
+
+    app = BlackBull()
+    reg = GrpcServiceRegistry()
+
+    @reg.method('/echo.Echo/Echo')
+    async def echo(request, context):
+        return request
+
+    app.enable_grpc(reg)
+
+    srv = ASGIServer(app)
+    srv.open_socket(port=0)
+    port = srv.port
+    asyncio.create_task(srv.run())
+    await asyncio.sleep(0.15)
+
+    payload = bytes((i % 256) for i in range(131072))  # 128 KiB, ~2x the window
+    async with HTTP2Client('127.0.0.1', port) as c:
+        r = await c.request(
+            'POST', '/echo.Echo/Echo',
+            headers=[('content-type', 'application/grpc')],
+            body=encode_message(payload))
+        assert r.status == 200
+        # The echoed body must survive intact — a partial/dropped refill
+        # would truncate it even if the stream did not hang.
+        assert decode_messages(r.body) == [(False, payload)]
+
+
 async def _scenario_step3_rapid_30():
     """Bug #3: 30 rapid gRPC Echo — late WU on closed stream."""
     from blackbull import BlackBull
@@ -151,6 +197,7 @@ _SCENARIOS = {
     'step1': _scenario_step1_rest_100kb,
     'step2': _scenario_step2_grpc_65531b,
     'step3': _scenario_step3_rapid_30,
+    'step4': _scenario_step4_grpc_128kb_bidir,
 }
 
 
@@ -203,6 +250,17 @@ def test_h2_flow_control_deadlocks():
         f'ignored.\n'
         f'Bug #3: blackbull/server/http2_actor.py sends RST_STREAM instead.\n'
         f'Fix: continue (ignore) for WU/RST/PRIORITY on CLOSED streams.')
+
+    # Step 4 — RFC 9113 §6.9: large *bidirectional* payload (128 KiB each
+    # way) forces multiple WINDOW_UPDATE refills in both directions at once,
+    # not just the single-refill boundary of steps 1-2.
+    ok, reason = _run_scenario('step4')
+    assert ok, (
+        f'STEP 4 FAILED ({reason})\n'
+        f'RFC 9113 §6.9: sustained bidirectional flow control — 128 KiB up '
+        f'and 128 KiB down must both credit and resume repeatedly.\n'
+        f'A regression in client crediting (bug #1) or sender resume '
+        f'(bug #2) that survives the boundary cases deadlocks here.')
 
 
 # ====================================================================

--- a/tests/unit/test_reload.py
+++ b/tests/unit/test_reload.py
@@ -68,21 +68,43 @@ def test_adopt_builds_sockets_and_clears_env(monkeypatch):
 # FileChangeWatcher
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def force_polling_watcher(monkeypatch):
+    """Force watchfiles into polling mode for the in-process watcher tests.
+
+    ``FileChangeWatcher`` uses watchfiles' default backend (inotify on
+    Linux).  inotify has a startup window where the arming races with the
+    first write, and on WSL2's drvfs/9p — and under the CPU/IO contention
+    of the full test suite — it silently drops that first event.  That is
+    the exact flake ``tests/integration/test_reload.py`` fixed by forcing
+    polling in its subprocess env; these unit tests run the watcher
+    in-process and were still on the flaky inotify path.
+
+    watchfiles reads ``WATCHFILES_FORCE_POLLING`` at ``watch()`` time (in
+    its Rust thread), so setting it before ``watcher.start()`` is enough.
+    Polling is backend-agnostic and reliable across filesystems; the
+    watcher logic under test is identical either way.  ``monkeypatch``
+    restores the environment after the test.
+    """
+    monkeypatch.setenv('WATCHFILES_FORCE_POLLING', '1')
+    monkeypatch.setenv('WATCHFILES_POLL_DELAY_MS', '50')
+
+
 def test_default_filter_accepts_only_py():
     assert _default_filter(None, '/x/y/app.py') is True
     assert _default_filter(None, '/x/y/notes.md') is False
     assert _default_filter(None, '/x/y/__pycache__/app.cpython-312.pyc') is False
 
 
-def test_watcher_fires_callback_on_py_change(tmp_path: Path):
+def test_watcher_fires_callback_on_py_change(tmp_path: Path, force_polling_watcher):
     """Touching a .py file inside the watched dir must invoke the callback.
 
-    Robustness note: watchfiles' Rust backend has a startup window where
-    its inotify install races with our first write; on WSL2 we have seen
-    the very first event lost.  Instead of a single fixed sleep we keep
-    rewriting the file at a slow cadence until the callback fires or the
-    test deadline expires — the real reload path has the same shape
-    (user mashes Save until they see effect).
+    Robustness note: the ``force_polling_watcher`` fixture pins watchfiles
+    to polling so the first write is not lost to an inotify startup race.
+    We still keep rewriting the file at a slow cadence until the callback
+    fires or the deadline expires — the real reload path has the same
+    shape (user mashes Save until they see effect), and it costs nothing
+    when the very first poll already catches the change.
     """
     target = tmp_path / 'app.py'
     target.write_text('print("v1")\n')
@@ -103,7 +125,7 @@ def test_watcher_fires_callback_on_py_change(tmp_path: Path):
         watcher.stop()
 
 
-def test_watcher_ignores_non_py(tmp_path: Path):
+def test_watcher_ignores_non_py(tmp_path: Path, force_polling_watcher):
     """Editing a .md file must NOT fire the callback (default filter)."""
     py = tmp_path / 'app.py'
     py.write_text('print("v1")\n')


### PR DESCRIPTION
Two CI-tier test-stability fixes for Sprint 58.

## 1. Reload watcher flake (fast tier, every PR)

`test_watcher_fires_callback_on_py_change` and `test_watcher_ignores_non_py` ran `FileChangeWatcher` **in-process** on watchfiles' default **inotify** backend. inotify has a startup window where its arming races with the first write, and under the CPU/IO contention of the full suite (and on WSL2 filesystems) it silently drops that first event — the callback never fires, the test fails. This is the exact flake the reload *integration* test already fixed by forcing polling in its subprocess env; the unit tests were still on the flaky path, and they run in the **fast tier on every PR**, so the flake blocked merges.

Fix: a `force_polling_watcher` `monkeypatch` fixture pins watchfiles to polling (`WATCHFILES_FORCE_POLLING=1`) for both tests. watchfiles reads the env var at `watch()` time, so setting it before `start()` is enough; polling is backend-agnostic and the watcher logic under test is identical either way. **10/10 clean locally.**

## 2. H2 flow-control deadlock gate — large bidirectional payload

The existing gate (`test_h2_flow_control_deadlock.py`, wired into the `h2-flow-control` conformance job on every PR by #105) exercises the three v0.46.0 flow-control bugs only at the **window boundary** — step 2 is 65536 bytes, a single `WINDOW_UPDATE` refill.

Added a 4th subprocess-isolated scenario: a gRPC Echo of **128 KiB up *and* down**, forcing ~2 full window refills in **each direction at once**. The client must credit received DATA (bug #1) *while* the server's sender resumes on incoming WINDOW_UPDATEs (bug #2), with neither side able to drain the other in one window — a regression that survives the boundary cases deadlocks here. The echoed body is asserted intact so a partial/dropped refill is caught even if the stream doesn't fully hang.

Rides the existing `h2-flow-control` CI job (docker-free, subprocess-isolated, every push/PR). 4 steps run in ~3s locally, well under the 8s/step + 90s/job guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)