### PR TITLE
Release v0.49.1 — audit correctness patch (Sprints 61 + 62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,96 @@ so the editable install's metadata catches up.
 
 ---
 
+## [0.49.1] — 2026-07-07
+
+Correctness patch — the HTTP/1.1 and HTTP/2 bug fixes from the 2026-07-07
+comprehensive audit (Sprints 61 + 62). No new features and no public-API
+removals; two small additions to the public API are noted below. Every fix
+ships with a regression test (`tests/unit/test_audit_sprint61.py`,
+`tests/conformance/http2/test_audit_sprint62.py`).
+
+### Fixed
+
+HTTP/1.1 + request handling:
+
+- **Chunked bodies split across TCP segments** are now reassembled whole — the
+  chunked path reads chunk-data with `readexactly`, not an up-to-`n` read
+  (RFC 9112 §7.1). *(audit 1.1)*
+- **A raising `app_startup` hook** now emits `lifespan.startup.failed` instead
+  of silently killing the lifespan task; `LifespanManager.__aenter__` races the
+  startup ack against the task so a failed startup can no longer hang the server
+  forever. *(audit 1.3)*
+- **Double-response splice**: `HTTP1Sender` drops response events once a
+  response has completed, so a handler that raises *after* completing can no
+  longer splice a second response onto the connection (mirrors the H2 sender's
+  post-`END_STREAM` drop). *(audit 1.4)*
+- **Non-WebSocket `Upgrade:` tokens** (e.g. curl's `Upgrade: h2c`) are ignored
+  rather than crashing dispatch and closing with no reply (RFC 9110 §7.8).
+  *(audit 1.5)*
+- **Keep-alive framing desync**: an unread request body is now drained (bounded)
+  or the connection is closed before the next pipelined request. *(audit 1.6)*
+- **Truncated uploads**: `read_body` raises the new `ClientDisconnected` on a
+  mid-body disconnect instead of returning a partial upload as if whole; the
+  gRPC bridge maps it to `CANCELLED`. *(audit 1.11)*
+- **Malformed JSON / dataclass request bodies** raise `HTTPException(400)`
+  instead of surfacing as a 500. *(audit 1.12)*
+- **A mid-path `{name:path}` wildcard** is rejected at registration time rather
+  than silently mis-routing. *(audit 1.13)*
+- **The WebSocket handshake** rejects an absent/malformed `Sec-WebSocket-Key`
+  with 400 (RFC 6455 §4.2.1). *(audit 1.15)*
+
+HTTP/2 flow control + lifecycle:
+
+- **Connection-level flow control** now uses one shared send window: every
+  stream sender references a single `ConnectionWindow`, so N concurrent streams
+  debit one stream-0 budget instead of each spending a full 65535-byte window.
+  A strict peer (nghttp2, grpc-go) no longer sees a connection
+  `FLOW_CONTROL_ERROR` + GOAWAY under concurrency (RFC 9113 §6.9.1). The
+  connection `WINDOW_UPDATE` handler credits the shared window once and wakes
+  all senders. *(audit 1.2; `stream_window_size` is now a plain int — refactor
+  2.5)*
+- **GOAWAY early-return** now signals recipients, so stream tasks blocked in
+  `receive()` get `http.disconnect` and the connection can drain instead of
+  wedging. *(audit 1.8)*
+- **Closed-stream tracking is bounded** (LRU cap + high-water mark), so a
+  long-lived connection cycling millions of streams no longer leaks memory.
+  *(audit 1.9)*
+- **A PRIORITY frame** naming an unknown dependency parents under the root
+  instead of crashing the frame loop. *(audit 1.10)*
+- **A single-frame HEADERS on an already-open stream** is treated as trailers
+  (clean end-of-stream), not respawned as a second request over the live
+  recipient/task. *(audit 1.14 #1)*
+- **Oversized-frame guard**: `receive()` rejects a frame whose declared payload
+  exceeds `SETTINGS_MAX_FRAME_SIZE` before buffering it — no 16 MiB allocation
+  on an attacker-declared length. *(audit 1.14 #3)*
+
+### Security
+
+- **`H2FaultServer`'s production guard** now checks the real signal
+  (`BLACKBULL_ENV=production`, with the `BB_PRODUCTION` override retained); the
+  previous `BB_PRODUCTION`-only check was a no-op in production. *(audit 1.22a)*
+- **`make_self_signed_h2_context`** registers a finalizer that removes its
+  tempdir, so the unencrypted private key no longer accumulates in `/tmp`.
+  *(audit 1.22b)*
+
+### Added (public API)
+
+- `ClientDisconnected` — raised by `read_body` on a mid-body client disconnect
+  (carries the `.partial` bytes read so far).
+- `HTTPException` — a status-carrying exception (`.status` / `.detail`) that the
+  dispatcher turns into the corresponding HTTP response.
+
+### Deferred (documented, not in this release)
+
+- **Refused multi-frame HEADERS / multi-frame trailers** (audit 1.14 #2) — needs
+  a CONTINUATION-accumulation restructure to keep HPACK decoder state coherent;
+  left for a focused follow-up rather than risking the H2 core.
+- **Consume-based inbound flow control**
+  (`proposals/consume-based-inbound-flow-control.md`) — credits the inbound
+  window on app consumption rather than enqueue, so a slow handler back-pressures
+  instead of triggering `RST_STREAM(ENHANCE_YOUR_CALM)`. Its strict-xfail gates
+  remain deferred; the large-over-window interop test stays a non-strict xfail.
+
 ## [0.49.0] — 2026-07-07
 
 Sprint 60 — completing the gRPC **transport** (the dependency-free gaps; no

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -42,10 +42,10 @@ except PackageNotFoundError:
     __version__ = '0.0.0+unknown'
 
 from .app import BlackBull, serve
-from .router import RouteInfo
+from .router import RouteInfo, HTTPException
 from .config import AppConfig
 from .headers import Headers
-from .request import read_body, read_json, read_text, parse_cookies
+from .request import read_body, read_json, read_text, parse_cookies, ClientDisconnected
 from .response import (
     Response, JSONResponse, RedirectResponse, StreamingResponse,
     EventSourceResponse, WebSocketResponse, cookie_header,

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -28,7 +28,8 @@ import logging
 from .event import Event, EventDispatcher, EventHandler
 from .headers import Headers
 from .utils import Scheme
-from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, has_middleware_param
+from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param
+from .request import ClientDisconnected
 from .config import AppConfig
 logger = logging.getLogger(__name__)
 
@@ -495,7 +496,19 @@ class BlackBull:
                     self._logger.error('Route configuration error:\n%s', exc)
                     await send({'type': 'lifespan.startup.failed', 'message': str(exc)})
                     return
-                await self._dispatcher.emit(Event('app_startup'))
+                try:
+                    await self._dispatcher.emit(Event('app_startup'))
+                except Exception as exc:
+                    # A raising @app.on_startup / @app.intercept('app_startup')
+                    # hook must fail startup, not kill the lifespan task before
+                    # it acks — otherwise LifespanManager.__aenter__ blocks
+                    # forever and the server never starts (bug 1.3).  Sending
+                    # lifespan.startup.failed is also the ASGI-correct signal
+                    # under external servers (uvicorn/hypercorn).
+                    self._logger.error('app_startup hook failed:\n%s',
+                                       traceback.format_exc())
+                    await send({'type': 'lifespan.startup.failed', 'message': str(exc)})
+                    return
                 await send({'type': 'lifespan.startup.complete'})
             elif event['type'] == 'lifespan.shutdown':
                 self._logger.debug('lifespan shutdown')
@@ -589,6 +602,22 @@ class BlackBull:
                 'handler':   function.__name__,
             }))
             await function(scope, receive, send)
+        except ClientDisconnected as e:
+            # Peer vanished mid-body — there is no one to answer.  Record it
+            # for the after_handler event but log quietly and send nothing.
+            exc_caught = e
+            self._logger.debug('client disconnected before request body completed')
+        except HTTPException as e:
+            # A status-carrying error (e.g. a malformed request body → 400).
+            # 4xx are client faults: log quietly, no traceback.  5xx still
+            # get the full traceback below.
+            exc_caught = e
+            if e.status.is_server_error:
+                self._logger.error(traceback.format_exc())
+            else:
+                self._logger.info('%s on %s %s: %s', int(e.status),
+                                  scope.get('method', ''), scope.get('path', ''),
+                                  e.detail or e)
         except Exception as e:
             exc_caught = e
             self._logger.error(traceback.format_exc())
@@ -602,9 +631,11 @@ class BlackBull:
                 'exception': exc_caught,
             }))
 
-        if exc_caught is not None:
+        if exc_caught is not None and not isinstance(exc_caught, ClientDisconnected):
+            err_status = (exc_caught.status if isinstance(exc_caught, HTTPException)
+                          else HTTPStatus.INTERNAL_SERVER_ERROR)
             scope.setdefault('state', {}).update({
-                'error_status': HTTPStatus.INTERNAL_SERVER_ERROR,
+                'error_status': err_status,
                 'error_exception': exc_caught,
             })
             handler = self._error_router[exc_caught]

--- a/blackbull/fault_injection/__init__.py
+++ b/blackbull/fault_injection/__init__.py
@@ -17,9 +17,10 @@ A single namespace for the two directions of protocol fault injection:
   lives at :mod:`blackbull.fault_injection.catalogue`.
 
 This module is an opt-in testing instrument.  The HTTP/2 server refuses
-to start when ``BB_PRODUCTION`` is set in the environment so a
-deliberate-misbehaviour code path cannot accidentally fire on a
-production deployment (see [`out-of-scope.md`](../../.claude/skills/update-roadmap/out-of-scope.md)).
+to start in a production context — when ``BLACKBULL_ENV=production`` (the
+framework's production signal) or the explicit ``BB_PRODUCTION`` override
+is set — so a deliberate-misbehaviour code path cannot accidentally fire on
+a production deployment (see [`out-of-scope.md`](../../.claude/skills/update-roadmap/out-of-scope.md)).
 
 See ``docs/guide/fault_injection.md`` for a tutorial.
 """

--- a/blackbull/fault_injection/_tls.py
+++ b/blackbull/fault_injection/_tls.py
@@ -15,8 +15,10 @@ from __future__ import annotations
 
 import datetime
 import ipaddress
+import shutil
 import ssl
 import tempfile
+import weakref
 from pathlib import Path
 
 
@@ -37,9 +39,12 @@ def make_self_signed_h2_context() -> ssl.SSLContext:
     extra (``pip install 'blackbull[fault-injection]'``).
     """
     cert_pem, key_pem = _generate_self_signed_pem()
-    # SSLContext.load_cert_chain demands file paths, not bytes.  We
-    # drop the PEMs into a tempdir; both files are removed when the
-    # context goes out of scope at process exit.
+    # SSLContext.load_cert_chain demands file paths, not bytes, so the PEMs
+    # (including the *unencrypted* private key) are written to a tempdir.  A
+    # weakref.finalize on the returned context removes that tempdir when the
+    # context is garbage-collected — or, failing that, at interpreter exit —
+    # so the key material doesn't accumulate in /tmp (bug 1.22b: the old code
+    # promised this cleanup but never registered it).
     tmp = Path(tempfile.mkdtemp(prefix='blackbull-fault-tls-'))
     cert_path = tmp / 'cert.pem'
     key_path = tmp / 'key.pem'
@@ -48,6 +53,7 @@ def make_self_signed_h2_context() -> ssl.SSLContext:
 
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     ctx.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+    weakref.finalize(ctx, shutil.rmtree, str(tmp), ignore_errors=True)
     # Real clients pick the strongest ALPN entry both sides advertise;
     # offering http/1.1 too keeps the example friendly to clients that
     # don't enable HTTP/2.

--- a/blackbull/fault_injection/h2_server.py
+++ b/blackbull/fault_injection/h2_server.py
@@ -8,11 +8,12 @@ suites that need to exercise a client against a server that
 **deliberately** does the wrong thing — half-closed streams, exhausted
 flow-control windows, illegal SETTINGS, weird frame sequences.
 
-The server is an opt-in testing instrument.  It refuses to start when
-``BB_PRODUCTION`` is set in the environment so a deliberate-misbehaviour
-code path cannot accidentally fire on a production deployment.  This
-is the isolated, hard-opt-in design called out in the project's
-out-of-scope list as the only acceptable form for fault-injection
+The server is an opt-in testing instrument.  It refuses to start in a
+production context — when the framework's ``BLACKBULL_ENV=production``
+signal (or the explicit ``BB_PRODUCTION`` override) is set — so a
+deliberate-misbehaviour code path cannot accidentally fire on a production
+deployment.  This is the isolated, hard-opt-in design called out in the
+project's out-of-scope list as the only acceptable form for fault-injection
 machinery inside a correctness-focused framework.
 
 Tutorial: ``docs/guide/fault_injection.md``.
@@ -72,22 +73,40 @@ CLIENT_PREFACE = b'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
 class H2FaultServerError(RuntimeError):
     """Raised when ``H2FaultServer`` cannot start.
 
-    The most common cause is ``BB_PRODUCTION`` being set in the
-    environment: deliberate-misbehaviour machinery refuses to run in
-    a production context regardless of how it was reached.
+    The most common cause is running in a production context: the
+    deliberate-misbehaviour machinery refuses to start when the framework's
+    production signal (``BLACKBULL_ENV=production``) — or the explicit
+    ``BB_PRODUCTION`` override — is set, regardless of how it was reached.
     """
 
 
 def _refuse_in_production() -> None:
-    """Hard-opt-out check.  ``BB_PRODUCTION=1`` blocks server start."""
-    value = os.environ.get('BB_PRODUCTION', '').strip().lower()
-    if value in ('1', 'true', 'yes', 'on'):
+    """Hard opt-out: refuse to start in a production context.
+
+    The framework's canonical production signal is
+    ``BLACKBULL_ENV=production`` (surfaced as ``Settings.env``); the previous
+    check keyed on ``BB_PRODUCTION`` alone — a var read nowhere else in the
+    codebase — so a standard production process did **not** trip the guard
+    (bug 1.22a).  ``BB_PRODUCTION`` is still honoured as an explicit override
+    so the guard also trips outside the Settings machinery.
+    """
+    override = os.environ.get('BB_PRODUCTION', '').strip().lower() in (
+        '1', 'true', 'yes', 'on')
+    in_production = False
+    try:
+        from ..env import get_settings, Environment  # noqa: PLC0415
+        in_production = get_settings().env == Environment.PRODUCTION
+    except Exception:
+        # If Settings can't be resolved for any reason, fall back to the
+        # explicit override alone rather than failing open silently.
+        pass
+    if override or in_production:
         raise H2FaultServerError(
-            "H2FaultServer refuses to run with BB_PRODUCTION set.  "
-            "This is a testing-only instrument that deliberately emits "
-            "wrong HTTP/2 responses; running it in a production process "
-            "would expose your service to the same misbehaviour.  Unset "
-            "BB_PRODUCTION to use it in a test harness."
+            "H2FaultServer refuses to run in a production context "
+            "(BLACKBULL_ENV=production or BB_PRODUCTION set).  This is a "
+            "testing-only instrument that deliberately emits wrong HTTP/2 "
+            "responses; running it in a production process would expose your "
+            "service to the same misbehaviour.  Run it only in a test harness."
         )
 
 

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -21,7 +21,7 @@ import logging
 import os
 import struct
 
-from ..request import read_body
+from ..request import read_body, ClientDisconnected
 from . import compression
 from .codec import decode_messages, encode_message, GrpcDecodeError, MAX_MESSAGE_LENGTH
 from .registry import GrpcServiceRegistry
@@ -345,7 +345,15 @@ async def _read_unary_request(receive, encoding: bytes) -> bytes:
     ``grpc-encoding`` header); the per-message size limit applies to the
     decompressed output.  Raises :class:`GrpcError` on a malformed /
     multi-message / unsupported-encoding / oversized request."""
-    body = await read_body(receive)
+    try:
+        body = await read_body(receive)
+    except ClientDisconnected as exc:
+        # RST_STREAM / client disconnect before the request finished — the
+        # canonical gRPC mapping is CANCELLED, not a fabricated INTERNAL over
+        # a truncated body (bug 1.11).
+        raise GrpcError(
+            GrpcStatus.CANCELLED,
+            'client disconnected before sending the request') from exc
     try:
         messages = decode_messages(body)
     except GrpcDecodeError as exc:

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -10,6 +10,24 @@ Provides:
 import json
 from typing import Any
 
+from .asgi import ASGIEvent
+
+
+class ClientDisconnected(Exception):
+    """Raised when the client disconnects before the request body is complete.
+
+    ASGI signals a mid-body disconnect with an ``http.disconnect`` event that
+    carries no ``body``/``more_body`` keys.  Treating it as end-of-message
+    would return a *truncated* upload as if it were whole, so
+    :func:`read_body` raises this instead — the handler must not process a
+    partial body as complete.  The ``partial`` attribute holds whatever body
+    bytes had arrived before the disconnect.
+    """
+
+    def __init__(self, partial: bytes = b''):
+        super().__init__('client disconnected before the request body completed')
+        self.partial = partial
+
 
 async def read_body(receive) -> bytes:
     """Read the complete request body from the ASGI receive channel.
@@ -17,10 +35,19 @@ async def read_body(receive) -> bytes:
     Collects chunks in a list and joins once, rather than the O(n²) ``+=``
     growth.  A single-chunk body (the common case) is returned directly with
     no intermediate copy at all (copy-reduction-http1 P1).
+
+    Raises :class:`ClientDisconnected` if an ``http.disconnect`` arrives
+    before the body is complete, so a truncated upload is never silently
+    returned as if whole.
     """
     chunks: list[bytes] = []
     while True:
         event = await receive()
+        if event.get('type') == ASGIEvent.HTTP_DISCONNECT:
+            # Peer went away mid-body — the accumulated bytes are a partial
+            # upload, not a complete one.  Surface it rather than returning
+            # the truncated body as if it were the whole message.
+            raise ClientDisconnected(b''.join(chunks))
         chunk = event.get('body', b'')
         if chunk:
             chunks.append(chunk)
@@ -49,6 +76,10 @@ async def read_json(receive) -> Any:
 
     Note that a literal JSON ``null`` body also parses to ``None``; if that
     distinction matters, read the body yourself with :func:`read_body`.
+
+    A mid-body client disconnect propagates as :class:`ClientDisconnected`
+    rather than being reported as invalid JSON — a truncated body is a
+    transport failure, not a parse error.
     """
     body = await read_body(receive)
     if not body:
@@ -65,6 +96,10 @@ async def read_text(receive, encoding: str = 'utf-8') -> str:
     Uses ``errors='replace'`` so undecodable bytes become U+FFFD rather than
     raising — a malformed body never crashes the handler.  Override
     *encoding* for non-UTF-8 payloads.
+
+    A mid-body client disconnect still propagates as
+    :class:`ClientDisconnected`: a truncated upload must not be decoded and
+    returned as if it were the complete text.
     """
     body = await read_body(receive)
     return body.decode(encoding, errors='replace')

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -97,13 +97,23 @@ class _RouteTrie:
         node = self.root
         param_specs: list[tuple] = []
 
-        for seg in segments:
+        for i, seg in enumerate(segments):
             if seg.startswith('{') and seg.endswith('}'):
                 inner = seg[1:-1]
                 name, _, spec = inner.partition(':')
                 spec = spec or 'str'
                 _, converter = _CONVERTERS.get(spec, (None, str))
                 if spec == 'path':
+                    # {name:path} consumes all remaining segments, so it must be
+                    # the final segment.  A route like ``/a/{p:path}/b`` used to
+                    # silently register as ``/a/{p:path}`` — dropping ``/b`` — so
+                    # reject it at registration (bug 1.13).
+                    if i != len(segments) - 1:
+                        raise ConfigurationError(
+                            f"path converter {seg!r} must be the last segment of "
+                            f"route {path!r}: a '{{name:path}}' wildcard consumes "
+                            f"all remaining segments, so nothing may follow it."
+                        )
                     # {name:path} consumes all remaining segments
                     param_specs.append((name, converter, True))
                     if node.wildcard_child is None:
@@ -185,6 +195,22 @@ class _RouteTrie:
 
 class ConfigurationError(Exception):
     """Raised by Router.validate() when route definitions are inconsistent."""
+
+
+class HTTPException(Exception):
+    """An exception carrying the HTTP status the dispatcher should report.
+
+    Raising this from a handler — or from the framework's own request-body
+    adapter — makes ``BlackBull._dispatch`` answer with ``status`` instead of
+    the generic 500, and (for 4xx) log it quietly as a client error rather
+    than dumping a server traceback.  ``detail`` is an optional
+    human-readable message surfaced in development-mode error pages.
+    """
+
+    def __init__(self, status: HTTPStatus, detail: str = ''):
+        super().__init__(detail or f'{int(status)} {status.phrase}')
+        self.status = status
+        self.detail = detail
 
 
 @dataclass
@@ -383,6 +409,32 @@ def _instantiate_dataclass(cls: Any, data: dict) -> Any:
     return cls(**kwargs)
 
 
+def _decode_json_body(cls: Any, raw: bytes, handler_name: str) -> Any:
+    """Parse *raw* JSON and instantiate the dataclass *cls*, mapping any
+    client-input error to a 400 (bug 1.12).
+
+    Malformed JSON, a wrong top-level shape, unknown/missing fields, or a
+    field that fails type coercion are all *client* errors — they must surface
+    as ``400 Bad Request``, not a generic ``500``.  ``_instantiate_dataclass``
+    signals these with ``JSONDecodeError`` / ``TypeError`` / ``ValueError``,
+    which this wrapper re-raises as :class:`HTTPException`.
+    """
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(
+            HTTPStatus.BAD_REQUEST,
+            f'malformed JSON body for handler {handler_name!r}: {exc}',
+        ) from exc
+    try:
+        return _instantiate_dataclass(cls, data)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            HTTPStatus.BAD_REQUEST,
+            f'request body does not match {getattr(cls, "__name__", cls)!r}: {exc}',
+        ) from exc
+
+
 def _lookup_converter(converters: dict, result_type: type):
     """Find a registered converter for *result_type* (exact match, then MRO).
 
@@ -546,12 +598,12 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
             elif name == 'body':
                 raw = await _read_body(receive)
                 if _is_body_dataclass_annotation(ann):
-                    kwargs[name] = _instantiate_dataclass(ann, json.loads(raw))
+                    kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
                 else:
                     kwargs[name] = raw
             elif _is_body_dataclass_annotation(ann) and name not in path_param_names:
                 raw = await _read_body(receive)
-                kwargs[name] = _instantiate_dataclass(ann, json.loads(raw))
+                kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
             else:
                 raw = scope.get('path_params', {}).get(name, '')
                 if (ann is not inspect.Parameter.empty and isinstance(ann, type)

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -5,7 +5,8 @@ RequestActor owns the lifetime of a single HTTP request.
 """
 import logging
 import re
-from base64 import b64encode
+from base64 import b64encode, b64decode
+from binascii import Error as BinasciiError
 from collections.abc import Awaitable, Callable
 from hashlib import sha1
 from http import HTTPStatus
@@ -28,6 +29,12 @@ _REQ_END = b'\r\n\r\n'
 _WS_GUID = b'258EAFA5-E914-47DA-95CA-C5AB0DC85B11'  # RFC 6455 §1.3
 _HTTP_PORT  = 80
 _HTTPS_PORT = 443
+
+# Upper bound on request-body bytes drained to recover keep-alive framing
+# when a handler leaves the body unread (bug 1.6).  A larger unread body
+# closes the connection rather than spending bandwidth draining it — nginx's
+# lingering-close does the same.
+_MAX_KEEPALIVE_DRAIN = 64 * 1024
 
 # Extensions advertised in scope['extensions'] for cleartext HTTP/1.1.
 # ``http.response.pathsend`` lets middleware (notably the static-file
@@ -532,6 +539,15 @@ class HTTP1Actor(Actor):
                 if not ok:
                     break  # unhandled error — close connection
 
+                # Drain any request body the handler left unread (e.g. a POST
+                # that 404s, or any handler that ignores ``receive``).  Without
+                # this the leftover body bytes are parsed as the next pipelined
+                # request line — a classic keep-alive framing desync.  A body
+                # larger than the drain bound closes the connection instead.
+                if inner_receive.needs_drain():
+                    if not await inner_receive.drain(_MAX_KEEPALIVE_DRAIN):
+                        break
+
                 # RFC 9112 §9.1 — honour Connection: close.  HTTP/1.0
                 # connections without ``Connection: keep-alive`` likewise
                 # default to non-persistent.
@@ -714,8 +730,15 @@ class HTTP1Actor(Actor):
             scope['server'] = [host, port]
 
         if headers.getlist(b'upgrade'):
-            scope['type'] = headers.get(b'upgrade').decode('utf-8').lower()
-            if scope['type'] == 'websocket':
+            # RFC 9110 §7.8 — a server MAY ignore an Upgrade it does not
+            # support; it MUST NOT fail the request over it.  Only WebSocket
+            # switches the scope type.  Any other token (notably curl's
+            # default ``Upgrade: h2c`` probe on ``--http2``) is ignored and
+            # the request is served as ordinary HTTP/1.1 — previously any
+            # unknown token became ``scope['type']`` and crashed dispatch,
+            # closing the connection with no reply.
+            if headers.get(b'upgrade').strip().lower() == b'websocket':
+                scope['type'] = 'websocket'
                 scope['scheme'] = 'ws'
 
         return scope
@@ -772,7 +795,19 @@ class HTTP1Actor(Actor):
         """
         send = SenderFactory.http1(self._writer)
         headers = scope.get('headers', Headers([]))
-        key = headers.get(b'sec-websocket-key', b'')
+        key = headers.get(b'sec-websocket-key', b'').strip()
+        # RFC 6455 §4.2.1 — the client MUST send a Sec-WebSocket-Key whose
+        # base64-decoded value is 16 bytes.  An absent or malformed key is a
+        # bad handshake; answer 400 rather than completing an accept hash over
+        # the GUID alone (which some clients would then wrongly accept).
+        try:
+            valid_key = bool(key) and len(b64decode(key)) == 16
+        except (ValueError, BinasciiError):
+            valid_key = False
+        if not valid_key:
+            await send(b'', HTTPStatus.BAD_REQUEST,
+                       [(b'content-type', b'text/plain')])
+            return False
         accept_key = b64encode(sha1(key + _WS_GUID).digest())
         version = headers.get(b'sec-websocket-version', b'')
         if version != b'13':

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -25,7 +25,7 @@ from .cap_log import log_cap_hit
 from .recipient import (AbstractReader, IncompleteReadError,
                         RecipientFactory, _HTTP2_STREAM_QUEUE_DEPTH)
 from .response import ResponderFactory
-from .sender import AbstractWriter, ConnCoalescer, SenderFactory
+from .sender import AbstractWriter, ConnCoalescer, ConnectionWindow, SenderFactory
 from .access_log import AccessLogRecord, _make_capturing_send, _make_disconnect_detecting_receive, emit_access_log as _emit_access_log
 from ..asgi import ASGIEvent
 from .http1_actor import RequestActor
@@ -69,6 +69,12 @@ def _make_log_record(scope):
     return AccessLogRecord.from_scope(scope)
 
 _DEFAULT_PRIORITY: dict[str, int | bool] = {'urgency': 3, 'incremental': False}
+
+# Upper bound on the per-connection closed-stream record (bug 1.9).  Streams
+# closed beyond this many back fall off the exact cache and are recognised as
+# CLOSED via the high-water mark instead, defaulting to the lenient
+# (non-RST-close) §5.1 treatment.
+_CLOSED_STREAMS_CAP = 1024
 
 
 def _build_h2_extensions(
@@ -317,7 +323,10 @@ class HTTP2Actor(Actor):
         # Flow-control state — updated by SettingsResponder / WindowUpdateResponder
         # so that new stream senders start with the current peer-granted windows.
         self._peer_initial_window_size: int = DEFAULT_INITIAL_WINDOW_SIZE
-        self._connection_window_size: int = DEFAULT_INITIAL_WINDOW_SIZE
+        # Shared connection-level send window (bug 1.2).  Every stream sender
+        # created by ``make_sender`` references this one object, so N concurrent
+        # streams debit a single stream-0 budget instead of N private copies.
+        self._conn_window = ConnectionWindow(DEFAULT_INITIAL_WINDOW_SIZE)
 
         # Concurrent-stream counter — incremented when a stream task is spawned,
         # decremented via Task.add_done_callback when the task finishes.
@@ -376,7 +385,17 @@ class HTTP2Actor(Actor):
         # root_stream.children (keeping that dict O(active-streams) and so
         # find_child stays O(1)) while still recognizing late frames on
         # already-closed identifiers and choosing the right error code.
+        # Bounded record of recently-closed stream ids → closed-via-RST bool,
+        # for §5.1 late-frame validation.  Capped so a long-lived connection
+        # cycling millions of streams (gRPC) does not grow it without bound
+        # (bug 1.9).  Ids below _closed_high_water that have fallen off the cap
+        # are still recognised as CLOSED via the watermark.
         self._closed_streams: dict[int, bool] = {}
+        self._closed_high_water: int = 0
+        # Set by receive() when a frame declares a payload larger than the
+        # SETTINGS_MAX_FRAME_SIZE we advertise; the frame loop raises a
+        # FRAME_SIZE_ERROR without the payload ever being buffered (bug 1.14).
+        self._oversize_frame_len: int = 0
 
     # ------------------------------------------------------------------
     # Public helpers (called by ResponderFactory duck-typing)
@@ -398,12 +417,13 @@ class HTTP2Actor(Actor):
                 self._writer, self.factory, stream_id,
                 push_callback=self._handle_push,
                 coalescer=self._coalescer,
+                conn_window=self._conn_window,  # shared stream-0 budget (bug 1.2)
             )
-            # Initialise with the windows the peer has currently granted us,
-            # rather than the RFC defaults, which may already have been exceeded
-            # by SETTINGS / WINDOW_UPDATE frames received before this stream opened.
-            sender.stream_window_size[stream_id] = self._peer_initial_window_size
-            sender.connection_window_size = self._connection_window_size
+            # Initialise the per-stream window from what the peer has currently
+            # granted us, rather than the RFC default, which may already have
+            # been exceeded by SETTINGS / WINDOW_UPDATE frames received before
+            # this stream opened.  The connection window is shared, not copied.
+            sender.stream_window_size = self._peer_initial_window_size
             self._senders[stream_id] = sender
         return self._senders[stream_id]
 
@@ -519,8 +539,22 @@ class HTTP2Actor(Actor):
             # CLOSED branch of §5.1 validation without keeping a Stream
             # object around for every completed request.
             if self.root_stream.children.pop(stream_id, None) is not None:
-                self._closed_streams[stream_id] = False
+                self._mark_closed(stream_id, via_rst=False)
         return _cb
+
+    def _mark_closed(self, stream_id: int, via_rst: bool) -> None:
+        """Record *stream_id* as closed for §5.1 late-frame validation.
+
+        Bounded (bug 1.9): only the most recent ``_CLOSED_STREAMS_CAP`` streams
+        keep their exact closed-via-RST bool; older ids are evicted (oldest
+        first) but stay recognisable as CLOSED through ``_closed_high_water``.
+        """
+        self._closed_streams[stream_id] = via_rst
+        if stream_id > self._closed_high_water:
+            self._closed_high_water = stream_id
+        if len(self._closed_streams) > _CLOSED_STREAMS_CAP:
+            # Evict the oldest recorded id (dict preserves insertion order).
+            del self._closed_streams[next(iter(self._closed_streams))]
 
     async def receive(self) -> bytes:
         """Read one HTTP/2 frame from the connection."""
@@ -530,6 +564,14 @@ class HTTP2Actor(Actor):
         except (IncompleteReadError, asyncio.IncompleteReadError):
             return b''
         size = int.from_bytes(data[:3], 'big', signed=False)
+        if size > DEFAULT_MAX_FRAME_SIZE:
+            # RFC 9113 §4.2 (bug 1.14) — a frame larger than the
+            # SETTINGS_MAX_FRAME_SIZE we advertise is a FRAME_SIZE_ERROR.
+            # Refuse to buffer its (attacker-declared, up to 16 MiB) payload:
+            # hand back the 9-byte header and let the frame loop raise the
+            # connection error and close.
+            self._oversize_frame_len = size
+            return data
         if size:
             try:
                 data += await self._reader.readexactly(size)
@@ -588,7 +630,25 @@ class HTTP2Actor(Actor):
         while data := await self.receive():
             if self._goaway_sent:
                 # A previous frame triggered a connection error and the GOAWAY
-                # has been flushed.  Exit cleanly so the writer can close.
+                # has been flushed.  Signal recipients before exiting (bug 1.8):
+                # stream tasks blocked in receive() awaiting body would
+                # otherwise never get http.disconnect, so the enclosing
+                # TaskGroup waits on them forever and the connection wedges.
+                # The normal EOF exit path already signals; this one didn't.
+                _signal_recipients(self._recipients)
+                return
+            if self._oversize_frame_len:
+                # receive() refused to buffer an over-sized frame's payload
+                # (bug 1.14).  Raise the FRAME_SIZE_ERROR and close without
+                # ever loading the frame — the un-read payload bytes stay in
+                # the socket buffer and are discarded on close.
+                n = self._oversize_frame_len
+                self._oversize_frame_len = 0
+                await self._connection_error(
+                    ErrorCodes.FRAME_SIZE_ERROR,
+                    f'frame length {n} exceeds SETTINGS_MAX_FRAME_SIZE '
+                    f'{DEFAULT_MAX_FRAME_SIZE}')
+                _signal_recipients(self._recipients)
                 return
             frame = self.factory.load(data)
             frame_type = frame.FrameType()
@@ -691,9 +751,17 @@ class HTTP2Actor(Actor):
             stream = self.root_stream.children.get(frame.stream_id)
 
             if frame.stream_id != 0 and stream is None:
-                if frame.stream_id in self._closed_streams:
+                closed_via_rst = self._closed_streams.get(frame.stream_id)
+                is_closed = closed_via_rst is not None
+                if not is_closed and 0 < frame.stream_id <= self._closed_high_water:
+                    # Recorded as closed but evicted from the bounded cache
+                    # (bug 1.9) — still CLOSED, not IDLE.  Default to the lenient
+                    # (non-RST) treatment so a late WINDOW_UPDATE/RST_STREAM is
+                    # ignored rather than answered.
+                    is_closed = True
+                    closed_via_rst = False
+                if is_closed:
                     # Late frame on a CLOSED stream (§5.1).
-                    closed_via_rst = self._closed_streams[frame.stream_id]
                     if frame_type == FrameTypes.PRIORITY:
                         pass  # PRIORITY is always allowed; let it through
                     elif frame_type in (FrameTypes.HEADERS, FrameTypes.CONTINUATION):
@@ -764,11 +832,31 @@ class HTTP2Actor(Actor):
             spawned = False
             match frame.FrameType():
                 case FrameTypes.HEADERS:
-                    send = self.make_sender(stream.stream_id)
-                    spawned = await self._on_headers_frame(frame, stream, send, tg)
-                    if not spawned:
-                        waiting_continuation = True
-                        header_frame = frame
+                    if stream.scope is not None and frame.end_headers:
+                        # RFC 9113 §8.1 — a second (single-frame) HEADERS on an
+                        # already-open request stream is *trailers*, not a new
+                        # request.  Previously _validate_stream_state permitted
+                        # HEADERS in OPEN and this respawned a second request
+                        # over the live recipient/task (bug 1.14).  We don't
+                        # surface request trailers to the ASGI app, so we mark a
+                        # clean end-of-stream instead.  Trailers MUST carry
+                        # END_STREAM; without it the request is malformed.
+                        if not frame.end_stream:
+                            await self.send_frame(self.factory.rst_stream(
+                                stream.stream_id, ErrorCodes.PROTOCOL_ERROR))
+                        else:
+                            stream.on_data_received(end_stream=True)
+                            recipient = self._recipients.get(stream.stream_id)
+                            if recipient is not None:
+                                recipient.put_event({
+                                    'type': ASGIEvent.HTTP_REQUEST,
+                                    'body': b'', 'more_body': False})
+                    else:
+                        send = self.make_sender(stream.stream_id)
+                        spawned = await self._on_headers_frame(frame, stream, send, tg)
+                        if not spawned:
+                            waiting_continuation = True
+                            header_frame = frame
                 case FrameTypes.CONTINUATION:
                     send = self.make_sender(stream.stream_id)
                     spawned = await self._on_continuation_frame(
@@ -870,7 +958,7 @@ class HTTP2Actor(Actor):
         scope['http2_priority'] = priority
         scope['extensions'] = _build_h2_extensions(
             stream.stream_id, priority,
-            self._peer_initial_window_size, self._connection_window_size)
+            self._peer_initial_window_size, self._conn_window.size)
 
     async def _on_headers_frame(
         self,
@@ -1258,7 +1346,7 @@ class HTTP2Actor(Actor):
             'extensions': _build_h2_extensions(
                 push_stream_id, _DEFAULT_PRIORITY,
                 self._peer_initial_window_size,
-                self._connection_window_size),
+                self._conn_window.size),
             # Deprecation alias — see HEADERS path note.
             'http2_priority': _DEFAULT_PRIORITY,
         }
@@ -1269,7 +1357,7 @@ class HTTP2Actor(Actor):
         self._recipients[push_stream_id] = push_recipient
         push_sender = SenderFactory.http2(
             self._writer, self.factory, push_stream_id, push_callback=None,
-            coalescer=self._coalescer)
+            coalescer=self._coalescer, conn_window=self._conn_window)
         log_record = _make_log_record(pushed_scope)
         capturing_send = _make_capturing_send(push_sender, log_record)
 

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -391,6 +391,35 @@ class HTTP1Recipient(BaseRecipient):
         self._body_timeout = body_timeout
         self._deadline = deadline
 
