### PR TITLE
fix(events): emit request_completed after the global middleware chain (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,23 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
-## [0.53.3] — 2026-07-14
+### Fixed
+
+- **`request_completed` now reports the real status / byte count when a
+  global middleware buffers the response** (issue #145). The event was
+  emitted from `BlackBull._dispatch`, but an `app.use` middleware wraps
+  *outside* `_dispatch` — so when `Compression` buffered the body and only
+  sent the response after `call_next` returned, the event fired first and
+  carried the `AccessLogRecord` placeholders (`status='-'` → `0`,
+  `response_bytes=0`). Any request whose `Accept-Encoding` selected an
+  installed codec (e.g. every browser visit, via `gzip`) was affected;
+  this was present in every release with global-middleware support, not a
+  0.53.3 regression. Emission moved to `BlackBull.__call__`, after the
+  global middleware chain returns (still exactly once per request, still
+  before `scope_completed`). A consequence: responses short-circuited by a
+  global middleware (e.g. a cache hit answered without calling
+  `call_next`) now fire `request_completed` too — previously they were
+  invisible to it.
 
 Sprint 70 — MQTT 5.0 broker hardening: the `1.19` correctness cluster (eight
 RFC-conformance bugs). All localised to the broker/connection actors on the MQTT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,12 @@ async def auth(event):               # every handler receives the Event
         raise PermissionError('denied')
 ```
 
-The four request-lifecycle events (`request_received`, `before_handler`,
-`after_handler`, `request_completed`) are emitted from `BlackBull._dispatch`
-only (Sprint 64) — exactly once per request under any transport (own server,
-uvicorn, TestClient).
+The four request-lifecycle events fire exactly once per request under any
+transport (own server, uvicorn, TestClient): `request_received`,
+`before_handler`, and `after_handler` are emitted from `BlackBull._dispatch`
+(Sprint 64); `request_completed` from `BlackBull.__call__` after the global
+middleware chain returns, so its wire fields reflect what a buffering
+`app.use` middleware (e.g. `Compression`) actually sent (issue #145).
 
 ## Logging
 

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -531,14 +531,19 @@ class BlackBull:
     async def _dispatch(self, scope, receive, send):
         """Route and dispatch a single non-lifespan request.
 
-        Single emission point for the request-lifecycle Level B events
-        (``request_received`` / ``before_handler`` / ``after_handler`` /
-        ``request_completed``) — Sprint 64 consolidated them here, the one
-        choke point every transport passes (BlackBull's own HTTP/1.1 and
-        HTTP/2 actors, uvicorn/hypercorn, TestClient), so each fires exactly
-        once per request regardless of how the app is served.  The protocol
-        actors emit only wire-level events (``request_disconnected``,
-        ``error``, websocket/connection lifecycle).
+        Single emission point for the in-request Level B lifecycle events
+        (``request_received`` / ``before_handler`` / ``after_handler``) —
+        Sprint 64 consolidated them here, the one choke point every
+        transport passes (BlackBull's own HTTP/1.1 and HTTP/2 actors,
+        uvicorn/hypercorn, TestClient), so each fires exactly once per
+        request regardless of how the app is served.  ``request_completed``
+        is emitted from ``__call__`` instead: a *global* middleware
+        (``app.use``) wraps outside ``_dispatch`` and may buffer the whole
+        response (e.g. ``Compression``), so its wire fields (status /
+        response_bytes) are only final after the full chain returns
+        (issue #145).  The protocol actors emit only wire-level events
+        (``request_disconnected``, ``error``, websocket/connection
+        lifecycle).
 
         Each emission is guarded by ``has_listeners`` so a request with no
         registered handlers pays only a dict lookup, not an ``Event`` +
@@ -573,29 +578,7 @@ class BlackBull:
                 'http_version': scope.get('http_version', '-'),
                 'headers':      scope.get('headers', []),
             }))
-        try:
-            await self._dispatch_http(scope, receive, send, scheme)
-        finally:
-            # Fires for every completed HTTP exchange — including 404/405 and
-            # handler errors answered by the error router — but not when the
-            # client disconnected mid-request.  Wire fields come from the
-            # AccessLogRecord BlackBull's own server publishes in
-            # scope['state']['access_log']; under external ASGI hosts they
-            # fall back to placeholders ('-'/0).
-            if (dispatcher.has_listeners('request_completed')
-                    and not scope.get('_disconnected')):
-                log = scope.get('state', {}).get('access_log')
-                client = scope.get('client') or ('-',)
-                await dispatcher.emit(Event('request_completed', detail={
-                    'scope':          scope,
-                    'client_ip':      str(client[0]),
-                    'method':         scope.get('method', '-'),
-                    'path':           scope.get('path', '-'),
-                    'http_version':   scope.get('http_version', '-'),
-                    'status':         log.status if log else '-',
-                    'response_bytes': log.response_bytes if log else 0,
-                    'duration_ms':    log.duration_ms() if log else 0.0,
-                }))
+        await self._dispatch_http(scope, receive, send, scheme)
 
     async def _dispatch_http(self, scope, receive, send, scheme):
         """Route and run one HTTP request (the non-WebSocket half of _dispatch)."""
@@ -733,16 +716,29 @@ class BlackBull:
         if raw_headers is not None and not isinstance(raw_headers, Headers):
             scope['headers'] = Headers(raw_headers)
 
-        # ``scope_completed`` — the guaranteed, cross-protocol terminal event.
-        # Emitted here, at the one point every scope (HTTP request, WebSocket
-        # connection, gRPC call) passes through exactly once, under *any* server
-        # (BlackBull's own actors, uvicorn, TestClient).  It is the application-
-        # level completion event (fires wherever the app runs), as distinct from
-        # the server-level telemetry events (``request_completed`` et al., which
-        # need wire data and fire only under BlackBull's server).  Register
-        # cleanup with ``@app.on('scope_completed', blocking=True)``.  Guarded so
-        # a request with no such listener pays only one dict lookup.
-        if not self._dispatcher.has_listeners('scope_completed'):
+        # Terminal events, emitted here — after the *global* middleware chain —
+        # because an ``app.use`` middleware wraps outside ``_dispatch`` and may
+        # buffer/transform the response (e.g. ``Compression``), so the wire
+        # data is only final once the full chain returns (issue #145):
+        #
+        # - ``request_completed`` — every finished HTTP exchange (including
+        #   404/405, error-router responses, and responses short-circuited by
+        #   a global middleware) unless the client disconnected mid-request.
+        #   Wire fields come from the AccessLogRecord BlackBull's own server
+        #   publishes in scope['state']['access_log']; under external ASGI
+        #   hosts they fall back to placeholders ('-'/0).
+        # - ``scope_completed`` — the guaranteed, cross-protocol terminal event
+        #   for every scope (HTTP request, WebSocket connection, gRPC call),
+        #   under *any* server (BlackBull's own actors, uvicorn, TestClient).
+        #   Register cleanup with ``@app.on('scope_completed', blocking=True)``.
+        #
+        # Both are guarded by ``has_listeners`` so a request with no such
+        # listener pays only a dict lookup.
+        dispatcher = self._dispatcher
+        want_request_completed = (scope.get('type') == 'http'
+                                  and dispatcher.has_listeners('request_completed'))
+        if not (want_request_completed
+                or dispatcher.has_listeners('scope_completed')):
             await self._chain(scope, receive, send)
             return
         exc: BaseException | None = None
@@ -752,19 +748,34 @@ class BlackBull:
             exc = e
             raise
         finally:
-            # ``exception`` reflects whether the scope encountered an error:
-            # either one that propagated out of the chain (exc), or a handler
-            # error that ``_dispatch`` already turned into a 500 and recorded in
-            # ``scope['state']['error_exception']``.  ``None`` for a clean
-            # request (including a 404, which is not an exception).
-            err = exc or scope.get('state', {}).get('error_exception')
-            await self._dispatcher.emit(Event('scope_completed', {
-                'scope':     scope,
-                'type':      scope.get('type', '-'),
-                'client_ip': str((scope.get('client') or ['-'])[0]),
-                'path':      scope.get('path', '-'),
-                'exception': err,
-            }))
+            if want_request_completed and not scope.get('_disconnected'):
+                log = scope.get('state', {}).get('access_log')
+                client = scope.get('client') or ('-',)
+                await dispatcher.emit(Event('request_completed', detail={
+                    'scope':          scope,
+                    'client_ip':      str(client[0]),
+                    'method':         scope.get('method', '-'),
+                    'path':           scope.get('path', '-'),
+                    'http_version':   scope.get('http_version', '-'),
+                    'status':         log.status if log else '-',
+                    'response_bytes': log.response_bytes if log else 0,
+                    'duration_ms':    log.duration_ms() if log else 0.0,
+                }))
+            if dispatcher.has_listeners('scope_completed'):
+                # ``exception`` reflects whether the scope encountered an
+                # error: either one that propagated out of the chain (exc), or
+                # a handler error that ``_dispatch`` already turned into a 500
+                # and recorded in ``scope['state']['error_exception']``.
+                # ``None`` for a clean request (including a 404, which is not
+                # an exception).
+                err = exc or scope.get('state', {}).get('error_exception')
+                await dispatcher.emit(Event('scope_completed', {
+                    'scope':     scope,
+                    'type':      scope.get('type', '-'),
+                    'client_ip': str((scope.get('client') or ['-'])[0]),
+                    'path':      scope.get('path', '-'),
+                    'exception': err,
+                }))
 
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,

--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -42,11 +42,12 @@ class EventAggregator:
     # ------------------------------------------------------------------
     # Request lifecycle
     # ------------------------------------------------------------------
-    # The request-lifecycle events (request_received / before_handler /
-    # after_handler / request_completed) are emitted by BlackBull._dispatch —
-    # the single cross-transport emission point (Sprint 64) — so they fire
-    # under external ASGI hosts (uvicorn, TestClient) too, exactly once per
-    # request.  Only wire-level events remain here.
+    # The request-lifecycle events are emitted by the application layer —
+    # request_received / before_handler / after_handler by BlackBull._dispatch
+    # (Sprint 64), request_completed by BlackBull.__call__ after the global
+    # middleware chain returns (issue #145) — so they fire under external
+    # ASGI hosts (uvicorn, TestClient) too, exactly once per request.  Only
+    # wire-level events remain here.
 
     async def on_request_disconnected(self, scope: dict[str, Any]) -> None:
         """Fire Level B ``request_disconnected``."""

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -278,9 +278,9 @@ class RequestActor(Actor):
 
     Spawned by HTTP1Actor, awaited to completion.  Calls the ASGI app.
 
-    The request-lifecycle Level B events (request_received / before_handler /
-    after_handler / request_completed) are emitted by ``BlackBull._dispatch``
-    — the single cross-transport emission point (Sprint 64) — not here.  The
+    The request-lifecycle Level B events are emitted by the application
+    layer (``BlackBull._dispatch`` / ``__call__``, Sprint 64 + issue #145) —
+    the cross-transport emission points — not here.  The
     actor layer emits only the Level B ``error`` event, for exceptions that
     escape the app call (e.g. a raising global middleware).
     """

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -68,8 +68,11 @@ documented in [Events](../guide/events.md) —
 `connection_accepted`, etc.  The request-lifecycle events
 (`request_received`, `before_handler`, `after_handler`,
 `request_completed`) are emitted by the application layer
-(`BlackBull._dispatch`) instead, so they fire identically under
-BlackBull's own server and under external ASGI hosts.
+instead (`BlackBull._dispatch`, except `request_completed`,
+which fires after the global middleware chain returns so a
+buffering middleware such as `Compression` has finished
+sending), so they fire identically under BlackBull's own
+server and under external ASGI hosts.
 
 ## Responsibilities
 

--- a/tests/architecture/events/test_request_completed_event.py
+++ b/tests/architecture/events/test_request_completed_event.py
@@ -61,8 +61,9 @@ class _FakeReader(AbstractReader):
 
 
 def _raw_request(method: str = 'GET', path: str = '/',
-                 version: str = 'HTTP/1.1', host: str = 'localhost:8000') -> bytes:
-    lines = [f'{method} {path} {version}', f'Host: {host}', '', '']
+                 version: str = 'HTTP/1.1', host: str = 'localhost:8000',
+                 extra_headers: list[str] = []) -> bytes:
+    lines = [f'{method} {path} {version}', f'Host: {host}', *extra_headers, '', '']
     return '\r\n'.join(lines).encode()
 
 
@@ -272,6 +273,48 @@ async def test_duration_is_nonnegative_float():
     d = captured[0].detail
     assert isinstance(d['duration_ms'], float)
     assert d['duration_ms'] >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_wire_fields_populated_with_global_buffering_middleware():
+    """Wire fields survive a global middleware that buffers the response.
+
+    Issue #145: ``app.use(Compression())`` wraps *outside* ``_dispatch``, and
+    Compression holds the whole body back until ``call_next`` returns.  The
+    event must still report the real status and the (compressed) byte count —
+    not the AccessLogRecord '-'/0 placeholders it reported when the emission
+    happened before the buffered response was sent.
+    """
+    from blackbull.middleware import Compression
+
+    body = b'<html><body>' + b'hello world ' * 50 + b'</body></html>'
+    app = BlackBull()
+    app.use(Compression())
+    captured: list[Event] = []
+    seen = asyncio.Event()
+
+    @app.on('request_completed')
+    async def observer(event: Event):
+        captured.append(event)
+        seen.set()
+
+    @app.route(path='/gz')
+    async def handler(scope, receive, send):
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'text/html')]})
+        await send({'type': 'http.response.body', 'body': body,
+                    'more_body': False})
+
+    await _run_request(app, _raw_request(
+        path='/gz', extra_headers=['Accept-Encoding: gzip']))
+    await asyncio.wait_for(seen.wait(), timeout=2.0)
+    await asyncio.sleep(0.2)
+    assert len(captured) == 1
+
+    d = captured[0].detail
+    assert d['status'] == 200
+    # The compressed body actually sent — smaller than the original, never 0.
+    assert 0 < d['response_bytes'] < len(body)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #145.

## Root cause

`request_completed` was emitted from `BlackBull._dispatch`'s `finally`, reading `status`/`response_bytes` from the `AccessLogRecord`. But a **global** middleware (`app.use`) wraps *outside* `_dispatch` (`_build_chain`: `chain = mw(call_next=self._dispatch)`). `Compression` buffers the whole body and only sends `http.response.start` after `call_next` returns — so the event fired before anything hit the wire, and the record still held its `'-'`/`0` defaults.

## Corrections to the issue's analysis

- **Not a 0.53.2 → 0.53.3 regression.** The two PyPI wheels differ only in `blackbull/mqtt/*` (verified by extracting and diffing both), and the same repro records `status='-'` on **both** wheels. The bug exists in every release where `Compression` is registered globally via `app.use` (as blackbull-demosite does).
- **The gzip/br matrix is codec availability, not codec-specific behaviour.** On the demo host brotli isn't installed, so `Accept-Encoding: br` finds no codec and takes the pass-through path (events forwarded inline → status captured). With brotli installed, `br` loses the status exactly like `gzip`. Any *actually compressed* response was affected.

## Fix

Move the `request_completed` emission from `_dispatch` to `BlackBull.__call__`, after the global middleware chain returns and immediately before `scope_completed`. Semantics preserved: exactly once per request under any transport, HTTP scopes only, skipped when the client disconnected, fires on handler exceptions and 404s, placeholders under external ASGI hosts.

**Behavioural consequence** (documented in the CHANGELOG and event catalogue): responses short-circuited by a global middleware without calling `call_next` (e.g. a `Cache` hit) now fire `request_completed` too — previously they were invisible to it, since `_dispatch` never ran.

## Testing

- New regression test: `test_wire_fields_populated_with_global_buffering_middleware` (global `Compression`, `Accept-Encoding: gzip`) — fails on master with `status='-'`, `response_bytes=0`; passes with the fix, asserting `status == 200` and `0 < response_bytes < len(body)`.
- Full suite: 3201 passed (1 docker-only test errors at setup for lack of Docker in this environment — pre-existing).
- Verified end-to-end against a live server: `gzip` → `200/59`, `br` → `200/47`, identity → `200/626`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)