### PR TITLE
fix(http2): validate and surface :authority per RFC 9113 §8.3.1 (Sprint 72, F.1)

### DIFF
--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -1428,8 +1428,10 @@ class HTTP2Actor(Actor):
         parent_stream = self.root_stream.find_child(parent_stream_id)
         parent_scope = (parent_stream.scope
                         if (parent_stream and parent_stream.scope is not None) else {})
+        # F.1b maps ``:authority`` into the scope's ``host`` header, so any
+        # dispatched parent stream carries one; ``localhost`` only covers a
+        # scope-less parent.
         raw_authority = (
-            parent_scope.get('headers', Headers([])).get(b':authority') or
             parent_scope.get('headers', Headers([])).get(b'host') or
             b'localhost')
         authority = raw_authority.decode() if isinstance(raw_authority, bytes) else raw_authority

--- a/blackbull/server/parser.py
+++ b/blackbull/server/parser.py
@@ -3,6 +3,7 @@ from urllib.parse import unquote, urlsplit
 from ..protocol.frame_types import PseudoHeaders
 import logging
 from ..headers import Headers
+from .http1_actor import _HOST_FORBIDDEN_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +56,58 @@ def _split_h2_path(raw: str):
     else:
         decoded = path
     return decoded, path.encode('utf-8'), parsed.query.encode('utf-8')
+
+
+def _request_headers_with_host(frame, *, require_present: bool) -> list | None:
+    """Validate the request's host authority and map ``:authority`` → ``host``.
+
+    RFC 9113 §8.3.1 — ``:authority`` MUST NOT include userinfo; an
+    ``http``/``https`` request without ``:authority`` must carry a valid
+    ``Host`` field (*require_present*).  The grammar is H1's
+    ``_validate_host`` (RFC 3986 §3.2 delimiters, same forbidden set);
+    a present ``:authority`` replaces any literal ``Host`` in the header
+    list handed to the application, mirroring H1's absolute-form
+    override (RFC 9112 §3.2.2) so handlers see one ``host`` under
+    either transport (ASGI host mapping).
+
+    Returns the header list for ``Headers(...)``, or ``None`` after
+    marking the frame malformed (the actor then answers RST_STREAM
+    PROTOCOL_ERROR, the §8.3.1 stream error).
+    """
+    authority = frame.pseudo_headers.get(PseudoHeaders.AUTHORITY)
+    if authority is not None:
+        value = authority.encode('utf-8')
+        if not value:
+            frame._mark_malformed('empty :authority')
+            return None
+        if any(b in _HOST_FORBIDDEN_BYTES for b in value):
+            frame._mark_malformed(
+                f'invalid :authority {authority!r}: contains userinfo, '
+                f'delimiter, or whitespace forbidden by RFC 3986 §3.2')
+            return None
+        return ([(k, v) for (k, v) in frame.headers if k != b'host']
+                + [(b'host', value)])
+
+    hosts = [v for (k, v) in frame.headers if k == b'host']
+    if len(hosts) > 1:
+        frame._mark_malformed(
+            f'multiple Host headers ({len(hosts)} — smuggling vector)')
+        return None
+    if not hosts:
+        if require_present:
+            frame._mark_malformed('missing :authority and Host')
+            return None
+        return frame.headers
+    value = hosts[0].strip(b' \t')
+    if not value:
+        frame._mark_malformed('empty Host header value')
+        return None
+    if any(b in _HOST_FORBIDDEN_BYTES for b in value):
+        frame._mark_malformed(
+            f'invalid Host authority {value!r}: contains delimiter / '
+            f'whitespace forbidden by RFC 3986 §3.2')
+        return None
+    return frame.headers
 
 
 def parse_headers(frame) -> dict:
@@ -113,7 +166,13 @@ def parse_headers(frame) -> dict:
         if path := frame.pseudo_headers.get(PseudoHeaders.PATH):
             scope['path'], scope['raw_path'], scope['query_string'] = \
                 _split_h2_path(path)
-        scope['headers'] = Headers(frame.headers)
+        # RFC 8441 requests carry ``:authority`` too — same grammar check
+        # and ``host`` mapping as plain requests, but presence is not
+        # enforced (the Extended CONNECT handshake already succeeded).
+        raw_headers = _request_headers_with_host(frame, require_present=False)
+        if raw_headers is None:
+            return scope
+        scope['headers'] = Headers(raw_headers)
         # Bug 1.16 — root_path is NOT taken from the client-controlled
         # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the
         # peer.  Default to the RFC-safe empty mount.
