### PR TITLE
fix(middleware): close the 1.21 correctness cluster (Sprint 69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,42 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **`StaticFiles` conditional requests.** `StaticFiles` now emits a strong
+  `ETag` (from the file's mtime + size) and a `Last-Modified` header on every
+  response, and honours `If-None-Match` / `If-Modified-Since` with a
+  `304 Not Modified` — answered before the body is read, so revalidating a
+  large asset costs no disk I/O. `If-None-Match` takes precedence over
+  `If-Modified-Since` (RFC 9110 §13). A new `conditional=` argument on
+  `app.static(...)` / `StaticFiles(...)` (default `True`) disables it; the
+  `blackbull serve --no-etag` flag now drives that argument directly and no
+  longer needs the `Cache` middleware to provide validators (bug 1.21d).
+
+### Fixed
+
+- **`Compression` now emits `Vary: Accept-Encoding` on compressed responses**
+  (RFC 9110 §12.5.5, bug 1.21a). Without it a shared cache could replay a
+  brotli/gzip body to a client that sent `identity` / no `Accept-Encoding`.
+  Folds into any existing `Vary`; a pre-existing `Vary: *` is left untouched.
+- **`Cache` is now variant-aware** (bug 1.21b). The response `Vary` fields are
+  folded into the cache key so a negotiated variant (e.g. an encoding behind
+  `Compression`) is no longer served to a client that asked for a different
+  one; a `Vary: *` response is passed through unstored.
+- **`StaticFiles` no longer returns `500` on a malformed `Range` header**
+  (bug 1.21c). A bad byte spec (`bytes=abc-def`), a non-`bytes` unit, or a
+  multi-range set is ignored and the full file served `200` (RFC 9110 §14.2);
+  a well-formed but unsatisfiable range still returns `416`.
+- **`TrustedProxy` parses multi-element RFC 7239 `Forwarded` headers
+  correctly** (bug 1.21e). Elements are split on `,` first (leftmost element
+  honoured); previously a chained `for=a, for=b` folded the second element's
+  `for=` into `scope['client']`.
+
+### Docs
+
+- Static-files and middleware guides document the new conditional-request
+  support, the malformed-`Range` handling, and the now variant-aware `Cache`.
+
 ## [0.53.0] — 2026-07-13
 
 Sprint 68 — ASGI path-decoding conformance (percent-decoding + RFC 3986

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -822,7 +822,8 @@ class BlackBull:
         self._chain = None  # invalidate cached chain
 
     def static(self, url_prefix: str, root_dir: str | Path, *,
-               cache: bool = False, index: str | None = None) -> None:
+               cache: bool = False, index: str | None = None,
+               conditional: bool = True) -> None:
         """Serve static files from *root_dir* under *url_prefix* via global middleware.
 
         ``cache`` (default ``False``): when ``True``, file bodies are
@@ -836,12 +837,17 @@ class BlackBull:
 
         ``index`` (default ``None`` — off): a filename (e.g.
         ``'index.html'``) served when a request resolves to a directory.
+
+        ``conditional`` (default ``True``): emit ``ETag`` / ``Last-Modified``
+        validators and answer ``If-None-Match`` / ``If-Modified-Since`` with
+        a 304.  Set ``False`` to disable conditional responses.
         """
         from blackbull.middleware.static import StaticFiles
         root = Path(root_dir).resolve()
         self._static_roots.append((url_prefix, root))
         self._global_middlewares.append(
-            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache, index=index))
+            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache,
+                        index=index, conditional=conditional))
         self._chain = None  # invalidate cached chain
 
     def on_error(self, key):

