### PR TITLE
release: v0.49.2 — Sprint 63 Http11Probe hardening + Sprint 62 flow-control closeout

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -267,10 +267,20 @@ jobs:
 
       - name: Run real-client gRPC interop conformance
         # Docker-free interop gate: a real grpcio client drives BlackBull's
-        # unary gRPC over a real h2c socket.  Guards the Trailers-Only framing
-        # regression (Sprint 58) — the error path must land grpc-status in a
-        # trailing HEADERS frame or strict clients decode every error as
-        # UNKNOWN.  Runs on every push/PR, not just the weekly full tier.
+        # unary + streaming gRPC over a real h2c socket.  Guards three
+        # regressions against a spec-strict peer:
+        #   - Trailers-Only framing (Sprint 58) — grpc-status must land in a
+        #     trailing HEADERS frame or strict clients decode every error as
+        #     UNKNOWN;
+        #   - consume-based inbound flow control (Sprint 62 deferral) — the
+        #     over-window client-streaming/bidi gates
+        #     (test_large_request_stream_over_window,
+        #     test_large_both_directions_over_window) fail with
+        #     RESOURCE_EXHAUSTED if enqueue-time crediting regresses;
+        #   - the shared connection send window (bug 1.2) — the multi-stream
+        #     concurrency gate fails with FLOW_CONTROL_ERROR if per-stream
+        #     window copies come back.
+        # Runs on every push/PR, not just the weekly full tier.
         run: |
           timeout 90 python -m pytest --timeout=60 -v \
               tests/conformance/grpc/test_grpc_real_client_h2c.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.49.2] — 2026-07-08
+
 Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16.
 HTTP/1.1 request framing and request-target parsing are tightened to reject
 the smuggling / malformed-input vectors the Http11Probe baseline flagged;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,65 +31,40 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
-Closes the two Sprint 62 deferrals from the 2026-07-07 comprehensive audit:
-consume-based inbound HTTP/2 flow control
-(`proposals/consume-based-inbound-flow-control.md`) and the strict-peer
-multi-stream concurrency gate for the shared connection send window
-(audit bug 1.2).
-
-### Fixed
-
-- **Consume-based inbound HTTP/2 flow control** — `WINDOW_UPDATE` credit for
-  an inbound DATA frame is now replayed when the application *consumes* the
-  event off the stream's recipient queue, not when the frame is enqueued
-  (`HTTP2Recipient` gained a `credit_callback`, mirroring `HTTP2WSReader`'s
-  credit-replay shape). A handler that stalls reading (e.g. a bidi gRPC
-  handler blocked on `yield` under response back-pressure, or a
-  client-streaming handler starved of CPU) now closes the inbound window and
-  back-pressures the peer instead of overflowing the 64-deep recipient queue
-  into `RST_STREAM(ENHANCE_YOUR_CALM)` — grpcio no longer sees intermittent
-  `RESOURCE_EXHAUSTED` on over-window request streams. The recipient queue is
-  bounded by the advertised inbound window in *bytes* (plus a generous
-  frame-count cap against zero/tiny-frame floods), so the queue-full RST is
-  now strictly an abuse backstop for peers that ignore the closed window. A
-  stream released without draining its body (handler ignored `receive`,
-  or was cancelled by RST_STREAM) replays the un-consumed balance to the
-  *connection* window so the shared stream-0 budget cannot leak shut.
-  The two Sprint 60 `xfail(strict=False)` interop tests
-  (`test_large_both_directions_over_window`,
-  `test_large_request_stream_over_window`) are now hard gates in the
-  `grpc-interop` CI job.
-
-### Added
-
-- **Strict-peer multi-stream flow-control gate (audit bug 1.2)** —
-  `test_concurrent_large_responses_share_connection_window`: 10 concurrent
-  unary calls multiplexed on ONE grpcio channel × 100 KB responses, so
-  cumulative response bytes far exceed the 65535-byte connection window.
-  Guards the shared connection send window on the wire: per-stream window
-  copies would over-emit and a strict peer kills the connection with
-  `FLOW_CONTROL_ERROR`. Runs in the `grpc-interop` CI job on every push/PR.
-- `h2_inbound_window_budget` cap-hit log site (`log_cap_hit`) — emitted when
-  a peer overruns the advertised inbound stream window (the abuse backstop
-  above); registered in the cap inventory audit.
-
-### Changed
-
-- The four enqueue-time crediting tests in
-  `tests/conformance/http2/test_http2_dispatch.py::TestHTTP2FlowControl`
-  now assert the consume-time contract (spec change): crediting tests use a
-  body-draining app, and the >65535-byte cumulative-inbound test models a
-  window-respecting (credit-paced) peer.
-
 ## [0.49.2] — 2026-07-08
 
-Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16.
-HTTP/1.1 request framing and request-target parsing are tightened to reject
-the smuggling / malformed-input vectors the Http11Probe baseline flagged;
-malformed chunked framing now answers a clean `400` instead of a `500` or a
-silent `200`. No public-API changes.
+Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16 —
+**plus** the two Sprint 62 HTTP/2 flow-control deferrals from the
+2026-07-07 comprehensive audit: consume-based inbound flow control
+(`proposals/consume-based-inbound-flow-control.md`) and the strict-peer
+multi-stream concurrency gate for the shared connection send window (audit
+bug 1.2). HTTP/1.1 request framing and request-target parsing are tightened
+to reject the smuggling / malformed-input vectors the Http11Probe baseline
+flagged; malformed chunked framing now answers a clean `400` instead of a
+`500` or a silent `200`. No public-API changes.
 
 ### Fixed