@@ -134,7 +193,18 @@ def parse_headers(frame) -> dict:
     if scheme := frame.pseudo_headers.get(PseudoHeaders.SCHEME):
         scope['scheme'] = scheme
 
-    scope['headers'] = Headers(frame.headers)
+    # RFC 9113 §8.3.1 — validate the host authority and surface
+    # ``:authority`` as the ``host`` header (ASGI).  Plain CONNECT is
+    # excluded: §8.5 gives its ``:authority`` tunnel semantics, and the
+    # presence rule only binds http/https requests.
+    if method == 'CONNECT':
+        scope['headers'] = Headers(frame.headers)
+    else:
+        raw_headers = _request_headers_with_host(
+            frame, require_present=scope['scheme'] in ('http', 'https'))
+        if raw_headers is None:
+            return scope
+        scope['headers'] = Headers(raw_headers)
 
     # Bug 1.16 — root_path is NOT taken from the client-controlled
     # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the peer.

--- a/tests/architecture/test_http2_actor.py
+++ b/tests/architecture/test_http2_actor.py
@@ -33,7 +33,7 @@ def _make_headers_frame(stream_id: int = 1, end_stream: bool = True,
     encoder = Encoder()
     block = encoder.encode([(b':method', method),
                              (b':path', path),
-                             (b':scheme', b'https')])
+                             (b':scheme', b'https'), (b':authority', b'example.com')])
     flags = HeaderFrameFlags.END_HEADERS
     if end_stream:
         flags |= HeaderFrameFlags.END_STREAM

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -271,7 +271,7 @@ async def test_trailers_do_not_respawn_request():
         FrameTypes.HEADERS,
         HeaderFrameFlags.END_HEADERS,  # open, no END_STREAM (body/trailers follow)
         1,
-        enc.encode([(b':method', b'POST'), (b':path', b'/x'), (b':scheme', b'https')]))
+        enc.encode([(b':method', b'POST'), (b':path', b'/x'), (b':scheme', b'https'), (b':authority', b'example.com')]))
     body = _make_h2_frame(FrameTypes.DATA, 0, 1, b'hello')
     trailers = _make_h2_frame(
         FrameTypes.HEADERS,
@@ -424,7 +424,7 @@ async def test_over_queue_depth_burst_within_window_is_not_rst():
         _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b''),
         _make_h2_frame(FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
                        enc.encode([(b':method', b'POST'), (b':path', b'/up'),
-                                   (b':scheme', b'https')])),
+                                   (b':scheme', b'https'), (b':authority', b'example.com')])),
     ]
     frames += [_make_h2_frame(FrameTypes.DATA, 0, 1, b'x' * 100)
                for _ in range(64)]
@@ -468,7 +468,7 @@ async def test_unread_body_balance_flushes_to_connection_window():
     headers = _make_h2_frame(
         FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
         enc.encode([(b':method', b'POST'), (b':path', b'/up'),
-                    (b':scheme', b'https')]))
+                    (b':scheme', b'https'), (b':authority', b'example.com')]))
     data1 = _make_h2_frame(FrameTypes.DATA, 0, 1, b'aaa')
     data2 = _make_h2_frame(
         FrameTypes.DATA, int(DataFrameFlags.END_STREAM), 1, b'bbbb')
@@ -503,7 +503,7 @@ async def test_window_overrun_is_rst_enhance_your_calm():
         _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b''),
         _make_h2_frame(FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1,
                        enc.encode([(b':method', b'POST'), (b':path', b'/up'),
-                                   (b':scheme', b'https')])),
+                                   (b':scheme', b'https'), (b':authority', b'example.com')])),
     ]
     # 5 × 16 KiB = 81920 bytes — crosses the 65535-byte budget at frame 4.
     frames += [_make_h2_frame(FrameTypes.DATA, 0, 1, b'x' * 16384)

--- a/tests/conformance/http2/test_h2_conn_coalescing.py
+++ b/tests/conformance/http2/test_h2_conn_coalescing.py
@@ -30,7 +30,7 @@ def _make_h2_frame(type_byte, flags, stream_id: int, payload: bytes) -> bytes:
 
 def _make_get(stream_id: int, path: bytes, encoder: Encoder) -> bytes:
     block = encoder.encode([(b':method', b'GET'), (b':path', path),
-                            (b':scheme', b'https')])
+                            (b':scheme', b'https'), (b':authority', b'example.com')])
     flags: FrameFlags = HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM
     return _make_h2_frame(FrameTypes.HEADERS, flags, stream_id, block)
 

