### PR TITLE
release: v0.53.3 — Sprint 70: MQTT 5.0 broker hardening (1.19 cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,63 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.53.3] — 2026-07-14
+
+Sprint 70 — MQTT 5.0 broker hardening: the `1.19` correctness cluster (eight
+RFC-conformance bugs). All localised to the broker/connection actors on the MQTT
+port; the HTTP request path is untouched. No API change.
+
+### Fixed
+
+- **Keep-alive is now enforced** (§3.1.2.10, bug 1.19a). A connection that
+  sends no packet within 1.5× its negotiated Keep Alive is treated as an
+  abnormal disconnect: its Will fires and the connection closes, so a dead peer
+  (crashed client, half-open NAT) no longer holds its connection, session and
+  Will indefinitely. Keep Alive `0` disables the check.
+- **Session takeover** (§3.1.4, bug 1.19b). A second `CONNECT` for a
+  `client_id` that is already connected now disconnects the previous connection
+  with `DISCONNECT` reason `0x8E` (Session taken over) and closes it, instead of
+  leaving the old connection live with its socket open.
+- **QoS 2 inbound de-duplication** (§4.3.3, bug 1.19c). A retransmitted (`DUP`)
+  `PUBLISH` whose Packet Identifier is already in the PUBREC-sent state is
+  acknowledged with `PUBREC` but no longer re-delivered or re-retained.
+- **Topic validation on `PUBLISH` / `SUBSCRIBE`** (§3.3.2.1 / §4.7, bug 1.19d).
+  A `PUBLISH` with a wildcard/null Topic Name is rejected (`0x90`, or a
+  `DISCONNECT` for QoS 0) and neither routed nor retained; a malformed Topic
+  Filter in `SUBSCRIBE` is rejected per-entry with `0x8F`. (Wires in the
+  previously-dead `validate_topic_name` / `validate_topic_filter`.)
+- **`No Local` and `Retain As Published` subscription options are honoured**
+  (§3.8.3.1 / §3.3.1.3, bug 1.19e). A client's own message is no longer echoed
+  back to it on a `No Local` subscription, and the publisher's `RETAIN` flag is
+  forwarded only when a matching subscription set Retain As Published.
+- **Shared subscriptions are rejected explicitly** (§4.8, part of 1.19e). A
+  `$share/...` filter now gets `0x9E` (Shared Subscriptions not supported)
+  rather than being silently broadcast to every group member (which violated
+  the §4.8.2 load-balancing contract).
+- **QoS 2 outbound + `DUP` replay on reconnect** (§4.4 / §3.3.1.1, bug 1.19f).
+  A session-present reconnect now retransmits unacknowledged outbound QoS 1 and
+  QoS 2 `PUBLISH` frames with `DUP=1`, and re-drives a `PUBREL` still awaiting
+  `PUBCOMP`.
+- **Malformed `CONNECT` no longer drops the connection on `IndexError`**
+  (§1.5.5 / §4.13, bug 1.19g). A `CONNECT` truncated before its fixed header
+  fields — and any packet whose body is inconsistent with its declared
+  Remaining Length — now decodes to `MQTTDecodeError`, which the framer resyncs
+  on, instead of an `IndexError` unwinding the read loop or an `IncompletePacket`
+  stalling it forever.
+- **Packet-identifier allocation skips in-flight ids** (§2.2.1, bug 1.19h).
+  `_alloc_pid` no longer hands out an identifier still awaiting acknowledgement
+  in either QoS>0 outbound bucket.
+
+### Changed
+
+- MQTT QoS-2 flow state is now modelled with named constants and helpers
+  (`_qos2_accept_inbound`, `_replay_pending`); outbound QoS-2 entries keep the
+  `PUBLISH` packet (not just a state string) so §4.4 replay can retransmit it
+  (refactor 2.9).
+- `docs/guide/mqtt.md` capability table updated for the above (shared
+  subscriptions now listed as rejected; keep-alive/session-takeover/QoS-2
+  behaviours documented).
+
 ## [0.53.2] — 2026-07-14
 
 Sprint 69 follow-on — two caching-correctness bugs found reviewing the v0.53.1

--- a/blackbull/mqtt/broker.py
+++ b/blackbull/mqtt/broker.py
@@ -13,20 +13,27 @@ subscribers during a peer's teardown with no special-casing.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Any
 
 from ..actor import Actor, Message as ActorMessage
 from .messages import (
-    MQTTConnect, MQTTConnack,
+    MQTTConnect, MQTTConnack, MQTTDisconnect,
     MQTTPublish, MQTTPuback, MQTTPubrec, MQTTPubrel, MQTTPubcomp,
     MQTTSubscribe, MQTTSuback,
     MQTTUnsubscribe, MQTTUnsuback,
     ProtocolLevel, ReasonCode,
-    topic_matches_filter,
+    topic_matches_filter, validate_topic_name, validate_topic_filter,
 )
 
 logger = logging.getLogger(__name__)
+
+# QoS 2 flow states (§4.3.3).  Named so every transition — inbound
+# PUBLISH→PUBREC, outbound PUBLISH→PUBREL — reads as one word rather than a
+# bare string literal scattered across the handlers.
+_QOS2_IN_PUBREC_SENT = 'PUBREC_SENT'      # inbound: PUBREC sent, awaiting PUBREL
+_QOS2_OUT_PUBLISH_SENT = 'PUBLISH_SENT'   # outbound: PUBLISH sent, awaiting PUBREC
+_QOS2_OUT_PUBREL_SENT = 'PUBREL_SENT'     # outbound: PUBREL sent, awaiting PUBCOMP
 
 
 # -- Level A messages: connection actor -> broker ---------------------------
@@ -92,6 +99,19 @@ class Close(ActorMessage):
     reason_code: int | None = field(default=None, compare=False, repr=False)
 
 
