### PR TITLE
release: v0.53.1 — Sprint 69 (half 1): middleware 1.21 correctness cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.53.1] — 2026-07-13
+
+Sprint 69 (first half) — the `1.21` middleware-correctness cluster: five
+localised RFC-conformance fixes across the shipped middleware, plus native
+conditional-request support in `StaticFiles`. (The in-tree `Session` removal,
+the sprint's other half, is calendar-gated and lands separately as `v0.54.0`.)
+
 ### Added
 
 - **`StaticFiles` conditional requests.** `StaticFiles` now emits a strong

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.0"
+version = "0.53.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Patch release of the `1.21` middleware-correctness cluster ([#137](https://github.com/TOKUJI/BlackBull/pull/137), already on master). Two-file release commit: `pyproject.toml` version bump + `CHANGELOG.md` stamp.

- **1.21a** `Compression` → `Vary: Accept-Encoding`
- **1.21b** `Cache` variant-aware (folds response `Vary` into the key)
- **1.21c** `StaticFiles` no longer `500`s on a malformed `Range`
- **1.21d** `StaticFiles` `ETag` / `Last-Modified` + conditional `304` (new `conditional=` arg)
- **1.21e** `TrustedProxy` multi-element RFC 7239 `Forwarded` parse

The breaking in-tree `Session` removal (the sprint's MINOR headline) is calendar-gated to on/after 2026-07-14 and ships separately as `v0.54.0`.

## Test plan

- [x] Feature code already merged + CI-green via #137 (CodeQL, Fast tier, Autobahn, h2spec, gRPC interop, H2 gate, dep audit)
- [x] `blackbull.__version__` → `0.53.1` after `pip install -e .`
- [x] Release commit touches only `pyproject.toml` + `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)