### PR TITLE
refactor(router): swappable lookup-cache (cache_max arg + _cache_get/_cache_set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **`Router(cache_max=…)`** — the route lookup-cache bound is now a
+  constructor argument (default 2048; `0` disables caching). Internally the
+  cache get/set mechanics moved into a swappable `_cache_get` / `_cache_set`
+  method pair so a future cache strategy can be dropped in without touching
+  `__getitem__` or `_resolve`. No behaviour change at the default.
+
 ## [0.52.0] — 2026-07-12
 
 Sprint 67 — gRPC bidi correctness closeout plus an inter-sprint perf fix

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -708,17 +708,23 @@ class Router:
     f_string = re.compile(r'\{([a-zA-Z_]\w*?)\}', flags=re.ASCII)
     _param_pattern = re.compile(r'\{([a-zA-Z_]\w*?)(?::([a-zA-Z_]\w*?))?\}', flags=re.ASCII)
 
-    # Per-worker lookup cache: maps (path, method, scheme) → resolved handler.
-    # Bounded at 2048 entries; cleared whenever a route is registered.
-    _LOOKUP_CACHE_MAX: int = 2048
+    # Default bound for the per-worker lookup cache (overridable per instance
+    # via the ``cache_max`` constructor argument).
+    _DEFAULT_CACHE_MAX: int = 2048
 
-    def __init__(self):
+    def __init__(self, cache_max: int = _DEFAULT_CACHE_MAX):
         self._route_info: list[_RouteInfo] = []
         self._named_routes: dict[str, tuple[str, dict[str, str]]] = {}
         self._frozen: bool = False
         self._trie = _RouteTrie()
         self._string_paths: set[str] = set()  # registered string paths (for __contains__/__repr__)
         self._raw_regex: dict = {}  # raw re.Pattern routes (not compiled from string paths)
+        # Per-worker lookup cache: maps (path, method, scheme) → resolved
+        # handler; cleared whenever a route is registered.  ``cache_max`` bounds
+        # it (0 disables caching entirely).  The get/set mechanics live in
+        # ``_cache_get`` / ``_cache_set`` so a future cache strategy can be
+        # swapped in without touching ``__getitem__`` or ``_resolve``.
+        self.cache_max: int = cache_max
         self._lookup_cache: OrderedDict = OrderedDict()
         # type → callable registry for simplified-handler return coercion.
         # Empty by default (falsy) so the common return paths never consult it.
@@ -824,21 +830,40 @@ class Router:
         Uses the routing trie for O(path-depth) lookup of string-path routes,
         then falls back to a linear scan of raw re.Pattern routes.
 
-        Results are cached in ``_lookup_cache`` (up to ``_LOOKUP_CACHE_MAX``
-        entries) so repeated requests to the same (path, method, scheme) skip
-        the trie traversal entirely after the first hit.
+        Results are cached (up to ``cache_max`` entries) so repeated requests
+        to the same (path, method, scheme) skip the trie traversal entirely
+        after the first hit.  The query→miss→resolve→store flow lives here;
+        the cache mechanics are delegated to ``_cache_get`` / ``_cache_set``
+        so the cache strategy can be swapped without touching this method.
         """
-        if key in self._lookup_cache:
-            if len(self._lookup_cache) >= self._LOOKUP_CACHE_MAX:
-                self._lookup_cache.move_to_end(key)  # maintain LRU order only when eviction is imminent
-            return self._lookup_cache[key]
+        hit, result = self._cache_get(key)
+        if hit:
+            return result
 
         result = self._resolve(key)
-
-        if len(self._lookup_cache) >= self._LOOKUP_CACHE_MAX:
-            self._lookup_cache.popitem(last=False)  # evict least-recently-used
-        self._lookup_cache[key] = result
+        self._cache_set(key, result)
         return result
+
+    def _cache_get(self, key: Tuple[str, str | HTTPMethod, Scheme]):
+        """Return ``(hit: bool, result)`` for *key*.  On a hit, refreshes LRU
+        order only when the cache is full (so ordering work is skipped until
+        eviction is actually imminent)."""
+        cache = self._lookup_cache
+        if key in cache:
+            if len(cache) >= self.cache_max:
+                cache.move_to_end(key)
+            return True, cache[key]
+        return False, None
+
+    def _cache_set(self, key: Tuple[str, str | HTTPMethod, Scheme], result) -> None:
+        """Store *result* under *key*, evicting the least-recently-used entry
+        when the cache is full.  A ``cache_max`` of 0 disables caching."""
+        if self.cache_max <= 0:
+            return
+        cache = self._lookup_cache
+        if len(cache) >= self.cache_max:
+            cache.popitem(last=False)  # evict least-recently-used
+        cache[key] = result
 
     def _resolve(
         self,

--- a/tests/unit/test_router_trie.py
+++ b/tests/unit/test_router_trie.py
@@ -209,7 +209,7 @@ def test_lookup_cache_cleared_on_route_registration():
 
 
 def test_lookup_cache_lru_evicts_least_recently_used():
-    """Cache stays at _LOOKUP_CACHE_MAX; least-recently-used entry is evicted, not the hottest."""
+    """Cache stays at cache_max; least-recently-used entry is evicted, not the hottest."""
     router = Router()
 
     @router.route(path='/items/{item_id}', methods=[HTTPMethod.GET])
@@ -217,7 +217,7 @@ def test_lookup_cache_lru_evicts_least_recently_used():
         pass
 
     # Shrink the cap to a testable size
-    router._LOOKUP_CACHE_MAX = 3
+    router.cache_max = 3
 
     k1 = ('/items/1', HTTPMethod.GET, Scheme.http)
     k2 = ('/items/2', HTTPMethod.GET, Scheme.http)
@@ -238,6 +238,43 @@ def test_lookup_cache_lru_evicts_least_recently_used():
     assert k2 not in router._lookup_cache, 'LRU entry (k2) must be evicted'
     assert k1 in router._lookup_cache, 'recently-accessed k1 must be retained'
     assert k4 in router._lookup_cache
+
+
+def test_cache_max_zero_disables_caching():
+    """cache_max=0 → the resolve result is never stored; every lookup misses
+    the cache but still resolves correctly."""
+    router = Router(cache_max=0)
+
+    @router.route(path='/ping', methods=[HTTPMethod.GET])
+    async def ping(scope, receive, send):
+        pass
+
+    key = ('/ping', HTTPMethod.GET, Scheme.http)
+    assert router[key] is not None            # resolves
+    assert router[key] is not None            # resolves again
+    assert len(router._lookup_cache) == 0     # nothing cached
+
+
+def test_cache_get_set_pair_round_trips():
+    """The extracted _cache_get / _cache_set pair is the cache's contract."""
+    router = Router()
+
+    @router.route(path='/ping', methods=[HTTPMethod.GET])
+    async def ping(scope, receive, send):
+        pass
+
+    key = ('/ping', HTTPMethod.GET, Scheme.http)
+    hit, _ = router._cache_get(key)
+    assert hit is False                       # cold
+
+    sentinel = object()
+    router._cache_set(key, sentinel)
+    hit, result = router._cache_get(key)
+    assert hit is True and result is sentinel
+
+
+def test_default_cache_max_is_2048():
+    assert Router().cache_max == 2048
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enabling refactor for future router optimisation work (Sprint 68). Extracts the inline lookup-cache mechanics from `Router.__getitem__` into a swappable `_cache_get` / `_cache_set` method pair, and makes the cache bound an instance attribute — `Router(cache_max=…)`, default 2048, `0` disables caching — instead of the `_LOOKUP_CACHE_MAX` class constant.

`__getitem__` keeps the query→miss→resolve→store flow but delegates the cache mechanics, so a future cache strategy or `_resolve` speed-up (the trie work in `router-cache-optimization.md`) can land without touching it.

**No behaviour change at the default**: same LRU eviction, same refresh-order-only-when-full optimisation.

## Context

This follows the Sprint 68 **W2** measurement outcome — sampled cache insertion was measured and closed as not-worth-it (unique-path churn saving +4–7%, below the +10% gate, because `_resolve` dominates). This PR is the structural groundwork that outcome pointed at, not a perf change itself.

## Tests

- `cache_max=0` disables caching (nothing stored, lookups still resolve)
- `_cache_get` / `_cache_set` round-trip
- default `cache_max` is 2048
- existing LRU-eviction test updated from `_LOOKUP_CACHE_MAX` to `cache_max`
- full suite green under beartype (2839 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)