+
+- **Consume-based inbound HTTP/2 flow control (Sprint 62)** —
+  `WINDOW_UPDATE` credit for an inbound DATA frame is now replayed when the
+  application *consumes* the event off the stream's recipient queue, not
+  when the frame is enqueued (`HTTP2Recipient` gained a `credit_callback`,
+  mirroring `HTTP2WSReader`'s credit-replay shape). A handler that stalls
+  reading (e.g. a bidi gRPC handler blocked on `yield` under response
+  back-pressure, or a client-streaming handler starved of CPU) now closes
+  the inbound window and back-pressures the peer instead of overflowing the
+  64-deep recipient queue into `RST_STREAM(ENHANCE_YOUR_CALM)` — grpcio no
+  longer sees intermittent `RESOURCE_EXHAUSTED` on over-window request
+  streams. The recipient queue is bounded by the advertised inbound window
+  in *bytes* (plus a generous frame-count cap against zero/tiny-frame
+  floods), so the queue-full RST is now strictly an abuse backstop for
+  peers that ignore the closed window. A stream released without draining
+  its body (handler ignored `receive`, or was cancelled by RST_STREAM)
+  replays the un-consumed balance to the *connection* window so the shared
+  stream-0 budget cannot leak shut. The two Sprint 60
+  `xfail(strict=False)` interop tests (`test_large_both_directions_over_window`,
+  `test_large_request_stream_over_window`) are now hard gates in the
+  `grpc-interop` CI job.
 
 - **Chunked request framing (RFC 9112 §7.1)** — the chunk-size token is
   validated against the strict `1*HEXDIG` grammar *before* `int()` (rejecting
@@ -127,6 +102,24 @@ silent `200`. No public-API changes.
 - `docs/getting-started/why-blackbull.md` — a scenario-based guide for
   deciding whether BlackBull fits a given project, plus the honest
   trade-off table.
+- **Strict-peer multi-stream flow-control gate (Sprint 62, audit bug 1.2)** —
+  `test_concurrent_large_responses_share_connection_window`: 10 concurrent
+  unary calls multiplexed on ONE grpcio channel × 100 KB responses, so
+  cumulative response bytes far exceed the 65535-byte connection window.
+  Guards the shared connection send window on the wire: per-stream window
+  copies would over-emit and a strict peer kills the connection with
+  `FLOW_CONTROL_ERROR`. Runs in the `grpc-interop` CI job on every push/PR.
+- `h2_inbound_window_budget` cap-hit log site (`log_cap_hit`) — emitted when
+  a peer overruns the advertised inbound stream window (the consume-based
+  crediting abuse backstop above); registered in the cap inventory audit.
+
+### Changed
+
+- The four enqueue-time crediting tests in
+  `tests/conformance/http2/test_http2_dispatch.py::TestHTTP2FlowControl`
+  now assert the consume-time contract (spec change, Sprint 62): crediting
+  tests use a body-draining app, and the >65535-byte cumulative-inbound test
+  models a window-respecting (credit-paced) peer.
 
 ### Docs
 
@@ -140,6 +133,10 @@ silent `200`. No public-API changes.
   the two new docs pages, and an updated Architecture doc link.
   `docs/index.md` now mentions gRPC and MQTT alongside HTTP/1.1, HTTP/2,
   and WebSocket, and links the two new pages.
+- `docs/about/rfc9113-implementation.md` §5.2/§6.1/§6.9.1 updated to
+  describe consume-time inbound crediting (Sprint 62); a pre-existing
+  staleness describing the pre-bug-1.2 per-sender window scalars was
+  fixed alongside.
 
 ## [0.49.1] — 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,56 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+Closes the two Sprint 62 deferrals from the 2026-07-07 comprehensive audit:
+consume-based inbound HTTP/2 flow control
+(`proposals/consume-based-inbound-flow-control.md`) and the strict-peer
+multi-stream concurrency gate for the shared connection send window
+(audit bug 1.2).
+
+### Fixed
+
+- **Consume-based inbound HTTP/2 flow control** — `WINDOW_UPDATE` credit for
+  an inbound DATA frame is now replayed when the application *consumes* the
+  event off the stream's recipient queue, not when the frame is enqueued
+  (`HTTP2Recipient` gained a `credit_callback`, mirroring `HTTP2WSReader`'s
+  credit-replay shape). A handler that stalls reading (e.g. a bidi gRPC
+  handler blocked on `yield` under response back-pressure, or a
+  client-streaming handler starved of CPU) now closes the inbound window and
+  back-pressures the peer instead of overflowing the 64-deep recipient queue
+  into `RST_STREAM(ENHANCE_YOUR_CALM)` — grpcio no longer sees intermittent
+  `RESOURCE_EXHAUSTED` on over-window request streams. The recipient queue is
+  bounded by the advertised inbound window in *bytes* (plus a generous
+  frame-count cap against zero/tiny-frame floods), so the queue-full RST is
+  now strictly an abuse backstop for peers that ignore the closed window. A
+  stream released without draining its body (handler ignored `receive`,
+  or was cancelled by RST_STREAM) replays the un-consumed balance to the
+  *connection* window so the shared stream-0 budget cannot leak shut.
+  The two Sprint 60 `xfail(strict=False)` interop tests
+  (`test_large_both_directions_over_window`,
+  `test_large_request_stream_over_window`) are now hard gates in the
+  `grpc-interop` CI job.
+
+### Added
+
+- **Strict-peer multi-stream flow-control gate (audit bug 1.2)** —
+  `test_concurrent_large_responses_share_connection_window`: 10 concurrent
+  unary calls multiplexed on ONE grpcio channel × 100 KB responses, so
+  cumulative response bytes far exceed the 65535-byte connection window.
+  Guards the shared connection send window on the wire: per-stream window
+  copies would over-emit and a strict peer kills the connection with
+  `FLOW_CONTROL_ERROR`. Runs in the `grpc-interop` CI job on every push/PR.
+- `h2_inbound_window_budget` cap-hit log site (`log_cap_hit`) — emitted when
+  a peer overruns the advertised inbound stream window (the abuse backstop
+  above); registered in the cap inventory audit.
+
+### Changed
+
+- The four enqueue-time crediting tests in
+  `tests/conformance/http2/test_http2_dispatch.py::TestHTTP2FlowControl`
+  now assert the consume-time contract (spec change): crediting tests use a
+  body-draining app, and the >65535-byte cumulative-inbound test models a
+  window-respecting (credit-paced) peer.
+
 ## [0.49.2] — 2026-07-08
 
 Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,66 @@ so the editable install's metadata catches up.
 
 ---
 
+## [Unreleased]
+
+Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16.
+HTTP/1.1 request framing and request-target parsing are tightened to reject
+the smuggling / malformed-input vectors the Http11Probe baseline flagged;
+malformed chunked framing now answers a clean `400` instead of a `500` or a
+silent `200`. No public-API changes.
+
+### Fixed
+
+- **Chunked request framing (RFC 9112 §7.1)** — the chunk-size token is
+  validated against the strict `1*HEXDIG` grammar *before* `int()` (rejecting
+  `-1`, `0x5`, `+0`, `1_0`, leading/trailing whitespace), the `chunk-ext`
+  grammar is validated (bare `;`, non-token names/values, and control
+  characters rejected), the size line must be CRLF-terminated (bare-LF
+  rejected), and the chunk-data terminator is checked as exactly `CRLF`
+  (chunk-data spill and bare CR/LF terminators rejected). Violations raise a
+  `400 Bad Request` and close the connection instead of surfacing as a
+  fabricated `500` or being silently accepted.
+- **Request-target forms (RFC 9112 §3.2)** — absolute-form
+  (`GET http://host/path`) is rewritten to origin-form for routing with the
+  request's authority overriding a spoofed/mismatched `Host`; asterisk-form
+  (`OPTIONS *`) is answered server-wide (`204` + `Allow`) rather than routed
+  to a 404, and is rejected (`400`) for any method other than OPTIONS;
+  `CONNECT` returns `501`; a raw non-ASCII byte in the request-target is
+  rejected (`400`).
+- **Header validation** — userinfo in the `Host` header (`user@host`) is
+  rejected (`400`, RFC 3986 §3.2); a duplicate `Content-Type` is rejected;
+  a `Transfer-Encoding` where `chunked` is not the sole final coding
+  (`chunked, gzip`, `chunked, chunked`) is `400` (undeterminable length),
+  distinct from an unimplemented coding (`gzip`) which stays `501`.
+- **Bug 1.16 — `X-Forwarded-Prefix` no longer trusted off the wire.** The
+  HTTP/1.1 and HTTP/2 parsers no longer set `scope['root_path']` from the
+  client-controlled `X-Forwarded-Prefix` header; only the `TrustedProxy`
+  middleware sets it, after verifying the direct peer — mirroring the
+  existing `X-Forwarded-For` / `X-Forwarded-Proto` trust model. A client
+  could previously spoof the application's mount prefix.
+
+### Added
+
+- `docs/about/architecture.md` — protocol ownership, the Actor model,
+  fault injection, conformance, and performance, with the reasoning
+  behind each design bet.
+- `docs/getting-started/why-blackbull.md` — a scenario-based guide for
+  deciding whether BlackBull fits a given project, plus the honest
+  trade-off table.
+
+### Docs
+
+- `docs/guide/grpc.md` and `KNOWN_LIMITATIONS.md` corrected — both
+  claimed client-streaming and bidirectional gRPC were unsupported and
+  that message compression was absent; both shipped in v0.49.0 (all
+  four RPC shapes + `gzip`).
+- `SECURITY.md` supported-versions table updated (`0.49.x` / `0.48.x`)
+  — it had not shifted when v0.49.0 (a MINOR release) shipped.
+- `README.md` gained an Actor-model bullet, a cross-reference line to
+  the two new docs pages, and an updated Architecture doc link.
+  `docs/index.md` now mentions gRPC and MQTT alongside HTTP/1.1, HTTP/2,
+  and WebSocket, and links the two new pages.
+
 ## [0.49.1] — 2026-07-07
 
 Correctness patch — the HTTP/1.1 and HTTP/2 bug fixes from the 2026-07-07

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -8,6 +8,12 @@ protocol-level test coverage behind the standards-compliance claims;
 this file is the narrative "things to know before you build on top
 of it" list.
 
+> **Read this alongside the strengths.** A gap list read on its own is
+> unbalanced.  For the architectural bets behind these trade-offs, see
+> [`docs/about/architecture.md`](docs/about/architecture.md); to decide
+> whether BlackBull fits your use case, see
+> [`docs/getting-started/why-blackbull.md`](docs/getting-started/why-blackbull.md).
+
 Every item here is something the project knows about and has a
 position on.  Behaviours that aren't listed below — anything that
 would surprise us as well — belong on the GitHub issue tracker.
@@ -233,17 +239,19 @@ opt-in knob is sketched in the roadmap but not built.
 
 Out of scope.  Revisit if a real user need appears.
 
-### gRPC: unary + server-streaming only
+### gRPC: no protobuf codegen toolchain
 
-Unary **and server-streaming** gRPC over HTTP/2 ship in `blackbull.grpc`
-(`app.enable_grpc`): `application/grpc` requests multiplex onto the same
-HTTP/2 port as REST and WebSocket, with `grpc-status` reported in trailers
-(a trailing HEADERS frame).  Client- and bidirectional-streaming are **not**
-implemented yet (they need a streamed request), and there is no protobuf
-codegen toolchain — handlers exchange raw message bytes, so
-descriptor/message classes are the application's choice.  Message
-compression is also unsupported (the server advertises
-`grpc-accept-encoding: identity`).
+All four gRPC RPC shapes — unary, server-streaming, client-streaming, and
+bidirectional — ship in `blackbull.grpc` (`app.enable_grpc`), with `gzip`
+message compression (`grpc-accept-encoding: identity,gzip`).
+`application/grpc` requests multiplex onto the same HTTP/2 port as REST and
+WebSocket, with `grpc-status` reported in trailers (a trailing HEADERS
+frame). What's still missing: a protobuf codegen toolchain — handlers
+exchange raw message bytes, so descriptor/message classes are the
+application's choice. A `blackbull-protobuf` package (codegen adapter,
+`grpc.health.v1`, reflection, rich errors) is planned as a separate,
+optional install — see
+[`docs/guide/grpc.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/grpc.md).
 
 ### CLI `--bind` host is advisory
 

--- a/README.md
+++ b/README.md
@@ -49,9 +49,14 @@ Hello, world!
   server.  Test your own HTTP/2 client against half-closed streams,
   exhausted windows, and illegal SETTINGS — in CI.
 - **Multi-protocol, one process.** A pure-Python MQTT 5 broker and
-  unary gRPC ride beside HTTP/2 and WebSocket on the same runtime;
+  gRPC ride beside HTTP/2 and WebSocket on the same runtime;
   extensions add new protocols without touching the core — still no
   C extension.
+- **Actor-model internals.** Connection-level isolation without a
+  single shared lock: a `ConnectionActor` spawns a per-connection
+  protocol actor whose inbox loop owns its own state.  The same
+  message-passing concurrency runs your HTTP routes, the MQTT broker,
+  and the gRPC handlers — one model across every protocol.
 - **RFC-grade correctness.** Passes the same external conformance
   suites used to validate nginx and Envoy (`h2spec`, Autobahn).
 - **Typed throughout.** Your editor and `mypy` / `pyright` see
@@ -138,6 +143,11 @@ Need a protocol BlackBull doesn't ship? `@app.raw_handler` hands you the
 raw reader/writer for a port. See
 [`docs/guide/mqtt.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/mqtt.md)
 and [`docs/guide/raw-protocols.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/raw-protocols.md).
+
+Deeper dives:
+[Architecture](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/architecture.md) ·
+[Is BlackBull right for you?](https://github.com/TOKUJI/BlackBull/blob/master/docs/getting-started/why-blackbull.md) ·
+[Known limitations](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md)
 
 ## Event API
 
@@ -249,7 +259,8 @@ for the full tutorial.
 ## Documentation
 
 - **Guide**: [`docs/guide/index.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/index.md)
-- **Architecture**: [`docs/about/internals.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/internals.md)
+- **Architecture & design rationale**: [`docs/about/architecture.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/architecture.md)
+- **Implementation internals**: [`docs/about/internals.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/about/internals.md)
 - **Changelog**: [`CHANGELOG.md`](https://github.com/TOKUJI/BlackBull/blob/master/CHANGELOG.md)
 
 ## Versioning

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.49.x  | :white_check_mark: |
 | 0.48.x  | :white_check_mark: |
-| 0.47.x  | :white_check_mark: |
-| < 0.47  | :x:                |
+| < 0.48  | :x:                |
 
 This table updates with each minor release.
 

--- a/bench/http11probe/probe_scan.py
+++ b/bench/http11probe/probe_scan.py
@@ -1,0 +1,136 @@
+"""Local substitute for the .NET Http11Probe — fires the exact Cluster A/B/C
+vectors from the baseline proposal at a live BlackBull server and reports the
+actual status / behaviour, so we can see the post-Sprint-61 delta and what
+Sprint 63 still needs to fix.  Not a pytest file; run directly."""
+import asyncio
+import socket
+from http import HTTPMethod
+from multiprocessing import Process
+
+from blackbull import BlackBull, read_body
+from blackbull.server import ASGIServer
+
+
+def make_app():
+    app = BlackBull()
+
+    @app.route(path='/', methods=[HTTPMethod.GET, HTTPMethod.POST])
+    async def index(scope, receive, send):
+        await read_body(receive)
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'text/plain')]})
+        await send({'type': 'http.response.body', 'body': b'ok'})
+
+    @app.route(path='/echo', methods=[HTTPMethod.GET, HTTPMethod.POST])
+    async def echo(scope, receive, send):
+        body = await read_body(receive)
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'application/octet-stream')]})
+        await send({'type': 'http.response.body', 'body': body})
+
+    return app
+
+
+def send_raw(port, request, timeout=2.0):
+    sock = socket.create_connection(('127.0.0.1', port), timeout=timeout)
+    try:
+        sock.sendall(request)
+        try:
+            sock.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        chunks = []
+        sock.settimeout(timeout)
+        try:
+            while True:
+                buf = sock.recv(4096)
+                if not buf:
+                    break
+                chunks.append(buf)
+        except (socket.timeout, TimeoutError):
+            return b''.join(chunks), 'TIMEOUT'
+    finally:
+        sock.close()
+    return b''.join(chunks), 'CLOSED'
+
+
+def status_of(raw):
+    if not raw:
+        return None
+    line = raw.split(b'\r\n', 1)[0]
+    parts = line.split(b' ', 2)
+    if len(parts) >= 2 and parts[0].startswith(b'HTTP/'):
+        try:
+            return int(parts[1])
+        except ValueError:
+            return None
+    return None
+
+
+# (name, expected-desc, raw request)
+VECTORS = [
+    # Cluster A — chunked
+    ('SMUG-CHUNK-NEGATIVE', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n-1\r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-HEX-PREFIX', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n0x5\r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-LEADING-SP', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n 5\r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-SIZE-PLUS', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n+0\r\n\r\n'),
+    ('SMUG-CHUNK-UNDERSCORE', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n1_0\r\n0123456789abcdef\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-BARE-SEMICOLON', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5;\r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-EXT-INVALID-TOKEN', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5;a@b=c\r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-SIZE-TRAILING-OWS', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5 \r\nhello\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-SPILL', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhelloEXTRA\r\n0\r\n\r\n'),
+    ('SMUG-CHUNK-EXT-CTRL', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n5;a=\x01\r\nhello\r\n0\r\n\r\n'),
+    # Cluster B — special URI forms
+    ('COMP-ABSOLUTE-FORM', '2xx',
+     b'GET http://localhost/ HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    ('COMP-ASTERISK-WITH-GET', '400/close',
+     b'GET * HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    ('COMP-OPTIONS-STAR', '2xx/405',
+     b'OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    ('COMP-METHOD-CONNECT', '400/405/501',
+     b'CONNECT localhost:80 HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    ('SMUG-ABSOLUTE-URI-HOST-MISMATCH', '400/2xx',
+     b'GET http://evil.com/ HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    # Cluster C — protocol validation
+    ('COMP-HOST-WITH-USERINFO', '400',
+     b'GET / HTTP/1.1\r\nHost: user@localhost\r\n\r\n'),
+    ('MAL-NON-ASCII-URL', '400',
+     b'GET /\xc3\xa9 HTTP/1.1\r\nHost: localhost\r\n\r\n'),
+    ('SMUG-TE-NOT-FINAL-CHUNKED', '400',
+     b'POST /echo HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked, gzip\r\n\r\n5\r\nhello\r\n0\r\n\r\n'),
+]
+
+
+def main():
+    app = make_app()
+    server = ASGIServer(app)
+    server.open_socket(0)
+    p = Process(target=lambda: asyncio.run(server.run()))
+    p.start()
+    try:
+        server.wait_for_port(timeout=10.0)
+        port = server.port
+        print(f'{"TEST":<32} {"EXPECT":<12} {"GOT":<8} {"CONN"}')
+        print('-' * 64)
+        for name, expect, req in VECTORS:
+            raw, conn = send_raw(port, req)
+            st = status_of(raw)
+            print(f'{name:<32} {expect:<12} {str(st):<8} {conn}')
+    finally:
+        server.close()
+        p.terminate()
+        p.join(timeout=5)
+
+
+if __name__ == '__main__':
+    main()

--- a/blackbull/middleware/proxy.py
+++ b/blackbull/middleware/proxy.py
@@ -93,4 +93,12 @@ class TrustedProxy:
             if xfp:
                 scope['scheme'] = xfp.strip().lower()
 
+        # X-Forwarded-Prefix — the reverse-proxy mount prefix, honoured only
+        # here (behind the trusted-peer gate).  The parser layer deliberately
+        # ignores it off the wire (bug 1.16); a spoofed prefix from an
+        # untrusted client would otherwise poison URL generation / routing.
+        xf_prefix = headers.get(b'x-forwarded-prefix', b'').decode()
+        if xf_prefix:
+            scope['root_path'] = xf_prefix.rstrip('/')
+
         await call_next(scope, receive, send)

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -27,6 +27,10 @@ logger = logging.getLogger(__name__)
 
 _REQ_END = b'\r\n\r\n'
 _WS_GUID = b'258EAFA5-E914-47DA-95CA-C5AB0DC85B11'  # RFC 6455 §1.3
+# Methods advertised in the Allow header of a server-wide ``OPTIONS *``
+# response (RFC 9112 §3.2.4).  The origin implements the standard set; route
+# dispatch is bypassed for asterisk-form, so this is a server-level answer.
+_SERVER_WIDE_ALLOW = b'GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS'
 _HTTP_PORT  = 80
 _HTTPS_PORT = 443
 
@@ -137,23 +141,48 @@ def _validate_message_framing(headers: 'Headers') -> None:
             raise BadRequestError(
                 f'conflicting Content-Length values: {sorted(values)!r}')
 
-    # Sprint 18 Phase 2 — TE coding validation.  Match nginx's behaviour:
-    # only the bare ``chunked`` token is accepted; everything else (gzip,
-    # deflate, identity-as-comma-list, etc.) is 501.  Both nginx and
-    # BlackBull's corpus showed nginx returning 501 on ``identity,
-    # chunked`` and ``gzip``.
-    for _, raw_value in tes:
-        te = raw_value.strip().lower()
-        if te != b'chunked':
+    # Sprint 18 Phase 2 / Sprint 63 — Transfer-Encoding validation.
+    #
+    # RFC 9112 §6.1 distinguishes two failure modes:
+    #   * ``chunked`` present but NOT the final coding (``chunked, gzip``,
+    #     ``chunked, chunked``) ⇒ the message length is undeterminable ⇒
+    #     **400 Bad Request** (SMUG-TE-NOT-FINAL-CHUNKED).  A server MUST NOT
+    #     process such a message.
+    #   * a coding we don't implement where chunked is absent (``gzip``,
+    #     ``deflate``) ⇒ **501 Not Implemented** (nginx parity).
+    # We accept exactly a single bare ``chunked`` token.
+    if tes:
+        # Flatten comma-combined + multi-header codings, in order.
+        codings = [c.strip().lower()
+                   for _, raw_value in tes for c in raw_value.split(b',')]
+        if codings == [b'chunked']:
+            pass  # the one accepted form
+        elif b'chunked' not in codings:
+            # No chunked at all (``gzip``, ``deflate``) ⇒ a coding we don't
+            # implement ⇒ 501 (nginx parity).
             raise NotImplementedFramingError(
-                f'Transfer-Encoding {raw_value!r} is not implemented')
+                f'Transfer-Encoding {codings!r} is not implemented')
+        elif codings[-1] != b'chunked' or codings.count(b'chunked') > 1:
+            # chunked present but not the sole final coding (``chunked, gzip``,
+            # ``chunked, chunked``) ⇒ message length undeterminable ⇒ 400.
+            raise BadRequestError(
+                f'Transfer-Encoding with chunked not the sole final coding: '
+                f'{codings!r}')
+        else:
+            # chunked IS final but preceded by a coding we can't decode
+            # (``gzip, chunked``) ⇒ 501.
+            raise NotImplementedFramingError(
+                f'Transfer-Encoding {codings!r} applies an unimplemented '
+                f'content coding before chunked')
 
 
 # RFC 3986 §3.2 — authority = [userinfo "@"] host [":" port].  None of
 # these delimiter octets belong in a Host header value; their presence
 # (or an empty value) is a smuggling / SSRF vector that nginx rejects
-# with 400 and BlackBull, pre-Sprint-18, accepted silently.
-_HOST_FORBIDDEN_BYTES = frozenset(b'/?# \t')
+# with 400 and BlackBull, pre-Sprint-18, accepted silently.  ``@`` is
+# included (Sprint 63, COMP-HOST-WITH-USERINFO): the deprecated userinfo
+# component has no place in a Host header and enables credential-spoofing.
+_HOST_FORBIDDEN_BYTES = frozenset(b'/?# \t@')
 
 
 def _parse_host_header(value: bytes, default_port: int) -> tuple[str, int]:
@@ -503,6 +532,30 @@ class HTTP1Actor(Actor):
                     deadline=dl,
                 )
 
+                if scope.get('_asterisk_form'):
+                    # RFC 9112 §3.2.4 — ``OPTIONS *`` is a server-wide request
+                    # whose target is not a resource, so it never routes.
+                    # Answer at the server level with 204 + an Allow header
+                    # advertising the methods the origin implements.
+                    await capturing_send(b'', HTTPStatus.NO_CONTENT,
+                                         [(b'allow', _SERVER_WIDE_ALLOW)])
+                    ok = True
+                    if not self._should_keep_alive(scope):
+                        break
+                    self._request = b''
+                    try:
+                        if cfg.keep_alive_timeout > 0:
+                            with dl.guard(cfg.keep_alive_timeout):
+                                next_chunk = await self._reader.readuntil(_REQ_END)
+                        else:
+                            next_chunk = await self._reader.readuntil(_REQ_END)
+                    except (TimeoutError, IncompleteReadError):
+                        break
+                    if next_chunk == _REQ_END:
+                        break
+                    self._request = next_chunk
+                    continue
+
                 # Sprint 38 Task B — BB_REQUEST_TIMEOUT parity with the
                 # HTTP/2 path.  ``HTTP2Actor._spawn_stream_task`` wraps each
                 # stream coroutine with ``asyncio.wait_for``; the HTTP/1.1
@@ -654,18 +707,59 @@ class HTTP1Actor(Actor):
         if not _HTTP_VERSION_RE.match(version):
             raise BadRequestError(f'invalid HTTP-version {version!r}')
 
-        # Request-target — for origin-form, leading slash; reject CTLs.
-        if not path or any(b < 0x21 or b == 0x7F for b in path):
+        # Request-target form dispatch (RFC 9112 §3.2).  Four forms:
+        # origin (``/path``), absolute (``http://host/path``), authority
+        # (CONNECT only), and asterisk (``*``, server-wide OPTIONS).
+        authority_override: bytes | None = None
+        asterisk_form = False
+        if method == b'CONNECT':
+            # authority-form target (§3.2.3) — tunnel establishment, which
+            # BlackBull does not implement.  Answer 501, not a spurious 404.
+            raise NotImplementedFramingError(
+                f'CONNECT (tunneling) is not implemented: {path!r}')
+        if path == b'*':
+            # asterisk-form (§3.2.4) — a server-wide request, valid only for
+            # OPTIONS.  Flag it so the dispatcher answers at the server level
+            # rather than routing ``*`` to a 404.
+            if method != b'OPTIONS':
+                raise BadRequestError(
+                    f'asterisk-form request-target is valid only for OPTIONS, '
+                    f'not {method!r}')
+            asterisk_form = True
+        elif (_ss := path.find(b'://')) != -1 and b'/' not in path[:_ss]:
+            # absolute-form (§3.2.2): ``scheme "://" authority path-abempty``.
+            # Rewrite it to origin-form and let the authority override Host
+            # (§3.2.2 — the origin server MUST ignore the Host header here).
+            rest = path[_ss + 3:]
+            slash = rest.find(b'/')
+            if slash == -1:
+                authority_override, path = rest, b'/'
+            else:
+                authority_override, path = rest[:slash], rest[slash:]
+            if not authority_override:
+                raise BadRequestError(
+                    f'absolute-form request-target has empty authority: '
+                    f'{path!r}')
+
+        # Request-target octets — reject CTLs, DEL, and non-ASCII (§2.1 /
+        # RFC 3986: a raw byte ≥ 0x80 in the target is a normalisation /
+        # smuggling vector, MAL-NON-ASCII-URL).  Skipped for asterisk-form
+        # (the literal ``*`` is validated above).
+        if not asterisk_form and (
+                not path or any(b < 0x21 or b == 0x7F or b >= 0x80 for b in path)):
             raise BadRequestError(f'invalid request-target {path!r}')
 
-        # Sprint 25 Phase A — replicate urllib.parse.urlparse() semantics
-        # on the bytes request-target with three C-level partition calls:
-        # strip #fragment, split ?query, separate ;params.  ~12× faster
-        # than urlparse (pyperf microbench).  Output is byte-for-byte
-        # equivalent for the .path + .query attributes we use.
-        _no_frag, _, _ = path.partition(b'#')
-        _path_and_params, _, _query_string = _no_frag.partition(b'?')
-        _scope_path_b, _, _ = _path_and_params.partition(b';')
+        if asterisk_form:
+            _scope_path_b, _query_string = b'*', b''
+        else:
+            # Sprint 25 Phase A — replicate urllib.parse.urlparse() semantics
+            # on the bytes request-target with three C-level partition calls:
+            # strip #fragment, split ?query, separate ;params.  ~12× faster
+            # than urlparse (pyperf microbench).  Output is byte-for-byte
+            # equivalent for the .path + .query attributes we use.
+            _no_frag, _, _ = path.partition(b'#')
+            _path_and_params, _, _query_string = _no_frag.partition(b'?')
+            _scope_path_b, _, _ = _path_and_params.partition(b';')
 
         raw: list[tuple[bytes, bytes]] = []
         for line in lines[idx + 1:]:
@@ -698,7 +792,20 @@ class HTTP1Actor(Actor):
                     f'CTL in header value (smuggling / log-injection): '
                     f'{key!r}: {value!r}')
             raw.append((key.lower(), value))
+
+        # RFC 9112 §3.2.2 — for an absolute-form target the request's own
+        # authority is definitive; replace any client Host so a mismatched or
+        # spoofed Host cannot influence routing / host validation
+        # (SMUG-ABSOLUTE-URI-HOST-MISMATCH).
+        if authority_override is not None:
+            raw = [(k, v) for k, v in raw if k != b'host']
+            raw.append((b'host', authority_override))
         headers = Headers(raw)
+
+        # RFC 9110 §8.3 — Content-Type is a singleton; multiple values are
+        # ambiguous and a request-smuggling surface (COMP-DUPLICATE-CT).
+        if len(headers.getlist(b'content-type')) > 1:
+            raise BadRequestError('multiple Content-Type headers')
 
         # RFC 9112 §6 — message framing validation.  Done here so a bad
         # framing header is rejected before any body bytes are read.
@@ -716,13 +823,22 @@ class HTTP1Actor(Actor):
             'path': _scope_path_b.decode('utf-8'),
             'raw_path': path,
             'query_string': _query_string,
-            'root_path': headers.get(b'X-Forwarded-Prefix', b'').decode('utf-8'),
+            # RFC-safe default.  ``root_path`` (mount prefix) is NOT taken
+            # from the client-controlled ``X-Forwarded-Prefix`` here (bug
+            # 1.16 — a client could spoof the mount point); only the
+            # ``TrustedProxy`` middleware sets it, after verifying the peer.
+            'root_path': '',
             'headers': headers,
             'client': None,
             'server': None,
             'state': {},
             'extensions': _H1_PATHSEND_EXTENSIONS if not self._ssl else {},
         }
+
+        if asterisk_form:
+            # Server-wide OPTIONS (§3.2.4): mark it so the dispatcher answers
+            # at the server level (200 with Allow) rather than routing ``*``.
+            scope['_asterisk_form'] = True
 
         if headers.getlist(b'host'):
             default_port = _HTTPS_PORT if self._ssl else _HTTP_PORT

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -23,7 +23,8 @@ from ..headers import Headers
 from .parser import parse_headers
 from .cap_log import log_cap_hit
 from .recipient import (AbstractReader, IncompleteReadError,
-                        RecipientFactory, _HTTP2_STREAM_QUEUE_DEPTH)
+                        HTTP2Recipient, RecipientFactory,
+                        _HTTP2_STREAM_QUEUE_DEPTH)
 from .response import ResponderFactory
 from .sender import AbstractWriter, ConnCoalescer, ConnectionWindow, SenderFactory
 from .access_log import AccessLogRecord, _make_capturing_send, _make_disconnect_detecting_receive, emit_access_log as _emit_access_log
@@ -327,6 +328,17 @@ class HTTP2Actor(Actor):
         # created by ``make_sender`` references this one object, so N concurrent
         # streams debit a single stream-0 budget instead of N private copies.
         self._conn_window = ConnectionWindow(DEFAULT_INITIAL_WINDOW_SIZE)
+        # The per-stream inbound window we advertise in SETTINGS (run() sends
+        # SETTINGS_INITIAL_WINDOW_SIZE from the same settings object).  Doubles
+        # as each stream recipient's byte budget under consume-based inbound
+        # crediting: a conformant peer can never have more un-credited bytes
+        # in flight than this.
+        self._inbound_stream_window: int = _cfg.h2_initial_window_size
+        # Fire-and-forget WINDOW_UPDATE(0) replay tasks created when a stream
+        # is released with an un-consumed credit balance (see
+        # _release_recipient_credit).  Held so the loop's weak refs can't drop
+        # a pending replay.
+        self._credit_flush_tasks: set[asyncio.Task] = set()
 
         # Concurrent-stream counter — incremented when a stream task is spawned,
         # decremented via Task.add_done_callback when the task finishes.
@@ -426,6 +438,72 @@ class HTTP2Actor(Actor):
             sender.stream_window_size = self._peer_initial_window_size
             self._senders[stream_id] = sender
         return self._senders[stream_id]
+
+    def _make_stream_recipient(self, stream_id: int) -> HTTP2Recipient:
+        """Recipient with consume-time WINDOW_UPDATE crediting.
+
+        Consume-based inbound flow control (the Sprint 62 deferral,
+        ``proposals/consume-based-inbound-flow-control.md``): credit is
+        replayed when the app pops the event off the queue, not when the
+        DATA frame is enqueued, so a stalled handler closes the window and
+        back-pressures the peer instead of overflowing the recipient queue
+        into RST_STREAM(ENHANCE_YOUR_CALM).
+        """
+        async def _credit(n: int, sid: int = stream_id) -> None:
+            # Mirrors the per-frame enqueue-credit shape (and the WS reader's
+            # _replay_credit): stream + connection WINDOW_UPDATE, in that
+            # order.  Skip the stream-level frame once the stream is released
+            # (§5.1 forbids non-PRIORITY frames on a closed stream); the
+            # connection-level credit must still flow or stream-0 leaks shut.
+            if sid in self._recipients:
+                await self.send_frame(self.factory.window_update(sid, n))
+            await self.send_frame(self.factory.window_update(0, n))
+
+        return RecipientFactory.http2(
+            queue_depth=self._stream_queue_depth,
+            credit_callback=_credit,
+            credit_budget=self._inbound_stream_window,
+        )
+
+    def _release_recipient_credit(self, recipient) -> None:
+        """Replay a released stream's un-consumed inbound credit to stream 0.
+
+        Under consume-based crediting a handler that finished (or was RST)
+        without draining its request body never credited those DATA bytes
+        back.  The peer debited them from the shared CONNECTION window, which
+        would leak shut for every later stream on this connection — so the
+        balance is replayed as WINDOW_UPDATE(0) here.  Stream-level credit is
+        not replayed: the stream is closed (RFC 9113 §5.1).
+        """
+        take = getattr(recipient, 'take_uncredited', None)
+        balance = take() if take is not None else 0
+        if balance <= 0 or self._goaway_sent:
+            return
+
+        async def _replay() -> None:
+            try:
+                await self.send_frame(self.factory.window_update(0, balance))
+            except Exception:
+                logger.debug('post-stream connection credit replay failed',
+                             exc_info=True)
+
+        # Callers may be sync done-callbacks — schedule the replay.  Prefer
+        # the connection TaskGroup so run() awaits it; fall back to a bare
+        # loop task when the group is already closing (teardown).
+        coro = _replay()
+        try:
+            if self._task_group is not None:
+                task = self._task_group.create_task(coro)
+            else:
+                task = asyncio.get_running_loop().create_task(coro)
+        except RuntimeError:
+            try:
+                task = asyncio.get_running_loop().create_task(coro)
+            except RuntimeError:
+                coro.close()
+                return  # no running loop — nothing left to credit against
+        self._credit_flush_tasks.add(task)
+        task.add_done_callback(self._credit_flush_tasks.discard)
 
     def _fill_scope_connection(self, scope: dict) -> None:
         """Inject peername/sockname into a freshly-parsed HTTP/2 scope."""
@@ -533,7 +611,12 @@ class HTTP2Actor(Actor):
                 self._ws_stream_count = max(0, self._ws_stream_count - 1)
             self._stream_tasks.pop(stream_id, None)
             self._senders.pop(stream_id, None)
-            self._recipients.pop(stream_id, None)
+            released = self._recipients.pop(stream_id, None)
+            if released is not None:
+                # Consume-based crediting: a handler that never drained its
+                # body leaves un-credited DATA bytes debited from the shared
+                # connection window — replay the balance to stream 0.
+                self._release_recipient_credit(released)
             # Prune the stream node from the tree and remember it as closed-
             # via-END_STREAM (closed_via_rst=False) so late frames hit the
             # CLOSED branch of §5.1 validation without keeping a Stream
@@ -1012,7 +1095,7 @@ class HTTP2Actor(Actor):
             return True
 
         self._apply_priority_and_extensions(stream, scope)
-        stream_recipient = RecipientFactory.http2(queue_depth=self._stream_queue_depth)
+        stream_recipient = self._make_stream_recipient(stream.stream_id)
         self._recipients[stream.stream_id] = stream_recipient
         stream.on_headers_received(end_stream=bool(frame.end_stream))
         if frame.end_stream:
@@ -1102,7 +1185,7 @@ class HTTP2Actor(Actor):
 
         self._apply_priority_and_extensions(stream, scope)
         stream.scope = scope
-        stream_recipient = RecipientFactory.http2(queue_depth=self._stream_queue_depth)
+        stream_recipient = self._make_stream_recipient(stream.stream_id)
         self._recipients[stream.stream_id] = stream_recipient
         log_record = _make_log_record(scope)
         capturing_send = _make_capturing_send(send, log_record)
@@ -1139,7 +1222,16 @@ class HTTP2Actor(Actor):
         if stream.stream_id in self._recipients:
             recipient = self._recipients[stream.stream_id]
             delivered = recipient.put_DATAFrame(frame)
-            if delivered and frame.length:
+            if (delivered and frame.length
+                    and not getattr(recipient, 'credits_on_consume', False)):
+                # Enqueue-time credit — only for recipients WITHOUT a
+                # consume-time credit callback (HTTP2WSReader under its
+                # buffer cap, push streams, direct test constructions).
+                # Regular request streams credit at consume-time instead:
+                # the recipient replays WINDOW_UPDATE when the app pops the
+                # event (consume-based inbound flow control), so a stalled
+                # handler closes the window and back-pressures the peer.
+                #
                 # RFC 9113 §6.9.1 — DATA frames are subject to BOTH
                 # stream and connection-level flow control.  Crediting
                 # only the stream window leaves the connection-level
@@ -1158,7 +1250,10 @@ class HTTP2Actor(Actor):
                 await self.send_frame(
                     self.factory.window_update(0, frame.length))
             elif delivered:
-                # Zero-length DATA delivered (carries END_STREAM); no credit owed.
+                # Either a zero-length DATA (END_STREAM carrier — no credit
+                # owed) or a consume-crediting recipient (credit replayed by
+                # its callback when the app pops the event; nothing owed at
+                # enqueue).
                 pass
             elif getattr(recipient, 'backpressures_via_credit', False):
                 # Recipient buffered the bytes but signalled backpressure
@@ -1169,6 +1264,11 @@ class HTTP2Actor(Actor):
                 # RST_STREAM — the bytes are safe in the buffer.
                 pass
             else:
+                # True abuse backstop under consume-based crediting: the peer
+                # either overran the advertised inbound window it was never
+                # credited for, or dribbled a degenerate tiny-frame flood.  A
+                # conformant peer is back-pressured by the closing window and
+                # never reaches this.
                 await self.send_frame(
                     self.factory.rst_stream(stream.stream_id, ErrorCodes.ENHANCE_YOUR_CALM))
         else:

--- a/blackbull/server/parser.py
+++ b/blackbull/server/parser.py
@@ -149,8 +149,10 @@ def parse_headers(frame) -> dict:
             scope['path'], scope['raw_path'], scope['query_string'] = \
                 _split_h2_path(path)
         scope['headers'] = Headers(frame.headers)
-        scope['root_path'] = scope['headers'].get(
-            b'x-forwarded-prefix', b'').decode('utf-8')
+        # Bug 1.16 — root_path is NOT taken from the client-controlled
+        # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the
+        # peer.  Default to the RFC-safe empty mount.
+        scope['root_path'] = ''
         raw_sp = scope['headers'].get(b'sec-websocket-protocol', b'')
         scope['subprotocols'] = (
             [p.strip().decode('utf-8', errors='replace') for p in raw_sp.split(b',')]
@@ -169,9 +171,9 @@ def parse_headers(frame) -> dict:
 
     scope['headers'] = Headers(frame.headers)
 
-    scope['root_path'] = scope['headers'].get(
-        b'x-forwarded-prefix', b''
-    ).decode('utf-8')
+    # Bug 1.16 — root_path is NOT taken from the client-controlled
+    # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the peer.
+    scope['root_path'] = ''
 
     return scope
 
@@ -179,9 +181,10 @@ def parse_headers(frame) -> dict:
 class HTTP2HEADParser(HTTP2ParserBase):
     """Parses an HTTP/2 HEADERS frame into an ASGI ``http`` scope dict.
 
-    Pulls ``:method`` / ``:path`` / ``:scheme`` from the frame's pseudo-headers,
-    encodes the regular headers as ``bytes`` pairs into a ``Headers`` object,
-    and resolves ``root_path`` from the ``X-Forwarded-Prefix`` header.
+    Pulls ``:method`` / ``:path`` / ``:scheme`` from the frame's pseudo-headers
+    and encodes the regular headers as ``bytes`` pairs into a ``Headers``
+    object.  ``root_path`` defaults to empty — a client ``X-Forwarded-Prefix``
+    is not trusted here (bug 1.16); only ``TrustedProxy`` sets it.
     """
 
     FRAME_TYPE = FrameTypes.HEADERS

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -1,5 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
+from typing import Awaitable, Callable, Optional
 
 from .cap_log import log_cap_hit
 from .deadline import ConnectionDeadline
@@ -11,7 +12,7 @@ from .ws_codec import (
 from .constants import WSCloseCode
 from ..asgi import ASGIEvent
 from ..headers import Headers
-from ..protocol.frame_types import FrameBase, Data
+from ..protocol.frame_types import FrameBase, Data, DEFAULT_INITIAL_WINDOW_SIZE
 from ..event import Event, EventDispatcher
 import logging
 
@@ -21,6 +22,14 @@ logger = logging.getLogger(__name__)
 # These cap memory growth under overload; see Phase 0 in bench/README.md.
 _HTTP2_STREAM_QUEUE_DEPTH = 64
 _WS_EVENT_QUEUE_DEPTH = 256
+
+# Consume-crediting mode bounds the HTTP/2 stream queue by BYTES (the
+# advertised inbound window), not frame count — a conformant peer sending
+# 65535 bytes as 1-byte frames must not be RST'd.  This multiplier bounds the
+# frame COUNT against zero/tiny-frame floods (CVE-2019-9518-style abuse) that
+# the byte budget cannot see: queue_depth × 16 (1024 by default) is far above
+# any conformant burst yet keeps per-stream event-dict overhead bounded.
+_EVENT_CAP_MULTIPLIER = 16
 
 
 # ---------------------------------------------------------------------------
@@ -596,13 +605,37 @@ class HTTP2Recipient(BaseRecipient):
     invokes :meth:`mark_end_of_stream_on_headers` instead of pre-queuing an empty
     ``http.request`` event.  The Queue is then never allocated — the empty event
     is synthesized lazily in :meth:`__call__` only if the handler reads it.
+
+    **Consume-based inbound flow control** (the Sprint 62 deferral,
+    ``proposals/consume-based-inbound-flow-control.md``): when constructed with
+    a ``credit_callback``, WINDOW_UPDATE credit for a DATA frame is replayed
+    through the callback when the app *pops* the event — not when the frame is
+    enqueued.  A stalled handler then stops crediting, the peer's window
+    closes, and the peer back-pressures instead of overflowing a frame-count
+    queue into RST_STREAM(ENHANCE_YOUR_CALM).  In this mode the queue is
+    bounded by ``credit_budget`` bytes (the advertised inbound window — a
+    conformant peer cannot exceed it) plus a generous frame-count abuse cap;
+    ``put_DATAFrame`` returning ``False`` therefore means the peer overran the
+    closed window or dribbled degenerate frames, and the RST is a true abuse
+    backstop.  Without a callback the historical bounded-queue,
+    credit-at-enqueue behaviour is preserved (push streams, direct test use).
     """
 
     def __init__(self, frame: FrameBase | None = None,
-                 queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH):
+                 queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH,
+                 credit_callback: Optional[
+                     Callable[[int], Awaitable[None]]] = None,
+                 credit_budget: int = DEFAULT_INITIAL_WINDOW_SIZE):
         super().__init__(None)
         self._queue: asyncio.Queue | None = None
         self._queue_depth = queue_depth
+        self._credit_cb = credit_callback
+        self._credit_budget = credit_budget
+        # Bytes enqueued but not yet consumed — and therefore not yet credited
+        # back to the peer.  For a conformant peer this can never exceed
+        # ``credit_budget``: the un-credited bytes ARE the closed part of the
+        # window the peer must respect.
+        self._uncredited: int = 0
         # When True, HEADERS carried END_STREAM — request has no body.
         # __call__() returns one empty http.request event without allocating a queue.
         self._end_of_stream_on_headers: bool = False
@@ -611,9 +644,23 @@ class HTTP2Recipient(BaseRecipient):
         if isinstance(frame, Data):
             self.put_DATAFrame(frame)
 
+    @property
+    def credits_on_consume(self) -> bool:
+        """True when WINDOW_UPDATE credit is replayed at consume-time.
+
+        The actor must then NOT credit at enqueue — the recipient's
+        ``credit_callback`` owns the replay.
+        """
+        return self._credit_cb is not None
+
     def _ensure_queue(self) -> asyncio.Queue:
         if self._queue is None:
-            self._queue = asyncio.Queue(maxsize=self._queue_depth)
+            # Consume-crediting mode enforces its own bounds (byte budget +
+            # frame-count abuse cap) in put_DATAFrame, so the queue itself is
+            # unbounded — put_disconnect can then always deliver.  Legacy mode
+            # keeps the historical frame-count maxsize.
+            maxsize = 0 if self._credit_cb is not None else self._queue_depth
+            self._queue = asyncio.Queue(maxsize=maxsize)
         return self._queue
 
     def mark_end_of_stream_on_headers(self) -> None:
@@ -632,9 +679,42 @@ class HTTP2Recipient(BaseRecipient):
         }
 
     def put_DATAFrame(self, frame: Data) -> bool:
-        """Enqueue a DATA frame event. Returns False if the queue is full."""
+        """Enqueue a DATA frame event.  Returns False when the frame must be
+        refused (the caller answers RST_STREAM): queue full in legacy mode;
+        inbound-window overrun or a tiny-frame flood in consume-crediting mode.
+        """
+        if self._credit_cb is not None:
+            # Flow-control debit is the full frame length including padding
+            # (RFC 9113 §6.9.1) — credit must mirror it exactly.
+            fc_len = frame.length
+            if self._uncredited + fc_len > self._credit_budget:
+                # The peer kept sending past the advertised inbound window it
+                # was never credited for — abuse, since a conformant peer is
+                # back-pressured by the closing window well before this.
+                logger.warning(
+                    'HTTP2Recipient inbound window overrun — refusing DATA frame')
+                log_cap_hit('h2_inbound_window_budget',
+                            requested=self._uncredited + fc_len,
+                            limit=self._credit_budget,
+                            protocol='http2')
+                return False
+            queue = self._ensure_queue()
+            event_cap = self._queue_depth * _EVENT_CAP_MULTIPLIER
+            if queue.qsize() >= event_cap:
+                # Zero/tiny-frame flood — invisible to the byte budget; see
+                # _EVENT_CAP_MULTIPLIER.
+                logger.warning(
+                    'HTTP2Recipient event-count cap hit — dropping DATA frame')
+                log_cap_hit('stream_queue_depth',
+                            requested=queue.qsize() + 1,
+                            limit=event_cap,
+                            protocol='http2')
+                return False
+            queue.put_nowait((self.make_event(frame), fc_len))
+            self._uncredited += fc_len
+            return True
         try:
-            self._ensure_queue().put_nowait(self.make_event(frame))
+            self._ensure_queue().put_nowait((self.make_event(frame), 0))
             return True
         except asyncio.QueueFull:
             logger.warning('HTTP2Recipient queue full on stream — dropping DATA frame')
@@ -647,7 +727,7 @@ class HTTP2Recipient(BaseRecipient):
     def put_event(self, event: dict) -> bool:
         """Enqueue a pre-built event dict. Returns False if the queue is full."""
         try:
-            self._ensure_queue().put_nowait(event)
+            self._ensure_queue().put_nowait((event, 0))
             return True
         except asyncio.QueueFull:
             logger.warning('HTTP2Recipient queue full on stream — dropping event %r', event.get('type'))
@@ -668,11 +748,26 @@ class HTTP2Recipient(BaseRecipient):
                 and self._initial_consumed):
             return
         try:
-            self._ensure_queue().put_nowait({'type': ASGIEvent.HTTP_DISCONNECT})
+            self._ensure_queue().put_nowait(
+                ({'type': ASGIEvent.HTTP_DISCONNECT}, 0))
         except asyncio.QueueFull:
             # If the queue is completely full the app task is hopelessly behind;
             # TaskGroup cancellation will clean up the stream regardless.
+            # (Unreachable in consume-crediting mode — that queue is unbounded.)
             logger.warning('HTTP2Recipient: could not deliver http.disconnect — queue full')
+
+    def take_uncredited(self) -> int:
+        """Return and clear the un-consumed credit balance.
+
+        Bytes enqueued but never popped by the app (a handler that finished —
+        or was RST — without draining its body).  The actor replays this to
+        the CONNECTION window when the stream is released, otherwise the
+        shared window leaks shut for every later stream; the stream-level
+        window is moot once the stream closes (RFC 9113 §5.1).
+        """
+        n = self._uncredited
+        self._uncredited = 0
+        return n
 
     async def __call__(self) -> dict:
         # Fast path: GET with END_STREAM on HEADERS and no body — synthesize the
@@ -682,7 +777,20 @@ class HTTP2Recipient(BaseRecipient):
                 and self._queue is None):
             self._initial_consumed = True
             return {'type': ASGIEvent.HTTP_REQUEST, 'body': b'', 'more_body': False}
-        return await self._ensure_queue().get()
+        event, credit = await self._ensure_queue().get()
+        if credit and self._credit_cb is not None:
+            # Decrement before the (interruptible) send so a racing
+            # take_uncredited() can never double-credit; worst case a
+            # cancellation mid-send under-credits by one frame.
+            self._uncredited -= credit
+            try:
+                await self._credit_cb(credit)
+            except Exception:
+                # Connection closing/gone — credit no longer matters; the
+                # disconnect event is the authoritative teardown signal.
+                logger.debug('consume-time WINDOW_UPDATE replay failed',
+                             exc_info=True)
+        return event
 
 
 class WebSocketRecipient(BaseRecipient):
@@ -1010,8 +1118,13 @@ class RecipientFactory:
 
     @staticmethod
     def http2(frame: FrameBase | None = None,
-              queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH) -> HTTP2Recipient:
-        return HTTP2Recipient(frame, queue_depth=queue_depth)
+              queue_depth: int = _HTTP2_STREAM_QUEUE_DEPTH,
+              credit_callback: Optional[
+                  Callable[[int], Awaitable[None]]] = None,
+              credit_budget: int = DEFAULT_INITIAL_WINDOW_SIZE) -> HTTP2Recipient:
+        return HTTP2Recipient(frame, queue_depth=queue_depth,
+                              credit_callback=credit_callback,
+                              credit_budget=credit_budget)
 
     @staticmethod
     def websocket(reader, writer, *,

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -37,22 +37,84 @@ class IncompleteReadError(EOFError):
 
 _HEXDIG_SET = frozenset(b'0123456789abcdefABCDEF')
 
+# RFC 9110 §5.6.2 — ``token = 1*tchar``.  Used to validate ``chunk-ext-name``
+# and an unquoted ``chunk-ext-val`` (RFC 9112 §7.1.1).
+_TCHAR_SET = frozenset(
+    b"!#$%&'*+-.^_`|~"
+    b"0123456789"
+    b"abcdefghijklmnopqrstuvwxyz"
+    b"ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+
+def _bad_request(detail: str):
+    """Build the framework's status-carrying 400 exception.
+
+    Imported lazily so ``recipient`` (loaded early via the server) never
+    depends on ``router`` at module-import time.  ``HTTPException`` is the
+    dispatcher's typed-error seam — raising it from the body reader makes a
+    malformed chunked frame surface as ``400 Bad Request`` instead of a
+    fabricated 500.
+    """
+    from http import HTTPStatus  # noqa: PLC0415
+    from ..router import HTTPException  # noqa: PLC0415
+    return HTTPException(HTTPStatus.BAD_REQUEST, detail)
+
+
+def _validate_chunk_ext(ext: bytes) -> None:
+    """RFC 9112 §7.1.1::
+
+        chunk-ext      = *( BWS ";" BWS chunk-ext-name [ BWS "=" BWS chunk-ext-val ] )
+        chunk-ext-name = token
+        chunk-ext-val  = token / quoted-string
+
+    *ext* is the chunk line **from the first ``;``** onward.  Reject a bare
+    ``;`` (empty ext-name), a non-token ext-name/val, and control characters
+    — all silent-acceptance smuggling vectors before this guard.  A
+    quoted-string ext-val is accepted leniently (matched quotes, no bare
+    CTLs) since chunk extensions are ignored on receipt.
+    """
+    for element in ext.split(b';')[1:]:
+        element = element.strip(b' \t')          # BWS around the element
+        name, eq, val = element.partition(b'=')
+        name = name.rstrip(b' \t')
+        if not name or any(c not in _TCHAR_SET for c in name):
+            raise _bad_request(f'invalid chunk-ext-name {name!r}')
+        if eq:
+            val = val.strip(b' \t')
+            if val[:1] == b'"':
+                if len(val) < 2 or not val.endswith(b'"') or any(
+                        c < 0x20 and c != 0x09 for c in val):
+                    raise _bad_request(f'invalid quoted chunk-ext-val {val!r}')
+            elif not val or any(c not in _TCHAR_SET for c in val):
+                raise _bad_request(f'invalid chunk-ext-val {val!r}')
+
 
 def _parse_chunk_size(line: bytes) -> int:
-    """RFC 9112 §7.1.1 — ``chunk-size = 1*HEXDIG``, optionally followed
-    by ``chunk-ext`` (everything from the first ``;``).  Reject anything
-    that isn't a non-empty hexadecimal string in the size portion.
+    """RFC 9112 §7.1.1 — ``chunk-size = 1*HEXDIG`` optionally followed by
+    ``chunk-ext``.  Validate the size token strictly (no sign, no ``0x``
+    prefix, no ``_``, no stray whitespace) **before** ``int()``, and
+    validate the chunk-ext grammar, so malformed framing is rejected rather
+    than silently accepted or crashed on.
 
-    Raises :class:`ValueError` on malformed input; the caller turns that
-    into a connection-closing failure (the request body is now
-    unframeable).
+    The line must be CRLF-terminated: a bare-LF terminator (``5\\n``) is a
+    framing violation, so we require the trailing CRLF rather than stripping
+    either.  Raises :class:`HTTPException` (400) on any violation; the caller
+    marks the body unframeable and closes the connection.
     """
-    # Drop trailing CRLF and optional chunk-ext.
-    line = line.rstrip(b'\r\n')
-    size_part, _, _ext = line.partition(b';')
-    size_part = size_part.rstrip(b' \t')  # OWS between size and ';' is allowed
+    if not line.endswith(b'\r\n') or line.count(b'\n') != 1:
+        raise _bad_request(f'chunk-size line not CRLF-terminated: {line!r}')
+    line = line[:-2]
+    if b';' in line:
+        size_part, _, _ext = line.partition(b';')
+        # BWS is tolerated between the size and ';' (RFC 9112 §7.1.1 BWS).
+        size_part = size_part.rstrip(b' \t')
+        _validate_chunk_ext(line[len(size_part):])
+    else:
+        # No chunk-ext — the whole line is the size; NO trailing OWS allowed
+        # (a bare ``5 \r\n`` is a smuggling vector, not a valid chunk-size).
+        size_part = line
     if not size_part or any(c not in _HEXDIG_SET for c in size_part):
-        raise ValueError(f'invalid chunk-size {size_part!r}')
+        raise _bad_request(f'invalid chunk-size {size_part!r}')
     return int(size_part, 16)
 
 
@@ -390,6 +452,10 @@ class HTTP1Recipient(BaseRecipient):
         # preserved.
         self._body_timeout = body_timeout
         self._deadline = deadline
+        # Set once a chunked-framing violation is detected: the byte stream is
+        # now desynced, so the connection MUST close rather than keep-alive
+        # (draining would parse smuggled bytes as the next request).
+        self.framing_broken = False
 
     def needs_drain(self) -> bool:
         """True if a declared request body may still be buffered unread.
@@ -400,6 +466,8 @@ class HTTP1Recipient(BaseRecipient):
         dispatch to decide whether to drain.  A body-less request (GET, no
         Content-Length, not chunked) never needs draining.
         """
+        if self.framing_broken:
+            return False  # stream is desynced — close, don't drain
         return not self._done and (self._chunked or bool(self._content_length))
 
     async def drain(self, max_bytes: int) -> bool:
@@ -419,6 +487,16 @@ class HTTP1Recipient(BaseRecipient):
             if drained > max_bytes:
                 return False
         return True
+
+    def _parse_chunk_size_or_400(self, size_line: bytes) -> int:
+        """Parse the chunk-size line, marking the stream unframeable on any
+        violation so the actor closes the connection instead of keep-aliving
+        a desynced byte stream."""
+        try:
+            return _parse_chunk_size(size_line)
+        except BaseException:
+            self.framing_broken = True
+            raise
 
     async def _read_with_timeout(self, coro):
         """Run *coro* under the configured body_timeout, if any."""
@@ -440,7 +518,7 @@ class HTTP1Recipient(BaseRecipient):
             if self._chunked:
                 size_line = await self._read_with_timeout(
                     self._reader.readuntil(b'\r\n'))
-                chunk_size = _parse_chunk_size(size_line)
+                chunk_size = self._parse_chunk_size_or_400(size_line)
                 if chunk_size == 0:
                     # RFC 9112 §7.1.2 — last-chunk is followed by an
                     # optional trailer-part and then a final CRLF.  Read
@@ -455,13 +533,19 @@ class HTTP1Recipient(BaseRecipient):
                 # RFC 9112 §7.1 — the chunk-data is exactly ``chunk_size``
                 # octets.  ``readexactly`` (not the up-to-n ``read``) is
                 # required: a chunk split across TCP segments would otherwise
-                # return short, and the following ``readuntil(CRLF)`` would
-                # swallow the rest of the payload up to the first CRLF,
-                # silently corrupting the body and desyncing chunk framing.
+                # return short, silently corrupting the body.
                 data = await self._read_with_timeout(
                     self._reader.readexactly(chunk_size))
-                await self._read_with_timeout(
-                    self._reader.readuntil(b'\r\n'))        # consume CRLF after chunk data
+                # RFC 9112 §7.1 — chunk-data is followed by exactly CRLF.
+                # Read those two octets and verify: reading *until* CRLF would
+                # swallow trailing spill (SMUG-CHUNK-SPILL) up to the next
+                # CRLF, and would tolerate a bare CR/LF terminator.
+                term = await self._read_with_timeout(
+                    self._reader.readexactly(2))
+                if term != b'\r\n':
+                    self.framing_broken = True
+                    raise _bad_request(
+                        f'chunk-data not CRLF-terminated: {term!r}')
                 return {'type': ASGIEvent.HTTP_REQUEST, 'body': data, 'more_body': True}
             else:
                 # P4: stream the Content-Length body in ``chunk_size`` slices so

--- a/blackbull/server/response.py
+++ b/blackbull/server/response.py
@@ -318,7 +318,12 @@ class RstStreamResponder(Responder):
         handler.root_stream.children.pop(stream_id, None)
         handler._mark_closed(stream_id, via_rst=True)
         handler._senders.pop(stream_id, None)
-        handler._recipients.pop(stream_id, None)
+        released = handler._recipients.pop(stream_id, None)
+        if released is not None:
+            # Consume-based crediting: DATA the cancelled handler never read
+            # was debited from the shared connection window — replay the
+            # balance to stream 0 so later streams aren't starved.
+            handler._release_recipient_credit(released)
 
     FRAME_TYPE = FrameTypes.RST_STREAM
 

--- a/docs/about/architecture.md
+++ b/docs/about/architecture.md
@@ -1,0 +1,102 @@
+# Architecture
+
+BlackBull makes a small number of deliberate architectural bets. This page
+states them and the reasoning behind each, so you can judge the framework on
+its design rather than a feature checklist. For the line-by-line internals,
+see [Internals](internals.md); for "does this fit my project?", see
+[Is BlackBull right for your project?](../getting-started/why-blackbull.md).
+
+## Protocol ownership
+
+BlackBull implements HTTP/1.1, HTTP/2, WebSocket, gRPC-over-h2c, and MQTT 5.0
+in pure Python. It does **not** delegate the wire to Uvicorn, Hypercorn,
+`h11`, `wsproto`, or `h2`. Every frame — every HPACK block, every stream
+state transition, every chunk boundary — is Python you can step through in a
+debugger.
+
+The trade-off is explicit: BlackBull carries the cost of implementing and
+conforming protocols itself, in exchange for two things no delegating stack
+can offer — end-to-end debuggability, and the ability to make the protocol
+layer do things a library won't let you (see *Fault injection* below).
+
+## Multi-protocol, one process
+
+A single `python app.py` serves every protocol at once — HTTP routes,
+a WebSocket channel, a gRPC service, and an MQTT broker, on their own ports,
+in one runtime. Non-HTTP protocols attach through one seam,
+`app.add_extension(...)`, while the HTTP core stays protocol-agnostic. There
+is no reverse proxy to configure, no separate broker process, and no C
+extension in the path.
+
+This is the bet behind the IoT-gateway and edge use cases: protocol density
+in a single deployable, on hardware where running four services is a burden.
+
+## Actor model
+
+Concurrency is message-passing, not shared-lock. A `ConnectionActor` owns
+each connection and spawns the protocol actor that claims it — `HTTP1Actor`,
+`HTTP2Actor`, `WebSocketActor`, `BrokerActor`. Each runs its own inbox loop;
+state that would otherwise need a lock lives inside one actor and is mutated
+only by that actor's loop.
+
+The payoff is isolation: a misbehaving or slow connection is contained to its
+own actor and cannot corrupt another's state. The same model runs your HTTP
+routes, the MQTT broker, and the gRPC handlers — one concurrency story across
+every protocol. See [Internals](internals.md) for the actor topology and the
+per-connection `TaskGroup` supervision.
+
+## Fault injection — the differentiator
+
+Because BlackBull owns its HTTP/2 implementation, it can be instructed to
+**misbehave on command**: half-closed streams, exhausted flow-control
+windows, illegal SETTINGS frames, trailers where none belong — crafted from a
+Python script. A delegating stack cannot easily do this, because the
+misbehaviour would have to be programmed into a third-party protocol library.
+
+That makes BlackBull a portable conformance test bench: if you maintain an
+HTTP client, proxy, or middleware, you can drive it against adversarial
+protocol conditions in CI, and run a differential oracle that compares
+BlackBull's wire behaviour against a reference server such as nginx. See the
+[Fault injection guide](../guide/fault_injection.md).
+
+## Conformance
+
+BlackBull is validated against the same external suites used to check nginx
+and Envoy, not just its own tests:
+
+- **h2spec** (RFC 9113 + RFC 7541) — the de-facto HTTP/2 + HPACK suite,
+  ~146 numbered cases, run in CI on every push.
+- **Autobahn|Testsuite** (RFC 6455) — ~500 WebSocket cases.
+- **Differential oracle** — BlackBull vs nginx, compared wire-for-wire on a
+  captured request corpus.
+
+The authoritative status is the CI pipeline, not any point-in-time local run;
+see [Conformance](conformance.md) for how to reproduce each suite and where
+the CI results live.
+
+## Performance
+
+BlackBull is benchmarked with [HttpArena](https://github.com/) against the
+popular Python async frameworks on identical cloud hardware; the harness and
+per-release results live under `bench/`. The headline is that a pure-Python
+stack is competitive-to-faster on throughput despite owning every byte — the
+numbers, and the methodology, are in the benchmark results rather than quoted
+here so they never go stale. See [Conformance](conformance.md) and the
+`bench/` directory.
+
+## Testing infrastructure
+
+The framework ships the tooling used to keep it correct:
+
+- Programmable fault injection (HTTP/1 client + HTTP/2 server scenarios).
+- Atheris fuzzing integration over the parsers.
+- A multi-job CI conformance pipeline (h2spec, Autobahn, corpus replay,
+  HTTP/2 flow control, gRPC interop).
+
+## What BlackBull defers
+
+These bets have a cost, and the honest list of what BlackBull leaves to the
+ecosystem — auth/rate-limiting middleware, ORM/DB integration, Pydantic-grade
+body-schema generation, AnyIO/Trio compatibility, community breadth — is in
+[Known limitations](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md)
+and the [use-case guide](../getting-started/why-blackbull.md).

--- a/docs/about/rfc9113-implementation.md
+++ b/docs/about/rfc9113-implementation.md
@@ -159,18 +159,23 @@ replay *every* request, punishing it for the server's own limit.
 
 **§5.2 Flow Control** ✅
 A DATA frame may be sent only when **two** windows both have credit — the
-stream window and the connection window.  `HTTP2Actor` tracks both:
-`HTTP2Actor._peer_initial_window_size` (per-stream) and
-`HTTP2Actor._connection_window_size` (connection-level), updated by
-`SettingsResponder` and
-`WindowUpdateResponder`; the credit mechanics — and the bug that follows from
-getting them wrong — are in §6.9.1.  *Because* the two windows do two jobs that
-a single window can't do at once.  The **stream** window stops any one stream
-from hogging the connection — fairness between streams.  The **connection**
-window caps the *total* data in flight across *all* streams at once — a bound on
-how much the receiver has to buffer.  You need both: per-stream fairness alone
-can't bound total memory, and a total bound alone can't stop one stream from
-starving the rest.
+stream window and the connection window.  On the *send* (outbound) side,
+`HTTP2Actor` tracks `HTTP2Actor._peer_initial_window_size` (seeds a new
+stream's window) and a single shared `HTTP2Actor._conn_window`
+(`ConnectionWindow`, `sender.py`) that every stream's `HTTP2Sender` debits and
+awaits — one object, not a per-sender copy, so N concurrent streams share one
+stream-0 budget rather than drifting apart (the bug this fixed: see §6.9.1's
+sibling note below). Updated by `SettingsResponder` and
+`WindowUpdateResponder`. On the *receive* (inbound) side each stream's
+`HTTP2Recipient` tracks its own byte budget against the window we advertised
+in SETTINGS — the credit mechanics, and the bug that follows from getting
+either direction wrong, are in §6.9.1.  *Because* the two windows do two jobs
+that a single window can't do at once.  The **stream** window stops any one
+stream from hogging the connection — fairness between streams.  The
+**connection** window caps the *total* data in flight across *all* streams at
+once — a bound on how much the receiver has to buffer.  You need both:
+per-stream fairness alone can't bound total memory, and a total bound alone
+can't stop one stream from starving the rest.
 
 **§5.3 Prioritization** ✅ (as deprecation)
 RFC 9113 **§5.3.2** deprecated the priority *tree* (dependencies and weights)
@@ -228,10 +233,11 @@ not one method but a chain of steps.
 the `Data` object is read in more than one place: a state check (DATA on
 HALF_CLOSED_REMOTE or CLOSED → RST STREAM_CLOSED, since the peer already sent
 END_STREAM), content-length accounting as bytes accumulate (§8.1.1), delivery to
-the stream's recipient, dual flow-control crediting (§6.9.1), and back-pressure
-(a full recipient queue → RST ENHANCE_YOUR_CALM).  *Because* DATA is the only
-frame that both moves application bytes and consumes flow-control credit — so it
-carries the most invariants and touches the most code.
+the stream's recipient, dual flow-control crediting on *consumption* (§6.9.1),
+and back-pressure (an inbound-window overrun or degenerate tiny-frame flood →
+RST ENHANCE_YOUR_CALM — the true abuse backstop once crediting is consume-based).
+*Because* DATA is the only frame that both moves application bytes and consumes
+flow-control credit — so it carries the most invariants and touches the most code.
 
 **§6.2 HEADERS — `Headers(FrameBase)`** ✅
 A `Headers` frame is handled by `HTTP2Actor._on_headers_frame()`, which runs the
@@ -305,19 +311,47 @@ FLOW_CONTROL_ERROR.  *Because* the two scopes share one frame type but mean
 different things — the responder must dispatch on the stream id.
 
 **§6.9.1 The Flow-Control Window** ✅
-The dual-credit mechanic in full:
+The dual-credit mechanic in full — credited on *consumption*, not delivery:
 
 ```python
-# in HTTP2Actor._on_data_frame() — after a DATA frame is delivered to the app
-await self.send_frame(factory.window_update(stream.stream_id, frame.length))  # stream
-await self.send_frame(factory.window_update(0, frame.length))                  # connection
+# in HTTP2Recipient.__call__() — when the app pops an event off the queue
+event, credit = await self._ensure_queue().get()
+if credit and self._credit_cb is not None:
+    self._uncredited -= credit
+    await self._credit_cb(credit)   # → window_update(stream_id, n); window_update(0, n)
 ```
 
 A single DATA frame debits *both* windows (§5.2), so both must be credited
-back — that is why there are two `window_update` calls, one on the stream and
-one on stream 0 (the connection).  Credit is sent **after** the recipient
-accepts the bytes, so a full application queue withholds credit and
-back-pressures the peer — the RFC's intended mechanism.
+back — one `WINDOW_UPDATE` on the stream, one on stream 0 (the connection).
+Credit is sent when the **application consumes** the event, not when the
+frame is *delivered* to the recipient's queue — a stalled handler (blocked on
+`yield` under response back-pressure, or simply CPU-starved) then stops
+crediting, the peer's window closes, and the peer back-pressures on its own:
+the RFC's intended mechanism, working end-to-end rather than stopping at the
+server's queue.
+
+*Because* enqueue-time crediting hides exactly the failure it should catch.
+Crediting the moment a frame lands in the queue reopens the peer's window
+whether or not the application is keeping up — so a queue with a bounded
+depth (frames, not bytes) becomes the only backstop, and once a slow-consumer
+handler fills it, the server's only remaining move is `RST_STREAM`. That
+surfaces as *application* churn (dropped streams under load) rather than the
+protocol back-pressure RFC 9113 actually describes. Crediting on consumption
+means the recipient's queue is sized in **bytes** — capped at the same
+value advertised in SETTINGS_INITIAL_WINDOW_SIZE, since a conformant peer can
+never have more un-credited bytes in flight than that — so `RST_STREAM` is
+reserved for a genuine abuse case (a peer that keeps sending past its closed
+window, or a degenerate flood of near-zero-length frames the byte budget
+can't see; the latter gets its own small frame-count cap).
+
+A stream that finishes — or is cancelled by `RST_STREAM` — without its
+handler draining the whole body leaves an "un-credited" balance: bytes the
+peer already debited from the shared *connection* window that were never
+paid back, because the app never popped them. `HTTP2Actor._release_recipient_credit`
+replays that balance to stream 0 when the stream is released (either
+completion path), so the connection window can't ratchet down to zero across
+a long-lived, high-churn connection. The stream-level side is not replayed —
+the stream is gone (§5.1) and any further frame on that id is `STREAM_CLOSED`.
 
 *Because* the connection window is the easy half to forget, and forgetting it
 fails *late*.  Credit only the stream window — the obvious half — and everything
@@ -325,7 +359,8 @@ works until ~65535 cumulative bytes have flowed; only then does the shared
 connection window reach zero, after which *every* stream stalls, even ones with
 plenty of their own credit.  A bug that surfaces only on a long-lived connection
 is exactly the kind that is easy to introduce and hard to notice, so crediting
-both windows on every DATA frame is the invariant to hold onto.
+both windows — accounting for every byte the peer was ever debited for,
+including ones an abandoned stream never read — is the invariant to hold onto.
 
 **§6.10 CONTINUATION — `Continuation(FrameBase)`** ✅
 A `Continuation` frame is handled by `HTTP2Actor._on_continuation_frame()`,

--- a/docs/getting-started/why-blackbull.md
+++ b/docs/getting-started/why-blackbull.md
@@ -1,0 +1,82 @@
+# Is BlackBull right for your project?
+
+BlackBull is not a general-purpose "use me for everything" framework. It makes
+specific [architectural bets](../about/architecture.md) that pay off in
+specific scenarios and cost you elsewhere. This page helps you self-select in
+about 60 seconds.
+
+## Scenarios where BlackBull excels
+
+### Multiple protocols in one process
+
+You're building an IoT gateway that ingests MQTT sensor data, serves a
+WebSocket dashboard, exposes a REST API, and talks to backend services over
+gRPC — all from a single `python app.py` on a small box. Most Python stacks
+need a reverse proxy plus a separate MQTT broker; BlackBull serves all of it
+in one runtime, on one process.
+
+### You want to see what your HTTP server is doing
+
+Every frame, every stream-state transition, every HPACK encoding is visible
+in your debugger. The protocol implementations are pure Python — no C
+extensions, no opaque libraries. That makes BlackBull a strong platform for
+learning HTTP/2 internals or prototyping protocol-level behaviour.
+
+### You need to test protocol edge cases
+
+BlackBull ships a programmable fault-injection framework: craft malformed
+HTTP/2 frames, simulate connection drops mid-stream, run differential oracles
+against a reference implementation. If your product depends on HTTP/2
+correctness under adverse conditions, this toolchain is unusual and useful.
+
+### You deploy to ARM, RISC-V, or constrained environments
+
+Zero C extensions means zero cross-compilation pain. BlackBull runs anywhere
+CPython runs — no build step, no native dependencies to source for your
+target architecture.
+
+### Throughput matters more than ecosystem breadth
+
+BlackBull is competitive-to-faster than the popular Python async frameworks on
+identical hardware (see the `bench/` HttpArena results). The trade-off is
+fewer community extensions, tutorials, and Stack Overflow answers.
+
+## Scenarios where another framework may fit better
+
+### A standard CRUD API with rich OpenAPI
+
+If your primary need is Pydantic models → OpenAPI schema → Swagger UI, a stack
+with mature body-schema generation and security-scheme declaration will get
+you to production faster today. BlackBull's OpenAPI support is functional but
+not yet as complete.
+
+### Built-in authentication and rate limiting
+
+BlackBull currently leaves auth and rate limiting to application code. If you
+want batteries-included `AuthenticationMiddleware` and rate-limiting backends,
+another framework reduces boilerplate for standard API projects.
+
+### AnyIO / Trio compatibility
+
+BlackBull is asyncio-only. If your codebase or dependencies require Trio via
+AnyIO, that's a genuine mismatch.
+
+### Server-driven UI (LiveView-style)
+
+If your primary need is server-driven, component-model UI updates, a
+purpose-built stack for that pattern will serve you better. BlackBull's
+WebSocket support is excellent for data channels but is not a UI framework.
+
+## The honest trade-off
+
+| BlackBull invests in | BlackBull defers to the ecosystem |
+|---|---|
+| Protocol correctness (h2spec, Autobahn, differential oracle) | Auth / rate-limiting middleware |
+| Multi-protocol density (five protocols, one process) | ORM / DB integration |
+| Raw throughput on identical hardware | Tutorial count / community size |
+| Testing infrastructure (fault injection, oracle, fuzzing) | Pydantic-grade body-schema generation |
+| Pure Python (zero C extensions, easy deploy) | AnyIO / Trio compatibility |
+
+For the reasoning behind these bets, see [Architecture](../about/architecture.md);
+for the current gaps in detail, see
+[Known limitations](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md).

--- a/docs/guide/grpc.md
+++ b/docs/guide/grpc.md
@@ -1,6 +1,7 @@
 # gRPC
 
-BlackBull serves **unary gRPC** calls over its own pure-Python HTTP/2 layer.
+BlackBull serves **gRPC** — all four RPC shapes: unary, server-streaming,
+client-streaming, and bidirectional — over its own pure-Python HTTP/2 layer.
 gRPC is just HTTP/2 with `content-type: application/grpc` and a length-prefixed
 message body, where the call result is reported in `grpc-status` trailers — so a
 gRPC service multiplexes onto the **same port** as your REST and WebSocket
@@ -82,8 +83,32 @@ Semantics that match the gRPC spec:
 - A `grpc-timeout` deadline bounds the **whole** stream (`DEADLINE_EXCEEDED` on
   expiry).
 
-Client-streaming and bidirectional streaming are not yet supported (they need the
-request delivered as a stream).
+## Client-streaming and bidirectional RPCs
+
+A handler whose first parameter is named `request_iter` (also accepted:
+`request_iterator`, `requests`, `request_stream`) receives the request as an
+**async iterator** of message bytes instead of one buffered `bytes` value —
+messages are delivered as they arrive on the wire. Pass
+`client_streaming=True` to override the name-based detection:
+
+```python
+@grpc.method('/pkg.Svc/Sum')
+async def sum_lengths(request_iter, context) -> bytes:   # client-streaming
+    total = 0
+    async for msg in request_iter:
+        total += len(msg)
+    return str(total).encode()
+
+@grpc.method('/pkg.Svc/Echo')
+async def echo(request_iter, context):                   # bidirectional
+    async for msg in request_iter:
+        yield msg
+```
+
+The response axis is detected automatically (a plain coroutine returns one
+message; an async generator streams), so the four gRPC shapes — unary,
+server-streaming, client-streaming, and bidirectional — all register through
+the same decorator.
 
 ## The call context
 
@@ -120,11 +145,12 @@ optional). Unknown methods return `GrpcStatus.UNIMPLEMENTED`.
 
 ## Scope and limits
 
-- **Unary and server-streaming** RPCs are served (see above). Client-streaming
-  and bidirectional streaming are not yet supported — they need the request
-  delivered as a stream.
-- **No message compression** — a request with the compressed flag set is
-  rejected with `UNIMPLEMENTED`.
+- **All four RPC shapes are served**: unary, server-streaming,
+  client-streaming, and bidirectional (see above).
+- **gzip message compression** is supported (`grpc-encoding: gzip` /
+  `identity`); a compressed request in any other coding is rejected with
+  `UNIMPLEMENTED`, and the response advertises
+  `grpc-accept-encoding: identity,gzip` so the client can retry.
 - **HTTP/2 required.** Run with TLS + ALPN (`h2`) for real clients; the gRPC
   request must arrive over the HTTP/2 layer.
 - BlackBull is **server-side**. For a client, use the standard `grpcio` client

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,9 @@
 BlackBull is a Python web framework that speaks the
 [**ASGI 3.0**](https://asgi.readthedocs.io/en/latest/specs/main.html)
 interface[^asgi], with pure-Python implementations of HTTP/1.1, HTTP/2
-(with ALPN), and WebSocket.  No required C extensions outside the
-standard library, one `pip install`, one deployable.
+(with ALPN), WebSocket, gRPC, and an MQTT 5 broker — all on one process,
+no reverse proxy or sidecar required.  No required C extensions outside
+the standard library, one `pip install`, one deployable.
 
 [^asgi]: ASGI is the async successor to WSGI — a single small interface
     that lets the same app object speak HTTP and WebSocket without
@@ -30,6 +31,10 @@ standard library, one `pip install`, one deployable.
 - **HTTP/1.1, HTTP/2, and WebSocket** on the same listener — ALPN
   negotiates HTTP/2; cleartext h2c is detected on first preface bytes;
   WebSocket-over-HTTP/2 (RFC 8441) is available as an opt-in.
+- **gRPC and MQTT 5 beside HTTP** — `app.enable_grpc()` serves gRPC
+  (all four RPC shapes, `gzip` compression) over the same HTTP/2 port;
+  `app.add_extension(MQTTExtension(...))` runs a pure-Python MQTT 5
+  broker on its own port, in the same process.
 - **Standards conformance** — RFC 9112 (HTTP/1.1), RFC 9113
   (HTTP/2 — h2spec passes), RFC 6455 (WebSocket — Autobahn passes),
   RFC 8441 (Extended CONNECT for WebSocket over HTTP/2).
@@ -79,10 +84,14 @@ ASGI-triplet form.
 
 ## Where to go next
 
+- Not sure BlackBull fits your project? [Why BlackBull?](getting-started/why-blackbull.md)
+  walks through the scenarios where its architectural bets pay off — and where
+  another framework may serve you better.
 - New to BlackBull? Start with [Installation](getting-started/installation.md).
 - Building something? The [Guide](guide/index.md) covers routing,
   middleware, WebSockets, error handling, HTTP/2, and configuration.
 - Deploying? See [Deployment](deployment/running.md) for multi-worker,
   TLS, AF_UNIX, systemd activation, and behind-nginx topologies.
-- Curious about the internals? [Internals](about/internals.md) walks
-  the actor model and the protocol stack.
+- Curious about the design? [Architecture](about/architecture.md) covers
+  the actor model, protocol ownership, and fault injection;
+  [Internals](about/internals.md) walks the implementation in detail.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ plugins:
 nav:
   - Home: index.md
   - Getting Started:
+    - Why BlackBull?: getting-started/why-blackbull.md
     - Installation: getting-started/installation.md
     - Hello World: getting-started/hello-world.md
     - Your First App: getting-started/first-app.md
@@ -71,6 +72,7 @@ nav:
     - Environment variables: reference/env-vars.md
     - API: api/
   - About:
+    - Architecture: about/architecture.md
     - Conformance: about/conformance.md
     - Internals: about/internals.md
     - MQTT broker design: about/mqtt-actor-design.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.49.1"
+version = "0.49.2"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conformance/grpc/test_grpc_real_client_h2c.py
+++ b/tests/conformance/grpc/test_grpc_real_client_h2c.py
@@ -291,6 +291,32 @@ async def _bidi(port: int, method: str, payloads: list[bytes]):
     return await asyncio.to_thread(_blocking_bidi, port, method, payloads)
 
 
+def _blocking_concurrent_unary(port: int, method: str, payloads: list[bytes],
+                               timeout: float = _CALL_TIMEOUT):
+    """Issue every payload as a concurrent unary call on ONE channel.
+
+    All futures are launched before any result is collected, so the calls
+    genuinely multiplex as concurrent streams over a single h2c connection —
+    unlike :func:`_unary`, which opens a fresh channel (connection) per call.
+    Returns the responses in payload order; raises ``grpc.RpcError`` if any
+    call failed."""
+    with grpc.insecure_channel(f'127.0.0.1:{port}') as channel:
+        grpc.channel_ready_future(channel).result(timeout=_CALL_TIMEOUT)
+        call = channel.unary_unary(
+            method,
+            request_serializer=lambda b: b,
+            response_deserializer=lambda b: b,
+        )
+        futures = [call.future(p, timeout=timeout) for p in payloads]
+        return [f.result(timeout=timeout) for f in futures]
+
+
+async def _concurrent_unary(port: int, method: str, payloads: list[bytes],
+                            timeout: float = _CALL_TIMEOUT):
+    return await asyncio.to_thread(
+        _blocking_concurrent_unary, port, method, payloads, timeout)
+
+
 # ---------------------------------------------------------------------------
 # Success path
 # ---------------------------------------------------------------------------
@@ -455,19 +481,15 @@ class TestRealClientClientStreaming:
         assert ok, f'unexpected error: {value}'
         assert value == str(40 * 1024).encode()
 
-    @pytest.mark.xfail(strict=False, reason=(
-        'Large client-streaming crosses the 65535-byte window on the request '
-        'direction; the server credits inbound flow control on enqueue, not on '
-        'app consumption, so under CPU load the handler drains the 64-deep '
-        'recipient queue slower than frames arrive and the stream is '
-        'RST_STREAM(ENHANCE_YOUR_CALM). Same root cause as the bidi over-window '
-        'case — needs consume-based inbound flow control '
-        '(proposals/consume-based-inbound-flow-control.md). Passes in isolation, '
-        'intermittent under full-suite load, so strict=False.'))
     @pytest.mark.asyncio
     async def test_large_request_stream_over_window(self, grpc_server_port):
-        # 200 × 1 KiB (~200 KiB) crosses the initial window on the request
-        # direction. Known limitation until consume-based crediting lands.
+        # 200 × 1 KiB (~200 KiB) crosses the initial 65535-byte window on the
+        # request direction.  Gate for consume-based inbound flow control
+        # (the Sprint 62 deferral): the server credits WINDOW_UPDATE as the
+        # handler consumes, so a slow drain closes the window and
+        # back-pressures grpcio instead of overflowing the recipient queue
+        # into RST_STREAM(ENHANCE_YOUR_CALM) — the pre-fix failure mode under
+        # CPU load.
         payloads = [b'x' * 1024] * 200
         ok, value = await _client_stream(
             grpc_server_port, '/echo.Echo/CountBytes', payloads)
@@ -504,18 +526,15 @@ class TestRealClientBidiStreaming:
         assert err is None, f'unexpected bidi error: {err}'
         assert msgs == payloads
 
-    @pytest.mark.xfail(strict=False, reason=(
-        'Large concurrent bidi crosses the 65535-byte window BOTH ways; the '
-        'server credits inbound flow control on enqueue, not on app consumption, '
-        'so a handler that stalls reading (blocked on yield / response '
-        'back-pressure) overflows the 64-deep recipient queue and the stream is '
-        'RST_STREAM(ENHANCE_YOUR_CALM). Needs consume-based inbound flow control '
-        '(proposals/consume-based-inbound-flow-control.md). Intermittent, so '
-        'strict=False.'))
     @pytest.mark.asyncio
     async def test_large_both_directions_over_window(self, grpc_server_port):
-        # 200 × 1 KiB echoed back — BOTH directions cross the initial window
-        # concurrently.  Known limitation until consume-based crediting lands.
+        # 200 × 1 KiB echoed back — BOTH directions cross the initial
+        # 65535-byte window concurrently.  Gate for consume-based inbound
+        # flow control (the Sprint 62 deferral): when the handler stalls
+        # reading (blocked on yield under response back-pressure) it stops
+        # crediting, the request-direction window closes, and grpcio
+        # back-pressures — pre-fix this overflowed the 64-deep recipient
+        # queue into RST_STREAM(ENHANCE_YOUR_CALM).
         payloads = [bytes([i % 256]) * 1024 for i in range(200)]
         msgs, err = await _bidi(grpc_server_port, '/echo.Echo/Chat', payloads)
         assert err is None, f'unexpected bidi error: {err}'
@@ -536,3 +555,21 @@ class TestRealClientConcurrency:
             assert value == payload[::-1]
 
         await asyncio.gather(*(one(i) for i in range(50)))
+
+    @pytest.mark.asyncio
+    async def test_concurrent_large_responses_share_connection_window(
+            self, grpc_server_port):
+        """Bug 1.2's wire-level gate (the missing Sprint 62 concurrency test):
+        N concurrent streams × 100 KB responses multiplexed on ONE connection.
+
+        Cumulative response bytes (10 × 100 KB) dwarf the 65535-byte
+        connection window, so every stream sender must debit the ONE shared
+        stream-0 budget and wait for connection-level credit.  With the
+        pre-fix per-sender window copies the server over-emits up to
+        N × 65535 un-credited bytes, and a strict peer (grpcio) kills the
+        whole connection with FLOW_CONTROL_ERROR (RFC 9113 §6.9.1) — every
+        call here would fail, not just one."""
+        responses = await _concurrent_unary(
+            grpc_server_port, '/echo.Echo/Big', [b'x'] * 10, timeout=15.0)
+        assert len(responses) == 10
+        assert all(r == b'Z' * 100_000 for r in responses)

--- a/tests/conformance/http1/test_rfc9112_request_forms.py
+++ b/tests/conformance/http1/test_rfc9112_request_forms.py
@@ -1,0 +1,117 @@
+"""RFC 9112 §3.2 — request-target forms + §7.1 chunk framing, on the wire.
+
+Sprint 63 (Http11Probe hardening).  These drive a live BlackBull server with
+byte-exact requests — the probe vectors that higher-level clients refuse to
+send — and assert the status BlackBull actually returns.
+"""
+import pytest
+
+from .conftest import send_raw
+
+
+@pytest.mark.integration
+class TestRequestTargetForms:
+    def test_absolute_form_routes_as_origin_form(self, h1_app):
+        # COMP-ABSOLUTE-FORM — GET http://host/path must reach the /echo route.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET http://localhost/echo HTTP/1.1\r\n'
+                     b'Host: localhost\r\n\r\n')
+        assert r.status == 200
+
+    def test_absolute_form_authority_overrides_spoofed_host(self, h1_app):
+        # SMUG-ABSOLUTE-URI-HOST-MISMATCH — the request-target authority is
+        # definitive; a mismatched Host must not change routing.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET http://localhost/echo HTTP/1.1\r\n'
+                     b'Host: evil.example\r\n\r\n')
+        assert r.status == 200
+
+    def test_options_asterisk_answered_at_server_level(self, h1_app):
+        # COMP-OPTIONS-STAR — server-wide OPTIONS is answered (2xx) with Allow,
+        # not routed to a 404.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'OPTIONS * HTTP/1.1\r\nHost: localhost\r\n\r\n')
+        assert 200 <= r.status < 300
+        assert r.header(b'allow') is not None
+
+    def test_get_asterisk_rejected(self, h1_app):
+        # COMP-ASTERISK-WITH-GET — '*' target is valid only for OPTIONS.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET * HTTP/1.1\r\nHost: localhost\r\n\r\n')
+        assert r.status == 400
+
+    def test_connect_not_implemented(self, h1_app):
+        # COMP-METHOD-CONNECT — tunneling is not implemented.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'CONNECT localhost:80 HTTP/1.1\r\nHost: localhost\r\n\r\n')
+        assert r.status in (400, 405, 501)
+
+    def test_non_ascii_request_target_rejected(self, h1_app):
+        # MAL-NON-ASCII-URL — raw non-ASCII bytes in the target.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET /caf\xc3\xa9 HTTP/1.1\r\nHost: localhost\r\n\r\n')
+        assert r.status == 400
+
+    def test_userinfo_in_host_rejected(self, h1_app):
+        # COMP-HOST-WITH-USERINFO.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET /echo HTTP/1.1\r\nHost: user@localhost\r\n\r\n')
+        assert r.status == 400
+
+    def test_duplicate_content_type_rejected(self, h1_app):
+        # COMP-DUPLICATE-CT.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Content-Length: 0\r\n'
+                     b'Content-Type: text/plain\r\n'
+                     b'Content-Type: text/html\r\n\r\n')
+        assert r.status == 400
+
+
+@pytest.mark.integration
+class TestTransferEncodingValidation:
+    def test_te_chunked_not_final_is_400(self, h1_app):
+        # SMUG-TE-NOT-FINAL-CHUNKED — chunked is present but not the final
+        # coding ⇒ unframeable ⇒ 400 (not 501).
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Transfer-Encoding: chunked, gzip\r\n\r\n'
+                     b'5\r\nhello\r\n0\r\n\r\n')
+        assert r.status == 400
+
+    def test_te_unknown_coding_is_501(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Transfer-Encoding: gzip\r\n\r\n')
+        assert r.status == 501
+
+
+@pytest.mark.integration
+class TestChunkFramingOnTheWire:
+    """Malformed chunk framing must answer 400, not 500 or a silent 200."""
+
+    @pytest.mark.parametrize('size_line', [
+        b'-1', b'0x5', b'+0', b'1_0', b' 5', b'5 ', b'5;', b'5;a@b=c',
+    ])
+    def test_malformed_chunk_size_is_400(self, h1_app, size_line):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Transfer-Encoding: chunked\r\n\r\n'
+                     + size_line + b'\r\nhello\r\n0\r\n\r\n')
+        assert r.status == 400, f'{size_line!r} should be 400, got {r.status}'
+
+    def test_chunk_data_spill_is_400(self, h1_app):
+        # SMUG-CHUNK-SPILL — data longer than the declared chunk-size.
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Transfer-Encoding: chunked\r\n\r\n'
+                     b'5\r\nhelloEXTRA\r\n0\r\n\r\n')
+        assert r.status == 400
+
+    def test_valid_chunked_still_200(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /echo HTTP/1.1\r\nHost: localhost\r\n'
+                     b'Transfer-Encoding: chunked\r\n\r\n'
+                     b'5\r\nhello\r\n0\r\n\r\n')
+        assert r.status == 200
+        assert r.body == b'hello'

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -9,17 +9,26 @@ Pins the bugs from the 2026-07-07 comprehensive audit:
 - 1.14 (#1) HEADERS on an OPEN stream respawns a second request (trailers)
 - 1.14 (#3) 16 MiB allocation before frame-size validation
 - 2.5  stream_window_size dict-of-one → int
+
+Plus the Sprint 62 deferral landed later: consume-based inbound flow control
+(proposals/consume-based-inbound-flow-control.md) — WINDOW_UPDATE credit for a
+DATA frame is replayed when the app pops the event off the recipient queue,
+not when the frame is enqueued, so a stalled handler closes the window and
+back-pressures the peer instead of overflowing a 64-deep frame-count queue
+into RST_STREAM(ENHANCE_YOUR_CALM).
 """
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from blackbull.protocol.frame import FrameFactory
 from blackbull.protocol.frame_types import (
-    ErrorCodes, FrameTypes, HeaderFrameFlags, DEFAULT_INITIAL_WINDOW_SIZE,
-    DEFAULT_MAX_FRAME_SIZE,
+    Data, DataFrameFlags, ErrorCodes, FrameTypes, HeaderFrameFlags,
+    DEFAULT_INITIAL_WINDOW_SIZE, DEFAULT_MAX_FRAME_SIZE,
 )
 from blackbull.server.http2_actor import HTTP2Actor, _CLOSED_STREAMS_CAP
+from blackbull.server.recipient import HTTP2Recipient
 from blackbull.server.sender import (
     AsyncioWriter, ConnectionWindow, HTTP2Sender,
 )
@@ -278,3 +287,238 @@ async def test_trailers_do_not_respawn_request():
     # No PROTOCOL_ERROR was raised for the (valid, END_STREAM-carrying) trailers.
     assert not [c.args[0] for c in handler.send_frame.call_args_list
                 if getattr(c.args[0], 'error_code', None) == ErrorCodes.PROTOCOL_ERROR]
+
+
+# ---------------------------------------------------------------------------
+# Consume-based inbound flow control (the Sprint 62 deferral) — credit is
+# replayed when the app pops the event, not when the DATA frame is enqueued.
+# ---------------------------------------------------------------------------
+
+def _data(payload: bytes, stream_id: int = 1, end_stream: bool = False) -> Data:
+    flags = int(DataFrameFlags.END_STREAM) if end_stream else 0
+    return Data(len(payload), FrameTypes.DATA, flags, stream_id, data=payload)
+
+
+def _window_updates(handler):
+    """(stream_id, increment) for every WINDOW_UPDATE the actor sent."""
+    return [(f.stream_id, f.window_size)
+            for f in (c.args[0] for c in handler.send_frame.call_args_list)
+            if f.FrameType() == FrameTypes.WINDOW_UPDATE]
+
+
+@pytest.mark.asyncio
+async def test_recipient_credits_on_consume_not_on_enqueue():
+    """No WINDOW_UPDATE credit is owed at enqueue; each pop replays exactly
+    the popped frame's flow-control length through the credit callback."""
+    credits = []
+
+    async def cb(n):
+        credits.append(n)
+
+    r = HTTP2Recipient(credit_callback=cb)
+    assert r.put_DATAFrame(_data(b'aaa')) is True
+    assert r.put_DATAFrame(_data(b'bbbb', end_stream=True)) is True
+    assert credits == []                      # nothing credited at enqueue
+    ev = await r()
+    assert ev['body'] == b'aaa' and credits == [3]
+    ev = await r()
+    assert ev['body'] == b'bbbb' and credits == [3, 4]
+    assert ev['more_body'] is False
+
+
+@pytest.mark.asyncio
+async def test_recipient_zero_length_data_yields_no_credit():
+    """The empty END_STREAM DATA grpcio sends consumes no window; a
+    WINDOW_UPDATE with increment 0 is a §6.9.1 protocol error, so consuming
+    it must not invoke the credit callback."""
+    credits = []
+
+    async def cb(n):
+        credits.append(n)
+
+    r = HTTP2Recipient(credit_callback=cb)
+    assert r.put_DATAFrame(_data(b'', end_stream=True)) is True
+    ev = await r()
+    assert ev['more_body'] is False
+    assert credits == []
+
+
+@pytest.mark.asyncio
+async def test_recipient_byte_budget_is_the_abuse_backstop():
+    """put_DATAFrame refuses (→ RST) only when the peer overruns the
+    advertised inbound window it was never credited for — not at a frame
+    count a conformant peer can legitimately reach."""
+    async def cb(n):
+        pass
+
+    r = HTTP2Recipient(credit_callback=cb, credit_budget=10)
+    assert r.put_DATAFrame(_data(b'x' * 6)) is True
+    assert r.put_DATAFrame(_data(b'x' * 4)) is True    # exactly at budget: fine
+    assert r.put_DATAFrame(_data(b'x')) is False       # overrun: refused
+
+
+@pytest.mark.asyncio
+async def test_recipient_event_count_cap_stops_tiny_frame_floods():
+    """The byte budget cannot see a zero/tiny-frame flood; a generous
+    frame-count cap (queue_depth × 16) refuses degenerate dribble."""
+    async def cb(n):
+        pass
+
+    r = HTTP2Recipient(queue_depth=1, credit_callback=cb, credit_budget=10**6)
+    for _ in range(16):
+        assert r.put_DATAFrame(_data(b'')) is True
+    assert r.put_DATAFrame(_data(b'')) is False
+
+
+@pytest.mark.asyncio
+async def test_recipient_take_uncredited_returns_the_unconsumed_balance():
+    """take_uncredited() reports (and clears) bytes enqueued but never popped
+    — the balance the actor replays to the connection window on release."""
+    async def cb(n):
+        pass
+
+    r = HTTP2Recipient(credit_callback=cb)
+    r.put_DATAFrame(_data(b'aaa'))
+    r.put_DATAFrame(_data(b'bb', end_stream=True))
+    await r()                          # consume 3 bytes → credited via cb
+    assert r.take_uncredited() == 2    # the un-popped frame's balance
+    assert r.take_uncredited() == 0    # cleared
+
+
+def test_legacy_recipient_without_callback_keeps_bounded_queue():
+    """Direct constructions without a credit callback (tests, push streams)
+    keep the historical bounded-queue, credit-at-enqueue behaviour."""
+    r = HTTP2Recipient(queue_depth=2)
+    assert r.credits_on_consume is False
+    assert r.put_DATAFrame(_data(b'a')) is True
+    assert r.put_DATAFrame(_data(b'b')) is True
+    assert r.put_DATAFrame(_data(b'c')) is False   # QueueFull → refused
+
+
+@pytest.mark.asyncio
+async def test_over_queue_depth_burst_within_window_is_not_rst():
+    """The original failure mode: more DATA frames than the old 64-deep queue,
+    all within the 65535-byte window, while the handler is stalled.  With
+    consume-based crediting the burst is buffered (bounded by the window
+    budget), never RST_STREAM(ENHANCE_YOUR_CALM); once the handler drains,
+    stream + connection credit is replayed in full."""
+    from hpack import Encoder
+    all_delivered = asyncio.Event()
+    consumed = []
+
+    async def app(scope, receive, send):
+        await all_delivered.wait()     # stall until every frame is enqueued
+        while True:
+            ev = await receive()
+            if ev['type'] != 'http.request':
+                break
+            consumed.append(ev['body'])
+            if not ev.get('more_body', False):
+                break
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'ok'})
+
+    handler = _make_actor(app)
+    enc = Encoder()
+    frames = [
+        _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b''),
+        _make_h2_frame(FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
+                       enc.encode([(b':method', b'POST'), (b':path', b'/up'),
+                                   (b':scheme', b'https')])),
+    ]
+    frames += [_make_h2_frame(FrameTypes.DATA, 0, 1, b'x' * 100)
+               for _ in range(64)]
+    frames.append(_make_h2_frame(
+        FrameTypes.DATA, int(DataFrameFlags.END_STREAM), 1, b'x' * 100))
+
+    async def fake_receive():
+        if frames:
+            return frames.pop(0)
+        all_delivered.set()
+        return None
+
+    handler.receive = fake_receive
+    await handler.run()
+
+    rsts = [f for f in (c.args[0] for c in handler.send_frame.call_args_list)
+            if f.FrameType() == FrameTypes.RST_STREAM]
+    assert not rsts, f'window-conformant burst must not be RST: {rsts}'
+    assert sum(len(b) for b in consumed) == 6500
+    wus = _window_updates(handler)
+    assert sum(n for sid, n in wus if sid == 1) == 6500
+    assert sum(n for sid, n in wus if sid == 0) == 6500
+
+
+@pytest.mark.asyncio
+async def test_unread_body_balance_flushes_to_connection_window():
+    """A handler that finishes without draining its body must not leak the
+    shared connection window shut: the un-consumed balance is replayed as
+    WINDOW_UPDATE(0) when the stream is released.  Stream-level credit is
+    NOT replayed — the stream is closed (RFC 9113 §5.1)."""
+    from hpack import Encoder
+
+    async def app(scope, receive, send):
+        await receive()                # reads ONLY the first 3-byte frame
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'done'})
+
+    handler = _make_actor(app)
+    enc = Encoder()
+    settings = _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b'')
+    headers = _make_h2_frame(
+        FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
+        enc.encode([(b':method', b'POST'), (b':path', b'/up'),
+                    (b':scheme', b'https')]))
+    data1 = _make_h2_frame(FrameTypes.DATA, 0, 1, b'aaa')
+    data2 = _make_h2_frame(
+        FrameTypes.DATA, int(DataFrameFlags.END_STREAM), 1, b'bbbb')
+    handler.receive = AsyncMock(side_effect=[settings, headers, data1, data2, None])
+    await handler.run()
+    for _ in range(10):                # let the release-time flush task run
+        await asyncio.sleep(0)
+
+    wus = _window_updates(handler)
+    assert sum(n for sid, n in wus if sid == 1) == 3   # only the consumed frame
+    assert sum(n for sid, n in wus if sid == 0) == 7   # consumed + flushed balance
+
+
+@pytest.mark.asyncio
+async def test_window_overrun_is_rst_enhance_your_calm():
+    """A peer that keeps sending past the advertised 65535-byte inbound window
+    (i.e. ignores the closed window) hits the abuse backstop: the frame is
+    refused and the stream is RST_STREAM(ENHANCE_YOUR_CALM)."""
+    from hpack import Encoder
+    all_delivered = asyncio.Event()
+
+    async def app(scope, receive, send):
+        await all_delivered.wait()     # never consumes while frames arrive
+        while (await receive())['type'] != 'http.disconnect':
+            pass
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b''})
+
+    handler = _make_actor(app)
+    enc = Encoder()
+    frames = [
+        _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b''),
+        _make_h2_frame(FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
+                       enc.encode([(b':method', b'POST'), (b':path', b'/up'),
+                                   (b':scheme', b'https')])),
+    ]
+    # 5 × 16 KiB = 81920 bytes — crosses the 65535-byte budget at frame 4.
+    frames += [_make_h2_frame(FrameTypes.DATA, 0, 1, b'x' * 16384)
+               for _ in range(5)]
+
+    async def fake_receive():
+        if frames:
+            return frames.pop(0)
+        all_delivered.set()
+        return None
+
+    handler.receive = fake_receive
+    await handler.run()
+
+    calms = [f for f in (c.args[0] for c in handler.send_frame.call_args_list)
+             if f.FrameType() == FrameTypes.RST_STREAM
+             and f.error_code == ErrorCodes.ENHANCE_YOUR_CALM]
+    assert calms, 'window overrun must trip the ENHANCE_YOUR_CALM backstop'

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -134,11 +134,31 @@ class TestHTTP2FlowControl:
         )
 
     @staticmethod