+def _valid_filter(topic_filter: str) -> bool:
+    """Bool wrapper over :func:`validate_topic_filter`.
+
+    The validator has a mixed contract — it returns ``False`` for a null char
+    but *raises* ``ValueError`` for structural violations.  The broker only
+    needs a yes/no, so normalise both failure shapes to ``False`` here.
+    """
+    try:
+        return validate_topic_filter(topic_filter)
+    except ValueError:
+        return False
+
+
 def _new_broker_session() -> dict[str, Any]:
     """Per-client session state owned by the broker (§3.1.2.11)."""
     return {
@@ -102,7 +122,10 @@ def _new_broker_session() -> dict[str, Any]:
         'subscriptions': [],
         'pending_qos1_out': {},     # packet_id -> MQTTPublish awaiting PUBACK
         'pending_qos2_in': {},      # packet_id -> state str (PUBREC sent ...)
-        'pending_qos2_out': {},     # packet_id -> state str (PUBLISH/PUBREL ...)
+        # packet_id -> {'state': _QOS2_OUT_*, 'packet': MQTTPublish}.  The
+        # PUBLISH itself is kept (not just the state) so §4.4 reconnect replay
+        # can retransmit it with DUP=1 while still awaiting PUBREC.
+        'pending_qos2_out': {},
         '_expiry': 0,
         '_next_pid': 0,
     }
@@ -157,8 +180,22 @@ class BrokerActor(Actor):
 
     @staticmethod
     def _alloc_pid(session) -> int:
-        session['_next_pid'] = (session.get('_next_pid', 0) % 65535) + 1
-        return session['_next_pid']
+        """§2.2.1 — allocate a non-zero Packet Identifier not currently in use.
+
+        Skips ids still awaiting acknowledgement in either QoS>0 outbound bucket,
+        so a connection with a very high in-flight fan-out cannot hand out an id
+        that is still live (the old ``(_next_pid % 65535) + 1`` could).
+        """
+        in_use = (session.get('pending_qos1_out') or {}).keys() \
+            | (session.get('pending_qos2_out') or {}).keys()
+        pid = session.get('_next_pid', 0)
+        for _ in range(65535):
+            pid = (pid % 65535) + 1
+            if pid not in in_use:
+                session['_next_pid'] = pid
+                return pid
+        # All 65535 identifiers are in flight — far past any conformant bound.
+        raise RuntimeError('No free MQTT packet identifier (65535 in flight)')
 
     def _store_retained(self, publish) -> None:
         # §3.3.2.3 — a zero-length retained payload deletes the retained message.
@@ -186,6 +223,21 @@ class BrokerActor(Actor):
         if not client_id:
             self._auto_seq += 1
             client_id = f'auto-{self._auto_seq}'
+
+        # §3.1.4-3 — a second CONNECT for a Client Identifier that is already
+        # connected takes the session over: the previous Network Connection MUST
+        # be disconnected (DISCONNECT 0x8E, then close).  Dropping its
+        # id(conn) → client_id mapping first also neutralises that connection's
+        # teardown Detach (it early-returns on the missing id), so the taken-over
+        # client's Will is not published (§3.1.2.5) and the new session is left
+        # untouched.
+        existing_conn = self._clients.get(client_id)
+        if existing_conn is not None and existing_conn is not conn:
+            self._client_by_conn.pop(id(existing_conn), None)
+            await existing_conn.send(Send(packet=MQTTDisconnect(
+                reason_code=ReasonCode.SESSION_TAKEN_OVER)))
+            await existing_conn.send(Close(
+                reason_code=ReasonCode.SESSION_TAKEN_OVER))
 
         self._clients[client_id] = conn
         self._client_by_conn[id(conn)] = client_id
@@ -228,10 +280,25 @@ class BrokerActor(Actor):
         await conn.send(Send(packet=MQTTConnack(
             session_present=session_present, reason_code=ReasonCode.SUCCESS)))
 
-        # Deliver QoS 1 messages queued while the client was offline.
+        # §4.4 — retransmit any unacknowledged outbound messages queued while
+        # the client was offline (QoS 1 + QoS 2, with DUP set on PUBLISH frames).
         if session_present:
-            for pending in list(session['pending_qos1_out'].values()):
-                await conn.send(Send(packet=pending))
+            await self._replay_pending(conn, session)
+
+    async def _replay_pending(self, conn, session) -> None:
+        """§4.4 — retransmit unacknowledged outbound messages on a
+        session-present reconnect.  Replayed PUBLISH frames carry DUP=1
+        (§3.3.1.1): QoS 1 PUBLISH awaiting PUBACK and QoS 2 PUBLISH awaiting
+        PUBREC.  A QoS 2 exchange already past PUBREC re-drives its PUBREL."""
+        for pending in list(session['pending_qos1_out'].values()):
+            await conn.send(Send(packet=replace(pending, dup=True)))
+        for packet_id, entry in list(session['pending_qos2_out'].items()):
+            publish = entry.get('packet')
+            if entry.get('state') == _QOS2_OUT_PUBLISH_SENT and publish is not None:
+                await conn.send(Send(packet=replace(publish, dup=True)))
+            else:  # PUBREL_SENT — the PUBLISH is acknowledged; re-drive PUBREL
+                await conn.send(Send(packet=MQTTPubrel(
+                    packet_id=packet_id, reason_code=ReasonCode.SUCCESS)))
 
     async def _on_subscribe(self, conn, subscribe) -> None:
         session = self._session_for(conn)
@@ -240,6 +307,18 @@ class BrokerActor(Actor):
         reason_codes = []
         options = subscribe.subscription_options or []
         for index, (topic_filter, qos) in enumerate(subscribe.subscriptions):
