### PR TITLE
chore(router,docs): Sprint 68 post-close review follow-ups

### DIFF
--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -203,9 +203,12 @@ class BlackBull:
                  observer_shutdown_timeout: float = 5.0,
                  trusted_proxies: list[str] | str | None = None,
                  config: AppConfig | None = None,
+                 cache_max: int | None = None,
                  ):
         self._config = config
-        self._router = Router()
+        # ``cache_max`` bounds the per-worker route lookup cache (0 disables
+        # it); ``None`` keeps the Router default (2048).  See the routing guide.
+        self._router = Router() if cache_max is None else Router(cache_max=cache_max)
         self._logger = logger
         # Miss-fallback covers every error status and unhandled exception
         # class; only user-registered handlers live in the registries.

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -698,6 +698,53 @@ def _to_tuple(value: Any) -> tuple:
     return (value,)
 
 
+class _LookupCache:
+    """Bounded LRU for resolved route lookups.
+
+    Encapsulates the ``OrderedDict`` store, the ``cache_max`` bound, the
+    refresh-LRU-order-only-when-full optimisation, and ``popitem`` eviction —
+    the whole caching *strategy* — behind ``get`` / ``set`` / ``clear``.  A
+    replacement strategy (e.g. a trie-backed or unbounded cache) is a drop-in:
+    swap ``Router._cache`` for a different instance with the same three-method
+    interface; ``__getitem__`` and the ``_cache_get`` / ``_cache_set``
+    delegates never change.  A ``cache_max`` of 0 (or less) disables caching.
+    """
+    __slots__ = ('cache_max', '_store')
+
+    def __init__(self, cache_max: int) -> None:
+        self.cache_max: int = cache_max
+        self._store: OrderedDict = OrderedDict()
+
+    def get(self, key):
+        """Return ``(hit: bool, result)``.  Refreshes LRU order only when the
+        cache is full, so ordering work is skipped until eviction is imminent."""
+        store = self._store
+        if key in store:
+            if len(store) >= self.cache_max:
+                store.move_to_end(key)
+            return True, store[key]
+        return False, None
+
+    def set(self, key, result) -> None:
+        """Store *result* under *key*, evicting the least-recently-used entry
+        when the cache is full.  A ``cache_max`` of 0 disables caching."""
+        if self.cache_max <= 0:
+            return
+        store = self._store
+        if len(store) >= self.cache_max:
+            store.popitem(last=False)  # evict least-recently-used
+        store[key] = result
+
+    def clear(self) -> None:
+        self._store.clear()
+
+    def __contains__(self, key) -> bool:
+        return key in self._store
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+
 # http://taichino.com/programming/1538
 class Router:
     """
@@ -720,17 +767,27 @@ class Router:
         self._string_paths: set[str] = set()  # registered string paths (for __contains__/__repr__)
         self._raw_regex: dict = {}  # raw re.Pattern routes (not compiled from string paths)
         # Per-worker lookup cache: maps (path, method, scheme) → resolved
-        # handler; cleared whenever a route is registered.  ``cache_max`` bounds
-        # it (0 disables caching entirely).  The get/set mechanics live in
-        # ``_cache_get`` / ``_cache_set`` so a future cache strategy can be
-        # swapped in without touching ``__getitem__`` or ``_resolve``.
-        self.cache_max: int = cache_max
-        self._lookup_cache: OrderedDict = OrderedDict()
+        # handler; cleared whenever a route is registered.  The whole caching
+        # strategy — bound, eviction, LRU order — lives in ``_LookupCache`` so
+        # it can be swapped by replacing this one instance, without touching
+        # ``__getitem__`` / ``_cache_get`` / ``_cache_set`` / ``_resolve``.
+        self._cache: _LookupCache = _LookupCache(cache_max)
         # type → callable registry for simplified-handler return coercion.
         # Empty by default (falsy) so the common return paths never consult it.
         # Shared by reference with every adapted handler, so a converter
         # registered after a route is still honoured.
         self._converters: dict[type, Callable] = {}
+
+    @property
+    def cache_max(self) -> int:
+        """The lookup cache's entry bound (0 disables caching).  Kept as a
+        property delegating to :class:`_LookupCache` so the constructor knob
+        and ``router.cache_max = N`` retuning both flow to the one store."""
+        return self._cache.cache_max
+
+    @cache_max.setter
+    def cache_max(self, value: int) -> None:
+        self._cache.cache_max = value
 
     def register_converter(self, type_: type, converter: Callable) -> None:
         """Register *converter* to turn a handler that returns *type_* into a