+    def _draining_app():
+        """An app that reads its request body to completion then responds.
+
+        Consume-based inbound flow control credits WINDOW_UPDATE when the
+        app pops each body event — an app that ignores ``receive`` earns no
+        credit (its balance is flushed to the connection window only when
+        the stream is released), so these crediting tests must actually
+        consume.
+        """
+        async def app(scope, receive, send):
+            while True:
+                ev = await receive()
+                if ev['type'] != 'http.request' or not ev.get('more_body', False):
+                    break
+            await send({'type': 'http.response.start', 'status': 200,
+                        'headers': []})
+            await send({'type': 'http.response.body', 'body': b''})
+        return app
+
+    @staticmethod
     def _wu_increments(handler) -> list[int]:
         # Stream-level WINDOW_UPDATEs (stream_id > 0) reflect per-stream
         # DATA consumption.  Connection-level (stream_id == 0) is
         # asserted separately via :meth:`_wu_increments_conn` — the
-        # server now emits one of each per DATA frame so both windows
+        # server emits one of each per consumed DATA frame so both windows
         # stay credited (RFC 9113 §6.9.1).
         return [call.args[0].window_size
                 for call in handler.send_frame.call_args_list
@@ -164,15 +184,16 @@ class TestHTTP2FlowControl:
                 and call.args[0].stream_id == 0]
 
     async def test_single_data_frame_window_update_increment(self):