+    def needs_drain(self) -> bool:
+        """True if a declared request body may still be buffered unread.
+
+        A handler that ignores ``receive`` (e.g. a 404/405 response to a POST)
+        leaves the body bytes in the reader; the next keep-alive request would
+        then parse them as its request line.  The actor consults this after
+        dispatch to decide whether to drain.  A body-less request (GET, no
+        Content-Length, not chunked) never needs draining.
+        """
+        return not self._done and (self._chunked or bool(self._content_length))
+
+    async def drain(self, max_bytes: int) -> bool:
+        """Discard any unread request body so the next pipelined request parses
+        cleanly.  Returns True if fully drained (or the peer disconnected),
+        False if the unread body exceeded *max_bytes* — the caller should then
+        close the connection rather than keep it alive.
+        """
+        drained = 0
+        while not self._done:
+            event = await self()
+            if event['type'] == ASGIEvent.HTTP_DISCONNECT:
+                # EOF / body_timeout mid-drain: nothing left to desync, and
+                # ``_done`` is now set so the loop would exit anyway.
+                return True
+            drained += len(event.get('body', b''))
+            if drained > max_bytes:
+                return False
+        return True
+
     async def _read_with_timeout(self, coro):
         """Run *coro* under the configured body_timeout, if any."""
         if self._body_timeout > 0 and self._deadline is not None:
