### PR TITLE
release: v0.54.0 — Sprint 71: remove the deprecated in-tree Session middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.54.0] — 2026-07-15
+
+Sprint 71 — removal of the deprecated in-tree `Session` middleware, the
+project's longest-running deprecation (since 0.38). The only breaking change;
+`blackbull-session` is the drop-in replacement.
+
 ### Removed
 
 - **The deprecated in-tree `Session` middleware** (`blackbull.middleware.Session`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.4"
+version = "0.54.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 71 close. Two-file release commit: `pyproject.toml` → 0.54.0; CHANGELOG `[Unreleased]` → `[0.54.0] — 2026-07-15`.

The MINOR's single breaking change (shipped in #148): the deprecated in-tree `Session` middleware is removed. Migration: `pip install blackbull-session`, swap `app.use(Session(...))` for `SessionExtension(app, ...)` — `scope['session']` and `BB_SESSION_SECRET` keep working unchanged.

## Test plan

- [x] Sprint PR #148 CI green (full checklist in that PR)
- [x] `blackbull.__version__` reports 0.54.0 after editable-install refresh
- [x] CHANGELOG headings: `[Unreleased]` (empty) → `[0.54.0]` → `[0.53.4]`
- [ ] CI green on this PR
- [ ] After squash-merge: tag `v0.54.0` → publish.yml (PyPI + GitHub Release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)