### PR TITLE
fix(client): H2 window seeding, shared WS codec, close discipline (Sprint 72)

### DIFF
--- a/blackbull/client/http2.py
+++ b/blackbull/client/http2.py
@@ -296,8 +296,15 @@ class HTTP2Client:
     def _make_sender(self, stream_id: int) -> HTTP2Sender:
         if stream_id not in self._senders:
             assert self._writer is not None
+            # Bug 1.20a — seed the per-stream send window from the server's
+            # announced SETTINGS_INITIAL_WINDOW_SIZE: a sender created after
+            # the SETTINGS exchange must not start at the RFC default
+            # (``_on_initial_window_size`` only delta-adjusts *existing*
+            # senders).  Same construction-time seeding as the server's
+            # ``make_sender`` (refactor 2.11).
             self._senders[stream_id] = HTTP2Sender(
-                self._writer, self._factory, stream_id)
+                self._writer, self._factory, stream_id,
+                initial_window=self.initial_window_size)
         return self._senders[stream_id]
 
     async def _send_raw_frame(self, frame: FrameBase) -> None:

--- a/blackbull/client/websocket.py
+++ b/blackbull/client/websocket.py
@@ -69,6 +69,10 @@ class WebSocketSession:
         self._recipient._connect_sent = True
         self.subprotocol = subprotocol
         self._closed = False
+        # True once a 'websocket.disconnect' has been surfaced via
+        # ``receive`` — close() then skips its drain loop (the closing
+        # handshake already completed from our side's point of view).
+        self._disconnect_seen = False
 
     # ---- public API ------------------------------------------------------
 
@@ -93,9 +97,22 @@ class WebSocketSession:
         ``WebSocketRecipient`` (with masking, since this session is the
         client).  Server PONG frames are silently dropped.
         """
-        return await self._recipient()
+        event = await self._recipient()
+        if event.get('type') == 'websocket.disconnect':
+            self._disconnect_seen = True
+        return event
 
-    async def close(self, code: int = _CLOSE_CODE_NORMAL) -> None:
+    async def close(self, code: int = _CLOSE_CODE_NORMAL, *,
+                    drain_timeout: float = 5.0) -> None:
+        """Send a CLOSE frame, await the peer's echoed CLOSE (bounded by
+        *drain_timeout*), and stop the background reader task.
+
+        Sprint 72 (audit 1.20c) — RFC 6455 §7.1.2: the closing handshake
+        is complete once both endpoints have sent and received a Close
+        frame.  A silent peer cannot hang ``close()``: after
+        *drain_timeout* the reader is shut down regardless.  Data frames
+        still in flight during the drain are discarded.  Idempotent.
+        """
         if self._closed:
             return
         self._closed = True
@@ -104,6 +121,19 @@ class WebSocketSession:
             await self._send_frame(payload, WSOpcode.CLOSE)
         except Exception:
             pass  # best-effort close frame; the socket may already be gone.
+        try:
+            if not self._disconnect_seen:
+                async with asyncio.timeout(drain_timeout):
+                    while True:
+                        event = await self._recipient()
+                        if event.get('type') == 'websocket.disconnect':
+                            break
+        except Exception:
+            # TimeoutError (silent peer) or a recipient-raised protocol
+            # error — either way the drain is over; shut the reader down.
+            pass
+        finally:
+            await self._recipient.shutdown()
 
     # ---- internal --------------------------------------------------------
 

--- a/blackbull/client/websocket_h2.py
+++ b/blackbull/client/websocket_h2.py
@@ -40,13 +40,15 @@ import asyncio
 import logging
 import ssl as _ssl
 import struct
-import time
 
 from ..asgi import ASGIEvent
 from ..protocol.frame import FrameFactory
 from ..protocol.frame_types import (
     DataFrameFlags, FrameTypes, HeaderFrameFlags, PseudoHeaders,
 )
+from ..server.http2_ws import HTTP2WSWriter
+from ..server.recipient import (AbstractReader, IncompleteReadError,
+                                WebSocketRecipient)
 from ..server.ws_codec import WSOpcode, encode_frame
 from .client import Client
 from .exceptions import HandshakeError
@@ -64,39 +66,67 @@ _CLOSE_CODE_NORMAL = 1000
 _WINDOW_UPDATE_THRESHOLD = 32768
 
 
-def _parse_ws_frame(data: bytes) -> tuple[int, bytes, int] | None:
-    """Parse one unmasked WebSocket frame from *data*.
+class _H2QueueReader(AbstractReader):
+    """``AbstractReader`` over a raw-stream DATA-frame queue.
 
-    Returns ``(opcode, payload, consumed)`` or ``None`` if the buffer
-    is incomplete.  Server → client frames are unmasked per RFC 6455
-    §5.1, so no mask bytes are expected.
+    Sprint 72 (audit 1.20b / F.2) — lets the H2 client session reuse the
+    shared ``ws_codec`` + ``WebSocketRecipient`` stack (whose read path
+    calls only ``readexactly``) instead of a third, private WS frame
+    parser.  DATA payloads are buffered as a byte stream; flow-control
+    credit is returned through *credit_cb* the moment a frame is consumed
+    off the queue — the same timing the old parser used.  END_STREAM or
+    RST_STREAM marks EOF, which the recipient's read loop surfaces as an
+    abnormal-closure ``websocket.disconnect`` (1006).
     """