+            # §4.8 — Shared Subscriptions are not implemented.  Reject them
+            # explicitly (0x9E) rather than silently broadcasting to every group
+            # member, which would violate the §4.8.2 load-balancing contract.
+            if topic_filter.startswith('$share/'):
+                reason_codes.append(ReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED)
+                continue
+            # §3.8.3 / §4.7 — a syntactically invalid Topic Filter is rejected
+            # per-entry with 0x8F; the SUBACK still carries one reason code per
+            # requested filter, so ordering with the remaining entries is kept.
+            if not _valid_filter(topic_filter):
+                reason_codes.append(ReasonCode.TOPIC_FILTER_INVALID)
+                continue
             opts = dict(options[index]) if index < len(options) else {}
             opts['qos'] = qos
             # §3.8.4 — a SUBSCRIBE for an existing Topic Filter replaces its
@@ -271,32 +350,85 @@ class BrokerActor(Actor):
             reason_codes=[ReasonCode.SUCCESS] * len(unsubscribe.topics))))
 
     async def _on_publish(self, conn, publish) -> None:
-        if publish.retain:
-            self._store_retained(publish)
+        # §3.3.2.1 — a Topic Name is literal: non-empty, no wildcards, no null.
+        # An invalid one is rejected (0x90) and neither routed nor retained.
+        if not validate_topic_name(publish.topic):
+            await self._reject_publish(conn, publish, ReasonCode.TOPIC_NAME_INVALID)
+            return
         if publish.qos == 1:
             await conn.send(Send(packet=MQTTPuback(
                 packet_id=publish.packet_id, reason_code=ReasonCode.SUCCESS)))
         elif publish.qos == 2:
+            # §4.3.3 — always acknowledge with PUBREC, but a DUP retransmit of an
+            # id we have already accepted must not be delivered a second time.
             await conn.send(Send(packet=MQTTPubrec(
                 packet_id=publish.packet_id, reason_code=ReasonCode.SUCCESS)))
-            session = self._session_for(conn)
-            if session is not None:
-                session['pending_qos2_in'][publish.packet_id] = 'PUBREC_SENT'
-        await self._route(publish)
+            if not self._qos2_accept_inbound(conn, publish.packet_id):
+                return  # duplicate — PUBREC re-sent above; skip retain + route
+        if publish.retain:
+            self._store_retained(publish)
+        await self._route(publish, source_conn=conn)
 
-    async def _route(self, publish) -> None:
-        """Deliver *publish* to every live client with a matching subscription."""
+    def _qos2_accept_inbound(self, conn, packet_id) -> bool:
+        """§4.3.3 — record a newly-received QoS 2 PUBLISH (PUBREC sent).
+
+        Returns ``False`` when *packet_id* was already accepted (a DUP
+        retransmit), so the caller re-sends PUBREC only and neither re-stores a
+        retained copy nor re-routes the message.
+        """
+        session = self._session_for(conn)
+        if session is None:
+            return True
+        if packet_id in session['pending_qos2_in']:
+            return False
+        session['pending_qos2_in'][packet_id] = _QOS2_IN_PUBREC_SENT
+        return True
+
+    async def _reject_publish(self, conn, publish, reason) -> None:
+        """Reject an invalid inbound PUBLISH — no routing, no retain (§3.3.2.1).
+
+        QoS 1/2 signal the failure in the normal acknowledgement (PUBACK/PUBREC
+        with the error reason code); QoS 0 has no ack channel, so §4.13 applies —
+        send a DISCONNECT carrying the reason and close the connection.
+        """
+        if publish.qos == 1:
+            await conn.send(Send(packet=MQTTPuback(
+                packet_id=publish.packet_id, reason_code=reason)))
+        elif publish.qos == 2:
+            await conn.send(Send(packet=MQTTPubrec(
+                packet_id=publish.packet_id, reason_code=reason)))
+        else:
+            await conn.send(Send(packet=MQTTDisconnect(reason_code=reason)))
+            await conn.send(Close(reason_code=reason))
+
+    async def _route(self, publish, source_conn=None) -> None:
+        """Deliver *publish* to every live client with a matching subscription.
+
+        *source_conn* is the connection that published (``None`` for a Will),
+        used to honour the No Local subscription option (§3.8.3.1).
+        """
         for client_id, conn in list(self._clients.items()):
             session = self._sessions.get(client_id)
             if session is None:
                 continue
             granted = None
-            for topic_filter, qos, _opts in session['subscriptions']:
-                if topic_matches_filter(publish.topic, topic_filter):
-                    granted = qos if granted is None else max(granted, qos)
+            rap = False
+            for topic_filter, qos, opts in session['subscriptions']:
+                if not topic_matches_filter(publish.topic, topic_filter):
+                    continue
+                # §3.8.3.1 No Local — do not echo a client's own message back to
+                # it on a subscription that set the No Local option.
+                if opts.get('no_local') and conn is source_conn:
+                    continue
+                granted = qos if granted is None else max(granted, qos)
+                rap = rap or bool(opts.get('retain_as_published'))
             if granted is None:
                 continue
-            await self._deliver(conn, session, publish, granted)
+            # §3.3.1.3 Retain As Published — forward the publisher's RETAIN flag
+            # only when a matching subscription requested it; otherwise a routed
+            # (non-retained-replay) message always carries RETAIN=0.
+            await self._deliver(conn, session, publish, granted,
+                                retain=(rap and publish.retain))
 
     async def _deliver(self, conn, session, publish, granted_qos, *, retain=False) -> None:
         qos = min(publish.qos, granted_qos)
@@ -307,7 +439,8 @@ class BrokerActor(Actor):
         if qos == 1:
             session['pending_qos1_out'][packet_id] = out
         elif qos == 2:
-            session['pending_qos2_out'][packet_id] = 'PUBLISH_SENT'
+            session['pending_qos2_out'][packet_id] = {
+                'state': _QOS2_OUT_PUBLISH_SENT, 'packet': out}
         await conn.send(Send(packet=out))
 
     async def _on_pubrel(self, conn, packet_id) -> None:
