### PR TITLE
release: v0.52.0 — Sprint 67: gRPC bidi correctness + writelines regression fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.52.0] — 2026-07-12
+
+Sprint 67 — gRPC bidi correctness closeout plus an inter-sprint perf fix
+that resolves the long-standing v0.33.1 → v0.51.0 HttpArena regression.
+
 ### Fixed
 
 - **Send-path size gate — `writelines` regression** (inter-sprint, releases with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.51.0"
+version = "0.52.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 67 close — gRPC bidi stream-state correctness fix plus an inter-sprint perf fix that resolves the long-standing v0.33.1 → v0.51.0 HttpArena regression.

### Fixed
- **HTTP/2 bidi stream state (RFC 9113 §5.1)**: client `END_STREAM` now half-closes the stream (`HALF_CLOSED_REMOTE`), not `CLOSED`. Fixes the `test_echo_each_message` RST(5) CI flake and a real correctness gap — any gRPC bidi client crediting response DATA after ending its request body was getting `RST_STREAM(STREAM_CLOSED)`. (PR #131)
- **Send-path size gate**: `BaseSender._write_many` joins parts ≤ 32 KiB into one `write()` instead of always using vectored `writelines`, which was a selector-loop pessimization for small payloads. Root cause of the Sprint 59 `writelines` regression. (PR #130)

### Changed
- Connection-accept path trims: cached protocol-detection order, one connection id per connection (counter-based instead of per-mint `uuid4`).

### Docs
- `SECURITY.md` supported-versions table bumped to 0.52.x/0.51.x. (PR #132)

## Test plan

- [x] `tests/unit` + `tests/architecture`: 1692 passed (write_many gate branch)
- [x] Full suite `--run-all --beartype-packages=blackbull`: 3076 passed (bidi fix branch)
- [x] `test_echo_each_message` (real grpcio client, h2c socket): 10/10 consecutive passes post-fix
- [x] Same-instance EC2 HttpArena A/B vs v0.33.1: 30/30 profiles flat-or-positive (`bench/results/httparena/v0.33.1-vs-v0.51.0-fix2-COMPARISON.md`)
- [x] PR #130, #131, #132 each went green on CI (CodeQL, Autobahn, h2spec, H2 flow-control deadlock gate, gRPC real-client interop) and are merged to master
- [ ] CodeQL / CI green on this release PR
- [ ] `blackbull.__version__` reports `0.52.0` after `pip install -e .` (confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)