--- a/tests/conformance/http2/test_h2_continuation.py
+++ b/tests/conformance/http2/test_h2_continuation.py
@@ -185,6 +185,7 @@ class TestContinuationHandling:
             (b':method', b'GET'),
             (b':path', b'/'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         h_frame = _make_h2_frame(FrameTypes.HEADERS,
                                  HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM, 1, block)
@@ -210,6 +211,7 @@ class TestContinuationHandling:
             (b':method', b'GET'),
             (b':path', b'/api/resource'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         # Split at an arbitrary byte boundary — the concatenated block is still valid HPACK
         split = len(full_block) // 2 + 1
@@ -240,6 +242,7 @@ class TestContinuationHandling:
             (b':method', b'POST'),
             (b':path', b'/submit'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         split = len(full_block) // 2 + 1
         part1, part2 = full_block[:split], full_block[split:]
@@ -281,6 +284,7 @@ class TestContinuationHandling:
             (b':method', b'PUT'),
             (b':path', b'/data'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         n = len(full_block)
         # Three roughly equal parts
@@ -313,11 +317,13 @@ class TestContinuationHandling:
             (b':method', b'GET'),
             (b':path', b'/first'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         block2 = encoder.encode([
             (b':method', b'POST'),
             (b':path', b'/second'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
 
         mid1 = len(block1) // 2 + 1
@@ -377,6 +383,7 @@ class TestContinuationFloodGuard:
             (b':method', b'GET'),
             (b':path', b'/'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         h_frame = _make_h2_frame(
             FrameTypes.HEADERS, SettingFrameFlags.INIT, 1, seed_block)
@@ -420,6 +427,7 @@ class TestContinuationFloodGuard:
             (b':method', b'GET'),
             (b':path', b'/legit'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         # Split the small valid block in half across HEADERS + CONTINUATION.
         mid = len(block) // 2 + 1

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -39,7 +39,7 @@ def _make_headers_frame(stream_id: int = 1, end_stream: bool = False,
     encoder = Encoder()
     block = encoder.encode([(b':method', method),
                              (b':path', path),
-                             (b':scheme', b'https')])
+                             (b':scheme', b'https'), (b':authority', b'example.com')])
     flags: FrameFlags = HeaderFrameFlags.END_HEADERS
     if end_stream:
         flags |= HeaderFrameFlags.END_STREAM
@@ -488,7 +488,7 @@ class TestHTTP2MaxConcurrentStreams:
         encoder = Encoder()
         block = encoder.encode([(b':method', b'GET'),
                                 (b':path', b'/'),
-                                (b':scheme', b'https')])
+                                (b':scheme', b'https'), (b':authority', b'example.com')])
         mid = len(block) // 2
         h1 = _make_headers_frame(stream_id=1, end_stream=True)
         h3 = _make_h2_frame(FrameTypes.HEADERS, 0, 3, block[:mid])
@@ -637,7 +637,7 @@ class TestHTTP2ServerPush:
                 'type': 'http.response.push',
                 'path': '/style.css',
                 'headers': [(b':method', b'GET'), (b':path', b'/style.css'),
-                            (b':scheme', b'https')],
+                            (b':scheme', b'https'), (b':authority', b'example.com')],
             })
             await send({'type': 'http.response.start', 'status': 200, 'headers': []})
             await send({'type': 'http.response.body', 'body': b''})
@@ -664,7 +664,7 @@ class TestHTTP2ServerPush:
                 'type': 'http.response.push',
                 'path': '/favicon.ico',
                 'headers': [(b':method', b'GET'), (b':path', b'/favicon.ico'),
-                            (b':scheme', b'https')],
+                            (b':scheme', b'https'), (b':authority', b'example.com')],
             })
             await send({'type': 'http.response.start', 'status': 200, 'headers': []})
             await send({'type': 'http.response.body', 'body': b''})
@@ -971,6 +971,7 @@ class TestHTTP2PriorityScope:
             (b':method', b'GET'),
             (b':path', b'/'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
             (b'priority', b'u=6'),
         ])
         flags = HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM
@@ -1010,6 +1011,7 @@ class TestHTTP2ScopeHeaders:
             (b':method', method),
             (b':path', path),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
             (b'cookie', cookie),
         ])
         flags: FrameFlags = HeaderFrameFlags.END_HEADERS