-        """Receiving one DATA frame must produce WINDOW_UPDATE with increment
-        equal to that frame's payload size (RFC 7540 §6.9)."""
+        """One DATA frame, once consumed by the app, must produce
+        WINDOW_UPDATE with increment equal to that frame's payload size
+        (RFC 7540 §6.9; credit is replayed at consume-time)."""
         payload = b'hello'
         stream_id = 1
         h_frame = _make_headers_frame(stream_id=stream_id, end_stream=False)
         d_frame = _make_h2_frame(FrameTypes.DATA, DataFrameFlags.END_STREAM,
                                  stream_id, payload)
 
-        handler, _ = _make_h2_actor()
+        handler, _ = _make_h2_actor(self._draining_app())
         handler.receive = AsyncMock(side_effect=[h_frame, d_frame, None])
         await handler.run()
 
@@ -184,7 +205,8 @@ class TestHTTP2FlowControl:
         )
 
     async def test_two_data_frames_window_update_sum(self):
-        """Two DATA frames → WINDOW_UPDATE increments must sum to total bytes."""
+        """Two DATA frames, consumed → WINDOW_UPDATE increments must sum to
+        total bytes."""
         chunk1 = b'hello'
         chunk2 = b' world'
         total = len(chunk1) + len(chunk2)