-    if len(data) < 2:
-        return None
-    opcode = data[0] & 0x0F
-    length = data[1] & 0x7F
-    offset = 2
-    if length == 126:
-        if len(data) < offset + 2:
-            return None
-        length = struct.unpack('>H', data[offset:offset + 2])[0]
-        offset += 2
-    elif length == 127:
-        if len(data) < offset + 8:
-            return None
-        length = struct.unpack('>Q', data[offset:offset + 8])[0]
-        offset += 8
-    if len(data) < offset + length:
-        return None
-    return opcode, data[offset:offset + length], offset + length
+
+    def __init__(self, queue: asyncio.Queue, credit_cb) -> None:
+        self._queue = queue
+        self._credit_cb = credit_cb
+        self._buf = bytearray()
+        self._eof = False
+
+    async def _fill(self, n: int) -> None:
+        while len(self._buf) < n and not self._eof:
+            frame = await self._queue.get()
+            ftype = frame.FrameType()
+            if ftype == FrameTypes.DATA:
+                if frame.payload:
+                    self._buf.extend(frame.payload)
+                    await self._credit_cb(len(frame.payload))
+                if frame.end_stream:
+                    self._eof = True
+            elif ftype == FrameTypes.RST_STREAM:
+                self._eof = True
+            # Other frame types (WINDOW_UPDATE etc.) are connection-level
+            # bookkeeping handled by the client's receive loop; ignore.
+
+    async def readexactly(self, n: int) -> bytes:
+        await self._fill(n)
+        if len(self._buf) < n:
+            raise IncompleteReadError()
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    async def read(self, n: int) -> bytes:
+        await self._fill(1)
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+    async def readuntil(self, sep: bytes) -> bytes:
+        raise NotImplementedError('_H2QueueReader does not support readuntil')
 
 
 class WebSocketH2Session:
     """Frame-level WebSocket session over one HTTP/2 stream.
 
     Outgoing frames are masked (RFC 6455 §5.1) and wrapped in H2 DATA
-    frames.  Incoming H2 DATA frame payloads are reassembled into
-    WebSocket frames in an internal buffer.
+    frames.  Incoming DATA payloads feed the shared
+    ``WebSocketRecipient`` stack through :class:`_H2QueueReader`
+    (Sprint 72, audit 1.20b) — fragmentation reassembly, FIN/RSV/mask
+    validation, UTF-8 checks, and auto-PONG all come from the same
+    codec the server and the H1 client use.
     """
 
     def __init__(self, http2_client: HTTP2Client, factory: FrameFactory,
@@ -105,8 +135,8 @@ class WebSocketH2Session:
         self._factory = factory
         self._stream_id = stream_id
         self._queue = frame_queue
-        self._buf: bytes = b''
         self._closed = False
+        self._disconnect_seen = False
         # Per-stream HTTP2Sender so outgoing WS payloads larger than
         # ``max_frame_size`` are split into multiple DATA frames and
         # respect the peer's send window — same machinery the server
@@ -116,6 +146,19 @@ class WebSocketH2Session:
         # Tracked at both stream and connection levels per RFC 9113 §5.2.
         self._unacked_stream: int = 0
         self._unacked_conn: int = 0
+        # Shared WS decode stack: DATA-frame queue → byte stream →
+        # WebSocketRecipient.  ``require_masked=False`` because server
+        # frames are unmasked — which also makes recipient-generated
+        # PONG / echo-CLOSE frames masked, as a client's must be.
+        # Recipient writes ride the per-stream sender via HTTP2WSWriter,
+        # inheriting H2 flow control.
+        self._recipient = WebSocketRecipient(
+            _H2QueueReader(frame_queue, self._credit_returned),
+            HTTP2WSWriter(self._sender),
+            require_masked=False)
+        # Skip the synthetic 'websocket.connect' first-call event — the
+        # Extended CONNECT handshake already established the session.
+        self._recipient._connect_sent = True
 
     async def send_text(self, text: str) -> None:
         await self._send_ws(text.encode('utf-8'), WSOpcode.TEXT)
@@ -125,36 +168,40 @@ class WebSocketH2Session:
 
     async def receive(self, timeout: float = 5.0) -> tuple[int, bytes]:
         """Return ``(opcode, payload)`` for the next complete WebSocket
-        frame on this stream.
+        **message** on this stream (fragmented messages are reassembled;
+        PING is answered transparently).
 
-        Raises :class:`TimeoutError` if no frame arrives within *timeout*.
-        Returned opcodes match :class:`blackbull.server.ws_codec.WSOpcode`.
+        Raises :class:`TimeoutError` if no message arrives within
+        *timeout*.  Returned opcodes match
+        :class:`blackbull.server.ws_codec.WSOpcode`; a peer CLOSE (or
+        stream end) is surfaced as ``(WSOpcode.CLOSE, 2-byte code)``.
         """
-        deadline = time.monotonic() + timeout
-        while True:
-            parsed = _parse_ws_frame(self._buf)
-            if parsed is not None:
-                opcode, payload, consumed = parsed
-                self._buf = self._buf[consumed:]
-                return opcode, payload
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f'no WebSocket frame within {timeout}s on stream '
-                    f'{self._stream_id}')
-            try:
-                frame = await asyncio.wait_for(self._queue.get(), remaining)
-            except asyncio.TimeoutError as e:
-                raise TimeoutError(
-                    f'no WebSocket frame within {timeout}s on stream '
-                    f'{self._stream_id}') from e
-            if frame.FrameType() == FrameTypes.DATA:
-                self._buf += frame.payload
-                await self._credit_returned(len(frame.payload))
+        try:
+            event = await asyncio.wait_for(self._recipient(), timeout)
+        except asyncio.TimeoutError as e:
+            raise TimeoutError(
+                f'no WebSocket frame within {timeout}s on stream '
+                f'{self._stream_id}') from e
+        if event.get('type') == ASGIEvent.WS_RECEIVE:
+            text = event.get('text')
+            if text is not None:
+                return WSOpcode.TEXT, text.encode('utf-8')
+            return WSOpcode.BINARY, event.get('bytes') or b''
+        # websocket.disconnect — peer CLOSE (echoed by the recipient) or
+        # abnormal stream end (1006).
+        self._disconnect_seen = True
+        code = event.get('code', 1006)
+        return WSOpcode.CLOSE, struct.pack('>H', code)
 