@@ -423,8 +452,14 @@ class HTTP1Recipient(BaseRecipient):
                             break
                     self._done = True
                     return {'type': ASGIEvent.HTTP_REQUEST, 'body': b'', 'more_body': False}
+                # RFC 9112 §7.1 — the chunk-data is exactly ``chunk_size``
+                # octets.  ``readexactly`` (not the up-to-n ``read``) is
+                # required: a chunk split across TCP segments would otherwise
+                # return short, and the following ``readuntil(CRLF)`` would
+                # swallow the rest of the payload up to the first CRLF,
+                # silently corrupting the body and desyncing chunk framing.
                 data = await self._read_with_timeout(
-                    self._reader.read(chunk_size))
+                    self._reader.readexactly(chunk_size))
                 await self._read_with_timeout(
                     self._reader.readuntil(b'\r\n'))        # consume CRLF after chunk data
                 return {'type': ASGIEvent.HTTP_REQUEST, 'body': data, 'more_body': True}

--- a/blackbull/server/response.py
+++ b/blackbull/server/response.py
@@ -108,9 +108,10 @@ class WindowUpdateResponder(Responder):
             return
 
         if self.frame.stream_id == 0:
-            # Connection-level: credit all cached stream senders and update the
-            # running total so future senders start with the current budget.
-            new_window = getattr(handler, '_connection_window_size', 65535) + increment
+            # Connection-level: credit the ONE shared connection window (bug
+            # 1.2), then wake every blocked stream sender so they re-check.
+            conn_window = handler._conn_window
+            new_window = conn_window.size + increment
             # RFC 9113 §6.9.1 — exceeding 2^31-1 is a connection-level
             # FLOW_CONTROL_ERROR with GOAWAY.
             if new_window > self._MAX_FLOW_WINDOW:
