### PR TITLE
release: v0.54.0 — Sprint 72: H2 :authority correctness cluster + Session removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,42 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Fixed
+
+- **HTTP/2 `:authority` is now validated and surfaced as the `host` header**
+  (#150, Sprint 72; RFC 9113 §8.3.1). Previously the pseudo-header was parsed
+  but never checked nor mapped into the ASGI scope, so
+  `request.headers.get(b'host')` returned `None` for virtually every HTTP/2
+  client (grpcio, browsers, and `curl --http2` send `:authority` without a
+  literal `Host`), and the server-push path silently synthesised
+  `:authority = localhost`. Now: an `http(s)` request carrying neither
+  `:authority` nor `Host` is rejected as malformed (`RST_STREAM
+  PROTOCOL_ERROR`), as are authorities containing userinfo, RFC 3986 §3.2
+  delimiters, or whitespace, and multiple `Host` fields — the same grammar
+  HTTP/1.1 has enforced since 0.49.3. A valid `:authority` replaces any
+  literal `Host` in `scope['headers']` (mirroring H1's
+  absolute-form-overrides-Host semantics) on both the request path and the
+  RFC 8441 WebSocket path, so the same handler sees the same headers under
+  either transport. Plain CONNECT is untouched (§8.5 tunnel semantics).
+- **Experimental H2 client: send windows now honour the server's
+  `SETTINGS_INITIAL_WINDOW_SIZE` for late streams** (#151, audit 1.20a).
+  A sender created after the SETTINGS exchange started at the RFC-default
+  65535 and could stall or overrun under a non-default window; both server
+  and client now seed the per-stream window at `HTTP2Sender` construction
+  (the shared helper audit item 2.11 called for).
+- **Experimental WS-over-H2 client: third divergent frame parser deleted**
+  (#151, audit 1.20b/F.2). `WebSocketH2Session` now reuses the same
+  `WebSocketRecipient`/`FragmentAssembler` stack as the server and the H1
+  client, gaining fragmentation reassembly, transparent PING→PONG (masked,
+  as a client's must be), UTF-8 validation, FIN/RSV/MASK enforcement, and
+  the frame-size cap. The `(opcode, payload)` `receive()` API is unchanged.
+- **Experimental WS clients: `close()` completes the closing handshake**
+  (#151, audit 1.20c). Both `WebSocketSession.close()` and
+  `WebSocketH2Session.close()` now drain the peer's echoed CLOSE (bounded
+  by a new `drain_timeout` parameter, default 5 s — a silent peer cannot
+  hang `close()`) and cancel the background reader via the new public
+  `WebSocketRecipient.shutdown()`, so no task outlives the session.
+
 ### Removed
 
 - **The deprecated in-tree `Session` middleware** (`blackbull.middleware.Session`
@@ -41,6 +77,19 @@ so the editable install's metadata catches up.
   `app.use(Session(...))` for `SessionExtension(app, ...)` — handlers keep
   reading and writing `scope['session']` unchanged, and `BB_SESSION_SECRET`
   is still honoured by the replacement package.
+
+### Internal
+
+- `bench/conformance/autobahn_run.sh` — `CASES='1.*'` (comma-separated
+  patterns accepted) now actually subsets the Autobahn run instead of being
+  silently ignored; a per-run config is rendered with only `"cases"`
+  substituted, so the unset-`CASES` CI job still runs the full 517-case
+  suite (#152, audit P.2).
+
+### Docs
+
+- `docs/about/rfc9113-implementation.md` §8.3 — documents the new
+  `:authority` validation and ASGI `host` mapping.
 
 ## [0.53.4] — 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.54.0] — 2026-07-16
+
 ### Fixed
 
 - **HTTP/2 `:authority` is now validated and surfaced as the `host` header**

--- a/docs/about/rfc9113-implementation.md
+++ b/docs/about/rfc9113-implementation.md
@@ -435,6 +435,20 @@ a correctness requirement.
 Pseudo-headers are parsed and validated before dispatch.  **§8.3.1 Request
 Pseudo-Headers** — `:method`, `:scheme`, `:path`, `:authority`; the `:path`
 split for pushed requests lives in `HTTP2Actor._handle_push()`.
+`:authority` is validated and surfaced by `_request_headers_with_host() in
+parser.py` (v0.54.0): an `http(s)` request carrying neither `:authority` nor
+`Host` is malformed, as is an authority containing userinfo, RFC 3986 §3.2
+delimiters, or whitespace (the same grammar HTTP/1.1 enforces on `Host`);
+multiple `Host` fields without `:authority` are likewise rejected.  A valid
+`:authority` is mapped into `scope['headers']` as the `host` header,
+replacing any literal `Host` — the ASGI host mapping, mirroring H1's
+absolute-form-overrides-Host semantics — on both the request path and the
+RFC 8441 Extended CONNECT path, so `HTTP2Actor._handle_push()` synthesises
+pushed `:authority` from the parent scope's `host`.  Plain CONNECT is
+excluded (its `:authority` carries §8.5 tunnel semantics).  *Because* a
+request without a host authority has no target and the userinfo prohibition
+is an explicit §8.3.1 MUST; surfacing it as `host` keeps the same handler
+seeing the same headers under either transport.
 **§8.3.2 Response Pseudo-Headers** — `:status` is synthesised on the response
 path.  For the seven most common status codes (200, 204, 206, 304, 400, 404,
 500) the wire bytes are precomputed in `hpack_fastpath.py` via HPACK

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -14,7 +14,7 @@ first — it covers installation and the shape of a minimal app.
   registration.
 - [**Middleware**](middleware.md) — writing middleware,
   `@as_middleware`, attaching to routes, built-in middleware
-  (`websocket`, `Compression`, `Session`, `Cache`, `CORS`,
+  (`websocket`, `Compression`, `Cache`, `CORS`,
   `StaticFiles`), common recipes.
 - [**Error handling**](error-handling.md) — `@app.on_error`,
   the DEV-mode traceback page, PROD-mode terse responses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.53.4"
+version = "0.54.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 72 close — the MINOR that ships both the H2/client correctness cluster and the Sprint 71 breaking `Session` removal (removal-only releases are not cut, so it rides this one).

### Fixed
- **HTTP/2 `:authority` validated (RFC 9113 §8.3.1) and surfaced as `host`** (#150) — missing-both / userinfo / delimiter authorities → RST_STREAM PROTOCOL_ERROR; `request.headers.get(b'host')` now works under grpcio/browsers/`curl --http2`; PUSH_PROMISE synthesises `:authority` from the real host instead of `localhost`.
- **Experimental H2 client window seeding** (#151) — senders created after the SETTINGS exchange honour the server's `SETTINGS_INITIAL_WINDOW_SIZE`.
- **WS-over-H2 client on the shared codec** (#151) — fragmentation reassembly, masked auto-PONG, UTF-8/FIN/RSV/MASK validation; third private parser deleted.
- **WS client `close()` discipline** (#151) — drains the peer CLOSE (bounded by `drain_timeout`), cancels the reader via new `WebSocketRecipient.shutdown()`.

### Removed
- **In-tree `Session` middleware** (Sprint 71, #148) — deprecated since 0.38, both removal floors passed. Migrate to [`blackbull-session`](https://github.com/TOKUJI/blackbull-session).

### Internal / Docs
- Autobahn `CASES` subset runs actually subset (#152); RFC 9113 doc §8.3 synced; guide index no longer lists `Session`.

Note: this branch replaces the abandoned removal-only release attempt (closed PR #149) that previously occupied `release/v0.54.0`.

## Test plan
- [x] Quick tier + `--run-all` full tier green locally on every feature PR (beartype-instrumented)
- [x] h2spec 146/146 (local + CI), Autobahn full suite green on all three feature PRs
- [x] `blackbull.__version__` reports 0.54.0 after editable reinstall
- [ ] CI green on this PR (CodeQL, Audit, conformance lanes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)