### PR TITLE
release: v0.53.0 — Sprint 68: ASGI path-decoding conformance + router cache refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.53.0] — 2026-07-13
+
+Sprint 68 — ASGI path-decoding conformance (percent-decoding + RFC 3986
+`;` sub-delimiter preservation), a router lookup-cache refactor, and gRPC
+server-reflection `v1` (shipped in the sibling `blackbull-protobuf 0.2.0`).
+
 ### Added
 
 - **`Router(cache_max=…)`** — the route lookup-cache bound is now a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.53.x  | :white_check_mark: |
 | 0.52.x  | :white_check_mark: |
-| 0.51.x  | :white_check_mark: |
-| < 0.51  | :x:                |
+| < 0.52  | :x:                |
 
 This table updates with each minor release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.52.0"
+version = "0.53.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conformance/grpc/test_grpc_protobuf_interop.py
+++ b/tests/conformance/grpc/test_grpc_protobuf_interop.py
@@ -146,8 +146,44 @@ async def test_reflection_lists_and_invokes_without_proto(grpc_server):
     services, message = await asyncio.to_thread(_reflection_flow, port)
     assert 'bbinterop.Greeter' in services
     assert 'grpc.health.v1.Health' in services
+    # Both reflection package versions are served (Sprint 68): v1alpha for
+    # older clients, v1 for the newer ones that probe it first.
     assert 'grpc.reflection.v1alpha.ServerReflection' in services
+    assert 'grpc.reflection.v1.ServerReflection' in services
     assert message == 'Hello, reflection!'
+
+
+def _reflection_v1_list_services(port: int):
+    """Drive the ``grpc.reflection.v1`` endpoint over a real socket.
+
+    grpcio only ships a ``v1alpha`` reflection client, but v1 and v1alpha
+    are wire-identical (same field numbers; only the descriptor's package
+    name differs), so we reuse the grpcio ``v1alpha`` message types as the
+    serializer/deserializer while calling the ``v1`` method path.  This
+    proves the v1 service is actually wired and answers on the wire, not
+    merely that it appears in the v1alpha service listing."""
+    from grpc_reflection.v1alpha import reflection_pb2
+
+    with grpc.insecure_channel(f'127.0.0.1:{port}') as channel:
+        grpc.channel_ready_future(channel).result(timeout=_CALL_TIMEOUT)
+        call = channel.stream_stream(
+            '/grpc.reflection.v1.ServerReflection/ServerReflectionInfo',
+            request_serializer=lambda m: m.SerializeToString(),
+            response_deserializer=reflection_pb2.ServerReflectionResponse.FromString,
+        )
+        req = reflection_pb2.ServerReflectionRequest(list_services='')
+        responses = list(call(iter([req]), timeout=_CALL_TIMEOUT))
+        names = [s.name for r in responses
+                 for s in r.list_services_response.service]
+        return names
+
+
+@pytest.mark.asyncio
+async def test_reflection_v1_endpoint_answers_on_the_wire(grpc_server):
+    port, _ = grpc_server
+    names = await asyncio.to_thread(_reflection_v1_list_services, port)
+    assert 'bbinterop.Greeter' in names
+    assert 'grpc.reflection.v1.ServerReflection' in names
 
 
 def _describe_service(port: int, symbol: str):


### PR DESCRIPTION
## Sprint 68 release — BlackBull v0.53.0

Closes Sprint 68. Companion release: **`blackbull-protobuf 0.2.0`** (reflection `v1`), already published to PyPI.

### What's in this release

- **ASGI path percent-decoding** (#134) — `scope['path']` is now percent-decoded (UTF-8) on all transports; `raw_path` is the undecoded path component only. `%`-guarded fast path; uvicorn decode semantics.
- **RFC 3986 `;` sub-delimiter preserved** (#134) — `;params` is no longer stripped from `path`/`raw_path` on either transport (H2 also fixed a latent `raw_path` strip). uvicorn/RFC 3986 parity.
- **`_split_h2_path` dead-code removal + WS test-client decode fix** (#134).
- **`Router(cache_max=…)` + swappable `_cache_get`/`_cache_set`** (#135) — enabling refactor, no behaviour change at the default.
- **gRPC reflection `v1` interop assertion** — real grpcio client drives the `v1` endpoint; lands now that `blackbull-protobuf 0.2.0` is on PyPI.

### Release commit

- `pyproject.toml`: 0.52.0 → 0.53.0
- `CHANGELOG.md`: `[Unreleased]` → `[0.53.0] — 2026-07-13`
- `SECURITY.md`: supported-versions table → 0.53.x + 0.52.x

Http11Probe held **161/161** across the path-decoding changes; full suite green under beartype; reflection interop (v1 + v1alpha) green against PyPI `blackbull-protobuf 0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)