@@ -118,14 +119,13 @@ class WindowUpdateResponder(Responder):
                     ErrorCodes.FLOW_CONTROL_ERROR,
                     f'connection flow window overflow: {new_window}')
                 return
-            handler._connection_window_size = new_window
+            conn_window.size = new_window
             for sender in handler._senders.values():
-                sender.connection_window_size += increment
                 sender.wake_window()
         else:
             sender = handler.make_sender(self.frame.stream_id)
             sid = self.frame.stream_id
-            current = sender.stream_window_size.get(sid, 65535)
+            current = sender.stream_window_size
             if current + increment > self._MAX_FLOW_WINDOW:
                 # RFC 9113 §6.9.1 — stream-level flow window overflow is a
                 # stream error of type FLOW_CONTROL_ERROR.
@@ -235,7 +235,15 @@ class PriorityResponder(Responder):
         stream = handler.root_stream.find_child(stream_id)
 
         if not stream:
-            stream = handler.root_stream.find_child(self.frame.dependent_stream).add_child(stream_id)
+            # RFC 9113 §5.3.1 — a dependency on an unknown (or pruned-as-closed)
+            # stream is treated as a dependency on stream 0.  Previously
+            # find_child returned None and .add_child() raised AttributeError,
+            # unwinding the frame loop and killing every stream on the
+            # connection without a GOAWAY (bug 1.10).
+            parent = handler.root_stream.find_child(self.frame.dependent_stream)
+            if parent is None:
+                parent = handler.root_stream
+            stream = parent.add_child(stream_id)
 
         stream.weight = self.frame.weight
 
@@ -308,7 +316,7 @@ class RstStreamResponder(Responder):
         # from the peer on this identifier are detected by the frame-loop's
         # _closed_streams check and trigger STREAM_CLOSED.
         handler.root_stream.children.pop(stream_id, None)
-        handler._closed_streams[stream_id] = True
+        handler._mark_closed(stream_id, via_rst=True)
         handler._senders.pop(stream_id, None)
         handler._recipients.pop(stream_id, None)
 

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -498,6 +498,7 @@ class HTTP1Sender(BaseSender):
     __slots__ = (
         '_buffered_status', '_buffered_headers', '_chunked',
         '_expect_trailers', '_head_mode', '_log_record', '_started',
+        '_completed',
     )
 
     def __init__(self, writer: AbstractWriter):
@@ -511,6 +512,13 @@ class HTTP1Sender(BaseSender):
         # consults this after BB_REQUEST_TIMEOUT expiry to decide
         # whether a synthetic 408 can still be emitted.
         self._started: bool = False
+        # Set True once a complete response has been written for this request
+        # (a full ``bytes`` response, a body event with ``more_body=False``,
+        # trailers, or a pathsend).  Further response events are then dropped
+        # (bug 1.4) so a handler that raises *after* completing its response
+        # can't write a second one onto the same keep-alive connection —
+        # mirrors the H2 sender's post-END_STREAM drop.
+        self._completed: bool = False
         # RFC 9110 §9.3.2 — when the request was HEAD, the response must
         # have the same headers (including Content-Length) as a GET would
         # but no body.  HTTP1Actor sets this before dispatch.
@@ -544,6 +552,16 @@ class HTTP1Sender(BaseSender):
         Unknown event types are logged and dropped; non-dict / non-bytes
         bodies raise ``TypeError``.
         """
+        if self._completed:
+            # bug 1.4 — a complete response has already gone out for this
+            # request; drop any further response events so a handler that
+            # raises after completing (→ the error handler emits a second
+            # response) can't splice two responses onto one connection.
+            # A disconnect signal still marks the writer closed.
+            if isinstance(body, dict) and body.get('type') == ASGIEvent.HTTP_DISCONNECT:
+                self._closed = True
+            return
+
         match body:
             case bytes():
                 h = headers if isinstance(headers, Headers) else Headers(headers)
@@ -551,6 +569,7 @@ class HTTP1Sender(BaseSender):
                     self._log_record.status = int(status)
                     self._log_record.response_bytes += len(body)
                 await self._flush(status, h, body)
+                self._completed = True
 
             case {'type': ASGIEvent.HTTP_RESPONSE_START}:
                 self._buffered_status = HTTPStatus(body.get('status', HTTPStatus.OK))
@@ -597,6 +616,8 @@ class HTTP1Sender(BaseSender):
                         # already wrote headers; HEAD response carries no body
                         if self._log_record is not None and not more_body:
                             self._log_record.mark('body_arm_out')
+                        if not more_body:
+                            self._completed = True
                         return
                     if self._chunked:
                         if content:
@@ -610,15 +631,19 @@ class HTTP1Sender(BaseSender):
                         await self._write(content)
                 if self._log_record is not None and not more_body:
                     self._log_record.mark('body_arm_out')
+                if not more_body:
+                    self._completed = True
 
             case {'type': ASGIEvent.HTTP_RESPONSE_TRAILERS}:
                 await self._write(b'0\r\n')
                 for name, value in body.get('headers', []):
                     await self._write(name + b': ' + value + b'\r\n')
                 await self._write(b'\r\n')
+                self._completed = True
 
             case {'type': ASGIEvent.HTTP_RESPONSE_PATHSEND}:
                 await self._pathsend(body['path'])
+                self._completed = True
 
             case {'type': ASGIEvent.HTTP_DISCONNECT}:
                 # http1_actor.py sends this on IncompleteReadError; the
@@ -644,6 +669,7 @@ class HTTP1Sender(BaseSender):
         self._chunked = False
         self._expect_trailers = False
         self._started = False
+        self._completed = False
         self._head_mode = False
         self._log_record = None
 

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -791,6 +791,30 @@ class HTTP1Sender(BaseSender):
                     await self._write(chunk)
 
 
+class ConnectionWindow:
+    """Shared HTTP/2 connection-level (stream 0) send flow-control window.
+
+    One instance per connection, referenced by every stream's
+    :class:`HTTP2Sender`, so all senders debit and await a single budget.
+
+    Without sharing (bug 1.2) each sender held a *private copy* of the
+    connection window and debited only that copy, while the actor-level total
+    was only ever incremented — so N concurrent streams could each spend a
+    full 65535-byte window and the server could emit N×65535 bytes with zero
+    real stream-0 credit.  A strict peer (nghttp2, grpc-go) treats that as a
+    connection ``FLOW_CONTROL_ERROR`` and GOAWAYs (RFC 9113 §6.9.1).
+
+    The object is a thin mutable holder: senders read/debit ``size`` directly
+    and the owning actor fans out wake-ups to blocked senders on a
+    connection-level ``WINDOW_UPDATE`` (it already tracks every live sender).
+    """
+
+    __slots__ = ('size',)
+
+    def __init__(self, size: int = DEFAULT_INITIAL_WINDOW_SIZE) -> None:
+        self.size = size
+
+
 class HTTP2Sender(BaseSender):
     """Translates content or ASGI HTTP send events into HTTP/2 frames.
 
@@ -811,14 +835,15 @@ class HTTP2Sender(BaseSender):
 
     __slots__ = (
         '_factory', '_stream_id', '_push_callback',
-        'connection_window_size', 'stream_window_size',
+        '_conn_window', 'stream_window_size',
         'max_frame_size', '_window_open', '_end_stream_sent',
         '_buffered_status', '_buffered_headers', '_expect_trailers',
         '_buffered_body', '_coalescer',
     )
 
     def __init__(self, writer: AbstractWriter, factory, stream_id: int,
-                 push_callback=None, coalescer: 'ConnCoalescer | None' = None):
+                 push_callback=None, coalescer: 'ConnCoalescer | None' = None,
+                 conn_window: 'ConnectionWindow | None' = None):
         super().__init__(writer)
         self._factory = factory
         self._stream_id = stream_id
@@ -827,8 +852,17 @@ class HTTP2Sender(BaseSender):
         # per-stream senders).  ``None`` → direct writes (today's behaviour).
         # Never set on the control sender (stream 0), so control frames bypass.
         self._coalescer = coalescer