@@ -195,7 +217,7 @@ class TestHTTP2FlowControl:
         d_frame2 = _make_h2_frame(FrameTypes.DATA, DataFrameFlags.END_STREAM,
                                   stream_id, chunk2)
 
-        handler, _ = _make_h2_actor()
+        handler, _ = _make_h2_actor(self._draining_app())
         handler.receive = AsyncMock(side_effect=[h_frame, d_frame1, d_frame2, None])
         await handler.run()
 
@@ -217,21 +239,22 @@ class TestHTTP2FlowControl:
 
     async def test_single_data_frame_emits_connection_window_update(self):
         """Per RFC 9113 §6.9.1, a DATA frame consumes both the stream
-        and connection windows; the server must credit both back."""
+        and connection windows; the server must credit both back once the
+        app consumes the frame."""
         payload = b'hello'
         stream_id = 1
         h_frame = _make_headers_frame(stream_id=stream_id, end_stream=False)
         d_frame = _make_h2_frame(FrameTypes.DATA, DataFrameFlags.END_STREAM,
                                  stream_id, payload)
 
-        handler, _ = _make_h2_actor()
+        handler, _ = _make_h2_actor(self._draining_app())
         handler.receive = AsyncMock(side_effect=[h_frame, d_frame, None])
         await handler.run()
 
         conn_increments = self._wu_increments_conn(handler)
         assert any(inc == len(payload) for inc in conn_increments), (
             f'connection-level WINDOW_UPDATE with increment {len(payload)} '
-            f'must follow each delivered DATA frame; '
+            f'must follow each consumed DATA frame; '
             f'got conn-level increments={conn_increments}'
         )
 
@@ -248,6 +271,13 @@ class TestHTTP2FlowControl:
         Chunk size stays under RFC 9113 §4.2 ``max_frame_size``
         (default 16,384); 5 chunks at 16,000 bytes = 80,000 cumulative,
         which clears the 65,535 threshold.
+
+        Consume-based crediting note: a conformant peer is paced by the
+        credit it receives — it never has more than 65,535 un-credited
+        bytes in flight (a burst that ignores the closed window trips the
+        ENHANCE_YOUR_CALM abuse backstop instead).  The fake peer below
+        models that by yielding to the loop between frames so the
+        draining app consumes (and the server credits) as frames arrive.
         """
         chunk_size = 16_000  # under max_frame_size
         n_chunks = 5
