### PR TITLE
ci: make the protobuf-layer gRPC interop gate strict

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -274,16 +274,12 @@ jobs:
         # install them explicitly here.
         run: pip install -e '.[testing,grpc-interop]'
 
-      # ── Sprint 66 / flip after blackbull-protobuf 0.1.0 is on PyPI ──
-      # The protobuf-layer interop suite (test_grpc_protobuf_interop.py)
-      # needs the separate blackbull-protobuf package on the *server* side.
-      # Until its first publish the suite self-skips; uncomment both lines
-      # below once it is published to make the gate strict (--no-deps avoids
-      # pip fighting the editable checkout over the blackbull version floor;
-      # every real dependency already arrives via grpc-interop above).
-      #
-      # - name: Install blackbull-protobuf (protobuf interop layer)
-      #   run: pip install --no-deps blackbull-protobuf
+      - name: Install blackbull-protobuf (protobuf interop layer)
+        # Server side of the protobuf-layer interop suite
+        # (test_grpc_protobuf_interop.py).  --no-deps keeps pip from
+        # fighting the editable checkout over the blackbull version floor;
+        # every real dependency already arrives via grpc-interop above.
+        run: pip install --no-deps blackbull-protobuf
 
       - name: Run real-client gRPC interop conformance
         # Docker-free interop gate: a real grpcio client drives BlackBull's
@@ -302,10 +298,12 @@ jobs:
         #     window copies come back.
         # Runs on every push/PR, not just the weekly full tier.
         # The protobuf-layer suite (reflection / health / rich errors against
-        # the official grpcio client packages) runs alongside; it self-skips
-        # until blackbull-protobuf is installed (see the step above).  Set
-        # BB_GRPC_INTEROP_REQUIRE_PROTOBUF=1 here at the same time as that
-        # flip so a missing package then fails loudly instead of skipping.
+        # the official grpcio client packages) runs alongside.
+        # BB_GRPC_INTEROP_REQUIRE_PROTOBUF=1 turns a missing
+        # blackbull-protobuf / client package into a loud failure instead of
+        # a silent skip — the gate must not pass on nothing.
+        env:
+          BB_GRPC_INTEROP_REQUIRE_PROTOBUF: '1'
         run: |
           timeout 120 python -m pytest --timeout=60 -v \
               tests/conformance/grpc/test_grpc_real_client_h2c.py \


### PR DESCRIPTION
## Summary

blackbull-protobuf 0.1.0 is published (PyPI + GitHub Release), so the deferred flip from #127 lands: the grpc-interop job now installs it (`--no-deps`; real deps come via the `grpc-interop` extra) and sets `BB_GRPC_INTEROP_REQUIRE_PROTOBUF=1`, turning any missing dependency into a loud failure instead of a silent skip.

## Test plan

- [x] The grpc-interop check on this PR runs the protobuf suite for real (7 tests, no skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)