-        self.connection_window_size = DEFAULT_INITIAL_WINDOW_SIZE
-        self.stream_window_size = {stream_id: DEFAULT_INITIAL_WINDOW_SIZE}
+        # Shared connection-level send window (bug 1.2).  The server passes one
+        # ``ConnectionWindow`` instance to every stream sender so they debit a
+        # single budget; when omitted (the experimental client, whose per-sender
+        # windowing is bug 1.20a and deferred) each sender gets a private one,
+        # preserving today's behaviour there.
+        self._conn_window = conn_window if conn_window is not None else ConnectionWindow()
+        # Per-stream send window.  Refactor 2.5 — a plain int (this was a
+        # dict-of-one keyed on the sender's own stream id, which obscured that
+        # it is scalar and invited readers to hunt for multi-stream semantics
+        # that never existed).
+        self.stream_window_size = DEFAULT_INITIAL_WINDOW_SIZE
         self.max_frame_size = DEFAULT_MAX_FRAME_SIZE
         self._window_open: asyncio.Event | None = None
         self._end_stream_sent: bool = False
@@ -841,6 +875,21 @@ class HTTP2Sender(BaseSender):
         # the trailers event (the unary-gRPC pattern).  Flushed early if a
         # second body chunk arrives (multi-frame body / streaming).
         self._buffered_body: bytes | None = None
+
+    @property
+    def connection_window_size(self) -> int:
+        """The shared connection-level send window (bug 1.2).
+
+        Proxies :attr:`ConnectionWindow.size` so existing call sites — the
+        experimental client's per-sender crediting and flow-control tests —
+        keep reading/writing ``sender.connection_window_size`` while the real
+        state lives on the shared object.
+        """
+        return self._conn_window.size
+
+    @connection_window_size.setter
+    def connection_window_size(self, value: int) -> None:
+        self._conn_window.size = value
 
     def reset_per_request_state(self) -> None:
         self._end_stream_sent = False
@@ -865,8 +914,8 @@ class HTTP2Sender(BaseSender):
         sid_bytes = self._stream_id.to_bytes(4, 'big')
         set_end_stream = end_stream and not expect_trailers
 