@@ -263,9 +293,16 @@ class TestHTTP2FlowControl:
         total = n_chunks * chunk_size
         assert total > 65_535, 'sanity: total must exceed initial conn window'
 
-        handler, _ = _make_h2_actor()
-        handler.receive = AsyncMock(
-            side_effect=[h_frame, *data_frames, None])
+        handler, _ = _make_h2_actor(self._draining_app())
+        frames = [h_frame, *data_frames]
+
+        async def fake_receive():
+            # Yield first so the app drains what is already queued — the
+            # credit-paced behaviour of a window-respecting peer.
+            await asyncio.sleep(0)
+            return frames.pop(0) if frames else None
+
+        handler.receive = fake_receive
         await handler.run()
 
         conn_increments = self._wu_increments_conn(handler)

--- a/tests/unit/test_audit_sprint63.py
+++ b/tests/unit/test_audit_sprint63.py
@@ -1,0 +1,353 @@
+"""Sprint 63 regression tests — Http11Probe hardening + audit bug 1.16.
+
+Covers:
+
+* Phase 1 (probe Cluster A) — strict RFC 9112 §7.1.1 chunk-size / chunk-ext
+  grammar, chunk-data spill, and CRLF-terminator strictness.  Malformed
+  chunked framing must surface as ``HTTPException(400)`` from the recipient
+  (the dispatcher's typed-exception seam), never a 500 or a silent 200.
+* Phase 2 (probe Cluster B) — special request-target forms: absolute-form,
+  asterisk-form, CONNECT.
+* Phase 3 (probe Cluster C, cheap wins) — userinfo-in-Host, non-ASCII
+  request-target, ``Transfer-Encoding`` where chunked is not final,
+  duplicate Content-Type.
+* Bug 1.16 — ``X-Forwarded-Prefix`` is only honoured via ``TrustedProxy``,
+  never straight off the wire.
+"""
+from http import HTTPStatus
+
+import pytest
+
+from blackbull.headers import Headers
+from blackbull.router import HTTPException
+from blackbull.server.recipient import (
+    AbstractReader, HTTP1Recipient, _parse_chunk_size,
+)
+from blackbull.server.sender import AbstractWriter
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+class _BufReader(AbstractReader):
+    """Serves a fixed wire buffer; EOF (empty bytes) once drained."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buf = bytearray(data)
+
+    async def read(self, n: int) -> bytes:
+        if not self._buf:
+            return b''
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+
+class _RecordingWriter(AbstractWriter):
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+async def _noop_app(scope, receive, send):  # pragma: no cover - never dispatched
+    pass
+
+
+def _make_actor(writer=None):
+    from blackbull.server.http1_actor import HTTP1Actor
+    return HTTP1Actor(
+        _BufReader(b''), writer or _RecordingWriter(),
+        app=_noop_app, aggregator=None,
+    )
+
+
+def _chunked_recipient(wire: bytes) -> HTTP1Recipient:
+    return HTTP1Recipient(
+        _BufReader(wire),
+        {'headers': [(b'transfer-encoding', b'chunked')]},
+        chunk_size=64 * 1024,
+    )
+
+
+async def _drain_body(recipient: HTTP1Recipient) -> bytes:
+    body = bytearray()
+    while True:
+        event = await recipient()
+        if event['type'] == 'http.disconnect':
+            break
+        body += event.get('body', b'')
+        if not event.get('more_body', False):
+            break
+    return bytes(body)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — chunk-size token grammar (RFC 9112 §7.1.1: chunk-size = 1*HEXDIG)
+# ---------------------------------------------------------------------------
+
+class TestChunkSizeGrammar:
+    @pytest.mark.parametrize('line,expected', [
+        (b'5\r\n', 5),
+        (b'A\r\n', 10),
+        (b'a\r\n', 10),
+        (b'10\r\n', 16),
+        (b'5;foo=bar\r\n', 5),          # chunk-ext ignored
+        (b'5 ;foo=bar\r\n', 5),         # BWS between size and ';'
+        (b'5;foo\r\n', 5),              # ext-name with no value
+        (b'5;a="quoted val"\r\n', 5),   # quoted-string ext-val
+    ])
+    def test_valid_chunk_size_lines(self, line, expected):
+        assert _parse_chunk_size(line) == expected
+
+    @pytest.mark.parametrize('line', [
+        b'-1\r\n',        # SMUG-CHUNK-NEGATIVE — sign not in 1*HEXDIG
+        b'+0\r\n',        # SMUG-CHUNK-SIZE-PLUS
+        b'0x5\r\n',       # SMUG-CHUNK-HEX-PREFIX — int(s,16) leniency
+        b'1_0\r\n',       # SMUG-CHUNK-UNDERSCORE — PEP 515 leniency
+        b' 5\r\n',        # SMUG-CHUNK-LEADING-SP
+        b'5 \r\n',        # SMUG-CHUNK-SIZE-TRAILING-OWS (no ext ⇒ no BWS)
+        b'5;\r\n',        # SMUG-CHUNK-BARE-SEMICOLON — empty ext-name
+        b'5;a@b=c\r\n',   # SMUG-CHUNK-EXT-INVALID-TOKEN — '@' not a tchar
+        b'5;a=\x01\r\n',  # SMUG-CHUNK-EXT-CTRL — control char in ext-val
+        b'5;a="unterminated\r\n',  # broken quoted-string ext-val
+        b'\r\n',          # empty size
+        b'XYZ\r\n',       # non-hex
+    ])
+    def test_malformed_chunk_size_lines_raise_400(self, line):
+        with pytest.raises(HTTPException) as exc_info:
+            _parse_chunk_size(line)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — recipient-level framing strictness (spill / terminators)
+# ---------------------------------------------------------------------------
+
+class TestChunkedFramingStrict:
+    @pytest.mark.asyncio
+    async def test_valid_chunked_body_still_round_trips(self):
+        wire = b'5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n'
+        assert await _drain_body(_chunked_recipient(wire)) == b'hello world'
+
+    @pytest.mark.asyncio
+    async def test_chunk_data_spill_raises_400(self):
+        # SMUG-CHUNK-SPILL — data exceeds the declared chunk-size.
+        wire = b'5\r\nhelloEXTRA\r\n0\r\n\r\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_bare_cr_chunk_terminator_raises_400(self):
+        # SMUG-CHUNK-BARE-CR-TERM — chunk-data terminated by CR alone.
+        wire = b'5\r\nhello\r0\r\n\r\n'
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(_chunked_recipient(wire))
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_bare_lf_chunk_terminator_raises_400(self):
+        # SMUG-CHUNK-LF-TERM — chunk-data terminated by LF alone.
+        wire = b'5\r\nhello\n0\r\n\r\n'
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(_chunked_recipient(wire))
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_bare_lf_size_line_raises_400(self):
+        # A chunk-size line terminated by a bare LF must not be accepted
+        # (and, pre-fix, could hang the parser waiting for CRLF).
+        wire = b'5\nhello\r\n0\r\n\r\n'
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(_chunked_recipient(wire))
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_missing_crlf_between_chunks_raises_400(self):
+        # SMUG-CHUNK-MISSING-TRAILING-CRLF — next chunk glued to the data.
+        wire = b'5\r\nhello0\r\n\r\n'
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(_chunked_recipient(wire))
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_framing_error_marks_recipient_broken(self):
+        # The actor must close the connection after a framing 400 — the
+        # byte stream is desynced, so keep-alive would be a smuggling
+        # vector.  The recipient signals this via ``framing_broken``.
+        recipient = _chunked_recipient(b'5\r\nhelloEXTRA\r\n0\r\n\r\n')
+        with pytest.raises(HTTPException):
+            await _drain_body(recipient)
+        assert recipient.framing_broken is True
+        assert recipient.needs_drain() is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — special request-target forms (RFC 9112 §3.2)
+# ---------------------------------------------------------------------------
+
+class TestSpecialRequestForms:
+    def test_absolute_form_rewritten_to_origin_form(self):
+        # COMP-ABSOLUTE-FORM — GET http://host/path must route as /path.
+        actor = _make_actor()
+        scope = actor._parse(b'GET http://example.com/echo?x=1 HTTP/1.1\r\n'
+                             b'Host: example.com\r\n\r\n')
+        assert scope['path'] == '/echo'
+        assert scope['query_string'] == b'x=1'
+
+    def test_absolute_form_authority_overrides_host(self):
+        # RFC 9112 §3.2.2 — the origin server MUST ignore the Host header
+        # and use the request-target's authority instead
+        # (SMUG-ABSOLUTE-URI-HOST-MISMATCH).
+        actor = _make_actor()
+        scope = actor._parse(b'GET http://real.example/ HTTP/1.1\r\n'
+                             b'Host: spoofed.example\r\n\r\n')
+        assert scope['headers'].get(b'host') == b'real.example'
+
+    def test_absolute_form_bare_authority_gets_root_path(self):
+        actor = _make_actor()
+        scope = actor._parse(b'GET http://example.com HTTP/1.1\r\n'
+                             b'Host: example.com\r\n\r\n')
+        assert scope['path'] == '/'
+
+    def test_asterisk_form_options_flagged_for_server_level_answer(self):
+        actor = _make_actor()
+        scope = actor._parse(b'OPTIONS * HTTP/1.1\r\n'
+                             b'Host: example.com\r\n\r\n')
+        assert scope.get('_asterisk_form') is True
+
+    def test_asterisk_form_non_options_rejected(self):
+        # COMP-ASTERISK-WITH-GET — '*' is only valid for OPTIONS (§3.2.4).
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET * HTTP/1.1\r\nHost: example.com\r\n\r\n')
+
+    def test_connect_method_not_implemented(self):
+        # COMP-METHOD-CONNECT — tunneling is not implemented → 501 path.
+        from blackbull.server.http1_actor import NotImplementedFramingError
+        actor = _make_actor()
+        with pytest.raises(NotImplementedFramingError):
+            actor._parse(b'CONNECT example.com:80 HTTP/1.1\r\n'
+                         b'Host: example.com\r\n\r\n')
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — protocol validation hardening (cheap Cluster C wins)
+# ---------------------------------------------------------------------------
+
+class TestProtocolValidation:
+    def test_userinfo_in_host_rejected(self):
+        # COMP-HOST-WITH-USERINFO — RFC 3986 §3.2 deprecates userinfo in
+        # authority; its presence in Host is an SSRF/smuggling vector.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET / HTTP/1.1\r\nHost: user@example.com\r\n\r\n')
+
+    def test_non_ascii_request_target_rejected(self):
+        # MAL-NON-ASCII-URL — raw non-ASCII bytes in the request-target.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET /\xc3\xa9 HTTP/1.1\r\nHost: example.com\r\n\r\n')
+
+    def test_te_chunked_not_final_rejected_400(self):
+        # SMUG-TE-NOT-FINAL-CHUNKED — RFC 9112 §6.1: chunked present but not
+        # final ⇒ body length undeterminable ⇒ MUST 400 (not 501).
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                         b'Transfer-Encoding: chunked, gzip\r\n\r\n')
+
+    def test_te_unknown_coding_still_501(self):
+        # gzip (chunked final absent) stays 501 Not Implemented.
+        from blackbull.server.http1_actor import NotImplementedFramingError
+        actor = _make_actor()
+        with pytest.raises(NotImplementedFramingError):
+            actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                         b'Transfer-Encoding: gzip\r\n\r\n')
+
+    def test_te_duplicate_chunked_rejected_400(self):
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                         b'Transfer-Encoding: chunked, chunked\r\n\r\n')
+
+    def test_plain_chunked_still_accepted(self):
+        actor = _make_actor()
+        scope = actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                             b'Transfer-Encoding: chunked\r\n\r\n')
+        assert scope['type'] == 'http'
+
+    def test_duplicate_content_type_rejected(self):
+        # COMP-DUPLICATE-CT — Content-Type is a singleton field.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET / HTTP/1.1\r\nHost: x\r\n'
+                         b'Content-Type: text/plain\r\n'
+                         b'Content-Type: text/html\r\n\r\n')
+
+
+# ---------------------------------------------------------------------------
+# Bug 1.16 — X-Forwarded-Prefix only honoured via TrustedProxy
+# ---------------------------------------------------------------------------
+
+class TestXForwardedPrefixTrust:
+    def test_h1_parse_ignores_forwarded_prefix(self):
+        actor = _make_actor()
+        scope = actor._parse(b'GET / HTTP/1.1\r\nHost: x\r\n'
+                             b'X-Forwarded-Prefix: /evil\r\n\r\n')
+        assert scope['root_path'] == ''
+
+    def test_h2_parse_headers_ignores_forwarded_prefix(self):
+        # Frame construction mirrors test_parser.py's H2 dispatch harness.
+        from hpack import Encoder
+        from blackbull.protocol.frame import FrameFactory
+        from blackbull.protocol.frame_types import FrameTypes, HeaderFrameFlags
+        from blackbull.server.parser import parse_headers
+
+        block = Encoder().encode([
+            (b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https'),
+            (b'x-forwarded-prefix', b'/evil'),
+        ])
+        flags = HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM
+        raw = (len(block).to_bytes(3, 'big') + FrameTypes.HEADERS
+               + bytes([flags]) + (1).to_bytes(4, 'big') + block)
+        scope = parse_headers(FrameFactory().load(raw))
+        assert scope.get('root_path', '') == ''
+
+    @pytest.mark.asyncio
+    async def test_trusted_proxy_sets_root_path(self):
+        from blackbull.middleware.proxy import TrustedProxy
+        mw = TrustedProxy(['127.0.0.1'])
+        scope = {'type': 'http', 'client': ['127.0.0.1', 1234],
+                 'headers': Headers([(b'x-forwarded-prefix', b'/app')])}
+        called = {}
+
+        async def call_next(scope, receive, send):
+            called['root_path'] = scope.get('root_path')
+
+        await mw(scope, None, None, call_next)
+        assert called['root_path'] == '/app'
+
+    @pytest.mark.asyncio
+    async def test_untrusted_peer_prefix_ignored(self):
+        from blackbull.middleware.proxy import TrustedProxy
+        mw = TrustedProxy(['10.0.0.1'])
+        scope = {'type': 'http', 'client': ['192.0.2.9', 1234],
+                 'headers': Headers([(b'x-forwarded-prefix', b'/evil')])}
+        called = {}
+
+        async def call_next(scope, receive, send):
+            called['root_path'] = scope.get('root_path', '')
+
+        await mw(scope, None, None, call_next)
+        assert called['root_path'] == ''

--- a/tests/unit/test_cap_log_sites.py
+++ b/tests/unit/test_cap_log_sites.py
@@ -684,6 +684,7 @@ _INVENTORY = (
     'write_timeout',
     'ws_max_frame_payload',
     'stream_queue_depth',
+    'h2_inbound_window_budget',
     'h2_max_concurrent_streams',
     'h2_ws_max_streams_per_connection',
     'compression_max_inflight',

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -153,11 +153,15 @@ class TestParse:
         assert _get_scope(_http_request()).get('root_path') == ''
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
-    def test_root_path_preserved_from_x_forwarded_prefix(self, prefix):
+    def test_root_path_ignores_x_forwarded_prefix_off_the_wire(self, prefix):
+        # Spec change (audit bug 1.16, Sprint 63): a client-controlled
+        # X-Forwarded-Prefix must NOT set root_path at the parser layer —
+        # it is only honoured behind TrustedProxy (see
+        # tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).
         scope = _get_scope(_http_request(
             headers={'Host': 'localhost:8000', 'X-Forwarded-Prefix': prefix}
         ))
-        assert scope.get('root_path') == prefix
+        assert scope.get('root_path') == ''
 
     def test_root_path_not_set_when_prefix_absent(self):
         assert _get_scope(_http_request(headers={'Host': 'localhost:8000'})).get('root_path') == ''
@@ -365,12 +369,16 @@ class TestHTTP2ScopeFields:
         assert scope.get('root_path') == ''
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
-    def test_root_path_preserved_from_x_forwarded_prefix(self, prefix):
+    def test_x_forwarded_prefix_ignored_off_the_wire(self, prefix):
+        # Bug 1.16 (Sprint 63): same contract on the H2 path — the frame-level
+        # parser must not trust a client-supplied X-Forwarded-Prefix.  Only
+        # the TrustedProxy middleware may set root_path, after verifying the
+        # peer (see tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).
         frame = _make_h2_headers_frame_dispatch(
             extra_headers=[(b'x-forwarded-prefix', prefix.encode())]
         )
         scope = _ParserFactory.Get(frame, _FakeStream()).parse()
-        assert scope.get('root_path') == prefix
+        assert scope.get('root_path') == ''
 
 
 class TestHTTP11DuplicateHeaders:


### PR DESCRIPTION
## Summary

Two batches of work, both previously unreleased, shipping together as v0.49.2:

- **Sprint 63** — Http11Probe hardening (RFC 9112 §3.2/§7.1: strict chunked-framing grammar, request-target forms, header validation) + audit bug 1.16 (`X-Forwarded-Prefix` trust) + a docs restructure (`docs/about/architecture.md`, `docs/getting-started/why-blackbull.md`).
- **Sprint 62 closeout** — the two HTTP/2 flow-control items deferred at the v0.49.1 cut (2026-07-07 comprehensive audit):
  - **Consume-based inbound flow control**: `WINDOW_UPDATE` credit for an inbound DATA frame is now replayed when the app *consumes* the event, not when it's enqueued, so a stalled gRPC handler back-pressures the peer instead of RST_STREAM(ENHANCE_YOUR_CALM). A released stream that never drained its body flushes its un-consumed balance to the shared connection window.
  - **Strict-peer multi-stream concurrency gate** (audit bug 1.2's missing wire test): 10 concurrent unary calls on one grpcio channel × 100 KB responses, guarding the shared connection send-window fix.
  - Both Sprint 60 `xfail(strict=False)` gRPC interop tests are now hard gates.

No public-API removals. `pyproject.toml` stays at `0.49.2` (prepared, never published).

## Test plan

- [x] Full suite green under beartype: 2760 passed, 265 skipped, 2 xfailed (pre-existing, unrelated)
- [x] `tests/conformance/grpc/test_grpc_real_client_h2c.py` — 24/24 passed, including both former xfails as hard gates and the new concurrency gate
- [x] `tests/conformance/http2/` — 553 passed (0 regressions from the consume-crediting rewrite)
- [x] `mkdocs build --strict` — same 6 pre-existing warnings as clean HEAD (verified via disposable worktree), none introduced
- [x] Editable-install smoke test: `blackbull.__version__ == '0.49.2'`
- [x] CodeQL + CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)