### PR TITLE
release: v0.53.2 — Compression/Cache Vary correctness (1.21f/1.21g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,36 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.53.2] — 2026-07-14
+
+Sprint 69 follow-on — two caching-correctness bugs found reviewing the v0.53.1
+`1.21` cluster. Both are shared-cache poisoning gaps in the `Compression` +
+`Cache` interaction; localised, no API change.
+
+### Fixed
+
+- **`Compression` now emits `Vary: Accept-Encoding` on compressible responses
+  it does not actually compress** (bug 1.21f). v0.53.1 added the header only on
+  the *successful-compression* path; a first request that hit one of the other
+  exit paths — no codec the client accepts (a `curl`/health-check/bot sending no
+  `Accept-Encoding`), body under `min_size`, or the executor-offload cap — served
+  a compressible body with no `Vary`, which a downstream `Cache` then stored
+  under the bare key and replayed to a later client that *did* accept an
+  encoding. The `Vary` decision is now made once at the `ResponseStart` decision
+  point (compressible Content-Type and no pre-existing `Content-Encoding`), so
+  every exit path carries it; the no-matching-codec path gets the same via a
+  lightweight send wrapper. Uncompressible types and already-encoded responses
+  still get no `Vary`.
+- **`Cache` no longer orphans variant entries after LRU eviction** (bug 1.21g).
+  The variant bookkeeping (a response's `Vary` field names) and the cached
+  entries were two independent `OrderedDict` LRUs; evicting the bookkeeping
+  first left the entries unreachable (lookups rebuilt the key with empty vary
+  fields and never matched), degrading to spurious misses. The store is now a
+  single LRU of per-URL buckets, each holding its `Vary` fields *beside* its
+  per-variant entries — so the fields can never outlive the entries they key.
+  `max_entries` now bounds distinct URLs; each bucket bounds its own variants
+  (16) against a hostile `Accept-*`-varying peer.
+
 ## [0.53.1] — 2026-07-13
 
 Sprint 69 (first half) — the `1.21` middleware-correctness cluster: five

--- a/blackbull/middleware/cache.py
+++ b/blackbull/middleware/cache.py
@@ -32,8 +32,12 @@ What it doesn't do (yet):
 * No cross-worker sharing.  The cache is per-process — each worker has
   its own.  Documented limitation.
 
-The base cache key is ``(method, path, query_string)``, extended with
-the ``(field, request-value)`` pairs named by the response ``Vary``.
+The store is keyed by ``(method, path, query_string)`` → a per-URL bucket
+that holds the response's ``Vary`` field names alongside its variant entries
+(one per distinct set of ``(field, request-value)`` pairs named by ``Vary``).
+Keeping the vary fields inside the bucket means they can never be evicted
+independently of the entries they key (which the earlier two-LRU design
+allowed — orphaning the entries).
 
 Usage::
 
@@ -85,6 +89,32 @@ class _Entry:
         return (now if now is not None else time.monotonic()) >= self.expires_at
 
 
+# Safety cap on the number of stored variants for a single base key, so a
+# hostile peer varying an Accept-* header cannot grow one bucket without bound.
+# Far above any real Accept-Encoding × Accept-Language cross-product.
+_MAX_VARIANTS_PER_KEY = 16
+
+
+class _Bucket:
+    """All cached variants for one base key ``(method, path, query_string)``.
+
+    The response ``Vary`` field names live *inside* the bucket, beside the
+    per-variant entries — not in a separate LRU.  That is the fix for 1.21g:
+    with two independent LRUs (the old ``_store`` + ``_vary_registry``) the vary
+    record could be evicted before its entries, orphaning them (future lookups
+    rebuilt the variant key with empty vary fields and never matched). Here the
+    vary fields cannot outlive their entries, so no orphan is possible.
+
+    ``entries`` is a per-variant LRU keyed by the variant tuple from
+    :func:`_vary_key` (``()`` for a non-varying response).
+    """
+    __slots__ = ('vary_fields', 'entries')
+
+    def __init__(self, vary_fields: tuple[bytes, ...] = ()):
+        self.vary_fields = vary_fields
+        self.entries: OrderedDict[tuple, _Entry] = OrderedDict()
+
+
 @as_middleware
 class Cache:
     """Per-worker in-memory response cache."""
@@ -109,14 +139,11 @@ class Cache:
         self._cacheable_statuses = frozenset(cacheable_statuses)
         self._cache_authenticated = cache_authenticated
         self._generate_etag = generate_etag
-        # OrderedDict gives us O(1) move-to-end on access + popitem(last=False)
-        # for LRU eviction — same pattern as :func:`functools.lru_cache`.
-        self._store: OrderedDict[tuple, _Entry] = OrderedDict()
-        # Per base-key record of the response ``Vary`` field names last seen,
-        # so a lookup (which happens before the handler runs, hence before we
-        # know the response's Vary) can reconstruct the variant key from the
-        # incoming request headers.  Bounded alongside the store.
-        self._vary_registry: OrderedDict[tuple, tuple[bytes, ...]] = OrderedDict()
+        # base_key → _Bucket.  OrderedDict gives O(1) move-to-end on access +
+        # popitem(last=False) for LRU eviction — same pattern as
+        # :func:`functools.lru_cache`.  ``_max_entries`` bounds the number of
+        # distinct URLs (base keys); each bucket LRU-bounds its own variants.
+        self._store: OrderedDict[tuple, _Bucket] = OrderedDict()
 
     # ---- ASGI surface ----------------------------------------------------
 
@@ -141,15 +168,17 @@ class Cache:
             return
 
         base_key = (method, scope.get('path', ''), scope.get('query_string', b''))
-        # Reconstruct the variant key from whatever Vary fields we last
-        # recorded for this base key (empty tuple ⇒ key == base_key).
-        vary_fields = self._vary_registry.get(base_key, ())
-        key = base_key + _vary_key(vary_fields, req_headers)
+        # Look up the bucket for this URL, then the specific variant inside it
+        # using the Vary fields recorded on the bucket (empty tuple ⇒ the single
+        # non-varying entry keyed by ``()``).
+        bucket = self._store.get(base_key)
+        variant_key = _vary_key(bucket.vary_fields, req_headers) if bucket else ()
+        entry = bucket.entries.get(variant_key) if bucket else None
 
         # --- cache hit? ---
-        entry = self._store.get(key)
         if entry is not None and not entry.expired():
-            self._store.move_to_end(key)  # touched → most-recently-used
+            self._store.move_to_end(base_key)      # URL touched → MRU
+            bucket.entries.move_to_end(variant_key)  # variant touched → MRU
             inm = req_headers.get(b'if-none-match')
             if inm is not None and _etag_matches(inm, entry.etag):
                 await send({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 304,
@@ -217,21 +246,28 @@ class Cache:
                         start['headers'] = new_hdrs
                     # ``vary_fields is None`` ⇒ ``Vary: *`` ⇒ uncacheable.
                     if etag is not None and vary_fields is not None:
-                        # Record the Vary fields so future lookups build the
-                        # matching variant key, then store under it.
-                        if vary_fields:
-                            self._vary_registry[base_key] = vary_fields
-                            self._vary_registry.move_to_end(base_key)
-                            while len(self._vary_registry) > self._max_entries:
-                                self._vary_registry.popitem(last=False)
-                        store_key = base_key + _vary_key(vary_fields, req_headers)
                         ttl = _response_max_age(response_headers) or self._max_age
-                        self._store[store_key] = _Entry(
+                        bucket = self._store.get(base_key)
+                        if bucket is None:
+                            bucket = _Bucket(vary_fields)
+                            self._store[base_key] = bucket
+                        elif bucket.vary_fields != vary_fields:
+                            # The response's Vary changed; the old variant keys
+                            # were built from the old fields and can no longer be
+                            # reached — adopt the new fields and drop them.
+                            bucket.vary_fields = vary_fields
+                            bucket.entries.clear()
+                        variant_key = _vary_key(vary_fields, req_headers)
+                        bucket.entries[variant_key] = _Entry(
                             events=[dict(e) for e in captured],
                             etag=etag,
                             expires_at=time.monotonic() + ttl,
                         )
-                        # LRU bound.
+                        bucket.entries.move_to_end(variant_key)
+                        self._store.move_to_end(base_key)
+                        # Per-bucket variant bound, then per-URL bound.
+                        while len(bucket.entries) > _MAX_VARIANTS_PER_KEY:
+                            bucket.entries.popitem(last=False)
                         while len(self._store) > self._max_entries:
                             self._store.popitem(last=False)
                 # Flush to client.

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -199,6 +199,25 @@ class Compression:
             cache[accept_header] = result
         return result
 
+    @staticmethod
+    def _vary_ensuring_send(send):
+        """Wrap *send* so a compressible, not-yet-encoded ``ResponseStart`` gains
+        ``Vary: Accept-Encoding`` — used on the no-matching-codec path where the
+        body is forwarded verbatim but must still be cache-keyed on the encoding
+        (bug 1.21f, Branch 1).  Same predicate as the compress path's decision
+        point: compressible Content-Type AND no pre-existing Content-Encoding.
+        """
+        async def vary_send(event: dict) -> None:
+            parsed = parse_response_event(event)
+            if isinstance(parsed, ResponseStart) and \
+                    _is_compressible_content_type(parsed.headers) and \
+                    not parsed.headers.get(b'content-encoding'):
+                hdrs = list(event.get('headers', []))
+                _merge_vary(hdrs)
+                event = {**event, 'headers': hdrs}
+            await send(event)
+        return vary_send
+
     async def __call__(self, scope, receive, send, call_next):
         if scope.get('type') != 'http':
             await call_next(scope, receive, send)
@@ -210,7 +229,12 @@ class Compression:
         accept = headers.get(b'accept-encoding', b'')
         selection = self._select_codec(accept)
         if selection is None:
-            await call_next(scope, receive, send)
+            # No codec the client accepts (e.g. no/identity Accept-Encoding).
+            # We won't compress, but the response may still be *compressible*,
+            # so a downstream shared cache needs Vary: Accept-Encoding — else it
+            # stores this identity variant under the bare key and replays it to a
+            # later client that does accept an encoding (bug 1.21f, Branch 1).
+            await call_next(scope, receive, self._vary_ensuring_send(send))
             return
 
         codec_name, compressor = selection
@@ -243,6 +267,17 @@ class Compression:
                     # Content-Encoding.  Don't double-wrap.
                     elif parsed.headers.get(b'content-encoding'):
                         skip_compression = True
+                    else:
+                        # Compressible + not pre-encoded: this response's body
+                        # varies by Accept-Encoding on *every* exit path
+                        # (compressed, too-small, executor-at-cap), so stamp
+                        # Vary now — at the decision point — instead of only
+                        # after a successful compress (bug 1.21f).  Later paths
+                        # inherit it via start_event; the compress path's own
+                        # _merge_vary then no-ops.
+                        hdrs = list(start_event.get('headers', []))
+                        _merge_vary(hdrs)
+                        start_event['headers'] = hdrs
                     # When skipping, forward the start event immediately
                     # so the downstream sender doesn't sit on a body with
                     # no headers (which would be invalid HTTP).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.1"
+version = "0.53.2"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_cache_middleware.py
+++ b/tests/unit/test_cache_middleware.py
@@ -486,6 +486,114 @@ class TestVaryAwareCaching:
         assert counter['n'] == 2, 'Vary: * responses must not be stored'
 
 
+@pytest.mark.asyncio
+class TestVaryBucketEviction:
+    """1.21g — variant metadata lives in the same bucket as its entries, so it
+    can never be evicted independently and orphan them."""
+
+    async def test_varied_entry_survives_other_url_churn(self):
+        mw = Cache(max_entries=8)
+        cn, counter = _vary_handler()
+        vscope = _scope(path='/v', headers=[(b'accept-encoding', b'br')])
+        await _run(mw, vscope, cn)                     # store /v br-variant
+        for p in ('/a', '/b', '/c'):                   # add other URLs (< cap)
+            h, _ = _make_handler()
+            await _run(mw, _scope(path=p), h)
+        _, _, body = _split_response(await _run(mw, vscope, cn))
+        assert body == b'ENC:br'
+        assert counter['n'] == 1, 'the br variant must still hit the cache'
+
+    async def test_bucket_evicted_as_a_unit(self):
+        """When a URL's bucket is LRU-evicted, its Vary fields and entries go
+        together — the next request is a clean miss + re-store, never a stale
+        lookup against orphaned entries (the old dual-LRU failure mode)."""
+        mw = Cache(max_entries=2)
+        cn, counter = _vary_handler()
+        vscope = _scope(path='/v', headers=[(b'accept-encoding', b'br')])
+        await _run(mw, vscope, cn)                     # counter → 1
+        for p in ('/a', '/b'):                         # evict /v (cap=2)
+            h, _ = _make_handler()
+            await _run(mw, _scope(path=p), h)
+        assert ('GET', '/v', b'') not in mw._store     # bucket gone as a unit
+        _, _, body = _split_response(await _run(mw, vscope, cn))  # clean miss
+        assert body == b'ENC:br'
+        assert counter['n'] == 2, 'handler re-ran; no orphaned stale entry'
+        await _run(mw, vscope, cn)                      # now hits again
+        assert counter['n'] == 2
+
+    async def test_vary_change_drops_stale_variants(self):
+        mw = Cache()
+        cn1, _ = _vary_handler(vary_value=b'Accept-Encoding')
+        await _run(mw, _scope(path='/x', headers=[(b'accept-encoding', b'br')]), cn1)
+        bucket = mw._store[('GET', '/x', b'')]
+        assert bucket.vary_fields == (b'accept-encoding',)
+        assert len(bucket.entries) == 1
+        # Same URL now varies by a different header → adopt it, drop the stale
+        # variant keyed on the old fields.
+        cn2, _ = _vary_handler(vary_value=b'Accept-Language')
+        await _run(mw, _scope(path='/x', headers=[(b'accept-language', b'en')]), cn2)
+        bucket = mw._store[('GET', '/x', b'')]
+        assert bucket.vary_fields == (b'accept-language',)
+        assert len(bucket.entries) == 1
+
+    async def test_per_bucket_variant_cap(self):
+        from blackbull.middleware.cache import _MAX_VARIANTS_PER_KEY
+        mw = Cache()
+        cn, _ = _vary_handler()
+        for i in range(_MAX_VARIANTS_PER_KEY + 5):
+            await _run(mw, _scope(path='/p',
+                                  headers=[(b'accept-encoding', f'enc{i}'.encode())]), cn)
+        bucket = mw._store[('GET', '/p', b'')]
+        assert len(bucket.entries) <= _MAX_VARIANTS_PER_KEY
+
+
+@pytest.mark.asyncio
+class TestCacheBehindCompression:
+    """End-to-end 1.21f + 1.21g: a ``Cache`` in front of ``Compression`` must
+    serve each Accept-Encoding client its own variant, no matter which client
+    arrives first — the first-request poisoning scenario the two fixes close."""
+
+    @staticmethod
+    def _stack():
+        from blackbull.middleware.compression import Compression
+        compression = Compression()
+
+        async def handler(scope, receive, send):
+            body = b'compressible payload ' * 40  # > _MIN_SIZE
+            await send({'type': 'http.response.start', 'status': 200,
+                        'headers': [(b'content-type', b'text/plain')]})
+            await send({'type': 'http.response.body', 'body': body,
+                        'more_body': False})
+
+        async def compression_layer(scope, receive, send):
+            await compression(scope, receive, send, handler)
+
+        return Cache(), compression_layer
+
+    async def _fetch(self, cache, layer, accept: bytes):
+        status, headers, body = _split_response(
+            await _run(cache, _scope(headers=[(b'accept-encoding', accept)]), layer))
+        return dict(headers), body
+
+    async def test_gzip_first_then_identity(self):
+        cache, layer = self._stack()
+        gz_hdrs, _ = await self._fetch(cache, layer, b'gzip')
+        id_hdrs, _ = await self._fetch(cache, layer, b'')
+        assert gz_hdrs.get(b'content-encoding') == b'gzip'
+        # The identity client must NOT be served the gzip variant.
+        assert id_hdrs.get(b'content-encoding') is None
+
+    async def test_identity_first_then_gzip(self):
+        # The dangerous order: the un-encoded response is cached first. Without
+        # 1.21f it would carry no Vary and poison the gzip client.
+        cache, layer = self._stack()
+        id_hdrs, _ = await self._fetch(cache, layer, b'')
+        gz_hdrs, _ = await self._fetch(cache, layer, b'gzip')
+        assert id_hdrs.get(b'content-encoding') is None
+        assert gz_hdrs.get(b'content-encoding') == b'gzip', \
+            'gzip client must get gzip, not the cached identity variant'
+
+
 class TestVaryHelpers:
     def test_response_vary_absent(self):
         from blackbull.middleware.cache import _response_vary

--- a/tests/unit/test_compression_vary.py
+++ b/tests/unit/test_compression_vary.py
@@ -88,6 +88,68 @@ async def test_vary_not_duplicated_when_already_present():
     assert tokens.count(b'accept-encoding') == 1
 
 
+def _has_vary_accept_encoding(headers) -> bool:
+    return any(k.lower() == b'vary' and b'accept-encoding' in v.lower()
+               for k, v in headers)
+
+
+class TestVaryOnCompressibleButUncompressedPaths:
+    """1.21f — a *compressible* response must carry ``Vary: Accept-Encoding``
+    even on the exit paths that do not actually compress, so a downstream
+    shared cache never stores an un-varied entry it then replays to a client
+    that does accept an encoding."""
+
+    @pytest.mark.asyncio
+    async def test_no_matching_codec_still_varies(self):
+        # Client accepts nothing we offer → we forward verbatim (Branch 1).
+        mw = Compression()
+        res = await _run(mw, _BODY, [(b'content-type', b'text/plain')], accept=b'')
+        assert dict(res['headers']).get(b'content-encoding') is None
+        assert _has_vary_accept_encoding(res['headers'])
+
+    @pytest.mark.asyncio
+    async def test_small_body_still_varies(self):
+        # Body under _MIN_SIZE → not compressed, but still compressible (2c).
+        mw = Compression()
+        res = await _run(mw, b'tiny', [(b'content-type', b'text/plain')], accept=b'gzip')
+        assert dict(res['headers']).get(b'content-encoding') is None
+        assert _has_vary_accept_encoding(res['headers'])
+
+    @pytest.mark.asyncio
+    async def test_executor_at_cap_still_varies(self):
+        # Executor-offload cap hit → served uncompressed but must vary (2d).
+        mw = Compression(executor_max_inflight=1, executor_threshold=1)
+        mw._executor_inflight = 1
+        res = await _run(mw, _BODY, [(b'content-type', b'text/plain')], accept=b'gzip')
+        assert dict(res['headers']).get(b'content-encoding') is None
+        assert _has_vary_accept_encoding(res['headers'])
+
+    @pytest.mark.asyncio
+    async def test_uncompressible_content_type_does_not_vary(self):
+        # An already-compressed Content-Type must NOT gain a spurious Vary (2a).
+        mw = Compression()
+        res = await _run(mw, _BODY, [(b'content-type', b'image/png')], accept=b'gzip')
+        assert not _has_vary_accept_encoding(res['headers'])
+
+    @pytest.mark.asyncio
+    async def test_precompressed_response_does_not_vary(self):
+        # A pre-existing Content-Encoding means we don't touch the body — and
+        # must not add our own Vary (2b).
+        mw = Compression()
+        res = await _run(mw, _BODY, [
+            (b'content-type', b'text/plain'),
+            (b'content-encoding', b'br'),
+        ], accept=b'gzip')
+        assert not _has_vary_accept_encoding(res['headers'])
+
+    @pytest.mark.asyncio
+    async def test_no_codec_path_leaves_uncompressible_alone(self):
+        # Branch 1 + uncompressible type → no compression, no Vary.
+        mw = Compression()
+        res = await _run(mw, _BODY, [(b'content-type', b'video/mp4')], accept=b'')
+        assert not _has_vary_accept_encoding(res['headers'])
+
+
 class TestMergeVaryHelper:
     def test_appends_when_absent(self):
         hdrs = [(b'content-type', b'text/plain')]


### PR DESCRIPTION
Sprint 69 follow-on. Two shared-cache poisoning bugs surfaced reviewing the
v0.53.1 `1.21` cluster, both in the `Compression` + `Cache` interaction.
Localised, no API change. Ships as **v0.53.2** (PATCH).

## Fixed

**1.21f — `Compression` misses `Vary` on compressible-but-uncompressed paths.**
v0.53.1 stamped `Vary: Accept-Encoding` only after a *successful* compression.
Three other exit paths served a compressible body with no `Vary` — no codec the
client accepts (curl/health-check/bot with no `Accept-Encoding`), body under
`min_size`, or the executor-offload cap — and a downstream `Cache` then stored
that un-varied entry and replayed it to a client that *did* accept an encoding.
The `Vary` decision now happens once at the `ResponseStart` decision point
(compressible Content-Type + no pre-existing `Content-Encoding`), so every exit
path inherits it; the no-matching-codec path gets the same via a lightweight
send wrapper. Uncompressible types and pre-encoded responses still get no `Vary`.

**1.21g — `Cache` orphans variant entries after LRU eviction.** The `Vary`
bookkeeping and the cached entries were two independent `OrderedDict` LRUs;
evicting the bookkeeping first left the entries unreachable (spurious misses).
The store is now a single LRU of per-URL buckets, each holding its `Vary` fields
*beside* its per-variant entries — the fields can't outlive the entries they
key. `max_entries` now bounds distinct URLs; each bucket bounds its own variants
(16) against a hostile `Accept-*`-varying peer.

## Test plan

- [x] `tests/unit/test_compression_vary.py` — new exit-path coverage (no-codec,
      small-body, executor-at-cap → Vary; uncompressible / pre-encoded → no Vary)
- [x] `tests/unit/test_cache_middleware.py` — bucket eviction-as-a-unit, no
      orphan, vary-change clear, per-bucket cap, **end-to-end Cache-behind-
      Compression poisoning test (both request orders)**
- [x] Full suite: 2916 passed, 258 skipped, 1 xfailed
- [x] Under beartype (`--beartype-packages=blackbull`): middleware suite green
- [x] `pip install -e .` → `blackbull.__version__ == 0.53.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)