-        if (total <= self.connection_window_size and
-                total <= self.stream_window_size[self._stream_id] and
+        if (total <= self._conn_window.size and
+                total <= self.stream_window_size and
                 total <= self.max_frame_size):
             end_flag = DataFrameFlags.END_STREAM if set_end_stream else 0
             if total == 0:
@@ -875,8 +924,8 @@ class HTTP2Sender(BaseSender):
                 d_bytes = (total.to_bytes(3, 'big') + b'\x00'
                            + end_flag.to_bytes(1, 'big') + sid_bytes + body)
             await super()._write(h_bytes + d_bytes)
-            self.connection_window_size -= total
-            self.stream_window_size[self._stream_id] -= total
+            self._conn_window.size -= total
+            self.stream_window_size -= total
         else:
             await super()._write(h_bytes)
             await self._write_data(body, end_stream=set_end_stream)
@@ -936,8 +985,8 @@ class HTTP2Sender(BaseSender):
 
         offset = 0
         while offset < total:
-            while (self.connection_window_size <= 0 or
-                   self.stream_window_size[self._stream_id] <= 0):
+            while (self._conn_window.size <= 0 or
+                   self.stream_window_size <= 0):
                 if self._window_open is None:
                     self._window_open = asyncio.Event()
                 self._window_open.clear()
@@ -947,14 +996,14 @@ class HTTP2Sender(BaseSender):
                 # would then discard that wake-up.  Without this guard we
                 # would ``await`` an event no further WINDOW_UPDATE will set
                 # → permanent block (lost-wakeup race, RFC 9113 §6.9).
-                if (self.connection_window_size > 0 and
-                        self.stream_window_size[self._stream_id] > 0):
+                if (self._conn_window.size > 0 and
+                        self.stream_window_size > 0):
                     break
                 await self._window_open.wait()
 
             chunk_size = min(
-                self.connection_window_size,
-                self.stream_window_size[self._stream_id],
+                self._conn_window.size,
+                self.stream_window_size,
                 self.max_frame_size,
                 total - offset,
             )
@@ -965,12 +1014,12 @@ class HTTP2Sender(BaseSender):
             await super()._write(
                 chunk_size.to_bytes(3, 'big') + b'\x00' + flags.to_bytes(1, 'big') + sid_bytes + chunk
             )
-            self.connection_window_size -= chunk_size
-            self.stream_window_size[self._stream_id] -= chunk_size
+            self._conn_window.size -= chunk_size
+            self.stream_window_size -= chunk_size
             offset += chunk_size
 
     def window_update(self, increment: int) -> None:
-        self.stream_window_size[self._stream_id] += increment
+        self.stream_window_size += increment
         self.wake_window()
 
     def wake_window(self) -> None:
@@ -988,7 +1037,7 @@ class HTTP2Sender(BaseSender):
         by the change in SETTINGS_INITIAL_WINDOW_SIZE since the peer's last
         announcement.  The window may legitimately become negative.
         """
-        self.stream_window_size[self._stream_id] += delta
+        self.stream_window_size += delta
         if delta > 0:
             self.wake_window()
 
@@ -1020,8 +1069,8 @@ class HTTP2Sender(BaseSender):
 
             total = len(body)
             sid_bytes = self._stream_id.to_bytes(4, 'big')
-            if (total <= self.connection_window_size and
-                    total <= self.stream_window_size[self._stream_id] and
+            if (total <= self._conn_window.size and
+                    total <= self.stream_window_size and
                     total <= self.max_frame_size):
                 # Fast path: body fits in one DATA frame — single write + drain
                 end_flag = DataFrameFlags.END_STREAM.to_bytes(1, 'big')
@@ -1030,8 +1079,8 @@ class HTTP2Sender(BaseSender):
                 else:
                     d_bytes = total.to_bytes(3, 'big') + b'\x00' + end_flag + sid_bytes + body
                 await super()._write(h_bytes + d_bytes)
-                self.connection_window_size -= total
-                self.stream_window_size[self._stream_id] -= total
+                self._conn_window.size -= total
+                self.stream_window_size -= total
             else:
                 await super()._write(h_bytes)
                 await self._write_data(body, end_stream=True)
@@ -1071,8 +1120,8 @@ class HTTP2Sender(BaseSender):
                     if (self._expect_trailers and not end_stream
                             and self._buffered_body is None
                             and 0 < len(payload) <= self.max_frame_size
-                            and len(payload) <= self.stream_window_size[self._stream_id]
-                            and len(payload) <= self.connection_window_size):
+                            and len(payload) <= self.stream_window_size
+                            and len(payload) <= self._conn_window.size):
                         self._buffered_body = payload
                     else:
                         # A second body chunk (or a multi-frame / terminal one):
@@ -1119,8 +1168,8 @@ class HTTP2Sender(BaseSender):
                                    + self._stream_id.to_bytes(4, 'big')
                                    + self._buffered_body)
                         await self._write(h_bytes + d_bytes + trailer_bytes)
-                        self.connection_window_size -= total
-                        self.stream_window_size[self._stream_id] -= total
+                        self._conn_window.size -= total
+                        self.stream_window_size -= total
                         self._buffered_body = None
                     else:
                         await self._write(h_bytes + trailer_bytes)
@@ -1235,9 +1284,11 @@ class SenderFactory:
 
     @staticmethod
     def http2(stream_writer, factory, stream_id: int,
-              push_callback=None, coalescer: 'ConnCoalescer | None' = None) -> HTTP2Sender:
+              push_callback=None, coalescer: 'ConnCoalescer | None' = None,
+              conn_window: 'ConnectionWindow | None' = None) -> HTTP2Sender:
         return HTTP2Sender(SenderFactory._ensure_writer(stream_writer),
-                           factory, stream_id, push_callback, coalescer)
+                           factory, stream_id, push_callback, coalescer,
+                           conn_window=conn_window)
 
     @staticmethod
     def websocket(stream_writer, *, compressor=None) -> WebSocketSender:

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -93,10 +93,37 @@ class LifespanManager:
         self._task = asyncio.create_task(
             self._app(scope, self._receive_q.get, self._send_q.put))
         await self._receive_q.put({'type': ASGIEvent.LIFESPAN_STARTUP})
-        event = await self._send_q.get()
-        if event.get('type') == ASGIEvent.LIFESPAN_STARTUP_FAILED:
-            raise RuntimeError(event.get('message', 'Lifespan startup failed'))
-        return self
+        # Race the startup ack against the lifespan task itself.  A lifespan
+        # app that dies before acking — e.g. a startup hook that raises and
+        # takes the task down with it — would otherwise strand __aenter__ on
+        # an empty send queue forever and the server would neither start nor
+        # error (bug 1.3).  Mirrors the FIRST_COMPLETED race in __aexit__.
+        getter = asyncio.ensure_future(self._send_q.get())
+        try:
+            await asyncio.wait(
+                {getter, self._task}, return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            if not getter.done():
+                getter.cancel()
+        if getter.done() and not getter.cancelled():
+            event = getter.result()
+            if event.get('type') == ASGIEvent.LIFESPAN_STARTUP_FAILED:
+                raise RuntimeError(event.get('message', 'Lifespan startup failed'))
+            return self
+        # The task finished before acking startup.
+        if self._task.done():
+            exc = self._task.exception()
+            if exc is not None:
+                # The lifespan app raised before acking — a real startup
+                # failure (bug 1.3: previously this stranded __aenter__ on an
+                # empty send queue and the server never started).
+                raise RuntimeError(f'Lifespan startup failed: {exc!r}') from exc
+            # The app returned without implementing the lifespan protocol — a
+            # bare ASGI app that ignores the lifespan scope.  ASGI treats this
+            # as "lifespan unsupported": proceed to serve rather than hang or
+            # error.
+            return self
+        raise RuntimeError('Lifespan startup did not complete')
 
     async def __aexit__(self, *_):
         task = self._task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.49.0"
+version = "0.49.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/architecture/test_http2_actor.py
+++ b/tests/architecture/test_http2_actor.py
@@ -287,8 +287,8 @@ async def test_make_sender_uses_peer_initial_window_size(fake_writer, mock_app):
 
     sender = actor.make_sender(stream_id=5)
 
-    assert sender.stream_window_size[5] == peer_iws, (
-        f'Expected stream window {peer_iws}, got {sender.stream_window_size[5]}'
+    assert sender.stream_window_size == peer_iws, (
+        f'Expected stream window {peer_iws}, got {sender.stream_window_size}'
     )
 
 
@@ -297,12 +297,17 @@ async def test_make_sender_uses_current_connection_window(fake_writer, mock_app)
     """Stream senders created after a connection WINDOW_UPDATE must see the updated budget."""
     aggregator = AsyncMock(spec=EventAggregator)
     actor = HTTP2Actor(None, fake_writer, mock_app, aggregator)
-    actor._connection_window_size = 4194304  # simulates post-WINDOW_UPDATE value
+    actor._conn_window.size = 4194304  # simulates post-WINDOW_UPDATE value
 
     sender = actor.make_sender(stream_id=7)
 
+    # The sender shares the actor's connection window (bug 1.2), so it reads
+    # the current budget from the one object rather than a stale copy.
     assert sender.connection_window_size == 4194304, (
         f'Expected connection window 4194304, got {sender.connection_window_size}'
+    )
+    assert sender._conn_window is actor._conn_window, (
+        'stream senders must share the actor connection window, not copy it'
     )
 
 

--- a/tests/conformance/grpc/test_grpc_transport.py
+++ b/tests/conformance/grpc/test_grpc_transport.py
@@ -118,13 +118,12 @@ class TestRstStreamDuringGrpc:
         events, send = _collector()
         await serve_grpc(reg, _grpc_scope('/svc/M'),
                          _receive_disconnect_immediate(), send)
-        # read_body gets '' (empty body without http.request events)
-        # decode_messages(b'') returns [] → len != 1 → UNIMPLEMENTED
+        # An immediate http.disconnect (RST_STREAM before any DATA) makes
+        # read_body raise ClientDisconnected, which the bridge maps to the
+        # canonical gRPC CANCELLED — not a fabricated INTERNAL over an empty
+        # body (bug 1.11).
         trailers = _trailers_of(events)
-        assert trailers.get(b'grpc-status') in (
-            str(int(GrpcStatus.INTERNAL)).encode(),
-            str(int(GrpcStatus.UNIMPLEMENTED)).encode(),
-        )
+        assert trailers.get(b'grpc-status') == str(int(GrpcStatus.CANCELLED)).encode()
 
     @pytest.mark.asyncio
     async def test_disconnect_during_body_delivery(self):

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -1,0 +1,280 @@
+"""Regression tests for the Sprint 62 HTTP/2 flow-control + lifecycle batch.
+
+Pins the bugs from the 2026-07-07 comprehensive audit:
+
+- 1.2  HTTP/2 connection-level send window is never shared
+- 1.8  GOAWAY early-return skips recipient disconnect signalling
+- 1.9  ``_closed_streams`` grows without bound per connection
+- 1.10 PRIORITY frame with unknown dependency crashes the connection
+- 1.14 (#1) HEADERS on an OPEN stream respawns a second request (trailers)
+- 1.14 (#3) 16 MiB allocation before frame-size validation
+- 2.5  stream_window_size dict-of-one → int
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from blackbull.protocol.frame import FrameFactory
+from blackbull.protocol.frame_types import (
+    ErrorCodes, FrameTypes, HeaderFrameFlags, DEFAULT_INITIAL_WINDOW_SIZE,
+    DEFAULT_MAX_FRAME_SIZE,
+)
+from blackbull.server.http2_actor import HTTP2Actor, _CLOSED_STREAMS_CAP
+from blackbull.server.sender import (
+    AsyncioWriter, ConnectionWindow, HTTP2Sender,
+)
+from blackbull.server.response import WindowUpdateResponder, PriorityResponder
+
+
+def _make_h2_frame(type_byte, flags=0, stream_id=0, payload=b''):
+    return (len(payload).to_bytes(3, 'big') + type_byte
+            + bytes([flags]) + stream_id.to_bytes(4, 'big') + payload)
+
+
+def _make_actor(app=None):
+    if app is None:
+        app = AsyncMock()
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.close = MagicMock()
+    handler = HTTP2Actor(None, AsyncioWriter(writer), app, aggregator=None)
+    handler.send_frame = AsyncMock()
+    return handler
+
+
+def _new_sender(factory, stream_id, conn_window):
+    writer = MagicMock()
+    writer.write = MagicMock()
+    writer.drain = AsyncMock()
+    return HTTP2Sender(AsyncioWriter(writer), factory, stream_id,
+                       conn_window=conn_window)
+
+
+# ---------------------------------------------------------------------------
+# 1.2 — shared connection send window (+ 2.5 stream window is a scalar int)
+# ---------------------------------------------------------------------------
+
+def test_senders_share_one_connection_window():
+    factory = FrameFactory()
+    conn = ConnectionWindow(1000)
+    a = _new_sender(factory, 1, conn)
+    b = _new_sender(factory, 3, conn)
+    # Both senders point at the same window object (bug 1.2 — not private copies).
+    assert a._conn_window is conn and b._conn_window is conn
+    # A debit through one sender is visible to the other immediately.
+    a._conn_window.size -= 400
+    assert b.connection_window_size == 600
+    assert conn.size == 600
+
+
+def test_connection_window_default_is_private_when_unshared():
+    """A sender constructed without a shared window (the experimental client
+    path) still gets its own ConnectionWindow — behaviour preserved."""
+    factory = FrameFactory()
+    s = HTTP2Sender(AsyncioWriter(MagicMock()), factory, 1)
+    assert isinstance(s._conn_window, ConnectionWindow)
+    assert s.connection_window_size == DEFAULT_INITIAL_WINDOW_SIZE
+
+
+def test_stream_window_size_is_a_scalar_int():
+    """Refactor 2.5 — the per-stream window is a plain int, not a dict-of-one."""
+    factory = FrameFactory()
+    s = _new_sender(factory, 1, ConnectionWindow())
+    assert isinstance(s.stream_window_size, int)
+    s.window_update(512)
+    assert s.stream_window_size == DEFAULT_INITIAL_WINDOW_SIZE + 512
+
+
+@pytest.mark.asyncio
+async def test_connection_window_update_credits_shared_window_once():
+    handler = _make_actor()
+    conn = handler._conn_window
+    start = conn.size
+    frame = MagicMock()
+    frame.stream_id = 0
+    frame.length = 4
+    frame.window_size = 1000
+    # Two live senders sharing the connection window.
+    handler._senders = {1: _new_sender(handler.factory, 1, conn),
+                        3: _new_sender(handler.factory, 3, conn)}
+    await WindowUpdateResponder(frame).respond(handler)
+    # Credited once — not once per sender.
+    assert conn.size == start + 1000
+
+
+# ---------------------------------------------------------------------------
+# 1.9 — bounded closed-stream record
+# ---------------------------------------------------------------------------
+
+def test_closed_streams_record_is_bounded():
+    handler = _make_actor()
+    for sid in range(1, (_CLOSED_STREAMS_CAP + 500) * 2, 2):  # odd ids
+        handler._mark_closed(sid, via_rst=False)
+    assert len(handler._closed_streams) <= _CLOSED_STREAMS_CAP
+    # The high-water mark still recognises an evicted-but-closed id as closed.
+    assert handler._closed_high_water >= _CLOSED_STREAMS_CAP
+
+
+def test_closed_stream_watermark_survives_eviction():
+    handler = _make_actor()
+    handler._mark_closed(1, via_rst=True)   # will be evicted
+    for sid in range(3, _CLOSED_STREAMS_CAP * 2 + 5, 2):
+        handler._mark_closed(sid, via_rst=False)
+    assert 1 not in handler._closed_streams          # evicted from exact cache
+    assert 1 <= handler._closed_high_water           # still ≤ watermark → CLOSED
+
+
+# ---------------------------------------------------------------------------
+# 1.8 — the GOAWAY early-return path still signals recipients
+# ---------------------------------------------------------------------------
+
+class _FakeRecipient:
+    """Minimal object satisfying the _StreamRecipient protocol."""
+    def __init__(self):
+        self.disconnected = False
+
+    def put_disconnect(self):
+        self.disconnected = True
+
+    def put_DATAFrame(self, frame):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_goaway_early_return_signals_recipients():
+    handler = _make_actor()
+    recipient = _FakeRecipient()
+    handler._recipients = {1: recipient}
+    handler._goaway_sent = True  # a prior frame already triggered a conn error
+    # A queued frame arrives after the error; the goaway early-return must
+    # inject http.disconnect into blocked recipients (bug 1.8) rather than
+    # returning and leaving a stream task waiting on receive() forever.
+    handler.receive = AsyncMock(side_effect=[
+        _make_h2_frame(FrameTypes.PING, 0, 0, b'\x00' * 8), None])
+    import asyncio
+    async with asyncio.TaskGroup() as tg:  # real TaskGroup; loop returns at once
+        await handler._frame_loop(tg)
+    assert recipient.disconnected is True
+
+
+# ---------------------------------------------------------------------------
+# 1.10 — PRIORITY with an unknown dependent stream must not crash
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_priority_unknown_dependency_does_not_crash():
+    handler = _make_actor()
+    frame = MagicMock()
+    frame.stream_id = 7          # not in the tree
+    frame.dependent_stream = 99  # also unknown
+    frame.exclusion = False
+    frame.weight = 16
+    # Must not raise AttributeError (find_child(99) → None); the stream is
+    # parented under the root instead (bug 1.10).
+    await PriorityResponder(frame).respond(handler)
+    assert handler.root_stream.find_child(7) is not None
+
+
+# ---------------------------------------------------------------------------
+# 1.14 (#3) — an over-sized frame is rejected without buffering its payload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_receive_refuses_to_buffer_oversized_frame():
+    """receive() detects an over-sized frame from its 9-byte header and returns
+    without ever reading (buffering) the declared payload (bug 1.14 #3)."""
+    from blackbull.server.recipient import AbstractReader
+    declared = DEFAULT_MAX_FRAME_SIZE + 1_000_000
+    header = (declared.to_bytes(3, 'big') + FrameTypes.DATA
+              + bytes([0]) + (1).to_bytes(4, 'big'))
+
+    class _HeaderOnlyReader(AbstractReader):
+        def __init__(self):
+            self.buf = bytearray(header)
+
+        async def read(self, n):
+            chunk = bytes(self.buf[:n]); del self.buf[:n]; return chunk
+
+        async def readexactly(self, n):
+            if len(self.buf) < n:
+                # receive() must not attempt to read the (absent) payload.
+                raise AssertionError('over-sized payload must not be buffered')
+            chunk = bytes(self.buf[:n]); del self.buf[:n]; return chunk
+
+    handler = _make_actor()
+    handler._reader = _HeaderOnlyReader()
+    data = await handler.receive()
+    assert handler._oversize_frame_len == declared
+    assert len(data) == 9, 'only the frame header should be returned'
+
+
+@pytest.mark.asyncio
+async def test_oversized_frame_len_drives_frame_size_error():
+    """When receive() flags an over-sized frame, the frame loop raises a
+    connection FRAME_SIZE_ERROR (bug 1.14 #3)."""
+    handler = _make_actor()
+    settings = _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b'')
+    header = ((DEFAULT_MAX_FRAME_SIZE + 1_000_000).to_bytes(3, 'big')
+              + FrameTypes.DATA + bytes([0]) + (1).to_bytes(4, 'big'))
+
+    async def fake_receive():
+        # First the SETTINGS handshake, then the over-sized header with the
+        # flag set exactly as the real receive() would.
+        if not getattr(fake_receive, '_sent_settings', False):
+            fake_receive._sent_settings = True
+            return settings
+        if not getattr(fake_receive, '_sent_oversize', False):
+            fake_receive._sent_oversize = True
+            handler._oversize_frame_len = DEFAULT_MAX_FRAME_SIZE + 1_000_000
+            return header
+        return b''
+
+    handler.receive = fake_receive
+    await handler.run()
+    goaway = [c.args[0] for c in handler.send_frame.call_args_list
+              if getattr(c.args[0], 'error_code', None) == ErrorCodes.FRAME_SIZE_ERROR]
+    assert goaway, 'expected a FRAME_SIZE_ERROR for the over-sized frame'
+
+
+# ---------------------------------------------------------------------------
+# 1.14 (#1) — trailers on an open stream do not respawn a request
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_trailers_do_not_respawn_request():
+    from hpack import Encoder
+    calls = []
+
+    async def app(scope, receive, send):
+        calls.append(scope['path'])
+        # Drain the body to completion (trailers deliver the clean EOS).
+        while True:
+            ev = await receive()
+            if not ev.get('more_body', False):
+                break
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'ok'})
+
+    handler = _make_actor(app)
+    enc = Encoder()
+    settings = _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b'')
+    headers = _make_h2_frame(
+        FrameTypes.HEADERS,
+        HeaderFrameFlags.END_HEADERS,  # open, no END_STREAM (body/trailers follow)
+        1,
+        enc.encode([(b':method', b'POST'), (b':path', b'/x'), (b':scheme', b'https')]))
+    body = _make_h2_frame(FrameTypes.DATA, 0, 1, b'hello')
+    trailers = _make_h2_frame(
+        FrameTypes.HEADERS,
+        HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM,
+        1,
+        enc.encode([(b'x-trailer', b'v')]))
+    handler.receive = AsyncMock(
+        side_effect=[settings, headers, body, trailers, None])
+    await handler.run()
+    # The app was dispatched exactly once — the trailers HEADERS did not spawn
+    # a second request over the live stream (bug 1.14).
+    assert calls == ['/x']
+    # No PROTOCOL_ERROR was raised for the (valid, END_STREAM-carrying) trailers.
+    assert not [c.args[0] for c in handler.send_frame.call_args_list
+                if getattr(c.args[0], 'error_code', None) == ErrorCodes.PROTOCOL_ERROR]

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -127,10 +127,10 @@ class TestHTTP2FlowControl:
         await handler.run()
 
         # _senders is pruned on stream completion (memory-leak fix); assert the