@@ -760,7 +817,7 @@ class Router:
             raise RuntimeError(
                 "Router is frozen — routes cannot be added after startup validation")
 
-        self._lookup_cache.clear()
+        self._cache.clear()
 
         # Unpack key
         if len(key) == 3:
@@ -845,25 +902,13 @@ class Router:
         return result
 
     def _cache_get(self, key: Tuple[str, str | HTTPMethod, Scheme]):
-        """Return ``(hit: bool, result)`` for *key*.  On a hit, refreshes LRU
-        order only when the cache is full (so ordering work is skipped until
-        eviction is actually imminent)."""
-        cache = self._lookup_cache
-        if key in cache:
-            if len(cache) >= self.cache_max:
-                cache.move_to_end(key)
-            return True, cache[key]
-        return False, None
+        """Return ``(hit: bool, result)`` for *key* — delegates to the
+        swappable :class:`_LookupCache` strategy."""
+        return self._cache.get(key)
 
     def _cache_set(self, key: Tuple[str, str | HTTPMethod, Scheme], result) -> None:
-        """Store *result* under *key*, evicting the least-recently-used entry
-        when the cache is full.  A ``cache_max`` of 0 disables caching."""
-        if self.cache_max <= 0:
-            return
-        cache = self._lookup_cache
-        if len(cache) >= self.cache_max:
-            cache.popitem(last=False)  # evict least-recently-used
-        cache[key] = result
+        """Store *result* under *key* — delegates to :class:`_LookupCache`."""
+        self._cache.set(key, result)
 
     def _resolve(
         self,

--- a/blackbull/testing.py
+++ b/blackbull/testing.py
@@ -238,7 +238,10 @@ class WebSocketTestSession:
             'path': (unquote(raw_path, encoding='utf-8', errors='replace')
                      if '%' in raw_path else raw_path),
             'raw_path': raw_path.encode('utf-8'),
-            'query_string': query.encode('latin-1'),
+            # UTF-8 for parity with raw_path above and the real server —
+            # latin-1 would raise UnicodeEncodeError on a non-ASCII query
+            # (e.g. '/x?q=café') that the utf-8 path accepts.
+            'query_string': query.encode('utf-8'),
             'root_path': '',
             'headers': encoded_headers,
             'client': ('testclient', 50000),

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -28,7 +28,7 @@ Read-side surface:
 
 | member | value |
 |---|---|
-| `request.method` / `request.path` / `request.scheme` | `str` |
+| `request.method` / `request.path` / `request.scheme` | `str` (`path` is **percent-decoded** — see below) |
 | `request.client` | `(host, port)` tuple, or `None` |
 | `request.headers` | case-insensitive [`Headers`](#reading-request-headers) view |
 | `request.cookies` | `dict[str, str]`, parsed once (all protocols) |
@@ -44,6 +44,18 @@ cached bytes — the body is never read twice.  Handlers that don't
 declare a `Request` pay nothing: injection is decided when the route
 is registered, and the raw `(scope, receive, send)` form is
 unaffected.
+
+!!! note "`path` is percent-decoded (since v0.53.0)"
+    `request.path` (and the underlying `scope['path']`) is the
+    **percent-decoded** request target with the query string removed —
+    `/files/a%2Fb` arrives as `/files/a/b`, matching the ASGI spec and
+    uvicorn.  The **un**decoded bytes are available as
+    `scope['raw_path']` (`bytes`, query excluded) for the rare consumer
+    — reverse proxies, WAFs, cache-key / signature verification — that
+    must reproduce the exact received byte sequence.  RFC 3986 `;`
+    parameters are preserved in both (`/cart;sid=abc` stays intact).
+    Before v0.53.0 `path` was not decoded; code that re-decoded it
+    itself should drop that step.
 
 The sections below cover the same reads on the raw ASGI surface —
 useful inside middleware (which always uses the full form) and for

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -212,6 +212,29 @@ apply.  See [WebSockets](websockets.md) for the handshake,
 subprotocol negotiation, fragmented messages, `permessage-deflate`,
 and the RFC 8441 (HTTP/2) transport.
 
+## Lookup cache
+
+Route resolution is backed by a per-worker LRU cache keyed on
+`(path, method, scheme)`, so repeated requests to the same target skip
+the trie traversal after the first hit.  The cache is cleared
+automatically whenever a route is registered, so it never serves a stale
+result during startup.
+
+The bound is a constructor argument on the router:
+
+```python
+from blackbull import BlackBull
+
+app = BlackBull(cache_max=4096)   # larger cache for high path cardinality
+app = BlackBull(cache_max=0)      # disable the lookup cache entirely
+```
+
+The default is `2048` entries.  Raising it helps when the application
+serves a very large number of distinct paths (the cache is a hit only
+when the exact `(path, method, scheme)` recurs); `0` disables caching so
+every request re-resolves through the trie.  Most applications never need
+to touch this.
+
 ## Next
 
 - [Middleware](middleware.md) — attaching per-route middleware,

--- a/tests/unit/test_router_trie.py
+++ b/tests/unit/test_router_trie.py
@@ -8,7 +8,7 @@ from http import HTTPMethod
 
 from blackbull.utils import Scheme
 from blackbull.router import (
-    Router, _RouteTrie, PathNotRegistered, MethodNotApplicable,
+    Router, _RouteTrie, _LookupCache, PathNotRegistered, MethodNotApplicable,
 )
 
 
@@ -158,7 +158,7 @@ async def test_router_trie_hit_bypasses_regex_scan():
 # ---------------------------------------------------------------------------
 
 def test_lookup_cache_populated_after_hit():
-    """A successful lookup must add the result to _lookup_cache."""
+    """A successful lookup must add the result to the lookup cache."""
     router = Router()
 
     @router.route(path='/ping', methods=[HTTPMethod.GET])
@@ -166,11 +166,11 @@ def test_lookup_cache_populated_after_hit():
         pass
 
     key = ('/ping', HTTPMethod.GET, Scheme.http)
-    assert key not in router._lookup_cache
+    assert key not in router._cache
 
     router[key]
 
-    assert key in router._lookup_cache
+    assert key in router._cache
 
 
 def test_lookup_cache_returns_same_object():
@@ -198,14 +198,14 @@ def test_lookup_cache_cleared_on_route_registration():
 
     key = ('/ping', HTTPMethod.GET, Scheme.http)
     router[key]
-    assert key in router._lookup_cache
+    assert key in router._cache
 
     # Adding a second route must clear the cache
     @router.route(path='/pong', methods=[HTTPMethod.GET])
     async def pong(scope, receive, send):
         pass
 
-    assert router._lookup_cache == {}
+    assert len(router._cache) == 0
 
 
 def test_lookup_cache_lru_evicts_least_recently_used():
@@ -227,17 +227,17 @@ def test_lookup_cache_lru_evicts_least_recently_used():
     router[k1]
     router[k2]
     router[k3]
-    assert len(router._lookup_cache) == 3
+    assert len(router._cache) == 3
 
     # Re-access k1 — it becomes the most recently used, so k2 is now the LRU
     router[k1]
 
     # Adding k4 must evict k2 (LRU), not k1 (recently accessed)
     router[k4]
-    assert len(router._lookup_cache) == 3
-    assert k2 not in router._lookup_cache, 'LRU entry (k2) must be evicted'
-    assert k1 in router._lookup_cache, 'recently-accessed k1 must be retained'
-    assert k4 in router._lookup_cache
+    assert len(router._cache) == 3
+    assert k2 not in router._cache, 'LRU entry (k2) must be evicted'
+    assert k1 in router._cache, 'recently-accessed k1 must be retained'
+    assert k4 in router._cache
 
 
 def test_cache_max_zero_disables_caching():
@@ -252,7 +252,7 @@ def test_cache_max_zero_disables_caching():
     key = ('/ping', HTTPMethod.GET, Scheme.http)
     assert router[key] is not None            # resolves
     assert router[key] is not None            # resolves again
-    assert len(router._lookup_cache) == 0     # nothing cached
+    assert len(router._cache) == 0     # nothing cached
 
 
 def test_cache_get_set_pair_round_trips():
@@ -290,7 +290,7 @@ async def test_lookup_cache_parametrized_route_injects_correct_params():
 
     # Populate cache
     fn = router[key]
-    assert key in router._lookup_cache
+    assert key in router._cache
 
     # Cached closure injects params correctly
     scope: dict = {}
@@ -303,3 +303,56 @@ async def test_lookup_cache_parametrized_route_injects_correct_params():
     scope2: dict = {}
     await fn2(scope2, None, None)
     assert scope2.get('path_params') == {'task_id': '99'}
+
+
+# ---------------------------------------------------------------------------
+# _LookupCache — swappable cache-strategy extraction (Sprint 68 follow-up)
+# ---------------------------------------------------------------------------
+
+def test_router_uses_lookupcache_instance():
+    assert isinstance(Router()._cache, _LookupCache)
+
+
+def test_lookupcache_get_set_clear_contract():
+    cache = _LookupCache(cache_max=8)
+    key = ('/x', HTTPMethod.GET, Scheme.http)
+    assert cache.get(key) == (False, None)
+    sentinel = object()
+    cache.set(key, sentinel)
+    assert key in cache and len(cache) == 1
+    assert cache.get(key) == (True, sentinel)
+    cache.clear()
+    assert key not in cache and len(cache) == 0
+
+
+def test_lookupcache_zero_disables():
+    cache = _LookupCache(cache_max=0)
+    cache.set(('/x', HTTPMethod.GET, Scheme.http), object())
+    assert len(cache) == 0
+
+
+def test_lookupcache_lru_eviction():
+    cache = _LookupCache(cache_max=2)
+    for p in ('/a', '/b'):
+        cache.set((p, HTTPMethod.GET, Scheme.http), p)
+    assert len(cache) == 2
+    cache.set(('/c', HTTPMethod.GET, Scheme.http), '/c')  # evicts LRU '/a'
+    assert len(cache) == 2
+    assert ('/a', HTTPMethod.GET, Scheme.http) not in cache
+    assert ('/c', HTTPMethod.GET, Scheme.http) in cache
+
+
+def test_router_cache_strategy_is_swappable():
+    """The point of the extraction: replace Router._cache with another
+    same-interface instance and lookups honour it — no __getitem__ change."""
+    router = Router()
+
+    @router.route(path='/ping', methods=[HTTPMethod.GET])
+    async def ping(scope, receive, send):
+        pass
+
+    # Swap in a caching-disabled strategy; lookups must stop being stored.
+    router._cache = _LookupCache(cache_max=0)
+    key = ('/ping', HTTPMethod.GET, Scheme.http)
+    assert router[key] is not None
+    assert len(router._cache) == 0

--- a/tests/unit/test_testclient.py
+++ b/tests/unit/test_testclient.py
@@ -196,6 +196,13 @@ def test_ws_testclient_plain_path_unchanged() -> None:
     assert session.scope['raw_path'] == b'/chat/room'
 
 
+def test_ws_testclient_non_ascii_query_string_utf8() -> None:
+    """query_string is UTF-8 encoded, for parity with raw_path and the real
+    server — a non-ASCII query must not raise (was latin-1, Sprint 68 follow-up)."""
+    session = WebSocketTestSession(app=None, path='/search?q=café')
+    assert session.scope['query_string'] == 'q=café'.encode('utf-8')
+
+
 def test_websocket_binary_round_trip() -> None:
     app = _make_app()
     payload = b'\x00\xff\x10\x20'


### PR DESCRIPTION
## Summary

The four post-close review action items you added to `bench/sprint-logs/sprint-68.md`. None are regressions.

- **Refactor — extract `_LookupCache`** (`router.py`): encapsulates the `OrderedDict`, `cache_max` bound, LRU-refresh-when-full, `popitem` eviction, and `clear` behind `get`/`set`/`clear`. `Router._cache` is now swappable for a different strategy **without touching** `__getitem__` / `_cache_get` / `_cache_set` — the logical completion of PR #135, which stopped at method extraction. `cache_max` kept as a delegating property.
- **`BlackBull(cache_max=…)` kwarg** — forwards to `Router` so the lookup-cache bound is reachable from the public constructor (was `Router`-only, so the routing-guide example below would otherwise not work).
- **Fix — `WebSocketTestSession` `query_string` UTF-8**: was `latin-1`; a non-ASCII query (`/x?q=café`) raised `UnicodeEncodeError` while the UTF-8 `raw_path` accepted it. Now consistent with the real server.
- **Docs** — `routing.md` gains a *Lookup cache* section (`cache_max`, default 2048, `0` disables); `requests-and-responses.md` notes that `request.path` / `scope['path']` are percent-decoded since v0.53.0 (with `raw_path` carrying the undecoded bytes).

## Test plan

- [x] New `_LookupCache` contract + Router cache-strategy-swap tests
- [x] WS test-client non-ASCII `query_string` test
- [x] Existing white-box router-cache tests migrated to `router._cache`
- [x] `BlackBull(cache_max=…)` forwarding verified (2048 / 4096 / 0)
- [x] Full unit suite green + beartype-clean (`1555 passed, 1 xfailed`)

## Note

CHANGELOG entry is **deferred to the v0.54.0 release** to avoid churning the in-flight `[Unreleased]` → `[0.53.1]` boundary owned by release PR #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)