### PR TITLE
release: v0.51.0 — Sprint 66: blackbull-protobuf + gRPC protobuf-layer core hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.51.0] — 2026-07-12
+
 Sprint 66 — the protobuf side of the gRPC story, shipped as the new
 optional [`blackbull-protobuf`](https://github.com/TOKUJI/blackbull-protobuf)
 package (`pip install 'blackbull[protobuf]'`) plus the core hooks it plugs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.50.0"
+version = "0.51.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Two-file release commit closing Sprint 66 (feature work merged in #127).

- **Added**: `blackbull[protobuf]` extra → the new `blackbull-protobuf` package (object-typed servicers, reflection v1alpha, health Check+Watch, rich error details); `GrpcContext.trailing_metadata()`; protobuf-layer real-grpcio interop suite in the grpc-interop CI job.
- **Fixed**: gRPC error paths deliver `set_trailing_metadata`; interactive server-streaming no longer withholds messages from parked producers (loop-idle flusher, burst batching preserved).
- **Docs**: gRPC guide protobuf section; SECURITY scope + versions table; KNOWN_LIMITATIONS updated.

## Test plan

- [x] Full suite `--beartype-packages=blackbull` green locally (pre-commit)
- [x] `python -c "import blackbull; print(blackbull.__version__)"` → 0.51.0 after editable reinstall
- [x] PR CI (CodeQL / audit / conformance) gates the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)