-    async def close(self, code: int = _CLOSE_CODE_NORMAL) -> None:
-        """Send a WebSocket close frame with the requested code and
-        END_STREAM on the carrying H2 DATA frame.  Idempotent."""
+    async def close(self, code: int = _CLOSE_CODE_NORMAL, *,
+                    drain_timeout: float = 5.0) -> None:
+        """Send a WebSocket close frame (END_STREAM on the carrying DATA
+        frame), await the peer's echoed CLOSE bounded by *drain_timeout*,
+        and stop the recipient's reader task.  Idempotent.
+
+        Sprint 72 (audit 1.20c) — same close discipline as the H1
+        client's :meth:`WebSocketSession.close`.
+        """
         if self._closed:
             return
         self._closed = True
@@ -164,8 +211,24 @@ class WebSocketH2Session:
             FrameTypes.DATA, DataFrameFlags.END_STREAM,
             self._stream_id, data=ws_bytes,
         )
-        await self._client.send_raw_frame(d_frame)
-        self._client.unregister_raw_stream(self._stream_id)
+        try:
+            await self._client.send_raw_frame(d_frame)
+        except Exception:
+            pass  # best-effort close frame; the connection may be gone.
+        try:
+            if not self._disconnect_seen:
+                async with asyncio.timeout(drain_timeout):
+                    while True:
+                        event = await self._recipient()
+                        if event.get('type') == ASGIEvent.WS_DISCONNECT:
+                            break
+        except Exception:
+            # TimeoutError (silent peer) or a recipient-raised protocol
+            # error — either way the drain is over.
+            pass
+        finally:
+            await self._recipient.shutdown()
+            self._client.unregister_raw_stream(self._stream_id)
 
     async def _send_ws(self, payload: bytes, opcode: int) -> None:
         if self._closed:

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -444,12 +444,12 @@ class HTTP2Actor(Actor):
                 push_callback=self._handle_push,
                 coalescer=self._coalescer,
                 conn_window=self._conn_window,  # shared stream-0 budget (bug 1.2)
+                # Seed the per-stream window from what the peer has currently
+                # granted us, rather than the RFC default, which may already
+                # have been changed by SETTINGS frames received before this
+                # stream opened.  The connection window is shared, not copied.
+                initial_window=self._peer_initial_window_size,
             )
