### PR TITLE
fix(conformance): make Autobahn CASES actually subset the run (Sprint 72, P.2)

### DIFF
--- a/bench/conformance/autobahn_run.sh
+++ b/bench/conformance/autobahn_run.sh
@@ -10,6 +10,13 @@
 # Usage:
 #   bash bench/conformance/autobahn_run.sh            # full fuzzingclient
 #   CASES='1.*' bash bench/conformance/autobahn_run.sh  # subset
+#   CASES='1.*,2.*,6.*,7.*' bash bench/conformance/autobahn_run.sh  # PR lane
+#
+# CASES is a comma-separated list of Autobahn case patterns (default '*').
+# The static autobahn_fuzzingclient.json is a template: a per-run copy with
+# "cases" substituted is rendered into the results dir and mounted instead
+# (P.2, Sprint 72 — previously CASES was documented but ignored and subset
+# runs silently ran all 517 cases).
 #
 # Reports land in bench/conformance/results/autobahn_<timestamp>/.
 
@@ -47,13 +54,30 @@ fi
 
 CONFIG_DIR="$(cd "$(dirname "$0")" && pwd)"
 
+# Render the per-run config: the checked-in JSON is the template, only
+# "cases" is replaced.  With CASES unset the rendered "cases" is ["*"] —
+# identical to the template — so the CI job (which sets no CASES) keeps
+# running the full suite.
+CASES="${CASES:-*}" python3 - "$CONFIG_DIR/autobahn_fuzzingclient.json" \
+    "$OUT/fuzzingclient.json" <<'PYEOF'
+import json, os, sys
+src, dst = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    cfg = json.load(f)
+cases = [c.strip() for c in os.environ['CASES'].split(',') if c.strip()]
+cfg['cases'] = cases or ['*']
+with open(dst, 'w') as f:
+    json.dump(cfg, f, indent=3)
+PYEOF
+
 echo "Autobahn|Testsuite vs ws://localhost:$PORT"
+echo "Cases:   ${CASES:-*}"
 echo "Results: $OUT"
 echo ""
 
 docker run --rm \
     --add-host=host.docker.internal:host-gateway \
-    -v "$CONFIG_DIR/autobahn_fuzzingclient.json:/config/fuzzingclient.json:ro" \
+    -v "$(realpath "$OUT/fuzzingclient.json"):/config/fuzzingclient.json:ro" \
     -v "$(realpath "$OUT"):/results" \
     crossbario/autobahn-testsuite \
     wstest -m fuzzingclient -s /config/fuzzingclient.json


### PR DESCRIPTION
## Summary

Sprint 72 rider — audit item **P.2**. `autobahn_run.sh` (and `.claude/patterns/conformance.md`) documented `CASES='1.*' bash …` subset runs, but the script never referenced `$CASES`: it unconditionally mounted the static full-suite `autobahn_fuzzingclient.json`, so subset runs silently ran all 517 cases (~11 min).

## Changes

- The checked-in JSON becomes a template: a per-run copy with only `"cases"` substituted is rendered (via `python3`, already a script prerequisite) into the run's results dir and mounted into the wstest container instead.
- `CASES` accepts comma-separated patterns (`CASES='1.*,2.*,6.*,7.*'`), whitespace-tolerant, default `'*'`.
- **CI invariant**: with `CASES` unset the rendered config is content-identical to the template, so the `conformance.yml` autobahn job (which sets no `CASES`) keeps running the full suite unchanged — its jq gate on this PR is the live verification.

Enables a fast PR-scoped Autobahn lane as a follow-up; deliberately **not** added to CI this sprint.

## Verification

- Render checked for unset / single-case / comma-list `CASES`; unset-`CASES` render asserted `==` template (json-equal)
- `bash -n` clean; docker unavailable locally, so the PR's CI Autobahn job is the authoritative full-suite check

🤖 Generated with [Claude Code](https://claude.com/claude-code)