@@ -1078,6 +1080,7 @@ class TestHTTP2PerStreamRecipient:
             (b':method', b'POST'),
             (b':path', path),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
         return _make_h2_frame(FrameTypes.HEADERS,
                               HeaderFrameFlags.END_HEADERS,

--- a/tests/conformance/http2/test_rfc9113_authority.py
+++ b/tests/conformance/http2/test_rfc9113_authority.py
@@ -1,0 +1,272 @@
+"""RFC 9113 §8.3.1 — ``:authority`` validation and ASGI ``host`` mapping.
+
+Sprint 72 F.1 (audit follow-up 2026-07-14): HTTP/2 requests must carry a
+host authority — either the ``:authority`` pseudo-header or a literal
+``Host`` field — and ``:authority`` must be surfaced to the application
+as the ``host`` header in ``scope['headers']`` (ASGI HTTP spec), mirroring
+HTTP/1.1's absolute-form-overrides-Host semantics (RFC 9112 §3.2.2) and
+its userinfo/grammar rejection (the 1.25 fix, Sprint 63).
+
+Raw-frame tests drive ``HTTP2Actor`` directly via in-process fakes (same
+helpers as ``test_rfc9113_gaps.py``); scope-mapping tests call
+``parse_headers`` directly on ``FrameFactory``-loaded frames.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from hpack import Encoder
+
+from blackbull.headers import Headers
+from blackbull.server.http2_actor import HTTP2Actor
+from blackbull.server.parser import parse_headers
+from blackbull.server.sender import AsyncioWriter
+from blackbull.protocol.frame import FrameFactory
+from blackbull.protocol.frame_types import (
+    FrameTypes, ErrorCodes, HeaderFrameFlags, PseudoHeaders,
+)
+
+
+# ---------------------------------------------------------------------------
+# Wire-format helpers (same as test_rfc9113_gaps.py)
+# ---------------------------------------------------------------------------
+
+def _make_h2_frame(type_byte: FrameTypes, flags: int = 0,
+                   stream_id: int = 0, payload: bytes = b'') -> bytes:
+    length = len(payload)
+    return (length.to_bytes(3, 'big') + type_byte
+            + bytes([flags]) + stream_id.to_bytes(4, 'big') + payload)
+
+
+def _make_headers_frame(stream_id: int = 1, end_stream: bool = True,
+                        fields: list[tuple[bytes, bytes]] | None = None) -> bytes:
+    encoder = Encoder()
+    if fields is None:
+        fields = [(b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https'),
+                  (b':authority', b'example.com')]
+    block = encoder.encode(fields)
+    flags = HeaderFrameFlags.END_HEADERS
+    if end_stream:
+        flags |= HeaderFrameFlags.END_STREAM
+    return _make_h2_frame(FrameTypes.HEADERS, flags, stream_id, block)
+
+
+def _make_h2_actor(app=None):
+    if app is None:
+        app = AsyncMock()
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.close = MagicMock()
+    handler = HTTP2Actor(None, AsyncioWriter(writer), app, aggregator=None)
+    handler.send_frame = AsyncMock()
+    return handler, app
+
+
+def _settings() -> bytes:
+    return _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b'')
+
+
+async def _run_with_headers(fields):
+    handler, app = _make_h2_actor()
+    h = _make_headers_frame(1, fields=fields)
+    handler.receive = AsyncMock(side_effect=[_settings(), h, None])
+    await handler.run()
+    return handler, app
+
+
+def _rst_streams(handler) -> list[int]:
+    out = []
+    for call in handler.send_frame.call_args_list:
+        frame = call.args[0]
+        if (hasattr(frame, 'FrameType')
+                and frame.FrameType() == FrameTypes.RST_STREAM):
+            out.append(frame.stream_id)
+    return out
+
+
+def _assert_malformed(handler):
+    """Malformed request HEADERS ⇒ stream error RST_STREAM PROTOCOL_ERROR."""
+    for call in handler.send_frame.call_args_list:
+        frame = call.args[0]
+        if (hasattr(frame, 'FrameType')
+                and frame.FrameType() == FrameTypes.RST_STREAM
+                and frame.stream_id == 1
+                and frame.error_code == ErrorCodes.PROTOCOL_ERROR):
+            return
+    pytest.fail(
+        'Expected RST_STREAM(PROTOCOL_ERROR) on stream 1.  Frames sent: '
+        f'{[c.args[0] for c in handler.send_frame.call_args_list]}')
+
+
+def _load_frame(fields: list[tuple[bytes, bytes]]):
+    """Build a HEADERS frame through the real wire parser."""
+    block = Encoder().encode(fields)
+    flags = HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM
+    raw = (len(block).to_bytes(3, 'big') + FrameTypes.HEADERS
+           + bytes([flags]) + (1).to_bytes(4, 'big') + block)
+    return FrameFactory().load(raw)
+
+
+_PSEUDO_TRIO = [(b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https')]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# F.1a — presence: neither :authority nor Host ⇒ malformed
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestAuthorityPresence:
+    """RFC 9113 §8.3.1: an ``http``/``https`` request without ``:authority``
+    must carry a ``Host`` header field; otherwise it is malformed."""
+
+    @pytest.mark.asyncio
+    async def test_missing_authority_and_host_is_malformed(self):
+        handler, app = await _run_with_headers(list(_PSEUDO_TRIO))
+        _assert_malformed(handler)
+        assert app.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_authority_only_is_accepted(self):
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b':authority', b'example.com')])
+        assert 1 not in _rst_streams(handler)
+        assert app.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_host_only_is_accepted(self):
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b'host', b'example.com')])
+        assert 1 not in _rst_streams(handler)
+        assert app.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_multiple_host_without_authority_is_malformed(self):
+        """Mirror of H1's multiple-Host smuggling rejection."""
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b'host', b'a.example'), (b'host', b'b.example')])
+        _assert_malformed(handler)
+        assert app.await_count == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# F.1a — grammar: userinfo / delimiters / whitespace ⇒ malformed
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestAuthorityGrammar:
+    """RFC 9113 §8.3.1: ``:authority`` MUST NOT include userinfo ('@');
+    delimiters and whitespace are equally not valid in a host authority
+    (RFC 3986 §3.2) — same grammar H1 enforces via ``_validate_host``."""
+
+    @pytest.mark.asyncio
+    async def test_userinfo_in_authority_is_malformed(self):
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b':authority', b'user@example.com')])
+        _assert_malformed(handler)
+        assert app.await_count == 0
+
+    @pytest.mark.parametrize('bad_byte', [b'/', b'?', b'#', b' ', b'\t', b'@'])
+    @pytest.mark.asyncio
+    async def test_forbidden_byte_in_authority_is_malformed(self, bad_byte):
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b':authority', b'exam' + bad_byte + b'ple.com')])
+        _assert_malformed(handler)
+
+    @pytest.mark.asyncio
+    async def test_empty_authority_is_malformed(self):
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b':authority', b'')])
+        _assert_malformed(handler)
+
+    @pytest.mark.asyncio
+    async def test_userinfo_in_host_without_authority_is_malformed(self):
+        """The Host fallback is held to the same grammar as H1."""
+        handler, app = await _run_with_headers(
+            _PSEUDO_TRIO + [(b'host', b'user@example.com')])
+        _assert_malformed(handler)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# F.1b — ASGI mapping: :authority → host in scope['headers']
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestAuthorityHostMapping:
+    """ASGI HTTP spec: a request's ``:authority`` pseudo-header is surfaced
+    as the ``host`` header; a literal ``Host`` is replaced (same semantics
+    as H1's absolute-form override, RFC 9112 §3.2.2)."""
+
+    def test_authority_maps_to_host_in_scope(self):
+        frame = _load_frame(
+            _PSEUDO_TRIO + [(b':authority', b'example.com:8443')])
+        scope = parse_headers(frame)
+        assert not frame.malformed
+        assert scope['headers'].get(b'host') == b'example.com:8443'
+        assert scope['headers'].get(b':authority') == b''  # never leaks
+
+    def test_authority_replaces_literal_host(self):
+        frame = _load_frame(
+            _PSEUDO_TRIO + [(b':authority', b'real.example'),
+                            (b'host', b'spoofed.example')])
+        scope = parse_headers(frame)
+        assert not frame.malformed
+        assert scope['headers'].getlist(b'host') == [
+            (b'host', b'real.example')]
+
+    def test_host_fallback_kept_when_no_authority(self):
+        frame = _load_frame(_PSEUDO_TRIO + [(b'host', b'example.com')])
+        scope = parse_headers(frame)
+        assert not frame.malformed
+        assert scope['headers'].get(b'host') == b'example.com'
+
+    def test_missing_both_marks_frame_malformed(self):
+        frame = _load_frame(list(_PSEUDO_TRIO))
+        parse_headers(frame)
+        assert frame.malformed
+
+    def test_ws_over_h2_scope_gets_host(self):
+        """RFC 8441 Extended CONNECT scopes get the same host mapping."""
+        frame = _load_frame([
+            (b':method', b'CONNECT'), (b':protocol', b'websocket'),
+            (b':scheme', b'https'), (b':path', b'/ws'),
+            (b':authority', b'example.com:8443'),
+        ])
+        scope = parse_headers(frame)
+        assert not frame.malformed
+        assert scope['type'] == 'websocket'
+        assert scope['headers'].get(b'host') == b'example.com:8443'
+
+    def test_plain_connect_headers_untouched(self):
+        """RFC 9113 §8.5 gives :authority different semantics on plain
+        CONNECT — no mapping, no presence rejection (out of F.1 scope)."""
+        frame = _load_frame([(b':method', b'CONNECT'),
+                             (b':authority', b'example.com:443')])
+        scope = parse_headers(frame)
+        assert not frame.malformed
+        assert scope['headers'].get(b'host') == b''
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# F.1c — server push reads the mapped host
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestPushPromiseAuthority:
+    """PUSH_PROMISE synthesises ``:authority`` from the parent scope's
+    (now guaranteed) ``host`` header instead of falling back to
+    ``localhost``."""
+
+    @pytest.mark.asyncio
+    async def test_push_promise_uses_scope_host(self):
+        handler, app = _make_h2_actor()
+        parent = handler.root_stream.add_child(1)
+        parent.scope = {
+            'type': 'http', 'scheme': 'https',
+            'headers': Headers([(b'host', b'example.com:8443')]),
+        }
+        await handler._handle_push({'path': '/style.css'}, 1)
+        pp = None
+        for call in handler.send_frame.call_args_list:
+            frame = call.args[0]
+            if (hasattr(frame, 'FrameType')
+                    and frame.FrameType() == FrameTypes.PUSH_PROMISE):
+                pp = frame
+                break
+        assert pp is not None, 'no PUSH_PROMISE sent'
+        assert pp.pseudo_headers[PseudoHeaders.AUTHORITY] == 'example.com:8443'