-            # Initialise the per-stream window from what the peer has currently
-            # granted us, rather than the RFC default, which may already have
-            # been exceeded by SETTINGS / WINDOW_UPDATE frames received before
-            # this stream opened.  The connection window is shared, not copied.
-            sender.stream_window_size = self._peer_initial_window_size
             self._senders[stream_id] = sender
         return self._senders[stream_id]
 

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -1150,6 +1150,24 @@ class WebSocketRecipient(BaseRecipient):
             self._event_queue = asyncio.Queue(maxsize=self._ws_queue_depth)
             self._reader_task = asyncio.create_task(self._read_loop())
 
+    async def shutdown(self) -> None:
+        """Cancel and await the background read-loop task.
+
+        Sprint 72 (audit 1.20c) — client sessions call this from
+        ``close()`` so no reader task outlives the session (a leaked task
+        warns at event-loop shutdown and keeps reading a dead transport).
+        Idempotent, and safe to call before the first ``__call__`` ever
+        started the loop.
+        """
+        task = self._reader_task
+        self._reader_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
     async def __call__(self) -> dict:
         if not self._connect_sent:
             self._connect_sent = True

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -866,7 +866,8 @@ class HTTP2Sender(BaseSender):
 
     def __init__(self, writer: AbstractWriter, factory, stream_id: int,
                  push_callback=None, coalescer: 'ConnCoalescer | None' = None,
-                 conn_window: 'ConnectionWindow | None' = None):
+                 conn_window: 'ConnectionWindow | None' = None,
+                 initial_window: int | None = None):
         super().__init__(writer)
         self._factory = factory
         self._stream_id = stream_id
@@ -884,8 +885,13 @@ class HTTP2Sender(BaseSender):
         # Per-stream send window.  Refactor 2.5 — a plain int (this was a
         # dict-of-one keyed on the sender's own stream id, which obscured that
         # it is scalar and invited readers to hunt for multi-stream semantics
-        # that never existed).
-        self.stream_window_size = DEFAULT_INITIAL_WINDOW_SIZE
+        # that never existed).  Seeded at construction from the peer's
+        # SETTINGS_INITIAL_WINDOW_SIZE when known (bugs 1.20a + 2.11): both
+        # server and client pass ``initial_window`` so a sender created after
+        # the SETTINGS exchange starts at the peer's announced window, not
+        # the RFC 9113 §6.9.2 default.
+        self.stream_window_size = (DEFAULT_INITIAL_WINDOW_SIZE
+                                   if initial_window is None else initial_window)
         self.max_frame_size = DEFAULT_MAX_FRAME_SIZE
         self._window_open: asyncio.Event | None = None
         self._end_stream_sent: bool = False
@@ -1308,10 +1314,12 @@ class SenderFactory:
     @staticmethod
     def http2(stream_writer, factory, stream_id: int,
               push_callback=None, coalescer: 'ConnCoalescer | None' = None,
-              conn_window: 'ConnectionWindow | None' = None) -> HTTP2Sender:
+              conn_window: 'ConnectionWindow | None' = None,
+              initial_window: int | None = None) -> HTTP2Sender:
         return HTTP2Sender(SenderFactory._ensure_writer(stream_writer),
                            factory, stream_id, push_callback, coalescer,
-                           conn_window=conn_window)
+                           conn_window=conn_window,
+                           initial_window=initial_window)
 
     @staticmethod
     def websocket(stream_writer, *, compressor=None) -> WebSocketSender:

--- a/tests/conformance/http1/test_client.py
+++ b/tests/conformance/http1/test_client.py
@@ -358,6 +358,26 @@ class TestWebSocketClient:
         # No exception raised — close() drained gracefully.
 
     @pytest.mark.asyncio
+    async def test_close_drains_peer_close_and_stops_reader(self, server_port):
+        # Sprint 72 (1.20c) — close() completes the RFC 6455 §7.1.2 closing
+        # handshake and cancels the background reader task, so nothing
+        # outlives the session (no pending-task warning at loop shutdown).
+        async with WebSocketClient('127.0.0.1', server_port) as c:
+            ws = await c.connect('/ws')
+            await ws.send_text('one')
+            await ws.receive()
+            await asyncio.wait_for(ws.close(), 5)
+            task = ws._recipient._reader_task
+            assert task is None or task.done()
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, server_port):
+        async with WebSocketClient('127.0.0.1', server_port) as c:
+            ws = await c.connect('/ws')
+            await asyncio.wait_for(ws.close(), 5)
+            await asyncio.wait_for(ws.close(), 5)  # returns immediately
+
+    @pytest.mark.asyncio
     async def test_subprotocol_negotiation(self, server_port):
         # Set the available subprotocols on the running app via attribute.
         # The server reads ``getattr(self.app, 'available_ws_protocols', [])``

