### PR TITLE
release: v0.47.0 — Sprint 58: server-streaming gRPC + cold-start early-bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.47.0] — 2026-07-03
+
 ### Added
 - **Server-streaming gRPC** — a gRPC handler may now be an async generator that
   `yield`s response messages (`async def m(request, context): yield ...`); the
@@ -62,8 +64,21 @@ so the editable install's metadata catches up.
   calls). It is the only test that puts a spec-strict external gRPC client on
   the wire; a dedicated docker-free `grpc-interop` CI job runs it on every
   push/PR (install with `pip install 'blackbull[grpc-interop]'`).
+- **Pre-fork warm-up hooks** — `@app.on_warmup` registers a coroutine that runs
+  **once in the master, before the listening socket is created and before
+  workers fork**, so every worker inherits the warmed heap (PEP 659
+  specialization, primed codecs/TLS) via copy-on-write. `app.drive_asgi(scope,
+  body=, n=)` drives the ASGI dispatch path in-process (no socket) to fault in
+  code pages, and `blackbull.server.warmup.warm_tls` primes the TLS handshake.
+  A no-op with no hooks registered (off by default); `BB_WARMUP_BUDGET_S` caps
+  total warm-up time and `BB_WARMUP_TLS_N` the number of in-memory TLS
+  handshakes.
 
 ### Changed
+- **Default `listen()` backlog raised from 128 to 1024** (`BB_SOCKET_BACKLOG`).
+  128 (the traditional `SOMAXCONN`) is shallow next to peers like nginx (511);
+  1024 reduces silent connection drops during burst arrivals. The kernel still
+  caps the effective queue at `net.core.somaxconn`.
 - **`Response(headers=...)` accepts a `dict`** (matching the
   FastAPI/Starlette/httpx convention) as well as a list of `(name, value)`
   pairs; names/values may be `str` or `bytes`. Malformed shapes now raise

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -233,13 +233,14 @@ opt-in knob is sketched in the roadmap but not built.
 
 Out of scope.  Revisit if a real user need appears.
 
-### gRPC: unary only
+### gRPC: unary + server-streaming only
 
-Unary gRPC over HTTP/2 ships in `blackbull.grpc` (`app.enable_grpc`):
-`application/grpc` requests multiplex onto the same HTTP/2 port as
-REST and WebSocket, with `grpc-status` reported in trailers.  Server-
-and client-streaming are **not** implemented yet, and there is no
-protobuf codegen toolchain — handlers exchange raw message bytes, so
+Unary **and server-streaming** gRPC over HTTP/2 ship in `blackbull.grpc`
+(`app.enable_grpc`): `application/grpc` requests multiplex onto the same
+HTTP/2 port as REST and WebSocket, with `grpc-status` reported in trailers
+(a trailing HEADERS frame).  Client- and bidirectional-streaming are **not**
+implemented yet (they need a streamed request), and there is no protobuf
+codegen toolchain — handlers exchange raw message bytes, so
 descriptor/message classes are the application's choice.  Message
 compression is also unsupported (the server advertises
 `grpc-accept-encoding: identity`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.47.x  | :white_check_mark: |
 | 0.46.x  | :white_check_mark: |
-| 0.45.x  | :white_check_mark: |
-| < 0.45  | :x:                |
+| < 0.46  | :x:                |
 
 This table updates with each minor release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.46.0"
+version = "0.47.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Closes Sprint 58 as **v0.47.0** (MINOR bump).

**Added**
- Server-streaming gRPC (async-generator handlers; status in the trailing HEADERS frame).
- `scope_completed` terminal event + blocking observers; `app.register_converter`.
- Real-client gRPC interop conformance suite + a `grpc-interop` CI job.
- Pre-fork warm-up hooks (`@app.on_warmup`, `drive_asgi`, `warm_tls`) — off by default.

**Changed**
- Default `listen()` backlog 128 → 1024 (`BB_SOCKET_BACKLOG`).
- `Response(headers=...)` accepts a `dict`; access-log hot-path ~28–30% cheaper; gRPC isolation catches `Exception` not `BaseException`.

**Fixed**
- gRPC Trailers-Only framing so real gRPC clients decode error status correctly.

Bench (not user-facing): early-bind the HttpArena gRPC listener (`BB_EARLY_BIND`) to fix the run-1 collapse at 256c.

## Release commit
Two-file: `pyproject.toml` (0.46.0 → 0.47.0) + `CHANGELOG.md` (`[Unreleased]` → `[0.47.0]`). Preceded by a docs-prep commit (SECURITY supported-versions shift + KNOWN_LIMITATIONS gRPC update).

## Test plan
- [x] Full beartype suite green on both commits (pre-commit, 2555 passed).
- [x] `python -c "import blackbull; print(blackbull.__version__)"` → `0.47.0` after `pip install -e .`.
- [ ] CodeQL / Audit dependencies / Build green (gating this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)