@@ -322,7 +455,15 @@ class BrokerActor(Actor):
             packet_id=packet_id, reason_code=ReasonCode.SUCCESS)))
         session = self._session_for(conn)
         if session is not None:
-            session['pending_qos2_out'][packet_id] = 'PUBREL_SENT'
+            # §4.3.3 — advance the outbound flow to await PUBCOMP; the PUBLISH is
+            # now acknowledged so we no longer need to keep it for replay.
+            entry = session['pending_qos2_out'].get(packet_id)
+            if entry is not None:
+                entry['state'] = _QOS2_OUT_PUBREL_SENT
+                entry.pop('packet', None)
+            else:
+                session['pending_qos2_out'][packet_id] = {
+                    'state': _QOS2_OUT_PUBREL_SENT}
 
     async def _on_detach(self, conn, graceful) -> None:
         client_id = self._client_by_conn.pop(id(conn), None)

--- a/blackbull/mqtt/connection.py
+++ b/blackbull/mqtt/connection.py
@@ -99,6 +99,11 @@ class MQTT5Actor(Actor):
         self._inline_taps = compile_taps(app_handlers) if tap is None else []
         self._done = False
         self.graceful = False
+        # §3.1.2.10 — negotiated Keep Alive (seconds; 0 disables the check),
+        # learned from the client's CONNECT.  ``_last_rx`` is the monotonic time
+        # of the last received packet, used to enforce the 1.5× idle deadline.
+        self._keep_alive = 0
+        self._last_rx = 0.0
 
     # -- inbox drain (the only writer) --------------------------------------
 
@@ -122,22 +127,50 @@ class MQTT5Actor(Actor):
         (``at_eof()``), a DISCONNECT (sets ``_done``), or task cancellation.
         """
         framer = PacketFramer()
+        loop = asyncio.get_running_loop()
+        self._last_rx = loop.time()
         while not self._done:
             for message in framer:
                 await self._forward(message)
                 if self._done:
                     return
-            data = await reader.read(_READ_CHUNK)
+            data = await self._read_with_keepalive(reader)
             if data:
+                self._last_rx = loop.time()
                 framer.feed(data)
             elif reader.at_eof():
                 break  # peer closed the connection (EOF)
+            elif self._keep_alive and (loop.time() - self._last_rx) > self._keep_alive * 1.5:
+                # §3.1.2.10 — no packet within 1.5× the negotiated Keep Alive.
+                # Treat it as an abnormal disconnect: fire the Will and close so
+                # a dead peer (crashed client, half-open NAT) stops holding its
+                # connection, session and Will indefinitely.
+                logger.debug('MQTT keep-alive timeout (%.1fs idle); closing',
+                             loop.time() - self._last_rx)
+                self.graceful = False
+                await self._broker.send(Detach(graceful=False, sender=self))
+                self._done = True
             else:
                 await asyncio.sleep(_IDLE_SLEEP)
+
+    async def _read_with_keepalive(self, reader: AbstractReader) -> bytes:
+        """Read a chunk, but wake at the keep-alive deadline so a silent peer on
+        a blocking socket cannot hold the connection open forever.  With Keep
+        Alive disabled (0) this is a plain blocking read; otherwise a read that
+        stalls past 1.5× the interval returns ``b''`` and the loop enforces the
+        idle deadline (§3.1.2.10)."""
+        if not self._keep_alive:
+            return await reader.read(_READ_CHUNK)
+        try:
+            return await asyncio.wait_for(
+                reader.read(_READ_CHUNK), self._keep_alive * 1.5)
+        except asyncio.TimeoutError:
+            return b''
 
     async def _forward(self, message: MQTTMessage) -> None:
         broker = self._broker
         if isinstance(message, MQTTConnect):
+            self._keep_alive = message.keep_alive
             await broker.send(Attach(connect=message, sender=self))
         elif isinstance(message, MQTTPublish):
             await broker.send(ClientPublish(publish=message, sender=self))

--- a/blackbull/mqtt/messages.py
+++ b/blackbull/mqtt/messages.py
@@ -247,7 +247,14 @@ class ReasonCode(IntEnum):
     """
     SUCCESS = 0x00
     DISCONNECT_WITH_WILL = 0x04
+    MALFORMED_PACKET = 0x81
+    PROTOCOL_ERROR = 0x82
     UNSUPPORTED_PROTOCOL_VERSION = 0x84
+    KEEP_ALIVE_TIMEOUT = 0x8D
+    SESSION_TAKEN_OVER = 0x8E
+    TOPIC_FILTER_INVALID = 0x8F
+    TOPIC_NAME_INVALID = 0x90
+    SHARED_SUBSCRIPTIONS_NOT_SUPPORTED = 0x9E
 
 
 # Guard against the typed subset and the name registry drifting apart: every
@@ -855,6 +862,14 @@ def encode_packet(message: MQTTMessage) -> bytes:
 def _decode_connect(body: bytes, flags: int) -> MQTTConnect:
     pos = 0
     _proto_name, pos = _decode_utf8(body, pos)
+    # §3.1.2 — Protocol Level (1), Connect Flags (1) and Keep Alive (2) are a
+    # fixed 4-byte block after the protocol name.  A CONNECT whose declared
+    # Remaining Length stops short of them must be rejected as a Malformed
+    # Packet (§1.5.5, §4.13) — a raw ``body[pos]`` here would raise IndexError,
+    # which the framer's ``except`` does not catch, unwinding ``read_loop``
+    # and dropping the connection instead of resyncing (audit 1.19g).
+    if pos + 4 > len(body):
+        raise MQTTDecodeError('CONNECT truncated before the fixed header fields')
     proto_level = body[pos]
     pos += 1
     cflags = body[pos]
