### PR TITLE
release: v0.49.3 — Sprint 63 remainder: Http11Probe plateau (161/161)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ bench/sprint-logs/
 bench/conformance/results/*.txt
 bench/conformance/results/*.xml
 bench/conformance/results/*.json
+
+# Http11Probe run output (kept directory, ignore data files)
+bench/http11probe/results/*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,59 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.49.3] — 2026-07-09
+
+### Security
+
+- **HTTP/1.1 — chunk-framing line length bound (audit bug 1.24,
+  CVE-2023-39326 class)**: the chunk-size+extension line and every trailer
+  line are now capped at 8 KiB; an oversized line (probe
+  `MAL-CHUNK-EXT-64K`) answers 400 instead of escaping as a
+  `LimitOverrunError`-backed 500.  A bare-LF-terminated trailer section
+  (`SMUG-CHUNK-LF-TRAILER`) is rejected 400 instead of hanging until the
+  client gives up.
+- **HTTP/1.1 — prohibited trailer fields rejected (RFC 9110 §6.5.1)**:
+  framing / routing / authentication / content-handling fields
+  (`Transfer-Encoding`, `Content-Length`, `Host`, `Authorization`,
+  `Content-Type`, …) in a chunked trailer section now answer 400.
+- **HTTP/1.1 — strict Content-Length (RFC 9110 §8.6)**: leading zeros,
+  doubled/tab/trailing OWS around the value (probe `SMUG-CL-*`,
+  `MAL-CL-TAB-BEFORE-VALUE`) are rejected 400 before the generic OWS strip
+  hides them.
+- **HTTP/1.1 — underscore framing confusables**: `Content_Length` /
+  `Transfer_Encoding` header names (probe `NORM-UNDERSCORE-*`) are
+  rejected 400.
+
+### Fixed
+
+- **HTTP/1.1 — missing `Host` on an HTTP/1.1 request now 400**
+  (RFC 9112 §3.2, audit bug 1.25); HTTP/1.0 requests may still omit it.
+- **HTTP/1.1 — unsupported HTTP major version now 505** (RFC 9110
+  §15.6.6, audit bug 1.25): `GET / HTTP/9.9` was served as if 1.1.
+  `HTTP/1.x` minors above 1.1 remain accepted as 1.x-compatible.
+- **HTTP/1.1 — no `100 Continue` to HTTP/1.0 clients** (RFC 9110 §15.2,
+  probe `COMP-NO-1XX-HTTP10`): `Expect: 100-continue` from a 1.0 client
+  is ignored and the body read normally.
+- **HTTP/2 — refused multi-frame HEADERS no longer kills the connection**
+  (audit bug 1.14 #2): a HEADERS refused at `MAX_CONCURRENT_STREAMS` with
+  `END_HEADERS` unset now keeps consuming the header block; the refusal
+  (RST_STREAM `REFUSED_STREAM`) happens at `END_HEADERS`, after the HPACK
+  decode that keeps the dynamic table in sync, instead of the peer's
+  legal CONTINUATION tripping a bogus GOAWAY(PROTOCOL_ERROR).
+
+With these fixes the authoritative Http11Probe re-score reaches
+**161/161 (0 failed, 5 warnings)** — up from 156/161 (5 failed, 13
+warnings) at v0.49.2.
+
+### Docs
+
+- `bench/conformance/README.md` — CI status badge + per-job coverage
+  table; removed the stale "work in progress / h2spec only" framing.
+- `bench/peers/NOTES.private.md` — AI-agent stale-data note on the
+  2026-05-18 h2spec 51 % calibration section.
+- `KNOWN_LIMITATIONS.md` — corrected the swapped nginx/BlackBull columns
+  on the HTTP/9.9 differential-corpus row.
+
 ## [0.49.2] — 2026-07-08
 
 Sprint 63 — Http11Probe hardening (RFC 9112 §3.2 / §7.1) + audit bug 1.16 —

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -93,7 +93,7 @@ treated as bugs:
 | Wire request | nginx | BlackBull | Why we're right |
 |---|---|---|---|
 | `GET&nbsp;&nbsp;http://localhost/x HTTP/1.0` (double-SP between method and target) | 200 | 400 | RFC 9112 §3 — request-line tokens are separated by exactly one SP.  nginx is lenient; we reject. |
-| `GET  /x HTTP/9.9` (validation-order on unknown version) | 400 | 505 | RFC 9110 §15 — unsupported HTTP version is 505 (HTTP Version Not Supported); nginx returns the more generic 400. |
+| `GET&nbsp;&nbsp;http://localhost/x HTTP/9.9` (double-SP **and** unknown version) | 505 | 400 | Validation-order choice: the request-line SP grammar (RFC 9112 §3) is checked before the HTTP version, so the malformed line is 400 first.  nginx reports the version problem (505) instead.  A *well-formed* request with an unsupported version does get 505 from BlackBull (RFC 9110 §15.6.6). |
 
 Both are documented in
 [`tests/conformance/http1/fuzz/user-corpus/diff_README.md`](tests/conformance/http1/fuzz/user-corpus/).

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ deliberate protocol misbehaviour.
 [![RFC conformance](https://github.com/TOKUJI/BlackBull/actions/workflows/conformance.yml/badge.svg)](https://github.com/TOKUJI/BlackBull/actions/workflows/conformance.yml)
 [![Benchmarked by HttpArena](https://cdn.jsdelivr.net/gh/MDA2AV/httparena-badge/wordmark.svg)](https://www.http-arena.com/leaderboard/)
 
+**[Live demo →](https://blackbull.alwaysdata.net/)** — BlackBull running in
+production on a free-tier host, no external server in front of it.
+
 ## Hello, world
 
 ```python

--- a/bench/conformance/README.md
+++ b/bench/conformance/README.md
@@ -4,10 +4,30 @@ Runs published HTTP/2 / HPACK conformance suites against a BlackBull server.
 Currently wires up [h2spec](https://github.com/summerwind/h2spec) (RFC 7540 +
 RFC 7541 conformance, ~150 test cases).
 
-**This is a work in progress.**  Coverage is limited to h2spec for now; we
-have not yet wired up Autobahn|Testsuite for WebSocket (RFC 6455) or any
-HTTP/1.1 conformance suite.  First-run results are stored locally for
-reference and are not published.
+## Current status
+
+[![RFC conformance](https://github.com/TOKUJI/BlackBull/actions/workflows/conformance.yml/badge.svg)](https://github.com/TOKUJI/BlackBull/actions/workflows/conformance.yml)
+
+CI-verified on every push and PR to master by
+[`.github/workflows/conformance.yml`](../../.github/workflows/conformance.yml)
+(plus a weekly scheduled run that picks up upstream tool releases).  A green
+badge means every job passed in full:
+
+| CI job | What it verifies |
+|---|---|
+| `h2spec` | RFC 7540 + RFC 7541 (HTTP/2 + HPACK), full suite, zero failures |
+| `autobahn` | RFC 6455 WebSocket (Autobahn\|Testsuite), zero failing cases |
+| `corpus-replay` | HTTP/1.1 differential corpus replay (captured divergences) |
+| `h2-flow-control` | HTTP/2 large bidirectional payload flow-control gate |
+| `grpc-interop` | Real `grpcio` client against the h2c gRPC transport |
+
+The badge — not a number quoted in any doc — is the authoritative
+conformance claim; per-job artefacts (JUnit XML, reports) attach to each
+workflow run.
+
+The sections below cover running the suites **locally**.  Local first-run
+results are stored under `bench/conformance/results/` (gitignored) and are
+not published.
 
 ## Install h2spec
 

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -73,6 +73,22 @@ _HTTP_VERSION_RE = re.compile(rb'^HTTP/\d\.\d$')
 _FIELD_NAME_INVALID_RE = re.compile(rb"[^!#$%&'*+\-.^_`|~0-9A-Za-z]")
 _FIELD_VALUE_INVALID_RE = re.compile(rb"[\x00-\x08\x0a-\x1f\x7f]")
 
+# RFC 9110 §8.6 — strict Content-Length: at most one canonical leading SP
+# (the byte after the colon), then ``0`` or a no-leading-zero decimal.
+# Matched against the *raw* post-colon bytes, before the generic OWS strip
+# discards the evidence: leading zeros, doubled/tab OWS, and trailing OWS
+# are all parser-disagreement smuggling vectors (SMUG-CL-LEADING-ZEROS /
+# -DOUBLE-ZERO / -TRAILING-SPACE / -EXTRA-LEADING-SP,
+# MAL-CL-TAB-BEFORE-VALUE) that a lenient ``int()`` would silently accept.
+_CL_STRICT_RE = re.compile(rb'\A ?(?:0|[1-9][0-9]*)\Z')
+
+# NORM-UNDERSCORE-CL / -TE — header names that differ from a framing
+# header only by ``_`` vs ``-``.  Underscore is a legal tchar, but these
+# two exist solely to desync a front-end that normalises ``_`` to ``-``
+# (CGI-style); nginx drops them by default, we reject.
+_UNDERSCORE_FRAMING_NAMES = frozenset((
+    b'content_length', b'transfer_encoding'))
+
 
 class BadRequestError(Exception):
     """Raised by :meth:`HTTP1Actor._parse` on an RFC 9112 framing violation.
@@ -97,6 +113,14 @@ class NotImplementedFramingError(Exception):
     """RFC 9112 §6.1 — the request used a Transfer-Encoding the server
     does not implement.  Answered with 501 Not Implemented (a separate
     response code from :class:`BadRequestError`'s 400)."""
+
+
+class UnsupportedVersionError(Exception):
+    """RFC 9110 §15.6.6 — the request-line carried a well-formed
+    ``HTTP/x.y`` version whose major version the server does not support
+    (RFC9112-2.3-INVALID-VERSION).  Answered with 505 HTTP Version Not
+    Supported and the connection is closed.  Distinct from
+    :class:`BadRequestError`: the request *grammar* was valid."""
 
 
 def _validate_message_framing(headers: 'Headers') -> None:
@@ -230,11 +254,10 @@ def _validate_host(headers: 'Headers') -> None:
         raise BadRequestError(
             f'multiple Host headers ({len(hosts)} — smuggling vector)')
     if not hosts:
-        # HTTP/1.1 §3.2 requires Host but HTTP/1.0 doesn't; we don't
-        # check version here because absent-Host on 1.1 is already
-        # handled elsewhere if at all.  Leaving the strict-absent
-        # check to a separate Sprint 18 follow-up keeps the patch
-        # focused on the captured-corpus divergences.
+        # HTTP/1.1 §3.2 requires Host but HTTP/1.0 doesn't.  The
+        # version-aware presence check lives in ``_parse`` (which knows
+        # the request version); this helper only validates the value's
+        # grammar when a Host is present.
         return
     value = hosts[0][1].strip(b' \t')
     if not value:
@@ -481,13 +504,27 @@ class HTTP1Actor(Actor):
                     await self._send_error_and_close(
                         send, b'501 Not Implemented', HTTPStatus.NOT_IMPLEMENTED)
                     return
+                except UnsupportedVersionError as exc:
+                    # RFC 9110 §15.6.6 — well-formed request-line, but a
+                    # major HTTP version this server does not speak
+                    # (RFC9112-2.3-INVALID-VERSION).  505 then close.
+                    logger.warning('505 HTTP Version Not Supported: %s', exc)
+                    await self._send_error_and_close(
+                        send, b'505 HTTP Version Not Supported',
+                        HTTPStatus.HTTP_VERSION_NOT_SUPPORTED)
+                    return
                 self._fill_connection_info(scope)
 
                 if scope.get('type') == 'websocket':
                     await self._handle_upgrade(scope)
                     return
 
-                if scope['headers'].get(b'expect').lower() == b'100-continue':
+                # RFC 9110 §10.1.1 / §15.2 — a server MUST NOT send a 1xx
+                # response to an HTTP/1.0 client (COMP-NO-1XX-HTTP10); the
+                # Expect header is ignored and the body read normally.
+                if (scope['http_version'] != '1.0'
+                        and scope['headers'].get(b'expect').lower()
+                        == b'100-continue'):
                     await send(b'', HTTPStatus.CONTINUE)
 
                 log_record = _AccessLogRecord.from_scope(scope)
@@ -706,6 +743,15 @@ class HTTP1Actor(Actor):
         # HTTP-version (§2.5) — exactly ``HTTP/d.d``.
         if not _HTTP_VERSION_RE.match(version):
             raise BadRequestError(f'invalid HTTP-version {version!r}')
+        # RFC 9110 §2.5 / §15.6.6 — only major version 1 is served here
+        # (RFC9112-2.3-INVALID-VERSION: ``HTTP/9.9`` was answered 200).
+        # A higher 1.x minor (``HTTP/1.2``) is 1.x-compatible and served
+        # as 1.1; any other major → 505.  The HTTP/2 preface never reaches
+        # this parser — ``protocol_registry`` sniffs ``PRI * HTTP/2.0``
+        # off the socket before the HTTP/1.1 binding is selected.
+        if version[5:6] != b'1':
+            raise UnsupportedVersionError(
+                f'HTTP version {version!r} is not supported')
 
         # Request-target form dispatch (RFC 9112 §3.2).  Four forms:
         # origin (``/path``), absolute (``http://host/path``), authority
@@ -784,6 +830,17 @@ class HTTP1Actor(Actor):
             # field-name must be a valid token (§5.1 / RFC 9110 §5.6.2).
             if _FIELD_NAME_INVALID_RE.search(key):
                 raise BadRequestError(f'invalid header name {key!r}')
+            lkey = key.lower()
+            if lkey in _UNDERSCORE_FRAMING_NAMES:
+                raise BadRequestError(
+                    f'framing-confusable header name {key!r} '
+                    f'(NORM-UNDERSCORE)')
+            # Strict Content-Length — checked against the raw post-colon
+            # bytes, before the OWS strip below erases the evidence.
+            if lkey == b'content-length' and not _CL_STRICT_RE.match(value):
+                raise BadRequestError(
+                    f'ambiguous Content-Length value {value!r} '
+                    f'(RFC 9110 §8.6)')
             # Strip the OWS surrounding the value (§5).
             value = value.strip(b' \t')
             # field-value MUST NOT contain CTLs except HTAB.
@@ -791,7 +848,7 @@ class HTTP1Actor(Actor):
                 raise BadRequestError(
                     f'CTL in header value (smuggling / log-injection): '
                     f'{key!r}: {value!r}')
-            raw.append((key.lower(), value))
+            raw.append((lkey, value))
 
         # RFC 9112 §3.2.2 — for an absolute-form target the request's own
         # authority is definitive; replace any client Host so a mismatched or
@@ -813,6 +870,15 @@ class HTTP1Actor(Actor):
         # transfer-coding registry (§6.1 → 501 on unknown coding).
         _validate_message_framing(headers)
         _validate_host(headers)
+        # RFC 9112 §3.2 / §7.2 — every HTTP/1.1 (and later 1.x) request
+        # MUST carry a Host header (RFC9112-7.1-MISSING-HOST); only
+        # HTTP/1.0, which predates Host, may omit it (COMP-HTTP10-NO-HOST).
+        # ``_validate_host`` checks the value's grammar when present; the
+        # presence rule is version-aware, so it lives here.
+        if version != b'HTTP/1.0' and not headers.getlist(b'host'):
+            raise BadRequestError(
+                f'missing Host header on {version.decode("ascii")} request '
+                f'(RFC 9112 §3.2)')
 
         scope = {
             'type': 'http',

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -1052,6 +1052,17 @@ class HTTP2Actor(Actor):
     ) -> bool:
         """Handle a HEADERS frame; return True if stream task spawned, False if awaiting CONTINUATION."""
         if self._active_stream_count >= self.max_concurrent_streams:
+            if not frame.end_headers:
+                # Bug 1.14 #2 — the header block legally continues in
+                # CONTINUATION frames (RFC 9113 §6.10); refusing here would
+                # leave run() not expecting them and escalate the peer's
+                # legal CONTINUATION into a bogus connection error.  Keep
+                # accumulating the block (the flood cap still bounds it);
+                # ``_on_continuation_frame`` re-checks capacity at
+                # END_HEADERS and refuses there — after the HPACK decode,
+                # which must happen regardless to keep the dynamic table
+                # in sync (§4.3).
+                return False
             log_cap_hit('h2_max_concurrent_streams',
                         requested=self._active_stream_count + 1,
                         limit=self.max_concurrent_streams,

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -98,6 +98,28 @@ def _validate_chunk_ext(ext: bytes) -> None:
                 raise _bad_request(f'invalid chunk-ext-val {val!r}')
 
 
+# Bug 1.24 (MAL-CHUNK-EXT-64K, CVE-2023-39326 class) — hard bound on any
+# single chunk-framing line (chunk-size + chunk-ext, or one trailer field
+# line).  Mirrors the BB_HEADER_MAX_LINE default: extensions and trailers
+# are ignored on receipt, so nothing legitimate needs more.  Without the
+# bound, ``asyncio.StreamReader.readuntil`` hits its own buffer limit first
+# and raises ``LimitOverrunError`` — a ValueError the dispatcher's 400 seam
+# doesn't catch — surfacing as a 500.
+_CHUNK_LINE_MAX = 8192
+
+# RFC 9110 §6.5.1 — fields controlling message framing, routing, request
+# modifiers, authentication, or content handling are prohibited in a
+# chunked trailer section (SMUG-TRAILER-*).  BlackBull never merges
+# trailers into the header section, but silently swallowing these invites
+# a front-end that *does* merge them to be desynced through us — reject.
+_PROHIBITED_TRAILER_FIELDS = frozenset((
+    b'transfer-encoding', b'content-length', b'host', b'content-type',
+    b'content-encoding', b'content-range', b'trailer', b'te',
+    b'authorization', b'proxy-authorization', b'cookie', b'set-cookie',
+    b'cache-control', b'expect', b'max-forwards', b'pragma', b'range',
+))
+
+
 def _parse_chunk_size(line: bytes) -> int:
     """RFC 9112 §7.1.1 — ``chunk-size = 1*HEXDIG`` optionally followed by
     ``chunk-ext``.  Validate the size token strictly (no sign, no ``0x``
@@ -507,6 +529,38 @@ class HTTP1Recipient(BaseRecipient):
             self.framing_broken = True
             raise
 
+    async def _read_chunk_line(self) -> bytes:
+        """Read one line of chunked framing (chunk-size line or trailer
+        line) with a hard length bound.
+
+        Reads to bare LF, not CRLF: a bare-LF-terminated line then returns
+        immediately and fails the caller's CRLF check with a 400 instead of
+        blocking in ``readuntil`` until the peer gives up
+        (SMUG-CHUNK-LF-TERM / SMUG-CHUNK-LF-TRAILER were timeouts, not
+        rejections, before this).  Length violations — whether detected by
+        our own bound or pre-empted by ``asyncio.StreamReader``'s buffer
+        limit (``LimitOverrunError``) — surface as 400 with the stream
+        marked unframeable (bug 1.24, MAL-CHUNK-EXT-64K).
+        """
+        try:
+            line = await self._read_with_timeout(self._reader.readuntil(b'\n'))
+        except asyncio.LimitOverrunError as exc:
+            self.framing_broken = True
+            log_cap_hit('h1_chunk_line_length',
+                        requested=exc.consumed, limit=_CHUNK_LINE_MAX,
+                        scope_path=self._scope.get('path') if self._scope else None,
+                        protocol='http1')
+            raise _bad_request(
+                'chunk framing line exceeds length limit') from None
+        if len(line) > _CHUNK_LINE_MAX:
+            self.framing_broken = True
+            log_cap_hit('h1_chunk_line_length',
+                        requested=len(line), limit=_CHUNK_LINE_MAX,
+                        scope_path=self._scope.get('path') if self._scope else None,
+                        protocol='http1')
+            raise _bad_request('chunk framing line exceeds length limit')
+        return line
+
     async def _read_with_timeout(self, coro):
         """Run *coro* under the configured body_timeout, if any."""
         if self._body_timeout > 0 and self._deadline is not None:
@@ -525,18 +579,30 @@ class HTTP1Recipient(BaseRecipient):
 
         try:
             if self._chunked:
-                size_line = await self._read_with_timeout(
-                    self._reader.readuntil(b'\r\n'))
+                size_line = await self._read_chunk_line()
                 chunk_size = self._parse_chunk_size_or_400(size_line)
                 if chunk_size == 0:
                     # RFC 9112 §7.1.2 — last-chunk is followed by an
                     # optional trailer-part and then a final CRLF.  Read
-                    # lines until we hit the terminator.
+                    # lines until we hit the terminator.  Each line must be
+                    # CRLF-terminated (a bare-LF terminator is the same
+                    # framing violation as on the chunk-size line), and
+                    # RFC 9110 §6.5.1-prohibited fields are rejected.
                     while True:
-                        line = await self._read_with_timeout(
-                            self._reader.readuntil(b'\r\n'))
+                        line = await self._read_chunk_line()
                         if line == b'\r\n':
                             break
+                        if not line.endswith(b'\r\n'):
+                            self.framing_broken = True
+                            raise _bad_request(
+                                f'trailer line not CRLF-terminated: '
+                                f'{line[-8:]!r}')
+                        name = line.split(b':', 1)[0].strip(b' \t').lower()
+                        if name in _PROHIBITED_TRAILER_FIELDS:
+                            self.framing_broken = True
+                            raise _bad_request(
+                                f'prohibited trailer field {name!r} '
+                                f'(RFC 9110 §6.5.1)')
                     self._done = True
                     return {'type': ASGIEvent.HTTP_REQUEST, 'body': b'', 'more_body': False}
                 # RFC 9112 §7.1 — the chunk-data is exactly ``chunk_size``

--- a/docs/about/rfc9113-implementation.md
+++ b/docs/about/rfc9113-implementation.md
@@ -157,6 +157,17 @@ streams, re-sending only the stream that didn't fit.  A connection error would
 be the wrong tool: it tears down the whole connection and forces the client to
 replay *every* request, punishing it for the server's own limit.
 
+When the over-limit HEADERS arrives with `END_HEADERS` unset, the refusal is
+**deferred to the end of the header block**: the CONTINUATION frames are
+accumulated (still under the `BB_HEADER_MAX_TOTAL` flood cap) and
+`HTTP2Actor._on_continuation_frame()` re-checks the limit at `END_HEADERS`,
+after the HPACK decode.  *Because* two §6.10 obligations survive the refusal:
+the peer's in-flight CONTINUATION frames are legal (refusing early would make
+the frame loop misread them as "unexpected CONTINUATION" and escalate to a
+bogus connection error), and the block must be HPACK-decoded regardless to
+keep the shared dynamic table in sync (§4.3).  A stream that no longer
+exceeds the limit by the time its block completes is simply admitted.
+
 **§5.2 Flow Control** ✅
 A DATA frame may be sent only when **two** windows both have credit — the
 stream window and the connection window.  On the *send* (outbound) side,
@@ -242,8 +253,9 @@ flow-control credit — so it carries the most invariants and touches the most c
 **§6.2 HEADERS — `Headers(FrameBase)`** ✅
 A `Headers` frame is handled by `HTTP2Actor._on_headers_frame()`, which runs the
 admission gauntlet: concurrency check first → REFUSED_STREAM if over the limit
-(§5.1.2).  If `END_HEADERS` is unset, stash the frame and set the
-`_frame_loop()`-local flag `waiting_continuation` (§6.10).
+(§5.1.2) — unless `END_HEADERS` is unset, in which case the refusal waits for
+the block to complete (§5.1.2 above).  If `END_HEADERS` is unset, stash the
+frame and set the `_frame_loop()`-local flag `waiting_continuation` (§6.10).
 Malformed headers → RST PROTOCOL_ERROR before dispatch (§8.1.1).  Extended
 CONNECT (`:protocol`) routes to WebSocket (RFC 8441).  *Because* HEADERS is the
 stream's birth certificate — every admission, framing, and routing decision has

--- a/examples/probe_target.py
+++ b/examples/probe_target.py
@@ -1,0 +1,74 @@
+"""
+Http11Probe target server for BlackBull.
+
+Endpoints:
+  GET  /        → 200 OK "Hello, world!"
+  POST /        → 200 OK with request body echoed back
+  GET  /echo    → 200 OK with all request headers echoed (name: value\\n)
+  POST /echo    → same as GET /echo
+  GET  /cookie  → 200 OK with parsed cookies echoed (name=value\\n)
+  POST /cookie  → same as GET /cookie
+"""
+from http import HTTPStatus
+from blackbull import BlackBull
+from blackbull.response import Response
+from blackbull.request import parse_cookies
+
+app = BlackBull()
+
+
+# ── Root: GET returns plain text, POST echoes body ──────────────────────
+
+@app.route(path='/', methods=['GET'])
+async def root_get():
+    return Response("Hello, world!", content_type="text/plain; charset=utf-8")
+
+
+@app.route(path='/', methods=['POST'])
+async def root_post(body: bytes):
+    return Response(body, content_type="application/octet-stream")
+
+
+# ── /echo: echo all request headers ─────────────────────────────────────
+
+@app.route(path='/echo', methods=['GET', 'POST'])
+async def echo_headers(scope, receive, send):
+    """Echo all request headers as ``name: value\\n`` per line."""
+    lines: list[str] = []
+    for name, value in scope.get('headers', []):
+        lines.append(f"{name.decode('latin-1')}: {value.decode('latin-1')}")
+    body = "\n".join(lines).encode()
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [(b'content-type', b'text/plain; charset=utf-8')],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': body,
+    })
+
+
+# ── /cookie: echo parsed cookies ────────────────────────────────────────
+
+@app.route(path='/cookie', methods=['GET', 'POST'])
+async def cookie_echo(scope, receive, send):
+    """Parse cookies and echo as ``name=value\\n`` per line."""
+    cookies = parse_cookies(scope)
+    lines: list[str] = []
+    for name, value in cookies.items():
+        lines.append(f"{name}={value}")
+    body = "\n".join(lines).encode()
+    await send({
+        'type': 'http.response.start',
+        'status': 200,
+        'headers': [(b'content-type', b'text/plain; charset=utf-8')],
+    })
+    await send({
+        'type': 'http.response.body',
+        'body': body,
+    })
+
+
+if __name__ == '__main__':
+    app.run(port=8080)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.49.2"
+version = "0.49.3"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/architecture/test_asgi_server.py
+++ b/tests/architecture/test_asgi_server.py
@@ -556,7 +556,8 @@ class TestTimeoutHandling:
         # Detection peek + the whole header block arrive in one read; the body
         # read (readexactly) is the one that hangs.
         reader.read = AsyncMock(
-            side_effect=[b'POST / HTTP/1.1\r\nContent-Length: 5\r\n\r\n'])
+            side_effect=[b'POST / HTTP/1.1\r\nHost: x\r\n'
+                         b'Content-Length: 5\r\n\r\n'])
         reader.readexactly = AsyncMock(side_effect=slow_body)
 
         async def noop_app(scope, receive, send):

--- a/tests/architecture/test_http1_actor.py
+++ b/tests/architecture/test_http1_actor.py
@@ -312,7 +312,10 @@ class TestScopePopulation:
 
     @pytest.mark.asyncio
     async def test_server_falls_back_to_sockname_when_no_host_header(self):
-        raw = _http_request(headers={})
+        # A Host-less request is only legal on HTTP/1.0 (RFC 9112 §3.2 —
+        # HTTP/1.1 without Host is now rejected 400), so the sockname
+        # fallback is exercised through a 1.0 request.
+        raw = _http_request(version='HTTP/1.0', headers={})
         captured = {}
 
         async def capture_app(scope, receive, send):

--- a/tests/conformance/http1/test_http11probe_remaining.py
+++ b/tests/conformance/http1/test_http11probe_remaining.py
@@ -1,0 +1,137 @@
+"""Sprint 63 remainder — wire-level round-trips for the last Http11Probe FAILs.
+
+Each test replays the exact probe vector against a live BlackBull server:
+
+* ``RFC9112-7.1-MISSING-HOST``   — HTTP/1.1 without Host → 400.
+* ``RFC9112-2.3-INVALID-VERSION``— ``HTTP/9.9`` → 505 (was a happy 200).
+* ``COMP-NO-1XX-HTTP10``         — no ``100 Continue`` to an HTTP/1.0 client.
+* ``MAL-CHUNK-EXT-64K``          — 64 KiB chunk extension → 400 (was a
+  ``LimitOverrunError``-backed 500 through the real asyncio StreamReader).
+* ``SMUG-CHUNK-LF-TRAILER``      — bare-LF trailer terminator → 400 (was a
+  hang until the probe's client timeout).
+* ``SMUG-CL-*`` / ``MAL-CL-TAB-BEFORE-VALUE`` — ambiguous Content-Length → 400.
+* ``NORM-UNDERSCORE-CL`` / ``-TE`` — framing-confusable underscore names → 400.
+"""
+from __future__ import annotations
+
+import pytest
+
+from .conftest import send_raw
+
+
+class TestMissingHostAndVersionWire:
+    def test_http11_missing_host_400(self, h1_app):
+        resp = send_raw('localhost', h1_app.port, b'GET / HTTP/1.1\r\n\r\n')
+        assert resp.status == 400
+
+    def test_http10_missing_host_200(self, h1_app):
+        resp = send_raw('localhost', h1_app.port, b'GET / HTTP/1.0\r\n\r\n')
+        assert resp.status == 200
+
+    def test_invalid_version_505(self, h1_app):
+        resp = send_raw('localhost', h1_app.port,
+                        b'GET / HTTP/9.9\r\nHost: x\r\n\r\n')
+        assert resp.status == 505
+        assert resp.closed
+
+    def test_http12_still_served(self, h1_app):
+        resp = send_raw('localhost', h1_app.port,
+                        b'GET / HTTP/1.2\r\nHost: x\r\n\r\n')
+        assert resp.status == 200
+
+
+class TestExpect100ContinueWire:
+    def test_http11_expect_still_gets_100(self, h1_app):
+        # Regression guard: the HTTP/1.0 suppression must not remove the
+        # interim 100 for HTTP/1.1 clients.
+        resp = send_raw('localhost', h1_app.port,
+                        b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                        b'Expect: 100-continue\r\nContent-Length: 5\r\n\r\n'
+                        b'hello')
+        assert b'100 Continue' in resp.raw
+        assert b'200' in resp.raw
+        assert resp.body.endswith(b'hello')
+
+    def test_http10_expect_gets_no_1xx(self, h1_app):
+        # COMP-NO-1XX-HTTP10 — RFC 9110 §15.2: a server MUST NOT send a
+        # 1xx response to an HTTP/1.0 client.
+        resp = send_raw('localhost', h1_app.port,
+                        b'POST /echo HTTP/1.0\r\nHost: x\r\n'
+                        b'Expect: 100-continue\r\nContent-Length: 5\r\n\r\n'
+                        b'hello')
+        assert b'100 Continue' not in resp.raw
+        assert resp.status == 200
+
+
+class TestChunkFramingWire:
+    def test_64k_chunk_extension_400_not_500(self, h1_app):
+        # MAL-CHUNK-EXT-64K — must traverse the real asyncio.StreamReader
+        # (LimitOverrunError path), which the unit fakes cannot reach.
+        req = (b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+               b'Transfer-Encoding: chunked\r\n\r\n'
+               b'5;ext=' + b'a' * 65536 + b'\r\nhello\r\n0\r\n\r\n')
+        resp = send_raw('localhost', h1_app.port, req)
+        assert resp.status == 400
+
+    def test_bare_lf_trailer_terminator_400_not_timeout(self, h1_app):
+        # SMUG-CHUNK-LF-TRAILER — must answer promptly, not stall until
+        # the client gives up.
+        req = (b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+               b'Transfer-Encoding: chunked\r\n\r\n'
+               b'5\r\nhello\r\n0\r\n\n')
+        resp = send_raw('localhost', h1_app.port, req, timeout=3.0)
+        assert resp.status == 400
+
+    def test_prohibited_trailer_field_400(self, h1_app):
+        req = (b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+               b'Transfer-Encoding: chunked\r\n\r\n'
+               b'5\r\nhello\r\n0\r\nAuthorization: Bearer evil\r\n\r\n')
+        resp = send_raw('localhost', h1_app.port, req)
+        assert resp.status == 400
+
+    def test_benign_trailer_still_200(self, h1_app):
+        req = (b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+               b'Transfer-Encoding: chunked\r\n\r\n'
+               b'5\r\nhello\r\n0\r\nx-checksum: abc\r\n\r\n')
+        resp = send_raw('localhost', h1_app.port, req)
+        assert resp.status == 200
+        assert resp.body == b'hello'
+
+
+class TestContentLengthStrictWire:
+    @pytest.mark.parametrize('cl_line', [
+        b'Content-Length: 005',    # SMUG-CL-LEADING-ZEROS
+        b'Content-Length: 00',     # SMUG-CL-DOUBLE-ZERO
+        b'Content-Length: 010',    # SMUG-CL-LEADING-ZEROS-OCTAL
+        b'Content-Length: 5 ',     # SMUG-CL-TRAILING-SPACE
+        b'Content-Length:  5',     # SMUG-CL-EXTRA-LEADING-SP
+        b'Content-Length:\t5',     # MAL-CL-TAB-BEFORE-VALUE
+    ])
+    def test_ambiguous_content_length_400(self, h1_app, cl_line):
+        req = (b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+               + cl_line + b'\r\n\r\nhello')
+        resp = send_raw('localhost', h1_app.port, req)
+        assert resp.status == 400
+
+    def test_canonical_content_length_still_200(self, h1_app):
+        resp = send_raw('localhost', h1_app.port,
+                        b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                        b'Content-Length: 5\r\n\r\nhello')
+        assert resp.status == 200
+        assert resp.body == b'hello'
+
+
+class TestUnderscoreFramingNamesWire:
+    def test_underscore_content_length_400(self, h1_app):
+        # NORM-UNDERSCORE-CL
+        resp = send_raw('localhost', h1_app.port,
+                        b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                        b'Content-Length: 5\r\nContent_Length: 99\r\n\r\nhello')
+        assert resp.status == 400
+
+    def test_underscore_transfer_encoding_400(self, h1_app):
+        # NORM-UNDERSCORE-TE
+        resp = send_raw('localhost', h1_app.port,
+                        b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                        b'Content-Length: 5\r\nTransfer_Encoding: chunked\r\n\r\nhello')
+        assert resp.status == 400

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -472,6 +472,50 @@ class TestHTTP2MaxConcurrentStreams:
         assert 1 not in handler._stream_tasks, \
             'stream task map not cleaned up after inbound RST_STREAM'
 
+    async def test_refused_multiframe_headers_consumes_continuation(self):
+        """Bug 1.14 #2 — refusing a HEADERS with END_HEADERS=0 must not turn
+        the peer's legal CONTINUATION into a bogus connection error.
+
+        RFC 9113 §6.10: after HEADERS without END_HEADERS the peer MUST send
+        the rest of the block as CONTINUATION frames.  A server that refuses
+        the stream at the HEADERS frame and forgets it was mid-block then
+        misreads those CONTINUATIONs as 'unexpected CONTINUATION' and kills
+        the whole connection with GOAWAY(PROTOCOL_ERROR).  The block must be
+        consumed and the stream refused with RST_STREAM(REFUSED_STREAM) only.
+        """
+        from blackbull.protocol.frame_types import ErrorCodes
+
+        encoder = Encoder()
+        block = encoder.encode([(b':method', b'GET'),
+                                (b':path', b'/'),
+                                (b':scheme', b'https')])
+        mid = len(block) // 2
+        h1 = _make_headers_frame(stream_id=1, end_stream=True)
+        h3 = _make_h2_frame(FrameTypes.HEADERS, 0, 3, block[:mid])
+        c3 = _make_h2_frame(FrameTypes.CONTINUATION,
+                            HeaderFrameFlags.END_HEADERS, 3, block[mid:])
+
+        handler, _ = _make_h2_actor()
+        handler.max_concurrent_streams = 1
+        handler.receive = AsyncMock(side_effect=[h1, h3, c3, None])
+        await asyncio.wait_for(handler.run(), timeout=5)
+
+        sent = [c.args[0] for c in handler.send_frame.call_args_list
+                if hasattr(c.args[0], 'FrameType')]
+        goaways = [f for f in sent if f.FrameType() == FrameTypes.GOAWAY]
+        assert not goaways, (
+            'refused mid-block stream escalated to a connection error '
+            '(GOAWAY) on the peer\'s legal CONTINUATION'
+        )
+        refused = [f for f in sent
+                   if f.FrameType() == FrameTypes.RST_STREAM
+                   and f.stream_id == 3
+                   and getattr(f, 'error_code', None) == ErrorCodes.REFUSED_STREAM]
+        assert len(refused) == 1, (
+            f'expected exactly one RST_STREAM(REFUSED_STREAM) for stream 3, '
+            f'got {len(refused)}'
+        )
+
     async def test_closed_stream_frees_slot(self):
         """After a stream closes, a new one must be accepted within the limit."""
         h1 = _make_headers_frame(stream_id=1, end_stream=True)

--- a/tests/unit/test_audit_sprint63.py
+++ b/tests/unit/test_audit_sprint63.py
@@ -351,3 +351,216 @@ class TestXForwardedPrefixTrust:
 
         await mw(scope, None, None, call_next)
         assert called['root_path'] == ''
+
+
+# ---------------------------------------------------------------------------
+# Sprint 63 remainder — chunk-line length bound (bug 1.24, MAL-CHUNK-EXT-64K)
+# ---------------------------------------------------------------------------
+
+class TestChunkLineLengthBound:
+    @pytest.mark.asyncio
+    async def test_oversized_chunk_ext_line_raises_400(self):
+        # MAL-CHUNK-EXT-64K / CVE-2023-39326 class — a 64 KiB chunk
+        # extension must be rejected with 400, not crash `readuntil` into
+        # a LimitOverrunError-backed 500.
+        wire = b'5;ext=' + b'a' * 65536 + b'\r\nhello\r\n0\r\n\r\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+    @pytest.mark.asyncio
+    async def test_limit_overrun_from_reader_maps_to_400(self):
+        # The asyncio.StreamReader path raises LimitOverrunError *inside*
+        # readuntil before the line ever materialises; the recipient must
+        # translate it into the same 400, not let it escape as a 500.
+        import asyncio
+
+        class _OverrunReader(AbstractReader):
+            async def read(self, n: int) -> bytes:  # pragma: no cover
+                return b''
+
+            async def readuntil(self, sep: bytes) -> bytes:
+                raise asyncio.LimitOverrunError(
+                    'Separator is found, but chunk is longer than limit', 65536)
+
+        recipient = HTTP1Recipient(
+            _OverrunReader(),
+            {'headers': [(b'transfer-encoding', b'chunked')]},
+            chunk_size=64 * 1024,
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await recipient()
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+    @pytest.mark.asyncio
+    async def test_oversized_trailer_line_raises_400(self):
+        wire = b'5\r\nhello\r\n0\r\nx-pad: ' + b'a' * 65536 + b'\r\n\r\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+
+# ---------------------------------------------------------------------------
+# Sprint 63 remainder — trailer-section strictness (SMUG-CHUNK-LF-TRAILER,
+# prohibited trailer fields per RFC 9110 §6.5.1)
+# ---------------------------------------------------------------------------
+
+class TestChunkedTrailerSection:
+    @pytest.mark.asyncio
+    async def test_benign_trailer_still_accepted(self):
+        wire = (b'5\r\nhello\r\n0\r\n'
+                b'x-checksum: abc123\r\n\r\n')
+        assert await _drain_body(_chunked_recipient(wire)) == b'hello'
+
+    @pytest.mark.asyncio
+    async def test_bare_lf_trailer_terminator_raises_400(self):
+        # SMUG-CHUNK-LF-TRAILER — bare LF terminating the trailer section
+        # (after the last-chunk ``0\r\n``).  Pre-fix the parser waited for
+        # a CRLF that never came and the request timed out.
+        wire = b'5\r\nhello\r\n0\r\n\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+    @pytest.mark.asyncio
+    async def test_bare_lf_trailer_line_raises_400(self):
+        # A trailer *field line* terminated by bare LF is the same
+        # framing violation as a bare-LF chunk-size line.
+        wire = b'5\r\nhello\r\n0\r\nfoo: bar\n\r\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('field', [
+        b'Transfer-Encoding: chunked',   # SMUG-TRAILER-TE
+        b'Content-Length: 999',          # SMUG-TRAILER-CL
+        b'Host: evil.example',           # SMUG-TRAILER-HOST
+        b'Authorization: Bearer evil',   # SMUG-TRAILER-AUTH
+        b'Content-Type: text/evil',      # SMUG-TRAILER-CONTENT-TYPE
+    ])
+    async def test_prohibited_trailer_field_raises_400(self, field):
+        # RFC 9110 §6.5.1 — framing, routing, authentication, and
+        # content-handling fields are prohibited in trailers.
+        wire = b'5\r\nhello\r\n0\r\n' + field + b'\r\n\r\n'
+        recipient = _chunked_recipient(wire)
+        with pytest.raises(HTTPException) as exc_info:
+            await _drain_body(recipient)
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert recipient.framing_broken is True
+
+
+# ---------------------------------------------------------------------------
+# Sprint 63 remainder — request-line / header validation (bugs 1.25, WARN
+# hardening: strict Content-Length, underscore framing-header names)
+# ---------------------------------------------------------------------------
+
+class TestMissingHostAndVersion:
+    def test_http11_without_host_rejected(self):
+        # RFC9112-7.1-MISSING-HOST — RFC 9112 §3.2 mandates Host on 1.1.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET / HTTP/1.1\r\n\r\n')
+
+    def test_http10_without_host_still_accepted(self):
+        # COMP-HTTP10-NO-HOST — HTTP/1.0 predates Host; must stay 200.
+        actor = _make_actor()
+        scope = actor._parse(b'GET / HTTP/1.0\r\n\r\n')
+        assert scope['http_version'] == '1.0'
+
+    def test_unsupported_major_version_rejected_505(self):
+        # RFC9112-2.3-INVALID-VERSION — HTTP/9.9 → 505, not a happy 200.
+        from blackbull.server.http1_actor import UnsupportedVersionError
+        actor = _make_actor()
+        with pytest.raises(UnsupportedVersionError):
+            actor._parse(b'GET / HTTP/9.9\r\nHost: x\r\n\r\n')
+
+    def test_http09_rejected_505(self):
+        from blackbull.server.http1_actor import UnsupportedVersionError
+        actor = _make_actor()
+        with pytest.raises(UnsupportedVersionError):
+            actor._parse(b'GET / HTTP/0.9\r\nHost: x\r\n\r\n')
+
+    def test_http12_accepted_as_http1x(self):
+        # COMP-HTTP12-VERSION — a higher 1.x minor is 1.x-compatible and
+        # should be served, not rejected (RFC 9110 §2.5).
+        actor = _make_actor()
+        scope = actor._parse(b'GET / HTTP/1.2\r\nHost: x\r\n\r\n')
+        assert scope['http_version'] == '1.2'
+
+    def test_malformed_version_still_400(self):
+        # Grammar violations (not a valid HTTP-version token at all) stay
+        # on the 400 path, distinct from a well-formed unsupported version.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'GET / HTTP/1.1.1\r\nHost: x\r\n\r\n')
+
+
+class TestContentLengthStrict:
+    @pytest.mark.parametrize('cl', [b'5', b'0', b'123'])
+    def test_canonical_content_length_accepted(self, cl):
+        actor = _make_actor()
+        scope = actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                             b'Content-Length: ' + cl + b'\r\n\r\n')
+        assert scope['headers'].get(b'content-length') == cl
+
+    def test_no_space_after_colon_accepted(self):
+        actor = _make_actor()
+        scope = actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                             b'Content-Length:5\r\n\r\n')
+        assert scope['headers'].get(b'content-length') == b'5'
+
+    @pytest.mark.parametrize('raw_value', [
+        b' 005',    # SMUG-CL-LEADING-ZEROS
+        b' 00',     # SMUG-CL-DOUBLE-ZERO
+        b' 010',    # SMUG-CL-LEADING-ZEROS-OCTAL
+        b'5 ',      # SMUG-CL-TRAILING-SPACE (raw value b' 5 ' on the wire)
+        b'  5',     # SMUG-CL-EXTRA-LEADING-SP
+        b'\t5',     # MAL-CL-TAB-BEFORE-VALUE
+        b' 5 ',
+    ])
+    def test_ambiguous_content_length_rejected(self, raw_value):
+        # RFC 9110 §8.6 — anything but a canonical 1*DIGIT (single
+        # optional leading SP, no leading zeros) is a parser-disagreement
+        # smuggling vector and is rejected before OWS-stripping hides it.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                         b'Content-Length:' + raw_value + b'\r\n\r\n')
+
+
+class TestUnderscoreFramingHeaderNames:
+    @pytest.mark.parametrize('line', [
+        b'Content_Length: 99',      # NORM-UNDERSCORE-CL
+        b'Transfer_Encoding: chunked',  # NORM-UNDERSCORE-TE
+    ])
+    def test_underscore_framing_confusable_rejected(self, line):
+        # Underscore is a valid tchar, but a header whose name differs
+        # from a framing header only by ``_`` vs ``-`` exists solely to
+        # desync front-ends that normalise it (nginx drops these by
+        # default).  Reject.
+        from blackbull.server.http1_actor import BadRequestError
+        actor = _make_actor()
+        with pytest.raises(BadRequestError):
+            actor._parse(b'POST /echo HTTP/1.1\r\nHost: x\r\n'
+                         b'Content-Length: 11\r\n' + line + b'\r\n\r\n')
+
+    def test_other_underscore_headers_still_accepted(self):
+        # Only the framing confusables are rejected — underscore is legal
+        # in tokens and arbitrary x_custom headers must keep working.
+        actor = _make_actor()
+        scope = actor._parse(b'GET / HTTP/1.1\r\nHost: x\r\n'
+                             b'x_request_id: abc\r\n\r\n')
+        assert scope['headers'].get(b'x_request_id') == b'abc'


### PR DESCRIPTION
## Summary

Closes out everything Sprint 63 (v0.49.2) cut from scope, reaching the
Http11Probe baseline proposal's projected plateau at its ceiling:
**161/161 (0 failed, 5 warnings)**, up from 156/161 (5 failed, 13 warnings).

- HTTP/2: refused multi-frame HEADERS no longer escalates the peer's legal
  CONTINUATION into a bogus connection error (audit bug 1.14 #2) — the
  refusal is deferred to `END_HEADERS`.
- HTTP/1.1: chunk-framing line length bound fixes `MAL-CHUNK-EXT-64K`
  (CVE-2023-39326 class, audit bug 1.24) — was an unhandled 500.
- HTTP/1.1: bare-LF chunked-trailer terminator and prohibited trailer
  fields (RFC 9110 §6.5.1) now rejected with 400.
- HTTP/1.1: missing Host on HTTP/1.1 → 400, unsupported HTTP version → 505
  (audit bug 1.25).
- HTTP/1.1: no `100 Continue` to HTTP/1.0 clients; strict Content-Length;
  underscore framing-header confusables rejected.
- Docs: CI badge on `bench/conformance/README.md`, AI-agent stale-data
  note, README live-demo link.

Bundles a fix commit (the actual changes) + a release commit
(`pyproject.toml` version bump + `CHANGELOG.md` heading rename), per this
project's established release pattern.

## Test plan

- [x] Full suite green: `pytest --timeout=30 --beartype-packages=blackbull -q` → 2811 passed, 265 skipped, 2 xfailed
- [x] New wire-level tests replay every fixed Http11Probe vector against a live server (`tests/conformance/http1/test_http11probe_remaining.py`)
- [x] New H2 dispatch regression test for the deferred-refusal fix
- [x] Authoritative .NET Http11Probe re-run: 161/161 (0 failed, 5 warnings)
- [x] `mkdocs build --strict` — only the 6 pre-existing warnings (verified unrelated to this change)
- [x] Editable-install smoke test: `blackbull.__version__` → `0.49.3`
- [ ] CI green (CodeQL, pip-audit, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)