--- a/tests/unit/client/test_http2_client_window.py
+++ b/tests/unit/client/test_http2_client_window.py
@@ -1,0 +1,59 @@
+"""Sprint 72 — client-side H2 window seeding (audit bugs 1.20a + 2.11).
+
+RFC 9113 §6.9.2: SETTINGS_INITIAL_WINDOW_SIZE governs the *initial* send
+window of streams the peer has not yet opened; existing streams are
+adjusted by the delta.  ``HTTP2Client`` propagated the delta to existing
+senders but seeded new senders at the RFC default, so a sender created
+*after* the SETTINGS exchange under- or over-estimated its send credit
+(stall, or overrun with a lenient peer).  Both sides now seed at
+construction through the shared ``HTTP2Sender(initial_window=...)``
+parameter (2.11's shared seeding helper).
+"""
+from __future__ import annotations
+
+from blackbull.client.http2 import HTTP2Client
+from blackbull.server.sender import AbstractWriter
+from blackbull.protocol.frame_types import DEFAULT_INITIAL_WINDOW_SIZE
+
+
+class _NullWriter(AbstractWriter):
+    async def write(self, data: bytes) -> None:
+        pass
+
+
+def _client() -> HTTP2Client:
+    c = HTTP2Client('localhost', 1)
+    c._writer = _NullWriter()
+    return c
+
+
+class TestClientWindowSeeding:
+    def test_sender_created_after_settings_is_seeded(self):
+        """Bug 1.20a — a sender made after the SETTINGS exchange must start
+        at the peer's announced initial window, not the RFC default."""
+        c = _client()
+        c._on_initial_window_size(123456)
+        sender = c._make_sender(1)
+        assert sender.stream_window_size == 123456
+
+    def test_sender_created_before_settings_gets_delta(self):
+        """Existing behaviour pin: pre-SETTINGS senders are delta-adjusted."""
+        c = _client()
+        sender = c._make_sender(1)
+        assert sender.stream_window_size == DEFAULT_INITIAL_WINDOW_SIZE
+        c._on_initial_window_size(70000)
+        assert sender.stream_window_size == (
+            DEFAULT_INITIAL_WINDOW_SIZE + (70000 - DEFAULT_INITIAL_WINDOW_SIZE))
+
+    def test_default_seed_matches_rfc_default(self):
+        c = _client()
+        sender = c._make_sender(1)
+        assert sender.stream_window_size == DEFAULT_INITIAL_WINDOW_SIZE
+
+    def test_shrunk_window_seeds_new_sender_low(self):
+        """A peer may announce a window *below* the default (e.g. 1024);
+        late senders must honour that too, or they overrun."""
+        c = _client()
+        c._on_initial_window_size(1024)
+        sender = c._make_sender(3)
+        assert sender.stream_window_size == 1024