--- a/blackbull/cli.py
+++ b/blackbull/cli.py
@@ -367,13 +367,11 @@ def _build_static_app(directory: str, *, etag: bool, cache: bool,
     from . import BlackBull  # noqa: PLC0415
 
     app = BlackBull()
-    if etag:
-        # Cache is the outermost middleware (registered first) so a matching
-        # If-None-Match short-circuits to 304 before StaticFiles touches the
-        # disk; it also injects the generated ETag on the storing pass.
-        from .middleware.cache import Cache  # noqa: PLC0415
-        app.use(Cache())
-    app.static('/', directory, cache=cache, index=index or None)
+    # StaticFiles emits ETag / Last-Modified and honours If-None-Match /
+    # If-Modified-Since natively (Sprint 69, bug 1.21d); ``--no-etag``
+    # (``etag=False``) turns that off.
+    app.static('/', directory, cache=cache, index=index or None,
+               conditional=etag)
     return app
 
 

--- a/blackbull/middleware/cache.py
+++ b/blackbull/middleware/cache.py
@@ -19,17 +19,21 @@ running the handler.  Supports:
   responses are NOT stored (RFC 9111 §3.5).  Override with
   ``cache_authenticated=True``.
 
+Variant-aware: the response ``Vary`` header is honoured (RFC 9110
+§12.5.5).  When a stored response carries e.g. ``Vary: Accept-Encoding``,
+the varied request-header values are folded into the cache key so a
+brotli variant is never replayed to an ``identity`` client.  A response
+with ``Vary: *`` is passed through and not stored.
+
 What it doesn't do (yet):
 
-* No ``Vary`` header support beyond identity matching.  A request that
-  differs only by ``Accept-Encoding`` or ``Accept-Language`` will get
-  the first variant cached.
 * No server-side invalidation API.  Restart the worker (or wait for
   TTL) to clear.
 * No cross-worker sharing.  The cache is per-process — each worker has
   its own.  Documented limitation.
 
-The cache key is ``(method, path, query_string)``.
+The base cache key is ``(method, path, query_string)``, extended with
+the ``(field, request-value)`` pairs named by the response ``Vary``.
 
 Usage::
 
@@ -108,6 +112,11 @@ class Cache:
         # OrderedDict gives us O(1) move-to-end on access + popitem(last=False)
         # for LRU eviction — same pattern as :func:`functools.lru_cache`.
         self._store: OrderedDict[tuple, _Entry] = OrderedDict()
+        # Per base-key record of the response ``Vary`` field names last seen,
+        # so a lookup (which happens before the handler runs, hence before we
+        # know the response's Vary) can reconstruct the variant key from the
+        # incoming request headers.  Bounded alongside the store.
+        self._vary_registry: OrderedDict[tuple, tuple[bytes, ...]] = OrderedDict()
 
     # ---- ASGI surface ----------------------------------------------------
 
@@ -131,7 +140,11 @@ class Cache:
             await call_next(scope, receive, send)
             return
 
-        key = (method, scope.get('path', ''), scope.get('query_string', b''))
+        base_key = (method, scope.get('path', ''), scope.get('query_string', b''))
+        # Reconstruct the variant key from whatever Vary fields we last
+        # recorded for this base key (empty tuple ⇒ key == base_key).
+        vary_fields = self._vary_registry.get(base_key, ())
+        key = base_key + _vary_key(vary_fields, req_headers)
 
         # --- cache hit? ---
         entry = self._store.get(key)
@@ -190,6 +203,7 @@ class Cache:
                 # Final body chunk arrived; decide cacheability + ETag now.
                 captured.append(event)
                 if self._should_cache(status, response_headers):
+                    vary_fields = _response_vary(response_headers)
                     body = b''.join(body_chunks)
                     etag = _read_etag(response_headers) or (
                         self._make_etag(body) if self._generate_etag else None)
@@ -201,9 +215,18 @@ class Cache:
                         new_hdrs = list(start.get('headers', []))
                         new_hdrs.append((b'etag', etag))
                         start['headers'] = new_hdrs
-                    if etag is not None:
+                    # ``vary_fields is None`` ⇒ ``Vary: *`` ⇒ uncacheable.
+                    if etag is not None and vary_fields is not None:
+                        # Record the Vary fields so future lookups build the
+                        # matching variant key, then store under it.
+                        if vary_fields:
+                            self._vary_registry[base_key] = vary_fields
+                            self._vary_registry.move_to_end(base_key)
+                            while len(self._vary_registry) > self._max_entries:
+                                self._vary_registry.popitem(last=False)
+                        store_key = base_key + _vary_key(vary_fields, req_headers)
                         ttl = _response_max_age(response_headers) or self._max_age
-                        self._store[key] = _Entry(
+                        self._store[store_key] = _Entry(
                             events=[dict(e) for e in captured],
                             etag=etag,
                             expires_at=time.monotonic() + ttl,
@@ -314,6 +337,33 @@ def _response_max_age(headers: list[tuple[bytes, bytes]]) -> int | None:
                 except ValueError:
                     pass  # malformed max-age → ignore this directive.
     return s_max if s_max is not None else max_age
+
+
+def _response_vary(headers: list[tuple[bytes, bytes]]) -> tuple[bytes, ...] | None:
+    """Return the response's ``Vary`` field names, lowercased and sorted.
+
+    ``None`` signals ``Vary: *`` (RFC 9110 §12.5.5 — response is
+    unstorable by a shared cache).  An absent ``Vary`` yields the empty
+    tuple (store under the bare base key).
+    """
+    fields: set[bytes] = set()
+    for name, value in headers:
+        if name.lower() != b'vary':
+            continue
+        for piece in value.split(b','):
+            t = piece.strip().lower()
+            if t == b'*':
+                return None
+            if t:
+                fields.add(t)
+    return tuple(sorted(fields))
+
+
+def _vary_key(vary_fields: tuple[bytes, ...],
+              req_headers: dict[bytes, bytes]) -> tuple:
+    """Build the variant portion of the cache key from the request headers
+    named by *vary_fields*.  A missing request header contributes ``b''``."""
+    return tuple((f, req_headers.get(f, b'')) for f in vary_fields)
 
 
 def _read_etag(headers: list[tuple[bytes, bytes]]) -> bytes | None:

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -88,6 +88,28 @@ def _is_compressible_content_type(headers: Headers) -> bool:
     return not any(ct_str.startswith(prefix) for prefix in _SKIP_CONTENT_TYPES)
 
 
+def _merge_vary(headers: list[tuple[bytes, bytes]],
+                field: bytes = b'Accept-Encoding') -> None:
+    """Ensure the response ``Vary`` header lists *field* (RFC 9110 §12.5.5).
+
+    A compressed response's body depends on the request ``Accept-Encoding``;
+    without ``Vary: Accept-Encoding`` a shared cache may replay the encoded
+    body to a client that sent ``identity``/no ``Accept-Encoding`` (bug 1.21a).
+    Folds *field* into an existing ``Vary`` (no duplicate token; a pre-existing
+    ``Vary: *`` already covers everything and is left untouched); otherwise
+    appends ``Vary: Accept-Encoding``.  Mutates *headers* in place.
+    """
+    field_l = field.lower()
+    for i, (k, v) in enumerate(headers):
+        if k.lower() == b'vary':
+            tokens = [t.strip().lower() for t in v.split(b',')]
+            if b'*' in tokens or field_l in tokens:
+                return
+            headers[i] = (k, v + b', ' + field)
+            return
+    headers.append((b'vary', field))
+
+
 # ---------------------------------------------------------------------------
 # Middleware
 # ---------------------------------------------------------------------------
@@ -307,6 +329,8 @@ class Compression:
                     if k.lower() != b'content-length']
         existing.append((b'content-encoding', codec_name.encode()))
         existing.append((b'content-length', str(len(compressed)).encode()))
+        # Shared caches must key this response on Accept-Encoding.
+        _merge_vary(existing)
         await send({**start_event, 'headers': existing})
         await send({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': compressed, 'more_body': False})
 

--- a/blackbull/middleware/proxy.py
+++ b/blackbull/middleware/proxy.py
@@ -4,12 +4,22 @@ from ..headers import Headers
 
 
 def _parse_forwarded(value: str) -> dict[str, str]:
-    """Parse the first directive of an RFC 7239 Forwarded header value.
+    """Parse the leftmost element of an RFC 7239 Forwarded header value.
 
-    e.g. 'for=203.0.113.1;proto=https;by=10.0.0.1' → {'for': '203.0.113.1', ...}
+    RFC 7239 §4 separates forwarded *elements* with ``,`` and the
+    parameters within one element with ``;``.  A chained-proxy header
+    such as ``for=203.0.113.1;proto=https, for=198.51.100.17`` therefore
+    carries two elements; we honour the leftmost (the hop closest to the
+    client) and return its parameters, e.g.
+    ``{'for': '203.0.113.1', 'proto': 'https'}``.
+
+    Splitting on ``;`` alone (the pre-Sprint-69 behaviour) folded the
+    second element's ``for=`` into the first value, poisoning
+    ``scope['client']``.
     """
+    first_element = value.split(',', 1)[0]
     result = {}
-    for part in value.split(';'):
+    for part in first_element.split(';'):
         part = part.strip()
         if '=' in part:
             k, v = part.split('=', 1)

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -3,6 +3,7 @@ import mimetypes
 import os
 import time
 from collections import OrderedDict
+from email.utils import formatdate, parsedate_to_datetime
 from pathlib import Path
 from urllib.parse import unquote
 from http import HTTPStatus
@@ -37,6 +38,85 @@ for _ext, _mime in (
 del _ext, _mime
 
 
+def _parse_byte_range(range_hdr: str, size: int) -> tuple[int, int] | None:
+    """Parse a single ``bytes=`` Range header into an inclusive ``(start, end)``.
+
+    Returns ``None`` for anything we do not answer with a partial response —
+    a non-``bytes`` unit, a multi-range set (we don't emit
+    ``multipart/byteranges``), or a syntactically malformed range.  Per
+    RFC 9110 §14.2 an unparseable/ignored Range is served as a normal 200,
+    so the caller treats ``None`` as "serve the whole file".  Never raises:
+    the pre-Sprint-69 code ran bare ``int()`` here and 500'd on
+    ``Range: bytes=abc-def`` (bug 1.21c).  *Satisfiability* against ``size``
+    is still checked by the caller (so an out-of-range spec stays a 416).
+    """
+    if not range_hdr.startswith('bytes='):
+        return None
+    spec = range_hdr[6:].strip()
+    if not spec or ',' in spec:
+        return None
+    start_s, sep, end_s = spec.partition('-')
+    if not sep:
+        return None
+    start_s, end_s = start_s.strip(), end_s.strip()
+    try:
+        if start_s == '':
+            # Suffix range: bytes=-N → the last N bytes.
+            if end_s == '':
+                return None
+            n = int(end_s)
+            return (max(0, size - n), size - 1)
+        start = int(start_s)
+        end = int(end_s) if end_s else size - 1
+    except ValueError:
+        return None
+    return (start, end)
+
+
+def _not_modified(headers, etag: bytes, mtime_ns: int) -> bool:
+    """Evaluate the conditional-GET preconditions (RFC 9110 §13).
+
+    ``If-None-Match`` takes precedence over ``If-Modified-Since``; when the
+    former is present the latter is ignored.  Returns ``True`` when the
+    client's cached copy is still fresh and the caller should answer 304.
+    """
+    inm = None
+    ims = None
+    for k, v in headers:
+        kl = k.lower()
+        if kl == b'if-none-match':
+            inm = v
+        elif kl == b'if-modified-since':
+            ims = v
+    if inm is not None:
+        candidate = inm.strip()
+        if candidate == b'*':
+            return True
+        target = etag[2:] if etag.startswith(b'W/') else etag
+        for tag in candidate.split(b','):
+            t = tag.strip()
+            if t.startswith(b'W/'):
+                t = t[2:]
+            if t == target:
+                return True
+        # If-None-Match present but no match → not fresh; ignore IMS.
+        return False
+    if ims is not None:
+        try:
+            ims_dt = parsedate_to_datetime(ims.decode('latin-1'))
+        except (ValueError, TypeError):
+            return False
+        if ims_dt is None:
+            return False
+        try:
+            ims_ts = ims_dt.timestamp()
+        except (ValueError, OverflowError, OSError):
+            return False
+        # HTTP dates carry 1-second granularity; compare at whole seconds.
+        return mtime_ns // 1_000_000_000 <= int(ims_ts)
+    return False
+
+
 class StaticFiles:
     # Files at or below this size are read once and held in memory.
     # Static assets in the wild (CSS/JS/manifest/small images) cluster
@@ -64,7 +144,8 @@ class StaticFiles:
 
     def __init__(self, directory: str | None = None, *,
                  url_prefix: str = '', root_dir: str | Path | None = None,
-                 cache: bool = False, index: str | None = None):
+                 cache: bool = False, index: str | None = None,
+                 conditional: bool = True):
         """Serve files from ``directory`` (or ``root_dir``).
 
         ``index`` (default ``None`` — off): when set to a filename (e.g.
@@ -86,6 +167,11 @@ class StaticFiles:
         caching").  Set ``cache=True`` only for standalone deployments
         where BlackBull terminates static traffic directly (i.e. no
         nginx / CDN in front).
+
+        ``conditional`` (default ``True``): emit ``ETag`` + ``Last-Modified``
+        validators and honour ``If-None-Match`` / ``If-Modified-Since`` with a
+        304.  Set ``False`` to suppress validators (e.g. the ``blackbull
+        serve --no-etag`` path).
         """
         resolved = directory or root_dir
         if resolved is None:
@@ -102,6 +188,7 @@ class StaticFiles:
         self._url_prefix = url_prefix.rstrip('/')
         self._cache_enabled: bool = cache
         self._index: str | None = index
+        self._conditional: bool = conditional
         # cache key = the actual filesystem path served (original or
         # sibling), held as a ``str`` so the hash is cheap and the
         # key matches the value returned by ``os.path.realpath``.
@@ -276,7 +363,7 @@ class StaticFiles:
         if (cached_entry is not None
                 and self._STAT_TTL_S > 0
                 and now - cached_entry[5] < self._STAT_TTL_S):
-            _, size, body, mime, _, _ = cached_entry
+            mtime_ns, size, body, mime, _, _ = cached_entry
             self._cache.move_to_end(served_path)
         else:
             # Cache miss, stale TTL, or caching disabled — re-stat to
@@ -341,24 +428,39 @@ class StaticFiles:
         status = HTTPStatus.OK
         extra_headers: list[tuple[bytes, bytes]] = []
 
-        if range_hdr and range_hdr.startswith('bytes='):
-            spec = range_hdr[6:]
-            start_s, _, end_s = spec.partition('-')
-            if start_s == '':
-                n = int(end_s)
-                start, end = max(0, size - n), size - 1
-            else:
-                start = int(start_s)
-                end = int(end_s) if end_s else size - 1
+        if self._conditional:
+            # Validators: a strong ETag over (mtime, size) plus Last-Modified,
+            # so ``If-None-Match`` / ``If-Modified-Since`` can produce a 304
+            # instead of a full re-transfer (bug 1.21d).  Cheap; emitted on
+            # every response, including the streaming path.
+            etag = f'"{mtime_ns:x}-{size:x}"'.encode()
+            last_modified = formatdate(mtime_ns / 1_000_000_000, usegmt=True).encode()
 
-            if start >= size or end >= size or start > end:
-                await self._respond(send, HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
-                    [(b'content-range', f'bytes */{size}'.encode())])
+            # Conditional GET — answer 304 before touching the body (avoids the
+            # large-file read/stream entirely on a cache revalidation).
+            if _not_modified(scope.get('headers', []), etag, mtime_ns):
+                cond_headers: list[tuple[bytes, bytes]] = [
+                    (b'etag', etag), (b'last-modified', last_modified)]
+                if content_encoding:
+                    cond_headers.append((b'vary', b'Accept-Encoding'))
+                await self._respond(send, HTTPStatus.NOT_MODIFIED, cond_headers)
                 return
 
-            status = HTTPStatus.PARTIAL_CONTENT
-            extra_headers.append(
-                (b'content-range', f'bytes {start}-{end}/{size}'.encode()))
+            extra_headers.append((b'etag', etag))
+            extra_headers.append((b'last-modified', last_modified))
+
+        if range_hdr:
+            parsed = _parse_byte_range(range_hdr, size)
+            # ``None`` → unparseable/multi-range → ignore and serve full 200.
+            if parsed is not None:
+                start, end = parsed
+                if start >= size or end >= size or start > end:
+                    await self._respond(send, HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE,
+                        [(b'content-range', f'bytes */{size}'.encode())])
+                    return
+                status = HTTPStatus.PARTIAL_CONTENT
+                extra_headers.append(
+                    (b'content-range', f'bytes {start}-{end}/{size}'.encode()))
 
         body_len = end - start + 1
 

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -175,6 +175,10 @@ pip install 'blackbull[compression]'
 The default `min_size` is 100 bytes — responses smaller than that
 pass through uncompressed.
 
+Every compressed response carries `Vary: Accept-Encoding` (folded into
+any existing `Vary`) so a shared cache never replays an encoded body to
+a client that sent `identity` / no `Accept-Encoding` (RFC 9110 §12.5.5).
+
 ### `Session`
 
 Signed-cookie sessions — session data lives entirely in a cookie
@@ -284,6 +288,13 @@ carrying `no-store`, `private`, or `no-cache` pass through
 unstored.  Requests with `Cache-Control: no-store` bypass the
 cache too.
 
+The cache is **variant-aware**: when a stored response carries a
+`Vary` header (e.g. `Vary: Accept-Encoding` behind the `Compression`
+middleware), the varied request-header values are folded into the
+cache key, so a brotli variant is never replayed to an `identity`
+client.  A response with `Vary: *` is passed through unstored
+(RFC 9110 §12.5.5).
+
 Constructor arguments:
 
 | Argument               | Default                | Notes                                                                  |
@@ -300,8 +311,6 @@ Limitations:
 - **Per-worker.**  Multi-worker deployments hold a separate cache
   in each process.
 - **No cross-restart persistence.**  In-memory only.
-- **No `Vary` matching.**  Requests differing only by
-  `Accept-Encoding` or `Accept-Language` share the same cache slot.
 - **No explicit invalidation API.**  Wait for TTL or restart the
   worker.
 - **Streaming responses** (any `more_body=True` chunk) are

--- a/docs/guide/static-files.md
+++ b/docs/guide/static-files.md
@@ -60,9 +60,11 @@ blackbull serve ./public --bind :8080
 blackbull serve ./public --certfile cert.pem --keyfile key.pem  # HTTPS + HTTP/2
 ```
 
-It wires `StaticFiles` with `index='index.html'` plus the
-[`Cache`](middleware.md) middleware for ETag / `304` conditional
-responses.  See [Configuration → blackbull serve](configuration.md#serving-static-files-with-blackbull-serve)
+It wires `StaticFiles` with `index='index.html'`; ETag / `304`
+conditional responses are served natively by `StaticFiles` (see
+[Conditional requests](#conditional-requests-etag--last-modified) below)
+and can be turned off with `--no-etag`.  See
+[Configuration → blackbull serve](configuration.md#serving-static-files-with-blackbull-serve)
 for the full flag list.
 
 ## Environment gate
@@ -188,7 +190,35 @@ Content-Range: bytes 0-1023/4096000
 Content-Length: 1024
 ```
 
-Unsatisfiable ranges return `416 Range Not Satisfiable`.
+A syntactically **unsatisfiable** range (start past the end of the
+file) returns `416 Range Not Satisfiable`.  A **malformed** or
+unsupported `Range` header — a bad byte spec (`bytes=abc-def`), a
+non-`bytes` unit, or a multi-range set — is ignored and the full file
+is served with `200 OK` (RFC 9110 §14.2); it never fails the request.
+
+### Conditional requests (ETag / Last-Modified)
+
+`StaticFiles` emits a strong `ETag` (derived from the file's
+modification time and size) and a `Last-Modified` header on every
+response.  A revalidating client can then avoid re-downloading an
+unchanged asset:
+
+```
+GET /assets/app.css HTTP/1.1
+If-None-Match: "18f3a-1c2"
+```
+
+```
+HTTP/1.1 304 Not Modified
+ETag: "18f3a-1c2"
+Last-Modified: Sun, 13 Jul 2026 00:00:00 GMT
+```
+
+`If-None-Match` takes precedence over `If-Modified-Since` (RFC 9110
+§13); the `304` is answered before the file body is read, so a
+revalidation of a large asset costs no disk I/O.  Pass
+`conditional=False` to `app.static(...)` (or `blackbull serve
+--no-etag`) to suppress the validators and always serve the full body.
 
 ## Security
 

--- a/tests/unit/test_cache_middleware.py
+++ b/tests/unit/test_cache_middleware.py
@@ -429,3 +429,83 @@ class TestHeaderHelpers:
 
     def test_etag_no_match(self):
         assert not _etag_matches(b'"abc"', b'"def"')
+
+
+# ---------------------------------------------------------------------------
+# 1.21b — Vary-aware caching (variant correctness)
+# ---------------------------------------------------------------------------
+
+def _vary_handler(vary_value: bytes = b'Accept-Encoding'):
+    """Handler that varies its body by Accept-Encoding and advertises Vary."""
+    counter = {'n': 0}
+
+    async def call_next(scope, receive, send):
+        counter['n'] += 1
+        ae = b''
+        for k, v in scope.get('headers', []):
+            if k.lower() == b'accept-encoding':
+                ae = v
+        body = b'ENC:' + ae
+        await send({'type': 'http.response.start', 'status': 200, 'headers': [
+            (b'content-type', b'text/plain'),
+            (b'vary', vary_value),
+        ]})
+        await send({'type': 'http.response.body', 'body': body})
+
+    return call_next, counter
+
+
+@pytest.mark.asyncio
+class TestVaryAwareCaching:
+    async def test_different_accept_encoding_not_cross_served(self):
+        """A brotli variant must never be replayed to an identity client (1.21b)."""
+        mw = Cache()
+        cn, counter = _vary_handler()
+        _, _, body_br = _split_response(
+            await _run(mw, _scope(headers=[(b'accept-encoding', b'br')]), cn))
+        _, _, body_id = _split_response(
+            await _run(mw, _scope(headers=[(b'accept-encoding', b'identity')]), cn))
+        assert body_br == b'ENC:br'
+        assert body_id == b'ENC:identity'
+        assert counter['n'] == 2, 'each variant must be produced by the handler'
+
+    async def test_same_variant_served_from_cache(self):
+        mw = Cache()
+        cn, counter = _vary_handler()
+        await _run(mw, _scope(headers=[(b'accept-encoding', b'br')]), cn)
+        _, _, body2 = _split_response(
+            await _run(mw, _scope(headers=[(b'accept-encoding', b'br')]), cn))
+        assert body2 == b'ENC:br'
+        assert counter['n'] == 1, 'identical variant must hit the cache'
+
+    async def test_vary_star_never_stored(self):
+        mw = Cache()
+        cn, counter = _vary_handler(vary_value=b'*')
+        await _run(mw, _scope(headers=[(b'accept-encoding', b'br')]), cn)
+        await _run(mw, _scope(headers=[(b'accept-encoding', b'br')]), cn)
+        assert counter['n'] == 2, 'Vary: * responses must not be stored'
+
+
+class TestVaryHelpers:
+    def test_response_vary_absent(self):
+        from blackbull.middleware.cache import _response_vary
+        assert _response_vary([(b'content-type', b'text/plain')]) == ()
+
+    def test_response_vary_fields_sorted_lowercased(self):
+        from blackbull.middleware.cache import _response_vary
+        assert _response_vary(
+            [(b'vary', b'Accept-Encoding, Accept-Language')]
+        ) == (b'accept-encoding', b'accept-language')
+
+    def test_response_vary_star_is_none(self):
+        from blackbull.middleware.cache import _response_vary
+        assert _response_vary([(b'vary', b'*')]) is None
+
+    def test_vary_key_pulls_request_values(self):
+        from blackbull.middleware.cache import _vary_key
+        req = {b'accept-encoding': b'br'}
+        assert _vary_key((b'accept-encoding',), req) == ((b'accept-encoding', b'br'),)
+
+    def test_vary_key_missing_header_is_empty(self):
+        from blackbull.middleware.cache import _vary_key
+        assert _vary_key((b'accept-encoding',), {}) == ((b'accept-encoding', b''),)

--- a/tests/unit/test_compression_vary.py
+++ b/tests/unit/test_compression_vary.py
@@ -1,0 +1,110 @@
+"""Unit tests for the Compression middleware's ``Vary: Accept-Encoding``
+emission (bug 1.21a).
+
+A compressed response's body depends on the request ``Accept-Encoding``;
+without ``Vary: Accept-Encoding`` a shared cache may replay the encoded
+body to a client that sent ``identity`` / no ``Accept-Encoding``
+(RFC 9110 §12.5.5).
+"""
+from __future__ import annotations
+
+import pytest
+
+from blackbull.middleware.compression import Compression, _merge_vary
+
+
+async def _noop_receive():
+    return {'type': 'http.disconnect'}
+
+
+def _scope(accept: bytes = b'gzip') -> dict:
+    return {
+        'type': 'http',
+        'method': 'GET',
+        'path': '/',
+        'headers': [(b'accept-encoding', accept)],
+    }
+
+
+async def _run(mw, body: bytes, resp_headers, accept: bytes = b'gzip') -> dict:
+    events: list[dict] = []
+
+    async def send(event: dict) -> None:
+        events.append(event)
+
+    async def call_next(scope, receive, send):
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': list(resp_headers)})
+        await send({'type': 'http.response.body', 'body': body, 'more_body': False})
+
+    await mw(_scope(accept), _noop_receive, send, call_next)
+    start = next(e for e in events if e['type'] == 'http.response.start')
+    return {'status': start['status'], 'headers': start['headers']}
+
+
+# A body over the default _MIN_SIZE (100) so compression actually runs.
+_BODY = b'the quick brown fox jumps over the lazy dog ' * 20
+
+
+def _vary_values(headers) -> list[bytes]:
+    return [v for k, v in headers if k.lower() == b'vary']
+
+
+@pytest.mark.asyncio
+async def test_compressed_response_emits_vary():
+    mw = Compression()
+    res = await _run(mw, _BODY, [(b'content-type', b'text/plain')])
+    assert res['headers']  # sanity
+    assert dict(res['headers']).get(b'content-encoding') == b'gzip'
+    varies = _vary_values(res['headers'])
+    assert len(varies) == 1
+    assert b'accept-encoding' in varies[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_vary_folds_into_existing():
+    """An upstream Vary must be extended, not duplicated with a 2nd header."""
+    mw = Compression()
+    res = await _run(mw, _BODY, [
+        (b'content-type', b'text/plain'),
+        (b'vary', b'Accept-Language'),
+    ])
+    varies = _vary_values(res['headers'])
+    assert len(varies) == 1, f'expected one folded Vary; got {varies}'
+    tokens = {t.strip().lower() for t in varies[0].split(b',')}
+    assert tokens == {b'accept-language', b'accept-encoding'}
+
+
+@pytest.mark.asyncio
+async def test_vary_not_duplicated_when_already_present():
+    mw = Compression()
+    res = await _run(mw, _BODY, [
+        (b'content-type', b'text/plain'),
+        (b'vary', b'accept-encoding'),
+    ])
+    varies = _vary_values(res['headers'])
+    assert len(varies) == 1
+    tokens = [t.strip().lower() for t in varies[0].split(b',')]
+    assert tokens.count(b'accept-encoding') == 1
+
+
+class TestMergeVaryHelper:
+    def test_appends_when_absent(self):
+        hdrs = [(b'content-type', b'text/plain')]
+        _merge_vary(hdrs)
+        assert (b'vary', b'Accept-Encoding') in hdrs
+
+    def test_folds_into_existing(self):
+        hdrs = [(b'vary', b'Accept-Language')]
+        _merge_vary(hdrs)
+        assert hdrs == [(b'vary', b'Accept-Language, Accept-Encoding')]
+
+    def test_no_dup(self):
+        hdrs = [(b'vary', b'Accept-Encoding')]
+        _merge_vary(hdrs)
+        assert hdrs == [(b'vary', b'Accept-Encoding')]
+
+    def test_star_untouched(self):
+        hdrs = [(b'vary', b'*')]
+        _merge_vary(hdrs)
+        assert hdrs == [(b'vary', b'*')]

--- a/tests/unit/test_proxy_middleware.py
+++ b/tests/unit/test_proxy_middleware.py
@@ -121,6 +121,34 @@ async def test_forwarded_header_for_only():
     assert scope['scheme'] == 'http'   # unchanged — no proto directive
 
 
+@pytest.mark.asyncio
+async def test_forwarded_multi_element_uses_leftmost():
+    """RFC 7239 §4 — elements are comma-separated; parse the leftmost only.
+
+    Bug 1.21e: splitting on ';' alone folded the second element's ``for=``
+    into the first value, poisoning ``scope['client']``.
+    """
+    mw = TrustedProxy('127.0.0.1')
+    scope = _make_scope('127.0.0.1', {
+        b'forwarded': b'for=203.0.113.1;proto=https, for=198.51.100.17',
+    })
+    scope, _ = await _call(mw, scope)
+    assert scope['client'] == ['203.0.113.1', 0]
+    assert scope['scheme'] == 'https'
+
+
+@pytest.mark.asyncio
+async def test_forwarded_multi_element_no_proto_leak():
+    """A trailing element must not leak its params into the leftmost."""
+    mw = TrustedProxy('127.0.0.1')
+    scope = _make_scope('127.0.0.1', {
+        b'forwarded': b'for=203.0.113.1, for=198.51.100.17;proto=https',
+    })
+    scope, _ = await _call(mw, scope)
+    assert scope['client'] == ['203.0.113.1', 0]
+    assert scope['scheme'] == 'http'   # proto belongs to the 2nd element → ignored
+
+
 # ---------------------------------------------------------------------------
 # WebSocket and non-HTTP scopes
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -601,3 +601,166 @@ class TestStaticFilesPathsend:
         body = b''.join(e.get('body', b'') for e in events
                         if e.get('type') == 'http.response.body')
         assert body == b'Hello, static world!'
+
+
+# ---------------------------------------------------------------------------
+# 1.21c — malformed / unsupported Range must never 500
+# ---------------------------------------------------------------------------
+
+def _headers_of(start: dict) -> dict[bytes, bytes]:
+    return {k.lower(): v for k, v in start.get('headers', [])}
+
+
+@pytest.mark.asyncio
+class TestStaticFilesMalformedRange:
+    """A crafted Range header must be ignored (200) or answered 416 — never 500.
+
+    Bug 1.21c: bare ``int()`` on the range bounds raised ``ValueError`` out
+    of ``_serve`` on inputs like ``bytes=abc-def``.
+    """
+
+    FILE = b'Hello, static world!'  # 20 bytes, matches static_dir fixture
+
+    @pytest.mark.parametrize('bad_range', [
+        'bytes=abc-def',
+        'bytes=1-2-3',
+        'bytes=xyz',
+        'bytes=',
+        'items=0-3',          # non-bytes unit
+        'bytes=0-1,5-9',      # multi-range (we don't emit multipart/byteranges)
+    ])
+    async def test_malformed_range_serves_full_200(self, static_dir, bad_range):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, body = await _collect(
+            app, _scope(path='/hello.txt', headers={'Range': bad_range})
+        )
+        assert start['status'] == 200, (
+            f'{bad_range!r} must be ignored → 200; got {start["status"]}'
+        )
+        assert body == self.FILE
+
+    @pytest.mark.parametrize('bad_range', [
+        'bytes=--5',          # int('-5') suffix → unsatisfiable
+        'bytes=-',
+        'bytes= - ',
+        'bytes=9999999999999999999999-',
+        'bytes=0x10-0x20',
+        'bytes=\x00-\x01',
+    ])
+    async def test_odd_range_never_500(self, static_dir, bad_range):
+        """The RFC contract is ignore→200 *or* 416, never a crash."""
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(
+            app, _scope(path='/hello.txt', headers={'Range': bad_range})
+        )
+        assert start['status'] in (200, 416), (
+            f'{bad_range!r} must not 500; got {start["status"]}'
+        )
+
+    async def test_unsatisfiable_range_still_416(self, static_dir):
+        """A well-formed but out-of-bounds range stays a 416 (not 200/500)."""
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(
+            app, _scope(path='/hello.txt', headers={'Range': 'bytes=100-200'})
+        )
+        assert start['status'] == 416
+
+
+# ---------------------------------------------------------------------------
+# 1.21d — validators (ETag / Last-Modified) + conditional GET
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+class TestStaticFilesConditional:
+    FILE = b'Hello, static world!'
+
+    async def test_emits_etag_and_last_modified(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(app, _scope(path='/hello.txt'))
+        h = _headers_of(start)
+        assert b'etag' in h, 'StaticFiles must emit an ETag'
+        assert b'last-modified' in h, 'StaticFiles must emit Last-Modified'
+
+    async def test_if_none_match_returns_304(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(app, _scope(path='/hello.txt'))
+        etag = _headers_of(start)[b'etag']
+
+        start2, body2 = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-None-Match': etag.decode()})
+        )
+        assert start2['status'] == 304
+        assert body2 == b''
+
+    async def test_if_none_match_star_returns_304(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, body = await _collect(
+            app, _scope(path='/hello.txt', headers={'If-None-Match': '*'})
+        )
+        assert start['status'] == 304
+        assert body == b''
+
+    async def test_if_none_match_mismatch_serves_200(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, body = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-None-Match': '"stale-tag"'})
+        )
+        assert start['status'] == 200
+        assert body == self.FILE
+
+    async def test_if_modified_since_returns_304(self, static_dir):
+        from email.utils import formatdate
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(app, _scope(path='/hello.txt'))
+        last_mod = _headers_of(start)[b'last-modified'].decode()
+
+        start2, body2 = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-Modified-Since': last_mod})
+        )
+        assert start2['status'] == 304
+        assert body2 == b''
+
+    async def test_if_modified_since_old_date_serves_200(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, body = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-Modified-Since':
+                                 'Thu, 01 Jan 1970 00:00:00 GMT'})
+        )
+        assert start['status'] == 200
+        assert body == self.FILE
+
+    async def test_malformed_if_modified_since_serves_200(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, body = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-Modified-Since': 'not-a-date'})
+        )
+        assert start['status'] == 200
+        assert body == self.FILE
+
+    async def test_304_carries_validators(self, static_dir):
+        from blackbull.middleware.static import StaticFiles
+        app = StaticFiles(directory=str(static_dir))
+        start, _ = await _collect(app, _scope(path='/hello.txt'))
+        etag = _headers_of(start)[b'etag']
+        start2, _ = await _collect(
+            app, _scope(path='/hello.txt',
+                        headers={'If-None-Match': etag.decode()})
+        )
+        h = _headers_of(start2)
+        assert h.get(b'etag') == etag
+        assert b'last-modified' in h


### PR DESCRIPTION
## Summary

Sprint 69, first half — the `1.21` middleware-correctness cluster from the
comprehensive audit. Five localised RFC-conformance fixes across the shipped
middleware, plus native conditional-request support in `StaticFiles`.

- **1.21a** `Compression` emits `Vary: Accept-Encoding` on compressed responses (RFC 9110 §12.5.5) — no more encoded-body-to-identity-client cache poisoning.
- **1.21b** `Cache` is variant-aware: response `Vary` fields fold into the key; `Vary: *` → passed through unstored.
- **1.21c** `StaticFiles` no longer `500`s on a malformed/multi-range `Range` — ignored → full `200` (RFC 9110 §14.2); unsatisfiable stays `416`.
- **1.21d** `StaticFiles` emits strong `ETag` + `Last-Modified` and honours `If-None-Match` / `If-Modified-Since` with `304`. New `conditional=` arg (default `True`); `blackbull serve --no-etag` drives it and drops the redundant `Cache`-for-ETag wrapper.
- **1.21e** `TrustedProxy._parse_forwarded` splits RFC 7239 elements on `,` first (leftmost element) — fixes `scope['client']` poisoning on chained proxies.

The `Session` middleware removal (the sprint's other half) is calendar-gated to on/after 2026-07-14 and lands separately as `v0.54.0`.

## Test plan

- [x] New/extended unit tests for all five items (proxy multi-element, static malformed-range + conditional GET, cache Vary-aware, `test_compression_vary.py`)
- [x] Full unit suite green: `2904 passed, 258 skipped, 1 xfailed` under `--beartype-packages=blackbull`
- [x] Relevant integration suites (static / cache / compression / trusted-proxy) green
- [x] MkDocs build validates (pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)