### PR TITLE
release: v0.55.0 — Sprint 73: RFC 9651 Structured Fields + protocol translation hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.55.0] — 2026-07-16
+
 ### Added
 
 - **RFC 9651 Structured Field Values** (Sprint 73). New module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.54.0"
+version = "0.55.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Two-file release commit closing Sprint 73 (feature work merged in #154):

- `pyproject.toml`: version 0.54.0 → 0.55.0 (MINOR — new public API surface)
- `CHANGELOG.md`: `[Unreleased]` → `[0.55.0] — 2026-07-16` (fresh empty `[Unreleased]` heading kept on top)

Headline: RFC 9651 Structured Field Values (`blackbull.protocol.structured_fields` + `Headers.get_sf_*`, 2,135/2,135 httpwg conformance cases) and the C4 protocol-translation-hub showcase; fixes dead MQTT taps in default actor mode and makes RFC 9218 priority parsing spec-strict.

## Test plan

- [x] Full suite green on #154 (all CI lanes incl. Autobahn, h2spec, CodeQL)
- [x] `python -c "import blackbull; print(blackbull.__version__)"` → 0.55.0 after editable reinstall
- [ ] CI green on this PR (release diff is version bump + heading rename only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)