### PR TITLE
docs: bump SECURITY.md supported-versions table for v0.52.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.52.x  | :white_check_mark: |
 | 0.51.x  | :white_check_mark: |
-| 0.50.x  | :white_check_mark: |
-| < 0.50  | :x:                |
+| < 0.51  | :x:                |
 
 This table updates with each minor release.
 


### PR DESCRIPTION
Sprint 67 close (bidi stream-state fix + write_many perf fix). 0.52.x/0.51.x supported, < 0.51 unsupported.