--- a/tests/conformance/http2/test_rfc9113_gaps.py
+++ b/tests/conformance/http2/test_rfc9113_gaps.py
@@ -43,7 +43,7 @@ def _make_headers_frame(stream_id: int = 1, end_stream: bool = False,
                         fields: list[tuple[bytes, bytes]] | None = None) -> bytes:
     encoder = Encoder()
     if fields is None:
-        fields = [(b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https')]
+        fields = [(b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https'), (b':authority', b'example.com')]
     block = encoder.encode(fields)
     flags = HeaderFrameFlags.END_HEADERS if end_headers else 0
     if end_stream:
@@ -181,7 +181,7 @@ class TestG2HalfClosedRemoteReceivesData:
         h2 = _make_headers_frame(1, end_stream=True, end_headers=True,
                                  fields=[(b':method', b'GET'),
                                          (b':path', b'/2'),
-                                         (b':scheme', b'https')])
+                                         (b':scheme', b'https'), (b':authority', b'example.com')])
         handler.receive = AsyncMock(side_effect=[
             self._settings(), h1, h2, None])
         await handler.run()
@@ -321,6 +321,7 @@ class TestG5ConnectionSpecificHeadersForbidden:
             (b':method', b'GET'),
             (b':path', b'/'),
             (b':scheme', b'https'),
+            (b':authority', b'example.com'),
             (bad_header, b'whatever'),
         ]
         h = _make_headers_frame(1, end_stream=True, fields=fields)
@@ -343,6 +344,7 @@ class TestG5ConnectionSpecificHeadersForbidden:
         handler, app = _make_h2_actor()
         fields = [
             (b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https'),
+            (b':authority', b'example.com'),
             (b'te', b'gzip, deflate'),
         ]
         h = _make_headers_frame(1, end_stream=True, fields=fields)
@@ -371,11 +373,11 @@ class TestG6MissingMandatoryPseudoHeaders:
 
     @pytest.mark.asyncio
     async def test_missing_method_is_malformed(self):
-        await self._check_malformed([(b':path', b'/'), (b':scheme', b'https')])
+        await self._check_malformed([(b':path', b'/'), (b':scheme', b'https'), (b':authority', b'example.com')])
 
     @pytest.mark.asyncio
     async def test_missing_path_is_malformed(self):
-        await self._check_malformed([(b':method', b'GET'), (b':scheme', b'https')])
+        await self._check_malformed([(b':method', b'GET'), (b':scheme', b'https'), (b':authority', b'example.com')])
 
     @pytest.mark.asyncio
     async def test_missing_scheme_is_malformed(self):
@@ -387,6 +389,7 @@ class TestG6MissingMandatoryPseudoHeaders:
         await self._check_malformed([
             (b':method', b'GET'), (b':method', b'POST'),
             (b':path', b'/'), (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
 
     @pytest.mark.asyncio
@@ -394,6 +397,7 @@ class TestG6MissingMandatoryPseudoHeaders:
         """§8.3.1: :path MUST NOT be empty for http/https URIs."""
         await self._check_malformed([
             (b':method', b'GET'), (b':path', b''), (b':scheme', b'https'),
+            (b':authority', b'example.com'),
         ])
 
     @staticmethod
@@ -564,6 +568,7 @@ class TestG13FieldCharacterValidation:
         handler, app = _make_h2_actor()
         fields = [
             (b':method', b'GET'), (b':path', b'/'), (b':scheme', b'https'),
+            (b':authority', b'example.com'),
             bad_field,
         ]
         h = _make_headers_frame(1, end_stream=True, fields=fields)
@@ -618,7 +623,7 @@ class TestG14PseudoHeaderOrdering:
         # CONTINUATION with pseudo-headers — still malformed
         encoder = Encoder()
         block = encoder.encode([(b':method', b'GET'), (b':path', b'/'),
-                                (b':scheme', b'https')])
+                                (b':scheme', b'https'), (b':authority', b'example.com')])
         cont = _make_h2_frame(FrameTypes.CONTINUATION,
                               HeaderFrameFlags.END_HEADERS,
                               stream_id=1, payload=block)

--- a/tests/unit/test_audit_sprint72.py
+++ b/tests/unit/test_audit_sprint72.py
@@ -1,0 +1,81 @@
+"""Sprint 72 audit follow-up — protocol-uniformity contracts.
+
+F.1b: the same authority must reach the application identically whether it
+arrives as an HTTP/1.1 absolute-form request-target (RFC 9112 §3.2.2) or as
+an HTTP/2 ``:authority`` pseudo-header (RFC 9113 §8.3.1 / ASGI host
+mapping).  A handler reading ``scope['headers'].get(b'host')`` must not be
+able to tell the transports apart.
+"""
+from __future__ import annotations
+
+from hpack import Encoder
+
+from blackbull.protocol.frame import FrameFactory
+from blackbull.protocol.frame_types import FrameTypes, HeaderFrameFlags
+from blackbull.server.parser import parse_headers
+from blackbull.server.recipient import AbstractReader
+from blackbull.server.sender import AbstractWriter
+
+
+class _BufReader(AbstractReader):
+    """Serves a fixed wire buffer; EOF (empty bytes) once drained."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buf = bytearray(data)
+
+    async def read(self, n: int) -> bytes:
+        if not self._buf:
+            return b''
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+
+class _RecordingWriter(AbstractWriter):
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+async def _noop_app(scope, receive, send):
+    pass
+
+
+def _h1_scope(raw: bytes) -> dict:
+    from blackbull.server.http1_actor import HTTP1Actor
+    actor = HTTP1Actor(_BufReader(b''), _RecordingWriter(),
+                       app=_noop_app, aggregator=None)
+    return actor._parse(raw)
+
+
+def _h2_scope(fields: list[tuple[bytes, bytes]]) -> dict:
+    block = Encoder().encode(fields)
+    flags = HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM
+    raw = (len(block).to_bytes(3, 'big') + FrameTypes.HEADERS
+           + bytes([flags]) + (1).to_bytes(4, 'big') + block)
+    frame = FrameFactory().load(raw)
+    scope = parse_headers(frame)
+    assert not frame.malformed
+    return scope
+
+
+class TestH1H2HostUniformity:
+    def test_h1_h2_host_uniformity(self):
+        h1 = _h1_scope(b'GET http://real.example/ HTTP/1.1\r\n'
+                       b'Host: spoofed.example\r\n\r\n')
+        h2 = _h2_scope([(b':method', b'GET'), (b':path', b'/'),
+                        (b':scheme', b'http'),
+                        (b':authority', b'real.example'),
+                        (b'host', b'spoofed.example')])
+        assert h1['headers'].get(b'host') == b'real.example'
+        assert h1['headers'].get(b'host') == h2['headers'].get(b'host')
+
+    def test_h1_h2_host_uniformity_with_port(self):
+        h1 = _h1_scope(b'GET / HTTP/1.1\r\nHost: example.com:8443\r\n\r\n')
+        h2 = _h2_scope([(b':method', b'GET'), (b':path', b'/'),
+                        (b':scheme', b'https'),
+                        (b':authority', b'example.com:8443')])
+        assert h1['headers'].get(b'host') == b'example.com:8443'
+        assert h1['headers'].get(b'host') == h2['headers'].get(b'host')

--- a/tests/unit/test_frame.py
+++ b/tests/unit/test_frame.py
@@ -94,7 +94,7 @@ class TestHeaderNameNormalization:
         block = encoder.encode([(b'content-type', b'text/plain'),
                                  (b':method', b'GET'),
                                  (b':path', b'/'),
-                                 (b':scheme', b'https')])
+                                 (b':scheme', b'https'), (b':authority', b'example.com')])
         raw = _make_h2_frame(FrameTypes.HEADERS, HeaderFrameFlags.END_HEADERS, 1, block)
         frame = factory.load(raw)
         names = [k for k, _ in frame.headers]
@@ -165,7 +165,7 @@ class TestDataFrameHandling:
         encoder = Encoder()
         block = encoder.encode([(b':method', b'POST'),
                                  (b':path', b'/upload'),
-                                 (b':scheme', b'https')])
+                                 (b':scheme', b'https'), (b':authority', b'example.com')])
         flags: FrameFlags = HeaderFrameFlags.END_HEADERS
         if end_stream:
             flags |= HeaderFrameFlags.END_STREAM
@@ -280,7 +280,7 @@ class TestGoAwayHandling:
         """After GOAWAY, no further frames should be dispatched to the app."""
         encoder = Encoder()
         block = encoder.encode([(b':method', b'GET'), (b':path', b'/'),
-                                 (b':scheme', b'https')])
+                                 (b':scheme', b'https'), (b':authority', b'example.com')])
         h_frame = _make_h2_frame(FrameTypes.HEADERS,
                                  HeaderFrameFlags.END_HEADERS | HeaderFrameFlags.END_STREAM, 1, block)
         goaway = self._make_goaway_frame(last_stream_id=0, error_code=0x0)


### PR DESCRIPTION
## Summary

Sprint 72 lead item — F.1 from the 2026-07-14 audit follow-up. HTTP/2 `:authority` was parsed into `frame.pseudo_headers` but never validated nor surfaced, so:

- **F.1a**: an `http(s)` request with neither `:authority` nor `Host` was accepted (RFC 9113 §8.3.1 requires treating it as malformed), and userinfo in the authority was never rejected — H1 has enforced both since the 1.25/Sprint 63 fixes; H2 had no twin.
- **F.1b**: `request.headers.get(b'host')` returned `None` for virtually every H2 client (grpcio, browsers, `curl --http2` send `:authority` without `Host`) — an ASGI deviation and a handler-visible H1/H2 non-uniformity.
- **F.1c**: the PUSH_PROMISE synth path read `headers.get(b':authority')`, which can never hit (pseudo-headers never enter `Headers`), silently synthesizing `:authority = localhost`.

## Changes

- `parse_headers` (`blackbull/server/parser.py`): new `_request_headers_with_host` — rejects missing-both / userinfo / delimiters / multiple-Host as malformed via the existing `frame._mark_malformed` → RST_STREAM `PROTOCOL_ERROR` plumbing (the §8.3.1 stream error, both HEADERS and CONTINUATION dispatch sites); maps `:authority` → `host` replacing any literal `Host` (H1 absolute-form override semantics, RFC 9112 §3.2.2). Applied on the request branch and the RFC 8441 Extended CONNECT branch (grammar+mapping only). Plain CONNECT untouched (§8.5 tunnel semantics).
- `_handle_push` (`blackbull/server/http2_actor.py`): reads the now-guaranteed scope `host`; dead `:authority` lookup removed.

## Tests

- New `tests/conformance/http2/test_rfc9113_authority.py` (presence, grammar, ASGI mapping, WS-over-H2, push) and `tests/unit/test_audit_sprint72.py` (H1/H2 host-uniformity contract).
- **Existing-test impact (spec change + incidental coupling)**: H2 test helpers that built HEADERS without an authority and expected dispatch now include `(b':authority', b'example.com')`; malformed-path tests (G5/G6/field grammar) gained an authority so each still isolates the violation it names.

## Verification

- Quick tier: 2926 passed (beartype-instrumented)
- `--run-all` full tier: 3177 passed (nginx docker fixture unavailable locally — environmental)
- h2spec: **146/146 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)