-        # actor-level source of truth used to seed new senders instead.
-        assert handler._connection_window_size >= 65535, (
-            f'Expected handler._connection_window_size >= 65535 after WINDOW_UPDATE, '
-            f'got {handler._connection_window_size}'
+        # shared connection window (bug 1.2) that seeds new senders instead.
+        assert handler._conn_window.size >= 65535, (
+            f'Expected handler._conn_window.size >= 65535 after WINDOW_UPDATE, '
+            f'got {handler._conn_window.size}'
         )
 
     @staticmethod
@@ -298,7 +298,7 @@ class TestHTTP2FlowControl:
         sender = HTTP2Sender(AsyncioWriter(mock_writer), factory, stream_id=1)
 
         sender.connection_window_size = 0
-        sender.stream_window_size[1] = 0
+        sender.stream_window_size = 0
 
         payload = b'x' * 100
 
@@ -336,7 +336,7 @@ class TestHTTP2FlowControl:
         mock_writer.drain = AsyncMock()
         sender = HTTP2Sender(AsyncioWriter(mock_writer), FrameFactory(), stream_id=1)
         sender.connection_window_size = 0
-        sender.stream_window_size[1] = 0
+        sender.stream_window_size = 0
 
         body = b'x' * 100
         task = asyncio.create_task(sender(body, HTTPStatus.OK, headers=[]))

--- a/tests/conformance/http2/test_server_response.py
+++ b/tests/conformance/http2/test_server_response.py
@@ -100,34 +100,36 @@ async def test_ping_responder_sends_ack():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_window_update_connection_level_credits_all_senders():
+async def test_window_update_connection_level_credits_shared_window():
+    """Connection-level WINDOW_UPDATE credits the ONE shared connection window
+    (bug 1.2) — not a private copy per sender — and wakes every stream sender."""
+    from blackbull.server.sender import ConnectionWindow
     frame = MagicMock()
     frame.stream_id = 0
     frame.length = 4  # valid frame length
     frame.window_size = 1024
 
     sender_a = MagicMock()
-    sender_a.connection_window_size = 0
     sender_b = MagicMock()
-    sender_b.connection_window_size = 100
 
     handler = MagicMock()
     handler._senders = {'a': sender_a, 'b': sender_b}
-    handler._connection_window_size = 65535
+    handler._conn_window = ConnectionWindow(65535)
 
     responder = WindowUpdateResponder(frame)
     await responder.respond(handler)
 
-    assert sender_a.connection_window_size == 1024
-    assert sender_b.connection_window_size == 1124
+    # The single shared window is credited exactly once (not once per sender).
+    assert handler._conn_window.size == 65535 + 1024
     sender_a.wake_window.assert_called_once()
     sender_b.wake_window.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_window_update_connection_level_updates_handler_tracking():
-    """Connection-level WINDOW_UPDATE must update handler._connection_window_size
-    so that stream senders created after the update inherit the correct budget."""
+async def test_window_update_connection_level_updates_shared_window():
+    """Connection-level WINDOW_UPDATE updates the shared window so that stream
+    senders created after the update read the current budget from it."""
+    from blackbull.server.sender import ConnectionWindow
     frame = MagicMock()
     frame.stream_id = 0
     frame.length = 4  # valid frame length
@@ -135,12 +137,12 @@ async def test_window_update_connection_level_updates_handler_tracking():
 
     handler = MagicMock()
     handler._senders = {}
-    handler._connection_window_size = 65535
+    handler._conn_window = ConnectionWindow(65535)
 
     responder = WindowUpdateResponder(frame)
     await responder.respond(handler)
 
-    assert handler._connection_window_size == 65535 + 4128769
+    assert handler._conn_window.size == 65535 + 4128769
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +278,7 @@ async def test_window_update_stream_level_only_credits_stream_window():
 
     sender.window_update(512)
 
-    assert sender.stream_window_size[1] == 65535 + 512
+    assert sender.stream_window_size == 65535 + 512
     assert sender.connection_window_size == original_conn_window, (
         "stream-level WINDOW_UPDATE must not change connection_window_size"
     )
@@ -481,7 +483,7 @@ async def test_body_exceeding_flow_control_window_is_chunked():
     sender = HTTP2Sender(AsyncioWriter(mock_writer), factory, stream_id=1)
     sender.max_frame_size = 300
     sender.connection_window_size = 200
-    sender.stream_window_size[1] = 200
+    sender.stream_window_size = 200
 
     body = b'y' * 500
 

--- a/tests/unit/test_audit_sprint61.py
+++ b/tests/unit/test_audit_sprint61.py
@@ -1,0 +1,417 @@
+"""Regression tests for the Sprint 61 HTTP/1.1 correctness batch.
+
+Each test pins a specific bug from the 2026-07-07 comprehensive audit
+(``.claude/planning/recommendations/comprehensive-audit-2026-07-07.md``):
+
+- 1.1  chunked request body corrupted by partial reads
+- 1.3  a raising ``@app.on_startup`` hook hangs the server forever
+- 1.4  HTTP/1.1 writes a second response when a handler raises after completing
+- 1.5  any non-websocket ``Upgrade:`` header kills the connection with no reply
+- 1.6  unread request body is never drained on keep-alive
+- 1.11 ``read_body`` returns a truncated body on client disconnect
+- 1.13 mid-path ``{name:path}`` wildcard silently drops trailing segments
+- 1.15 WebSocket handshake accepts a missing ``Sec-WebSocket-Key``
+- 1.22a fault-injection production guard keyed on the wrong env var
+- 1.22b ``make_self_signed_h2_context`` leaks the private key on disk
+
+(Bug 1.12 — malformed dataclass body → 400 — is covered in
+``tests/unit/test_router.py::TestDataclassBodyDeserialization``.)
+"""
+import asyncio
+import gc
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+
+from blackbull.asgi import ASGIEvent
+from blackbull.request import read_body, read_json, read_text, ClientDisconnected
+from blackbull.server.recipient import (
+    AbstractReader, HTTP1Recipient, IncompleteReadError,
+)
+from blackbull.server.sender import AbstractWriter, HTTP1Sender
+
+
+
+# ---------------------------------------------------------------------------
+# In-process fakes
+# ---------------------------------------------------------------------------
+
+class _DribbleReader(AbstractReader):
+    """A reader whose ``read(n)`` returns at most one byte per call.
+
+    It deliberately does *not* override ``readexactly`` / ``readuntil`` — the
+    ``AbstractReader`` base loops over ``read`` to satisfy those.  This is the
+    fragmented-delivery case that the conformance ``_FakeReader`` (whole wire in
+    one buffer) can never exercise: with the old ``read(chunk_size)`` the
+    recipient would take a one-byte short read as the whole chunk (bug 1.1).
+    """
+
+    def __init__(self, data: bytes) -> None:
+        self._buf = bytearray(data)
+
+    async def read(self, n: int) -> bytes:
+        if not self._buf:
+            return b''
+        take = min(n, 1)  # dribble: never hand back more than one byte
+        chunk = bytes(self._buf[:take])
+        del self._buf[:take]
+        return chunk
+
+
+class _RecordingWriter(AbstractWriter):
+    """Captures every byte written so tests can inspect the wire."""
+
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+async def _drain_recipient(recipient: HTTP1Recipient) -> bytes:
+    """Consume a recipient to completion, concatenating body bytes."""
+    body = bytearray()
+    while True:
+        event = await recipient()
+        if event['type'] == ASGIEvent.HTTP_DISCONNECT:
+            break
+        body += event.get('body', b'')
+        if not event.get('more_body', False):
+            break
+    return bytes(body)
+
+
+# ---------------------------------------------------------------------------
+# 1.1 — chunked body reassembled with readexactly (not up-to-n read)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_chunked_body_reassembled_across_fragmented_reads():
+    payload = b'x' * 200  # one chunk, larger than the 1-byte dribble
+    wire = f'{len(payload):x}\r\n'.encode() + payload + b'\r\n0\r\n\r\n'
+    recipient = HTTP1Recipient(
+        _DribbleReader(wire),
+        {'headers': [(b'transfer-encoding', b'chunked')]},
+        chunk_size=64 * 1024,
+    )
+    body = await _drain_recipient(recipient)
+    assert body == payload, 'chunk split across reads must be reassembled whole'
+
+
+@pytest.mark.asyncio
+async def test_chunked_multiple_chunks_fragmented():
+    a, b = b'a' * 50, b'b' * 70
+    wire = (f'{len(a):x}\r\n'.encode() + a + b'\r\n'
+            + f'{len(b):x}\r\n'.encode() + b + b'\r\n0\r\n\r\n')
+    recipient = HTTP1Recipient(
+        _DribbleReader(wire),
+        {'headers': [(b'transfer-encoding', b'chunked')]},
+        chunk_size=64 * 1024,
+    )
+    assert await _drain_recipient(recipient) == a + b
+
+
+# ---------------------------------------------------------------------------
+# 1.6 — unread body is drained on keep-alive (bounded)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_needs_drain_false_for_bodyless_request():
+    recipient = HTTP1Recipient(_DribbleReader(b''), {'headers': []})
+    assert recipient.needs_drain() is False
+
+
+@pytest.mark.asyncio
+async def test_drain_consumes_unread_content_length_body():
+    body = b'z' * 300
+    recipient = HTTP1Recipient(
+        _DribbleReader(body),
+        {'headers': [(b'content-length', str(len(body)).encode())]},
+        chunk_size=64 * 1024,
+    )
+    assert recipient.needs_drain() is True
+    assert await recipient.drain(max_bytes=64 * 1024) is True
+    assert recipient.needs_drain() is False
+
+
+@pytest.mark.asyncio
+async def test_drain_gives_up_past_bound_so_caller_closes():
+    body = b'z' * 5000
+    recipient = HTTP1Recipient(
+        _DribbleReader(body),
+        {'headers': [(b'content-length', str(len(body)).encode())]},
+        chunk_size=64,
+    )
+    # A body larger than the drain bound returns False → caller closes the
+    # connection instead of spending bandwidth draining it.
+    assert await recipient.drain(max_bytes=1024) is False
+
+
+# ---------------------------------------------------------------------------
+# 1.4 — HTTP1Sender drops a second response once one has completed
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sender_drops_second_bytes_response():
+    writer = _RecordingWriter()
+    sender = HTTP1Sender(writer)
+    await sender(b'first', HTTPStatus.OK)
+    boundary = len(writer.data)
+    await sender(b'second', HTTPStatus.INTERNAL_SERVER_ERROR)  # must be dropped
+    assert len(writer.data) == boundary, 'a completed response must not be followed by a second'
+    assert b'first' in bytes(writer.data)
+    assert b'second' not in bytes(writer.data)
+
+
+@pytest.mark.asyncio
+async def test_sender_drops_streamed_response_then_error():
+    writer = _RecordingWriter()
+    sender = HTTP1Sender(writer)
+    await sender({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200, 'headers': []})
+    await sender({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'done', 'more_body': False})
+    boundary = len(writer.data)
+    # Handler raised after completing → error handler emits a 2nd response.
+    await sender({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 500, 'headers': []})
+    await sender({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'oops', 'more_body': False})
+    assert len(writer.data) == boundary
+    assert b'oops' not in bytes(writer.data)
+
+
+@pytest.mark.asyncio
+async def test_sender_reset_allows_next_keepalive_response():
+    writer = _RecordingWriter()
+    sender = HTTP1Sender(writer)
+    await sender(b'first', HTTPStatus.OK)
+    sender.reset_per_request_state()  # next keep-alive request
+    await sender(b'second', HTTPStatus.OK)
+    assert b'second' in bytes(writer.data)
+
+
+# ---------------------------------------------------------------------------
+# 1.11 — read_body surfaces a mid-body disconnect instead of truncating
+# ---------------------------------------------------------------------------
+
+def _receive_seq(events):
+    it = iter(events)
+
+    async def receive():
+        return next(it)
+    return receive
+
+
+@pytest.mark.asyncio
+async def test_read_body_raises_on_mid_body_disconnect():
+    receive = _receive_seq([
+        {'type': ASGIEvent.HTTP_REQUEST, 'body': b'par', 'more_body': True},
+        {'type': ASGIEvent.HTTP_DISCONNECT},
+    ])
+    with pytest.raises(ClientDisconnected) as exc_info:
+        await read_body(receive)
+    assert exc_info.value.partial == b'par', 'the partial bytes are attached'
+
+
+@pytest.mark.asyncio
+async def test_read_body_complete_body_unaffected():
+    receive = _receive_seq([
+        {'type': ASGIEvent.HTTP_REQUEST, 'body': b'whole', 'more_body': False},
+    ])
+    assert await read_body(receive) == b'whole'
+
+
+@pytest.mark.asyncio
+async def test_read_json_and_text_propagate_disconnect():
+    for reader in (read_json, read_text):
+        receive = _receive_seq([
+            {'type': ASGIEvent.HTTP_REQUEST, 'body': b'{', 'more_body': True},
+            {'type': ASGIEvent.HTTP_DISCONNECT},
+        ])
+        with pytest.raises(ClientDisconnected):
+            await reader(receive)
+
+
+# ---------------------------------------------------------------------------
+# 1.5 & 1.15 — Upgrade handling and WebSocket-key validation (via HTTP1Actor)
+# ---------------------------------------------------------------------------
+
+async def _noop_app(scope, receive, send):  # pragma: no cover - never dispatched here
+    return None
+
+
+def _make_actor(writer=None):
+    from blackbull.server.http1_actor import HTTP1Actor
+    return HTTP1Actor(
+        _DribbleReader(b''), writer or _RecordingWriter(),
+        app=_noop_app, aggregator=None,
+    )
+
+
+def test_upgrade_h2c_is_ignored_not_fatal():
+    actor = _make_actor()
+    request = (b'GET / HTTP/1.1\r\n'
+               b'Host: example.com\r\n'
+               b'Connection: Upgrade\r\n'
+               b'Upgrade: h2c\r\n\r\n')
+    scope = actor._parse(request)
+    # A non-websocket Upgrade token is ignored: the request stays plain HTTP
+    # rather than becoming scope['type']='h2c' and crashing dispatch (bug 1.5).
+    assert scope['type'] == 'http'
+
+
+def test_upgrade_websocket_still_switches_scope():
+    actor = _make_actor()
+    request = (b'GET /ws HTTP/1.1\r\n'
+               b'Host: example.com\r\n'
+               b'Connection: Upgrade\r\n'
+               b'Upgrade: websocket\r\n\r\n')
+    scope = actor._parse(request)
+    assert scope['type'] == 'websocket'
+    assert scope['scheme'] == 'ws'
+
+
+@pytest.mark.asyncio
+async def test_ws_handshake_rejects_missing_key():
+    writer = _RecordingWriter()
+    actor = _make_actor(writer)
+    scope = {'headers': __import__('blackbull.headers', fromlist=['Headers']).Headers([
+        (b'sec-websocket-version', b'13'),
+    ])}
+    ok = await actor._do_ws_handshake(scope)
+    assert ok is False
+    assert b'400' in bytes(writer.data), 'missing Sec-WebSocket-Key must 400'
+
+
+@pytest.mark.asyncio
+async def test_ws_handshake_rejects_malformed_key():
+    from blackbull.headers import Headers
+    writer = _RecordingWriter()
+    actor = _make_actor(writer)
+    scope = {'headers': Headers([
+        (b'sec-websocket-key', b'not-16-bytes-base64!!'),
+        (b'sec-websocket-version', b'13'),
+    ])}
+    assert await actor._do_ws_handshake(scope) is False
+    assert b'400' in bytes(writer.data)
+
+
+@pytest.mark.asyncio
+async def test_ws_handshake_accepts_valid_key():
+    from base64 import b64encode
+    from blackbull.headers import Headers
+    writer = _RecordingWriter()
+    actor = _make_actor(writer)
+    scope = {'headers': Headers([
+        (b'sec-websocket-key', b64encode(b'0123456789abcdef')),  # 16 bytes
+        (b'sec-websocket-version', b'13'),
+    ])}
+    assert await actor._do_ws_handshake(scope) is True
+
+
+# ---------------------------------------------------------------------------
+# 1.13 — mid-path {name:path} rejected at registration
+# ---------------------------------------------------------------------------
+
+def test_midpath_path_converter_rejected_at_registration():
+    from blackbull.router import _RouteTrie, ConfigurationError
+    trie = _RouteTrie()
+    with pytest.raises(ConfigurationError, match='last segment'):
+        trie.insert('/a/{p:path}/b', (), None, object())
+
+
+def test_final_path_converter_allowed():
+    from blackbull.router import _RouteTrie
+    trie = _RouteTrie()
+    trie.insert('/a/{p:path}', (), None, object())  # no raise
+
+
+# ---------------------------------------------------------------------------
+# 1.3 — a raising app_startup hook fails the lifespan instead of hanging
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_raising_startup_hook_fails_lifespan_without_hanging():
+    from blackbull import BlackBull
+    from blackbull.server.server import LifespanManager
+
+    app = BlackBull()
+
+    async def boom(event):
+        raise RuntimeError('startup blew up')
+    app._dispatcher.intercept('app_startup', boom)
+
+    mgr = LifespanManager(app)
+    # The bug hangs here forever; wait_for turns a regression into a failure.
+    with pytest.raises(RuntimeError, match='startup blew up'):
+        await asyncio.wait_for(mgr.__aenter__(), timeout=3.0)
+    await mgr.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_clean_startup_still_completes():
+    from blackbull import BlackBull
+    from blackbull.server.server import LifespanManager
+
+    app = BlackBull()
+    started = {}
+
+    async def note(event):
+        started['ok'] = True
+    app._dispatcher.intercept('app_startup', note)
+
+    mgr = LifespanManager(app)
+    await asyncio.wait_for(mgr.__aenter__(), timeout=3.0)
+    assert started.get('ok') is True
+    await mgr.__aexit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# 1.22a — fault-injection production guard keys on the real signal
+# ---------------------------------------------------------------------------
+
+def test_fault_server_guard_trips_on_blackbull_env_production(monkeypatch):
+    from blackbull.env import reset_settings_cache
+    from blackbull.fault_injection.h2_server import (
+        _refuse_in_production, H2FaultServerError,
+    )
+    monkeypatch.delenv('BB_PRODUCTION', raising=False)
+    monkeypatch.setenv('BLACKBULL_ENV', 'production')
+    reset_settings_cache()
+    with pytest.raises(H2FaultServerError):
+        _refuse_in_production()
+
+
+def test_fault_server_guard_trips_on_bb_production_override(monkeypatch):
+    from blackbull.env import reset_settings_cache
+    from blackbull.fault_injection.h2_server import (
+        _refuse_in_production, H2FaultServerError,
+    )
+    monkeypatch.setenv('BLACKBULL_ENV', 'development')
+    monkeypatch.setenv('BB_PRODUCTION', '1')
+    reset_settings_cache()
+    with pytest.raises(H2FaultServerError):
+        _refuse_in_production()
+
+
+def test_fault_server_guard_allows_development(monkeypatch):
+    from blackbull.env import reset_settings_cache
+    from blackbull.fault_injection.h2_server import _refuse_in_production
+    monkeypatch.delenv('BB_PRODUCTION', raising=False)
+    monkeypatch.setenv('BLACKBULL_ENV', 'development')
+    reset_settings_cache()
+    _refuse_in_production()  # no raise
+
+
+# ---------------------------------------------------------------------------
+# 1.22b — self-signed TLS context removes its keydir when collected
+# ---------------------------------------------------------------------------
+
+def test_self_signed_tls_context_cleans_up_keydir():
+    pytest.importorskip('cryptography')
+    from blackbull.fault_injection._tls import make_self_signed_h2_context
+
+    ctx = make_self_signed_h2_context()
+    keydir = Path(ctx.bb_ca_cert_path).parent
+    assert keydir.exists()
+    del ctx
+    gc.collect()
+    assert not keydir.exists(), 'the private-key tempdir must be removed on finalize'

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -24,7 +24,7 @@ from blackbull.router import (
     Router, BaseRouter, ErrorRouter,
     _middleware_param, has_middleware_param,
     _is_simplified_handler, _adapt_handler,
-    PathNotRegistered, MethodNotApplicable, ConfigurationError,
+    PathNotRegistered, MethodNotApplicable, ConfigurationError, HTTPException,
 )
 from blackbull import BlackBull, Response, JSONResponse
 from blackbull.router import RouteGroup
@@ -894,17 +894,21 @@ class TestDataclassBodyDeserialization:
 
     @pytest.mark.asyncio
     async def test_missing_required_field_raises(self):
+        """A body missing a required field is a client error → 400 (bug 1.12)."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')
-        with pytest.raises(TypeError):
+        with pytest.raises(HTTPException) as exc_info:
             await wrapper({}, self._receive_with(b'{"qty":3}'), AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
 
     @pytest.mark.asyncio
     async def test_unknown_field_raises(self):
+        """An unknown body field is a client error → 400 (bug 1.12)."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')
-        with pytest.raises(TypeError, match='Unknown field'):
+        with pytest.raises(HTTPException, match='Unknown field') as exc_info:
             await wrapper({}, self._receive_with(b'{"name":"x","extra":1}'), AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
 
     @pytest.mark.asyncio
     async def test_nested_dataclass(self):
@@ -960,10 +964,13 @@ class TestDataclassBodyDeserialization:
 
     @pytest.mark.asyncio
     async def test_invalid_json_raises(self):
+        """Malformed JSON in the body is a client error → 400 (bug 1.12),
+        not the raw JSONDecodeError that used to surface as a 500."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')
-        with pytest.raises(json.JSONDecodeError):
+        with pytest.raises(HTTPException) as exc_info:
             await wrapper({}, self._receive_with(b'not json'), AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
 
     @pytest.mark.asyncio
     async def test_bytes_body_still_works(self):

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -230,7 +230,7 @@ async def test_http2_sender_blocks_when_window_closed():
     sender = HTTP2Sender(writer, FrameFactory(), stream_id=1)
     # Force the peer's window closed BEFORE the write starts.
     sender.connection_window_size = 0
-    sender.stream_window_size[1] = 0
+    sender.stream_window_size = 0
 
     write_done = asyncio.Event()
 
@@ -250,7 +250,7 @@ async def test_http2_sender_blocks_when_window_closed():
         # Reopen the window and signal the waiter — the write should now
         # run to completion and put the full payload on the wire.
         sender.connection_window_size = 100
-        sender.stream_window_size[1] = 100
+        sender.stream_window_size = 100
         assert sender._window_open is not None
         sender._window_open.set()
         await asyncio.wait_for(write_done.wait(), timeout=1.0)


### PR DESCRIPTION
Correctness patch release. Ships the HTTP/1.1 + HTTP/2 bug fixes from the 2026-07-07 comprehensive audit (Sprints 61 + 62) on top of v0.49.0. **No new features**; two additions to the public API (`ClientDisconnected`, `HTTPException`).

Rebuilt as `origin/master (v0.49.0) + audit 61 + audit 62` via `git rebase --onto` (the duplicate v0.48.1 IPv6 hotfix commit was dropped — its equivalent is already on master). One merge conflict in `blackbull/grpc/asgi.py` resolved by keeping both v0.49.0's gzip/compression path **and** Sprint 61's `ClientDisconnected → CANCELLED` mapping.

## Fixed — HTTP/1.1 + request handling
- 1.1 chunked bodies split across TCP segments reassembled whole (`readexactly`)
- 1.3 raising `app_startup` hook emits `lifespan.startup.failed`; startup ack raced against the task (no more hang)
- 1.4 `HTTP1Sender` drops post-completion events (no double-response splice)
- 1.5 non-WebSocket `Upgrade:` tokens ignored, not fatal
- 1.6 unread keep-alive bodies drained-or-closed (no framing desync)
- 1.11 `read_body` raises `ClientDisconnected` on mid-body disconnect (gRPC → `CANCELLED`)
- 1.12 malformed JSON/dataclass bodies → `HTTPException(400)`, not 500
- 1.13 mid-path `{name:path}` wildcard rejected at registration
- 1.15 WebSocket handshake rejects absent/malformed `Sec-WebSocket-Key` (400)

## Fixed — HTTP/2 flow control + lifecycle
- 1.2 one shared connection send window (no connection `FLOW_CONTROL_ERROR` under concurrency); `stream_window_size` now an int (refactor 2.5)
- 1.8 GOAWAY early-return signals recipients (connection drains, no wedge)
- 1.9 bounded closed-stream tracking (no memory leak on long-lived connections)
- 1.10 PRIORITY frame with unknown dependency parents under root, no crash
- 1.14 #1 single-frame HEADERS on open stream treated as trailers
- 1.14 #3 oversize-frame guard before buffering (no attacker-declared 16 MiB alloc)

## Security (fault injection)
- 1.22a `H2FaultServer` production guard checks `BLACKBULL_ENV=production` (old `BB_PRODUCTION`-only check was a no-op)
- 1.22b `make_self_signed_h2_context` finalizer removes its tempdir (no key left in `/tmp`)

## Deferred (documented, not in this release)
- audit 1.14 #2 (refused multi-frame HEADERS / trailers) — needs a CONTINUATION-accumulation restructure to keep HPACK state coherent
- consume-based inbound flow control (`proposals/consume-based-inbound-flow-control.md`) — the large-over-window interop test stays a **non-strict** xfail

## Testing
- New regression suites: `tests/unit/test_audit_sprint61.py` (24), `tests/conformance/http2/test_audit_sprint62.py` (11)
- Full gRPC conformance suite green locally (280 passed; the one over-window interop xfail is non-strict by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)