--- a/tests/unit/client/test_websocket_close.py
+++ b/tests/unit/client/test_websocket_close.py
@@ -1,0 +1,100 @@
+"""Sprint 72 (1.20c) — H1 client close discipline + recipient shutdown.
+
+``WebSocketSession.close()`` previously sent a best-effort CLOSE frame and
+returned: the peer's echoed CLOSE was never drained and the recipient's
+background read-loop task was left running (RFC 6455 §7.1.2 expects the
+closing handshake to complete; a leaked task warns at loop shutdown).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from blackbull.client.websocket import WebSocketSession
+from blackbull.server.recipient import AbstractReader, WebSocketRecipient
+from blackbull.server.sender import AbstractWriter
+from blackbull.server.ws_codec import WSOpcode, encode_frame
+
+
+class _ScriptedReader(AbstractReader):
+    """Serves a fixed byte script, then blocks forever (silent peer)."""
+
+    def __init__(self, data: bytes = b'') -> None:
+        self._buf = bytearray(data)
+        self._starved = asyncio.Event()
+
+    async def read(self, n: int) -> bytes:
+        if not self._buf:
+            await self._starved.wait()  # never set — models a silent peer
+        chunk = bytes(self._buf[:n])
+        del self._buf[:n]
+        return chunk
+
+
+class _CaptureWriter(AbstractWriter):
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+def _session(peer_bytes: bytes = b'') -> WebSocketSession:
+    reader = _ScriptedReader(peer_bytes)
+    writer = _CaptureWriter()
+    raw_writer = MagicMock(spec=asyncio.StreamWriter)
+    return WebSocketSession(reader, writer, raw_writer=raw_writer,
+                            subprotocol=None)
+
+
+class TestSessionClose:
+    @pytest.mark.asyncio
+    async def test_close_drains_peer_close_and_stops_reader(self):
+        peer_close = encode_frame((1000).to_bytes(2, 'big'),
+                                  opcode=WSOpcode.CLOSE)
+        ws = _session(peer_close)
+        await asyncio.wait_for(ws.close(), 2)
+        task = ws._recipient._reader_task
+        assert task is None or task.done()
+
+    @pytest.mark.asyncio
+    async def test_close_times_out_on_silent_peer(self):
+        ws = _session()
+        await asyncio.wait_for(ws.close(drain_timeout=0.1), 2)
+        task = ws._recipient._reader_task
+        assert task is None or task.done()
+
+    @pytest.mark.asyncio
+    async def test_close_skips_drain_after_disconnect_seen(self):
+        peer_close = encode_frame((1000).to_bytes(2, 'big'),
+                                  opcode=WSOpcode.CLOSE)
+        ws = _session(peer_close)
+        event = await ws.receive()
+        assert event['type'] == 'websocket.disconnect'
+        await asyncio.wait_for(ws.close(drain_timeout=30.0), 2)
+
+
+class TestRecipientShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_safe_before_start(self):
+        r = WebSocketRecipient(_ScriptedReader(), _CaptureWriter(),
+                               require_masked=False)
+        await r.shutdown()
+        await r.shutdown()  # idempotent
+
+    @pytest.mark.asyncio
+    async def test_shutdown_cancels_running_reader(self):
+        r = WebSocketRecipient(_ScriptedReader(), _CaptureWriter(),
+                               require_masked=False)
+        r._connect_sent = True
+        recv = asyncio.create_task(r())
+        await asyncio.sleep(0.05)  # let the read loop start and park
+        task = r._reader_task
+        assert task is not None and not task.done()
+        await r.shutdown()
+        assert task.done()
+        recv.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await recv

--- a/tests/unit/client/test_websocket_h2_session.py
+++ b/tests/unit/client/test_websocket_h2_session.py
@@ -1,0 +1,199 @@
+"""Sprint 72 — WebSocketH2Session on the shared WS codec (1.20b / F.2, 1.20c).
+
+The session previously rolled a third, private WebSocket frame parser that
+ignored FIN, RSV, and MASK bits entirely — no fragmentation reassembly, no
+control-frame handling.  It now reuses the same ``WebSocketRecipient`` /
+``FragmentAssembler`` stack as the server and the H1 client, fed by a small
+``AbstractReader`` adapter over the raw-stream DATA-frame queue.
+
+Tests drive a real ``HTTP2Client`` (never connected: ``_writer`` stubbed
+with a byte-capturing writer, ``send_raw_frame`` recorded) and hand-feed
+``FrameFactory``-loaded DATA frames into the raw-stream queue.
+"""
+from __future__ import annotations
+
+import asyncio
+import struct
+
+import pytest
+
+from blackbull.client.http2 import HTTP2Client
+from blackbull.client.websocket_h2 import WebSocketH2Session
+from blackbull.protocol.frame import FrameFactory
+from blackbull.protocol.frame_types import DataFrameFlags, FrameTypes
+from blackbull.server.sender import AbstractWriter
+from blackbull.server.ws_codec import WSFrameBits, WSOpcode, encode_frame
+
+
+class _CaptureWriter(AbstractWriter):
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+def _make_session(stream_id: int = 1):
+    client = HTTP2Client('localhost', 1)
+    writer = _CaptureWriter()
+    client._writer = writer
+    sent_raw: list = []
+
+    async def _record_raw(frame):
+        sent_raw.append(frame)
+
+    client.send_raw_frame = _record_raw  # type: ignore[method-assign]
+    queue = client.register_raw_stream(stream_id)
+    factory = FrameFactory()
+    session = WebSocketH2Session(client, factory, stream_id, queue)
+    return session, queue, factory, writer, sent_raw
+
+
+def _data_frame(factory, ws_bytes: bytes, stream_id: int = 1,
+                end_stream: bool = False):
+    flags = DataFrameFlags.END_STREAM if end_stream else 0
+    return factory.create(FrameTypes.DATA, flags, stream_id, data=ws_bytes)
+
+
+def _fragment(payload: bytes, opcode: WSOpcode | int, fin: bool) -> bytes:
+    """Server→client (unmasked) WS frame with an explicit FIN bit."""
+    frame = bytearray(encode_frame(payload, opcode=opcode))
+    if not fin:
+        frame[0] &= ~WSFrameBits.FIN & 0xFF
+    return bytes(frame)
+
+
+def _sent_ws_bytes(writer: _CaptureWriter, stream_id: int = 1) -> bytes:
+    """Extract the WS bytes the session wrote, out of captured H2 frames."""
+    factory = FrameFactory()
+    buf = bytes(writer.data)
+    out = bytearray()
+    while buf:
+        length = int.from_bytes(buf[:3], 'big')
+        frame = factory.load(buf[:9 + length])
+        if (frame.FrameType() == FrameTypes.DATA
+                and frame.stream_id == stream_id):
+            out += frame.payload
+        buf = buf[9 + length:]
+    return bytes(out)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1.20b / F.2 — shared-codec receive path
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestSharedCodecReceive:
+    @pytest.mark.asyncio
+    async def test_fragmented_message_reassembled(self):
+        """RFC 6455 §5.4 — TEXT(FIN=0) + CONTINUATION(FIN=1) is one message.
+        The old private parser ignored FIN and returned the first fragment
+        as a complete message."""
+        session, queue, factory, writer, _ = _make_session()
+        queue.put_nowait(_data_frame(
+            factory, _fragment(b'Hel', WSOpcode.TEXT, fin=False)))
+        queue.put_nowait(_data_frame(
+            factory, _fragment(b'lo', WSOpcode.CONTINUATION, fin=True)))
+        opcode, payload = await session.receive(timeout=2.0)
+        assert (opcode, payload) == (WSOpcode.TEXT, b'Hello')
+
+    @pytest.mark.asyncio
+    async def test_ws_frame_split_across_data_frames(self):
+        """One WS frame's bytes may span several H2 DATA frames."""
+        session, queue, factory, writer, _ = _make_session()
+        ws = encode_frame(b'spanning', opcode=WSOpcode.BINARY)
+        queue.put_nowait(_data_frame(factory, ws[:3]))
+        queue.put_nowait(_data_frame(factory, ws[3:]))
+        opcode, payload = await session.receive(timeout=2.0)
+        assert (opcode, payload) == (WSOpcode.BINARY, b'spanning')
+
+    @pytest.mark.asyncio
+    async def test_ping_is_auto_ponged_masked(self):
+        """RFC 6455 §5.5.2/§5.5.3 — PING answered with a PONG carrying the
+        same payload; §5.1 — client frames MUST be masked."""
+        session, queue, factory, writer, _ = _make_session()
+        queue.put_nowait(_data_frame(
+            factory, encode_frame(b'probe', opcode=WSOpcode.PING)))
+        queue.put_nowait(_data_frame(
+            factory, encode_frame(b'after', opcode=WSOpcode.TEXT)))
+        opcode, payload = await session.receive(timeout=2.0)
+        assert (opcode, payload) == (WSOpcode.TEXT, b'after')
+        pong = _sent_ws_bytes(writer)
+        assert pong, 'no PONG bytes written'
+        assert pong[0] & 0x0F == WSOpcode.PONG
+        assert pong[1] & WSFrameBits.MASK_BIT, 'client PONG must be masked'
+
+    @pytest.mark.asyncio
+    async def test_server_close_yields_close_tuple(self):
+        session, queue, factory, writer, _ = _make_session()
+        queue.put_nowait(_data_frame(
+            factory,
+            encode_frame((1000).to_bytes(2, 'big'), opcode=WSOpcode.CLOSE)))
+        opcode, payload = await session.receive(timeout=2.0)
+        assert opcode == WSOpcode.CLOSE
+        assert payload == struct.pack('>H', 1000)
+
+    @pytest.mark.asyncio
+    async def test_end_stream_without_close_disconnects(self):
+        """END_STREAM with no CLOSE frame = abnormal closure (1006)."""
+        session, queue, factory, writer, _ = _make_session()
+        queue.put_nowait(_data_frame(factory, b'', end_stream=True))
+        opcode, payload = await session.receive(timeout=2.0)
+        assert opcode == WSOpcode.CLOSE
+        assert payload == struct.pack('>H', 1006)
+
+    @pytest.mark.asyncio
+    async def test_receive_timeout_message_shape(self):
+        session, queue, factory, writer, _ = _make_session()
+        with pytest.raises(TimeoutError, match='no WebSocket frame within'):
+            await session.receive(timeout=0.05)
+        await session.close(drain_timeout=0.05)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# 1.20c — close() drains the peer CLOSE and stops the recipient
+# ═══════════════════════════════════════════════════════════════════════
+
+class TestCloseDiscipline:
+    @pytest.mark.asyncio
+    async def test_close_completes_when_peer_echoes_close(self):
+        session, queue, factory, writer, sent_raw = _make_session()
+        queue.put_nowait(_data_frame(
+            factory,
+            encode_frame((1000).to_bytes(2, 'big'), opcode=WSOpcode.CLOSE)))
+        await asyncio.wait_for(session.close(), 2)
+        # The outgoing CLOSE rode a DATA frame with END_STREAM.
+        assert any(
+            f.FrameType() == FrameTypes.DATA and f.end_stream
+            for f in sent_raw)
+        task = session._recipient._reader_task
+        assert task is None or task.done()
+
+    @pytest.mark.asyncio
+    async def test_close_times_out_on_silent_peer(self):
+        session, queue, factory, writer, _ = _make_session()
+        await asyncio.wait_for(session.close(drain_timeout=0.1), 2)
+        task = session._recipient._reader_task
+        assert task is None or task.done()
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self):
+        session, queue, factory, writer, sent_raw = _make_session()
+        await asyncio.wait_for(session.close(drain_timeout=0.1), 2)
+        n = len(sent_raw)
+        await asyncio.wait_for(session.close(drain_timeout=0.1), 2)
+        assert len(sent_raw) == n
+
+    @pytest.mark.asyncio
+    async def test_close_skips_drain_after_disconnect_seen(self):
+        """If receive() already surfaced the peer CLOSE, close() must not
+        sit in the drain loop waiting for a second one."""
+        session, queue, factory, writer, _ = _make_session()
+        queue.put_nowait(_data_frame(
+            factory,
+            encode_frame((1000).to_bytes(2, 'big'), opcode=WSOpcode.CLOSE)))
+        opcode, _payload = await session.receive(timeout=2.0)
+        assert opcode == WSOpcode.CLOSE
+        # Generous outer bound, tiny inner drain budget would be wrong here:
+        # the drain must be skipped entirely, so even a long drain_timeout
+        # returns immediately.
+        await asyncio.wait_for(session.close(drain_timeout=30.0), 2)


