### PR TITLE
release: v0.53.4 — request_completed wire fields under global buffering middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.53.4] — 2026-07-15
+
 ### Fixed
 
 - **`request_completed` now reports the real status / byte count when a
@@ -48,6 +50,8 @@ so the editable install's metadata catches up.
   global middleware (e.g. a cache hit answered without calling
   `call_next`) now fire `request_completed` too — previously they were
   invisible to it.
+
+## [0.53.3] — 2026-07-14
 
 Sprint 70 — MQTT 5.0 broker hardening: the `1.19` correctness cluster (eight
 RFC-conformance bugs). All localised to the broker/connection actors on the MQTT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.3"
+version = "0.53.4"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

PATCH release carrying the single fix merged in #146 (closes the demo-site stats bug, issue #145):

- **`request_completed` now reports the real status / response_bytes when a global (`app.use`) middleware buffers the response.** Emission moved from `BlackBull._dispatch` to `BlackBull.__call__`, after the global middleware chain returns — still exactly once per request, still before `scope_completed`. Responses short-circuited by a global middleware (e.g. a cache hit) now fire the event too.
- CHANGELOG repair: restores the `## [0.53.3] — 2026-07-14` heading that PR #146 accidentally dropped while inserting its `[Unreleased]` notes (Sprint 70's notes had been left attributed to `[Unreleased]`).

## Test plan

- [x] Full suite + beartype green on the fix PR (#146): 3201 passed
- [x] `blackbull.__version__` reports 0.53.4 after editable-install refresh
- [x] CHANGELOG headings verified: `[Unreleased]` (empty) → `[0.53.4]` → `[0.53.3]`
- [ ] CI checks green on this PR
- [ ] After squash-merge: tag `v0.53.4` from master → publish.yml (PyPI + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)