### PR TITLE
fix(http1): parse bracketed IPv6 Host header — v0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@ so the editable install's metadata catches up.
 
 ---
 
+## [0.48.1] — 2026-07-05
+
+### Fixed
+- **IPv6 requests returned an empty reply** (RFC 3986 §3.2.2) — parsing a
+  bracketed IPv6 Host header (`[::1]:8100`) with a naive `split(b':')` produced
+  `int(b'')` → `ValueError`, which propagated past `HTTP1Actor.run` and closed
+  the transport with no response bytes. Every IPv6 request saw "empty reply from
+  server" even though the TCP handshake succeeded; IPv4 on the same host worked.
+  Host parsing now understands the bracket form and falls back to the default
+  port on a missing/invalid port. This unblocks deployment behind IPv6-only
+  reverse proxies (e.g. Alwaysdata, whose proxy connects over `::`).
+- **IPv6 `scope['client']` / `scope['server']` were 4-tuples** — `AF_INET6`
+  `getpeername`/`getsockname` return `(host, port, flowinfo, scope_id)`; these
+  are now truncated to the ASGI-required `(host, port)` 2-tuple.
+
 ## [0.48.0] — 2026-07-04
 
 ### Added

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -149,6 +149,34 @@ def _validate_message_framing(headers: 'Headers') -> None:
 _HOST_FORBIDDEN_BYTES = frozenset(b'/?# \t')
 
 
+def _parse_host_header(value: bytes, default_port: int) -> tuple[str, int]:
+    """Split a Host header value into ``(host, port)``.
+
+    Handles the RFC 3986 §3.2.2 IPv6 bracket form ``[::1]:8100`` — a
+    naive ``value.split(b':')`` yields ``int(b'')`` → ``ValueError`` on
+    those (``b'[::1]:8100'.split(b':')`` == ``[b'[', b'', b'1]', b'8100']``).
+    Pre-fix that exception bubbled past ``HTTP1Actor.run`` and closed the
+    transport with no response bytes — every IPv6 request saw an "empty
+    reply from server".
+
+    A missing or non-numeric port falls back to *default_port*.
+    """
+    if value.startswith(b'['):
+        end = value.find(b']')
+        if end != -1:
+            host = value[1:end]
+            rest = value[end + 1:]
+            if rest.startswith(b':') and rest[1:].isdigit():
+                return host.decode('utf-8'), int(rest[1:])
+            return host.decode('utf-8'), default_port
+        # Unterminated bracket — treat the whole value as the host.
+        return value.decode('utf-8'), default_port
+    host, sep, port_s = value.rpartition(b':')
+    if sep and port_s.isdigit():
+        return host.decode('utf-8'), int(port_s)
+    return value.decode('utf-8'), default_port
+
+
 def _validate_host(headers: 'Headers') -> None:
     """RFC 9112 §3.2 / §7.2 — Host MUST be present and contain a valid
     URI-authority component.  Sprint 17 Finding B captured several
@@ -681,10 +709,9 @@ class HTTP1Actor(Actor):
         }
 
         if headers.getlist(b'host'):
-            parts = headers.get(b'host').split(b':')
-            host = parts[0]
-            port = int(parts[1]) if len(parts) > 1 else (_HTTPS_PORT if self._ssl else _HTTP_PORT)
-            scope['server'] = [host.decode('utf-8'), port]
+            default_port = _HTTPS_PORT if self._ssl else _HTTP_PORT
+            host, port = _parse_host_header(headers.get(b'host'), default_port)
+            scope['server'] = [host, port]
 
         if headers.getlist(b'upgrade'):
             scope['type'] = headers.get(b'upgrade').decode('utf-8').lower()

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -319,6 +319,15 @@ class Server:
             sockname = (sockname, None)
         if isinstance(peername, str):
             peername = (peername or '', None)
+        # AF_INET6 get_extra_info returns a 4-tuple
+        # ``(host, port, flowinfo, scope_id)``; ASGI 3.0 §Connection Scope
+        # requires ``scope['client']`` / ``scope['server']`` to be
+        # ``(host, port)``.  Truncate so IPv6 peers get spec-compliant
+        # 2-tuples instead of ``['::1', port, 0, 0]``.
+        if isinstance(sockname, tuple) and len(sockname) > 2:
+            sockname = sockname[:2]
+        if isinstance(peername, tuple) and len(peername) > 2:
+            peername = peername[:2]
         ssl_object = transport.get_extra_info('ssl_object') if transport else None
         ssl_flag = ssl_object is not None
         alpn = ssl_object.selected_alpn_protocol() if ssl_object else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.48.0"
+version = "0.48.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -111,6 +111,20 @@ class TestParse:
         scope = _get_scope(_http_request(headers={'Host': 'localhost:9000'}))
         assert scope['server'] == ['localhost', 9000]
 
+    def test_ipv6_bracketed_host_and_port_are_parsed(self):
+        """RFC 3986 §3.2.2 — ``[::1]:8100`` must not crash Host parsing.
+
+        Regression: ``b'[::1]:8100'.split(b':')`` gave ``int(b'')`` →
+        ValueError, which closed the connection with no response ("empty
+        reply from server") for every IPv6 request.
+        """
+        scope = _get_scope(_http_request(headers={'Host': '[::1]:8100'}))
+        assert scope['server'] == ['::1', 8100]
+
+    def test_ipv6_bracketed_host_without_port(self):
+        scope = _get_scope(_http_request(headers={'Host': '[2001:db8::1]'}))
+        assert scope['server'] == ['2001:db8::1', 80]
+
     def test_websocket_upgrade_sets_type_websocket(self):
         scope = _get_scope(_ws_request_dispatch())
         assert scope['type'] == 'websocket', (


### PR DESCRIPTION
## Urgent hotfix — IPv6 requests return an empty reply

**Root cause:** parsing a bracketed IPv6 Host header (`[::1]:8100`) with a naive `split(b':')` produces `int(b'')` → `ValueError`. It propagates past `HTTP1Actor.run` (which only handles `HeaderTooLargeError` / `BadRequestError` / `NotImplementedFramingError`) into `ConnectionActor.run`'s generic handler, which silently closes the transport with **no response bytes** — every IPv6 request sees "empty reply from server" while IPv4 works. Blocks deployment behind IPv6-only reverse proxies (Alwaysdata connects over `::`).

Ref: `.claude/planning/recommendations/blackbull-ipv6-empty-reply.md`, RFC 3986 §3.2.2.

## Fix
- `_parse_host_header` understands the bracket form and falls back to the default port on a missing/non-numeric port (also hardened against non-numeric ports generally, which previously also raised).
- Truncate `AF_INET6` 4-tuples `(host, port, flowinfo, scope_id)` → ASGI-required `(host, port)` in `scope['client']` / `scope['server']`.

## Verification
- New regression tests: `[::1]:8100` and `[2001:db8::1]` → correct `scope['server']`.
- Live `curl http://[::1]:PORT/` now returns `HTTP/1.1 200 OK` (was empty reply).
- Full unit suite (1354) + beartype pre-commit suite pass.

Cut cleanly off `master` (v0.48.0); does not include the in-flight Sprint 60 gRPC work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)