### PR DESCRIPTION
## Summary

Sprint 72's experimental-client cluster — retires audit findings **1.20a + 2.11**, **1.20b/F.2**, and **1.20c** (working list: comprehensive-audit-followup-2026-07-14).

### 1.20a + 2.11 — construction-time window seeding
`HTTP2Sender` gains a keyword `initial_window` parameter — the shared seeding helper finding 2.11 asked for. The server passes `_peer_initial_window_size` as before (no more construct-then-patch); the client passes `initial_window_size`, fixing the real bug: **a sender created after the SETTINGS exchange started at the RFC-default 65535** (`_on_initial_window_size` only delta-adjusts *existing* senders), stalling or overrunning under a non-default `SETTINGS_INITIAL_WINDOW_SIZE`. The two SETTINGS delta-propagation loops stay deliberately separate (seeding only — noted non-goal).

### 1.20b / F.2 — third WS frame parser deleted
`client/websocket_h2.py::_parse_ws_frame` ignored FIN/RSV/MASK entirely — no fragmentation reassembly, no control-frame handling. `WebSocketH2Session` now reuses the shared `WebSocketRecipient`/`FragmentAssembler` stack via a new `_H2QueueReader` (an `AbstractReader` over the raw-stream DATA-frame queue; WINDOW_UPDATE credit timing preserved exactly) and the existing `HTTP2WSWriter` (recipient-generated PONG/echo-CLOSE ride the per-stream sender, masked as a client's must be). `receive()` keeps its `(opcode, payload)` return type. Free wins: fragmentation, auto-PONG, UTF-8 validation, FIN/RSV/MASK enforcement, frame-size cap.

### 1.20c — close() completes the closing handshake
`WebSocketRecipient` gains a public `shutdown()` (cancel + await the read loop; idempotent, safe before start). Both client sessions' `close()` now drain the peer's echoed CLOSE bounded by `drain_timeout` (default 5 s — a silent peer cannot hang `close()`) and shut the recipient down, so no reader task outlives the session. A disconnect already surfaced via `receive()` skips the drain.

Known pre-existing quirk recorded, not fixed: the shared recipient echoes any peer CLOSE, so a client-initiated close may emit a second CLOSE during the drain — harmless post-close traffic.

## Tests

New: `tests/unit/client/test_http2_client_window.py`, `tests/unit/client/test_websocket_h2_session.py` (fragmentation, frame-split-across-DATA, masked auto-PONG, CLOSE mapping, END_STREAM→1006, close discipline), `tests/unit/client/test_websocket_close.py` (H1 close drain/timeout/skip + recipient shutdown). Extended `TestWebSocketClient` with end-to-end close-drain and idempotence tests.

## Verification

- Quick tier: 2925 passed (beartype-instrumented)
- `--run-all` full tier: 3176 passed (nginx docker fixture unavailable locally — environmental)
- `test_rfc8441_interop.py` + `test_rfc8441.py`: 46 passed **unchanged**

🤖 Generated with [Claude Code](https://claude.com/claude-code)