@@ -1065,7 +1080,19 @@ def decode_packet(data: bytes) -> MQTTMessage:
     decoder = _DECODERS.get(packet_type)
     if decoder is None:  # pragma: no cover - MQTTPacketType is exhaustive above
         raise MQTTDecodeError(f'Unhandled packet type {packet_type!r}')
-    msg = decoder(body, flags)
+    # ``body`` is exactly Remaining Length bytes (validated above), so we hold
+    # the whole declared packet.  An inner decoder that still claims "need more"
+    # (IncompletePacket) or indexes past the body (IndexError) means the packet's
+    # contents are inconsistent with its declared length — a Malformed Packet
+    # (§1.5.5, §4.13), not a short read.  Both must surface as MQTTDecodeError so
+    # the framer resyncs (drops a byte) instead of stalling forever on a body
+    # that will never grow, or unwinding read_loop on an uncaught IndexError.
+    try:
+        msg = decoder(body, flags)
+    except IncompletePacket as exc:
+        raise MQTTDecodeError('Packet body inconsistent with Remaining Length') from exc
+    except IndexError as exc:
+        raise MQTTDecodeError('Packet body indexed past its Remaining Length') from exc
 
     msg._set_consumed(total)
     return msg

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -89,13 +89,15 @@ conformance matrix:
 | Area | Support |
 |------|---------|
 | Connection | CONNECT / CONNACK, protocol-level check (rejects non-5 with `0x84`), Clean Start, Session Present |
-| Subscriptions | SUBSCRIBE / SUBACK, UNSUBSCRIBE / UNSUBACK, `+` and `#` wildcards, `$`-topic rules, shared subscriptions |
+| Subscriptions | SUBSCRIBE / SUBACK, UNSUBSCRIBE / UNSUBACK, `+` and `#` wildcards, `$`-topic rules; `No Local` and `Retain As Published` options honoured; invalid Topic Filters rejected (`0x8F`). Shared subscriptions (`$share/…`) are **not implemented** and are rejected with `0x9E` rather than silently broadcast |
+| Publish | invalid Topic Names (wildcards / null) rejected (`0x90`), never routed or retained |
 | QoS 0 | fire-and-forget delivery |
 | QoS 1 | PUBACK round-trip |
-| QoS 2 | PUBREC → PUBREL → PUBCOMP four-way handshake |
+| QoS 2 | PUBREC → PUBREL → PUBCOMP four-way handshake; duplicate PUBLISH de-duplicated; unacked messages replayed with `DUP=1` on reconnect |
 | Retained | one retained message per topic; delivered to late subscribers; zero-length payload clears |
 | Will (LWT) | delivered on abnormal disconnect; suppressed on a normal `DISCONNECT` (`0x00`) |
-| Keep-alive | PINGREQ / PINGRESP |
+| Keep-alive | PINGREQ / PINGRESP; an idle connection is closed (Will fired) at 1.5× the negotiated Keep Alive (§3.1.2.10) |
+| Session takeover | a second CONNECT for a live Client Identifier disconnects the prior connection with `0x8E` (§3.1.4) |
 | Properties | the full MQTT 5 property set (§2.2.2.2) on every packet that carries properties |
 | Sessions | subscriptions and pending QoS state preserved across reconnects with Clean Start = 0 |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.2"
+version = "0.53.3"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conformance/mqtt/test_mqtt_edge_cases.py
+++ b/tests/conformance/mqtt/test_mqtt_edge_cases.py
@@ -370,14 +370,16 @@ class TestSessionStateDetails:
                 201: 'PUBREC_SENT',
             },
             'pending_qos2_out': {
-                300: 'PUBLISH_SENT',  # PUBLISH sent, waiting for PUBREC
-                301: 'PUBREL_SENT',   # PUBREL sent, waiting for PUBCOMP
+                # Outbound entries keep the PUBLISH for §4.4 DUP replay while
+                # still awaiting PUBREC; a PUBREL-stage entry is state-only.
+                300: {'state': 'PUBLISH_SENT', 'packet': None},
+                301: {'state': 'PUBREL_SENT'},
             },
         }
         session = mqtt.sessions.get('qos2-client')
         assert session['pending_qos2_in'][200] == 'PUBREC_SENT'
-        assert session['pending_qos2_out'][300] == 'PUBLISH_SENT'
-        assert session['pending_qos2_out'][301] == 'PUBREL_SENT'
+        assert session['pending_qos2_out'][300]['state'] == 'PUBLISH_SENT'
+        assert session['pending_qos2_out'][301]['state'] == 'PUBREL_SENT'
 
 
 # ============================================================================

--- a/tests/unit/test_mqtt_hardening.py
+++ b/tests/unit/test_mqtt_hardening.py
@@ -1,0 +1,405 @@
+"""Behaviour-level tests for the Sprint 70 MQTT-broker hardening cluster (1.19).
+
+The pre-existing MQTT suite asserted mostly *codec round-trips* — which is
+exactly why the broker-behaviour gaps in this cluster (keep-alive enforcement,
+QoS-2 dedup, session takeover, No Local, …) stayed hidden.  Every test here
+drives real broker/connection behaviour, not encode/decode symmetry.
+"""
+import asyncio
+import contextlib
+
+import pytest
+
+from blackbull.actor import Actor
+from blackbull.mqtt.broker import (
+    BrokerActor,
+    Attach, ClientSubscribe, ClientPublish, ClientPubrec, Detach, Send, Close,
+    _new_broker_session,
+)
+from blackbull.mqtt.connection import MQTT5Actor, PacketFramer
+from blackbull.mqtt.messages import (
+    MQTTConnect, MQTTPublish, MQTTPuback, MQTTPubrec, MQTTPubrel,
+    MQTTSubscribe, MQTTSuback, MQTTDisconnect, MQTTDecodeError,
+    ReasonCode, decode_packet,
+)
+from blackbull.server.protocol_registry import ProtocolContext
+from blackbull.server.recipient import AbstractReader
+from blackbull.server.sender import AbstractWriter
+
+pytestmark = pytest.mark.asyncio
+
+
+class RecordingConn(Actor):
+    """A fake connection actor that records what the broker sends it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.outbox = []
+
+    async def send(self, msg) -> None:  # override: record instead of enqueue
+        self.outbox.append(msg)
+
+    def packets(self) -> list:
+        return [m.packet for m in self.outbox if isinstance(m, Send)]
+
+
+def _connect(client_id='c1', clean_start=True, **kw):
+    return MQTTConnect(client_id=client_id, clean_start=clean_start,
+                       keep_alive=kw.pop('keep_alive', 60), **kw)
+
+
+async def _attach(broker, conn, **kw):
+    await broker._handle(Attach(connect=_connect(**kw), sender=conn))
+
+
+async def _subscribe(broker, conn, packet_id, subs, options=None):
+    await broker._handle(ClientSubscribe(
+        subscribe=MQTTSubscribe(packet_id=packet_id, subscriptions=subs,
+                                subscription_options=options),
+        sender=conn))
+
+
+# ===========================================================================
+# 1.19g — malformed CONNECT decodes to MQTTDecodeError, not IndexError
+# ===========================================================================
+
+class TestConnectDecodeBounds:
+    async def test_connect_truncated_after_protocol_name_is_malformed(self):
+        """A CONNECT whose Remaining Length covers only the protocol name must
+        raise MQTTDecodeError (which the framer resyncs on), not an IndexError
+        that unwinds the read loop."""
+        # 0x10 = CONNECT, RL=6, body = 2-byte-len-prefixed "MQTT" only.
+        packet = b'\x10\x06\x00\x04MQTT'
+        with pytest.raises(MQTTDecodeError):
+            decode_packet(packet)
+
+    async def test_framer_resyncs_past_a_truncated_connect(self):
+        """The framer drops the malformed CONNECT byte-by-byte and does not
+        raise IncompletePacket forever (which would stall the connection)."""
+        framer = PacketFramer()
+        framer.feed(b'\x10\x06\x00\x04MQTT')
+        # Draining the framer must terminate without raising.
+        assert list(framer) == []
+
+
+# ===========================================================================
+# 1.19d — topic validation on PUBLISH / SUBSCRIBE
+# ===========================================================================
+
+class TestTopicValidation:
+    async def test_publish_wildcard_topic_qos1_rejected_and_not_routed(self):
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('a/#', 1)])
+        sub.outbox.clear()
+        await _attach(broker, pub, client_id='pub')
+        # A Topic *Name* with a wildcard is illegal (§3.3.2.1).
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='a/#', payload=b'x', qos=1, packet_id=9),
+            sender=pub))
+        pubacks = [p for p in pub.packets() if isinstance(p, MQTTPuback)]
+        assert pubacks and pubacks[0].reason_code == ReasonCode.TOPIC_NAME_INVALID
+        # Not routed to the subscriber, and not retained.
+        assert not [p for p in sub.packets() if isinstance(p, MQTTPublish)]
+        assert broker._retained == {}
+
+    async def test_publish_invalid_topic_qos0_disconnects(self):
+        broker, pub = BrokerActor(), RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        pub.outbox.clear()
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='bad/+', payload=b'x', qos=0), sender=pub))
+        # QoS 0 has no ack channel — reject via DISCONNECT + Close (§4.13).
+        assert any(isinstance(m, Send) and isinstance(m.packet, MQTTDisconnect)
+                   and m.packet.reason_code == ReasonCode.TOPIC_NAME_INVALID
+                   for m in pub.outbox)
+        assert any(isinstance(m, Close) for m in pub.outbox)
+
+    async def test_subscribe_invalid_filter_gets_0x8f(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn)
+        # '#' not terminal — an invalid Topic Filter (§4.7.1.2).
+        await _subscribe(broker, conn, 5, [('a/#/b', 0)])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [ReasonCode.TOPIC_FILTER_INVALID]
+        assert broker._sessions['c1']['subscriptions'] == []
+
+    async def test_subscribe_mixed_valid_and_invalid_keeps_ordering(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn)
+        await _subscribe(broker, conn, 6, [('ok/1', 1), ('bad/#/x', 2), ('ok/2', 0)])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [1, ReasonCode.TOPIC_FILTER_INVALID, 0]
+
+
+# ===========================================================================
+# 1.19c — QoS 2 inbound duplicate PUBLISH is not re-delivered
+# ===========================================================================
+
+class TestQoS2InboundDedup:
+    async def test_duplicate_qos2_publish_reacks_but_delivers_once(self):
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('t', 2)])
+        sub.outbox.clear()
+        await _attach(broker, pub, client_id='pub')
+
+        publish = MQTTPublish(topic='t', payload=b'x', qos=2, packet_id=7)
+        await broker._handle(ClientPublish(publish=publish, sender=pub))
+        # Retransmit (DUP) of the same id before PUBREL.
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'x', qos=2, packet_id=7, dup=True),
+            sender=pub))
+
+        # PUBREC re-sent both times ...
+        assert len([p for p in pub.packets() if isinstance(p, MQTTPubrec)]) == 2
+        # ... but the subscriber only ever saw the message once.
+        assert len([p for p in sub.packets() if isinstance(p, MQTTPublish)]) == 1
+
+
+# ===========================================================================
+# 1.19f — reconnect replay of unacked outbound QoS 1/2 with DUP=1
+# ===========================================================================
+
+class TestReconnectReplay:
+    async def test_qos1_replayed_with_dup_flag(self):
+        broker = BrokerActor()
+        broker._sessions['c1'] = _new_broker_session()
+        broker._sessions['c1']['_expiry'] = 3600
+        broker._sessions['c1']['pending_qos1_out'][5] = MQTTPublish(
+            topic='alerts', payload=b'!', qos=1, packet_id=5)
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1', clean_start=False)
+        replayed = [p for p in conn.packets() if isinstance(p, MQTTPublish)]
+        assert len(replayed) == 1 and replayed[0].packet_id == 5
+        assert replayed[0].dup is True
+
+    async def test_qos2_publish_stage_replayed_with_dup(self):
+        broker = BrokerActor()
+        session = _new_broker_session()
+        session['_expiry'] = 3600
+        session['pending_qos2_out'][9] = {
+            'state': 'PUBLISH_SENT',
+            'packet': MQTTPublish(topic='m', payload=b'p', qos=2, packet_id=9)}
+        broker._sessions['c1'] = session
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1', clean_start=False)
+        replayed = [p for p in conn.packets() if isinstance(p, MQTTPublish)]
+        assert len(replayed) == 1 and replayed[0].packet_id == 9
+        assert replayed[0].dup is True
+
+    async def test_qos2_pubrel_stage_replays_pubrel(self):
+        broker = BrokerActor()
+        session = _new_broker_session()
+        session['_expiry'] = 3600
+        session['pending_qos2_out'][11] = {'state': 'PUBREL_SENT'}
+        broker._sessions['c1'] = session
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1', clean_start=False)
+        pubrels = [p for p in conn.packets() if isinstance(p, MQTTPubrel)]
+        assert len(pubrels) == 1 and pubrels[0].packet_id == 11
+
+    async def test_outbound_qos2_keeps_publish_for_replay(self):
+        """A delivered QoS 2 PUBLISH is stored with its packet so it can be
+        replayed; after PUBREC it advances to PUBREL_SENT and drops the packet."""
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('t', 2)])
+        await _attach(broker, pub, client_id='pub')
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'x', qos=2, packet_id=3),
+            sender=pub))
+        out = broker._sessions['sub']['pending_qos2_out']
+        (pid, entry), = out.items()
+        assert entry['state'] == 'PUBLISH_SENT'
+        assert isinstance(entry['packet'], MQTTPublish)
+        # Subscriber acks with PUBREC → advance to PUBREL, packet no longer kept.
+        await broker._handle(ClientPubrec(packet_id=pid, sender=sub))
+        assert out[pid]['state'] == 'PUBREL_SENT'
+        assert out[pid].get('packet') is None
+
+
+# ===========================================================================
+# 1.19b — session takeover
+# ===========================================================================
+
+class TestSessionTakeover:
+    async def test_second_connect_evicts_prior_connection(self):
+        broker = BrokerActor()
+        first, second = RecordingConn(), RecordingConn()
+        await _attach(broker, first, client_id='dup')
+        first.outbox.clear()
+        await _attach(broker, second, client_id='dup')
+
+        # The prior connection is told to disconnect (0x8E) then closed.
+        assert any(isinstance(m, Send) and isinstance(m.packet, MQTTDisconnect)
+                   and m.packet.reason_code == ReasonCode.SESSION_TAKEN_OVER
+                   for m in first.outbox)
+        assert any(isinstance(m, Close) for m in first.outbox)
+        # The registry now points at the new connection.
+        assert broker._clients['dup'] is second
+
+    async def test_taken_over_connection_detach_is_noop(self):
+        """The old connection's teardown Detach must not fire the (new) Will or
+        disturb the taken-over session — its id mapping is already gone."""
+        broker = BrokerActor()
+        first, second, watcher = RecordingConn(), RecordingConn(), RecordingConn()
+        await _attach(broker, watcher, client_id='watch')
+        await _subscribe(broker, watcher, 1, [('will/t', 0)])
+        watcher.outbox.clear()
+        await _attach(broker, first, client_id='dup',
+                      will_topic='will/t', will_payload=b'bye')
+        await _attach(broker, second, client_id='dup')
+        # Old connection tears down abnormally after being taken over.
+        await broker._handle(Detach(graceful=False, sender=first))
+        assert not [p for p in watcher.packets() if isinstance(p, MQTTPublish)]
+        assert broker._clients['dup'] is second
+
+
+# ===========================================================================
+# 1.19e — No Local, Retain As Published, and $share rejection
+# ===========================================================================
+
+class TestSubscriptionOptions:
+    async def test_no_local_does_not_echo_own_publish(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn, client_id='self')
+        await _subscribe(broker, conn, 1, [('t', 0)], options=[{'no_local': True}])
+        conn.outbox.clear()
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'x', qos=0), sender=conn))
+        assert not [p for p in conn.packets() if isinstance(p, MQTTPublish)]
+
+    async def test_no_local_still_delivers_from_other_client(self):
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('t', 0)], options=[{'no_local': True}])
+        sub.outbox.clear()
+        await _attach(broker, pub, client_id='pub')
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'y', qos=0), sender=pub))
+        assert [p for p in sub.packets() if isinstance(p, MQTTPublish)]
+
+    async def test_retain_as_published_preserves_retain_flag(self):
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('t', 0)],
+                         options=[{'retain_as_published': True}])
+        sub.outbox.clear()
+        await _attach(broker, pub, client_id='pub')
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'z', qos=0, retain=True),
+            sender=pub))
+        delivered = [p for p in sub.packets() if isinstance(p, MQTTPublish)][0]
+        assert delivered.retain is True
+
+    async def test_without_rap_retain_flag_cleared_on_forward(self):
+        broker = BrokerActor()
+        sub, pub = RecordingConn(), RecordingConn()
+        await _attach(broker, sub, client_id='sub')
+        await _subscribe(broker, sub, 1, [('t', 0)])  # no RAP
+        sub.outbox.clear()
+        await _attach(broker, pub, client_id='pub')
+        await broker._handle(ClientPublish(
+            publish=MQTTPublish(topic='t', payload=b'z', qos=0, retain=True),
+            sender=pub))
+        delivered = [p for p in sub.packets() if isinstance(p, MQTTPublish)][0]
+        assert delivered.retain is False
+
+    async def test_shared_subscription_rejected(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn)
+        await _subscribe(broker, conn, 1, [('$share/g/t', 0)])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [
+            ReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED]
+        assert broker._sessions['c1']['subscriptions'] == []
+
+
+# ===========================================================================
+# 1.19h — packet-id allocation skips in-flight ids
+# ===========================================================================
+
+class TestPacketIdAllocation:
+    async def test_alloc_pid_skips_in_flight_ids(self):
+        session = _new_broker_session()
+        session['pending_qos1_out'] = {1: object(), 2: object()}
+        session['pending_qos2_out'] = {3: {'state': 'PUBLISH_SENT'}}
+        session['_next_pid'] = 0
+        assert BrokerActor._alloc_pid(session) == 4  # 1,2,3 all in use
+
+    async def test_alloc_pid_wraps_and_skips(self):
+        session = _new_broker_session()
+        session['pending_qos1_out'] = {1: object()}
+        session['_next_pid'] = 65534
+        assert BrokerActor._alloc_pid(session) == 65535
+        # Next wraps to 1, which is in use → 2.
+        assert BrokerActor._alloc_pid(session) == 2
+
+
+# ===========================================================================
+# 1.19a — keep-alive idle timeout fires the Will and closes
+# ===========================================================================
+
+class _SilentReader(AbstractReader):
+    """Never yields data and never reports EOF — a peer gone silent."""
+
+    async def read(self, n: int) -> bytes:
+        await asyncio.sleep(0.005)
+        return b''
+
+    def at_eof(self) -> bool:
+        return False
+
+
+class _RecordingBroker(BrokerActor):
+    """A real BrokerActor (satisfies the isinstance hint) that records inbound
+    messages instead of enqueueing them, so the test can inspect the Detach."""
+
+    def __init__(self):
+        super().__init__()
+        self.inbox = []
+
+    async def send(self, msg) -> None:
+        self.inbox.append(msg)
+
+
+class _NullWriter(AbstractWriter):
+    async def write(self, data: bytes) -> None:
+        pass
+
+    async def drain(self) -> None:
+        pass
+
+
+def _ctx():
+    return ProtocolContext(peername=('127.0.0.1', 5), sockname=('0.0.0.0', 1883),
+                           ssl=False, aggregator=None, connection_id='c',
+                           protocol='mqtt')
+
+
+class TestKeepAliveTimeout:
+    async def test_silent_peer_past_deadline_detaches_abnormally(self):
+        broker = _RecordingBroker()
+        conn = MQTT5Actor(_NullWriter(), broker, _ctx())
+        # Sub-second interval so the 1.5× deadline (0.075 s) elapses fast.
+        conn._keep_alive = 0.05
+        await asyncio.wait_for(conn.read_loop(_SilentReader()), timeout=2.0)
+        assert conn._done is True
+        detaches = [m for m in broker.inbox if isinstance(m, Detach)]
+        assert detaches and detaches[-1].graceful is False
+
+    async def test_keepalive_zero_never_times_out(self):
+        broker = _RecordingBroker()
+        conn = MQTT5Actor(_NullWriter(), broker, _ctx())
+        conn._keep_alive = 0  # disabled (§3.1.2.10)
+        with pytest.raises(asyncio.TimeoutError):
+            # No deadline → the loop idles forever; the test timeout proves it
+            # never self-terminates on keep-alive.
+            await asyncio.wait_for(conn.read_loop(_SilentReader()), timeout=0.3)
+        assert conn._done is False


### PR DESCRIPTION
Sprint 70 close. Eight RFC-conformance fixes to the MQTT 5.0 broker — the
`1.19` correctness cluster. All localised to the broker/connection actors on the
MQTT port; the HTTP request path is untouched. **No API change** (PATCH).

The work was implemented on 2026-07-13 and checkpointed on
`fix/sprint70-mqtt-hardening`; it ships one slot behind the `1.21f`/`1.21g`
middleware fixes (v0.53.2), which the user prioritised ahead of it.

## Fixed

- **1.19a** keep-alive enforcement (§3.1.2.10) — idle connection closed (Will fired) at 1.5× the negotiated Keep Alive
- **1.19b** session takeover (§3.1.4) — second CONNECT for a live `client_id` disconnects the prior connection with `0x8E`
- **1.19c** QoS 2 inbound de-duplication (§4.3.3) — a `DUP` retransmit is re-acked but not re-delivered
- **1.19d** topic validation (§3.3.2.1 / §4.7) — wildcard/null Topic Name → `0x90`; bad Topic Filter → `0x8F` (wires in the once-dead validators)
- **1.19e** `No Local` + `Retain As Published` honoured; `$share` rejected with `0x9E` (was silently broadcast, violating §4.8.2)
- **1.19f** QoS 2 outbound reconnect replay with `DUP=1` (§4.4 / §3.3.1.1)
- **1.19g** malformed `CONNECT` → `MQTTDecodeError` (framer resyncs) instead of an `IndexError` unwinding the read loop or an `IncompletePacket` stalling it forever
- **1.19h** `_alloc_pid` skips in-flight packet ids (§2.2.1)

## Changed

- Named QoS-2 state helpers/constants (refactor 2.9); outbound QoS-2 entries keep the PUBLISH for §4.4 replay.
- `docs/guide/mqtt.md` capability table updated (shared subs now listed as rejected; keep-alive/session-takeover/QoS-2 behaviours documented).

## Test plan

- [x] New behaviour-level suite `tests/unit/test_mqtt_hardening.py` (drives real broker behaviour, not codec round-trips — the gap that hid 1.19a/1.19c)
- [x] Full suite: **2944 passed**, 258 skipped, 1 xfailed
- [x] MQTT suite under beartype (`--beartype-packages=blackbull`) green
- [x] `pip install -e .` → `blackbull.__version__ == 0.53.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)