### PR TITLE
feat: query params + Depends in the simplified handler model (Sprint 74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@ so the editable install's metadata catches up.
 
 ### Changed
 
+- **Dev-mode error page: no traceback for 4xx `HTTPException`s**
+  (Sprint 74). A client fault the framework itself diagnosed — missing
+  required query parameter, malformed JSON body — now renders as status +
+  detail line in development mode, without the Python traceback (the
+  frames only showed framework internals; the detail line is the
+  actionable part). 5xx `HTTPException`s and unexpected exceptions keep
+  the full traceback. Mirrors the dispatcher's existing quiet-log rule
+  for the same errors.
 - **Simplified-handler registration contract** (Sprint 74). A scalar
   parameter that matches no other category is now a query param instead of
   a registration-time `TypeError`; the fail-fast `TypeError` remains for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,44 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **Query params in the simplified handler model** (Sprint 74). A handler
+  parameter that is neither a path param, `body`, `scope`, `Request`, a
+  dataclass body, nor `Depends(...)` now resolves from the query string,
+  coerced to its annotation (`str`/`int`/`float`/`bool`, optionally
+  `| None`; unannotated → `str`): `async def search(q: str, page: int = 1)`
+  handles `/search?q=bull&page=2` directly. A default makes the param
+  optional; a missing required key or a failed coercion is answered with
+  **400**, never a 500. Repeated keys: last occurrence wins. Classification
+  happens once at registration — handlers that declare no query params keep
+  the exact wrapper they had before. Query params are emitted in the
+  generated OpenAPI spec (`in: query`, schema from the annotation,
+  `required` from default-presence). Deferred since Sprint 41.
+- **`Depends` — per-request provider injection** (Sprint 74). New module
+  `blackbull.di`; `db=Depends(get_db)` as a parameter default injects the
+  provider's value per request. Async-generator providers yield the value
+  and tear down **after the response is sent** (`AsyncExitStack`-backed,
+  LIFO across providers, exception-safe); plain async/sync callables
+  inject a value with no cleanup. `use_cache=True` (default) shares one
+  instance per request across parameters naming the same provider. v1
+  fences: providers take no parameters, nested `Depends` is a
+  registration-time `TypeError`, simplified handlers only. The
+  anti-FastAPI design point: everything resolves at registration time, so
+  handlers without `Depends` gain zero per-request cost (FastAPI runs
+  `solve_dependencies()` + two `AsyncExitStack`s per request even with no
+  dependencies declared). New guide page *Dependency injection*.
+
+### Changed
+
+- **Simplified-handler registration contract** (Sprint 74). A scalar
+  parameter that matches no other category is now a query param instead of
+  a registration-time `TypeError`; the fail-fast `TypeError` remains for
+  unsupported annotations (containers, arbitrary classes). A path param
+  declaring a default now draws a registration-time `UserWarning` (the
+  path value always wins; the default suggests a query param was
+  intended).
+
 ## [0.55.0] — 2026-07-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,14 +59,24 @@ async def echo(body: bytes):       # full body buffered automatically
 async def inspect(request: Request):   # opt-in context object
     return {'ua': request.headers.get(b'user-agent').decode(),
             'data': await request.json()}
+
+@app.route(path='/search')
+async def search(q: str, page: int = 1, db=Depends(get_db)):
+    ...   # q/page from the query string; db from the provider, torn down after send
 ```
 
 Supported parameters: named path params (coerced to annotation type), `body: bytes`,
-`scope`, and `Request` (annotation `Request` under any name, or the bare name
+`scope`, `Request` (annotation `Request` under any name, or the bare name
 `request` unannotated) — `request.body()`/`json()`/`text()` cache one drain of
-`receive`, shared with a coexisting `body` param. Return `str`, `bytes`, `dict`,
-`Response`, or `None`. Middleware functions and WebSocket handlers always use the
-full `(scope, receive, send)` form.
+`receive`, shared with a coexisting `body` param — `Depends(provider)` as a
+default value (per-request provider injection, Sprint 74), and **query params**
+as the fallback category: any leftover scalar param (`str`/`int`/`float`/`bool`,
+optionally `| None`; unannotated → `str`) resolves from the query string, with
+defaults → optional and missing-required/failed-coercion → 400. Classification
+happens once at registration (`_handler_param_plan`, router.py); handlers using
+neither new feature keep the pre-Sprint-74 wrapper (zero-overhead pin). Return
+`str`, `bytes`, `dict`, `Response`, or `None`. Middleware functions and
+WebSocket handlers always use the full `(scope, receive, send)` form.
 
 ## Middleware convention
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ async def create_note(note_id: int, request: Request):
     return {"id": note_id, "note": await request.json()}
 ```
 
+Query params and per-request resources are declared the same way —
+everything is resolved when the route is registered, so handlers that
+don't use a feature pay nothing for it at request time:
+
+```python
+from blackbull import Depends
+
+async def get_db():
+    conn = await pool.acquire()
+    try:
+        yield conn                 # injected value
+    finally:
+        await pool.release(conn)  # runs after the response is sent
+
+@app.route(path='/search')
+async def search(q: str, page: int = 1, db=Depends(get_db)):
+    return await db.find(q, page=page)   # /search?q=bull&page=2
+```
+
 Drop down to full ASGI `(scope, receive, send)` whenever you need it
 — routes accept either shape.
 

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -12,6 +12,7 @@ Public API exports:
 - `RouteInfo`: immutable ``(method, path, name)`` snapshot returned by ``app.get_routes()``.
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
 - `Request`: opt-in context object for HTTP handlers (headers/cookies/client/``body()``/``json()``), injected by signature.
+- `Depends`: per-request provider injection for simplified handlers (async-generator providers get teardown after the response is sent).
 - `cookie_header`: builds a ``Set-Cookie`` header tuple.
 - `read_body`: reads and buffers the full request body from the ASGI receive channel.
 - `read_json`: reads the body and parses it as JSON (``None`` on empty/invalid).
@@ -43,6 +44,7 @@ except PackageNotFoundError:
     __version__ = '0.0.0+unknown'
 
 from .app import BlackBull, serve
+from .di import Depends
 from .router import RouteInfo, HTTPException
 from .config import AppConfig
 from .headers import Headers

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -129,8 +129,11 @@ async def _default_error_handler(scope, receive, send):  # noqa: ARG001
 
     * ``development`` — include the full Python traceback when an exception
       is present, so users debugging locally see the failure inline.
-      ``Accept: text/html`` returns a styled HTML page; everything else
-      gets text/plain.
+      Exception: a **4xx** :class:`HTTPException` is a *diagnosed client
+      fault* (missing query param, malformed body, …) — the page keeps the
+      status + detail line but drops the traceback, mirroring the quiet-log
+      rule the dispatcher applies to the same errors.  ``Accept: text/html``
+      returns a styled HTML page; everything else gets text/plain.
     * ``production`` — terse: status code + phrase only.  No exception
       class or message is leaked.  Browsers get a minimal HTML page;
       curl-style clients get text/plain.
@@ -152,8 +155,13 @@ async def _default_error_handler(scope, receive, send):  # noqa: ARG001
 
     tb_text = None
     if is_dev and exc is not None:
-        tb_text = ''.join(
-            traceback.format_exception(type(exc), exc, exc.__traceback__))
+        # 4xx HTTPExceptions are client faults the framework already
+        # diagnosed — the detail line below is the actionable part, and the
+        # server-side frames are noise.  5xx and unexpected exceptions keep
+        # the full traceback.
+        if not (isinstance(exc, HTTPException) and exc.status.is_client_error):
+            tb_text = ''.join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     if html_ok:
         body = _render_error_html(status, exc if is_dev else None,

--- a/blackbull/di.py
+++ b/blackbull/di.py
@@ -1,0 +1,135 @@
+"""Per-request dependency injection for simplified handlers.
+
+``Depends`` marks a simplified-handler parameter as *provided by the
+framework* rather than by the request::
+
+    async def get_db():                    # async-generator provider
+        pool = await create_pool()
+        try:
+            yield pool                     # ← injected value
+        finally:
+            await pool.close()             # ← runs after the response is sent
+
+    @app.route(path='/items/{id:int}')
+    async def get_item(id: int, db=Depends(get_db)):
+        return await db.fetch_item(id)
+
+Design (Sprint 74): everything is resolved at **registration time** on the
+``_adapt_handler`` seam — a handler that declares no ``Depends`` parameter
+compiles to exactly the wrapper it compiled to before this module existed
+(no per-request stack, no empty dependency loop).  Contrast FastAPI, which
+enters two ``AsyncExitStack``s and runs ``solve_dependencies()`` on every
+request even with an empty dependency list.
+
+v1 scope fences (add on real demand, not speculatively):
+
+* providers take **no parameters** — a provider that itself declares
+  ``Depends`` (nesting) is a registration-time ``TypeError``;
+* simplified handlers only — middleware and full ``(scope, receive, send)``
+  handlers are unchanged;
+* no interface binding and no interception: duck typing and the event API
+  (``@app.intercept``) already cover those.
+"""
+import inspect
+from contextlib import asynccontextmanager
+from typing import Any, Callable
+
+__all__ = ['Depends']
+
+
+class Depends:
+    """Declare a per-request provider for one simplified-handler parameter.
+
+    Use as the parameter's *default value*: ``db=Depends(get_db)``.
+
+    Provider forms (detected once, here):
+
+    * **async generator** — yields the injected value exactly once; the code
+      after ``yield`` (or the ``finally`` block) runs after the response has
+      been sent, LIFO when several providers are active.
+    * **async function** — awaited for the value; no cleanup.
+    * **sync function** — called for the value; no cleanup.
+
+    Args:
+        provider: Zero-parameter callable in one of the three forms above.
+        use_cache: When ``True`` (default), parameters of one handler that
+            name the *same* provider share a single instance per request;
+            ``use_cache=False`` calls the provider once per parameter.
+
+    Raises:
+        TypeError: At construction, when *provider* is not callable, takes
+            parameters (including a nested ``Depends`` default — not
+            supported in v1), or is a sync generator function.
+    """
+
+    __slots__ = ('provider', 'use_cache', '_kind', '_acm_factory')
+
+    _ASYNC_GEN = 'async_gen'
+    _ASYNC_FN = 'async_fn'
+    _SYNC_FN = 'sync_fn'
+
+    def __init__(self, provider: Callable[[], Any], *, use_cache: bool = True):
+        if not callable(provider):
+            raise TypeError(
+                f'Depends(provider): provider must be callable, got '
+                f'{type(provider).__name__!r}')
+
+        try:
+            sig = inspect.signature(provider)
+        except (TypeError, ValueError):
+            sig = None
+        if sig is not None and sig.parameters:
+            if any(isinstance(p.default, Depends) for p in sig.parameters.values()):
+                raise TypeError(
+                    f'Depends provider {getattr(provider, "__name__", provider)!r} '
+                    f'declares a nested Depends parameter. Nested dependencies '
+                    f'are not supported in v1 — compose inside the provider '
+                    f'body instead (call or close over the other provider).')
+            raise TypeError(
+                f'Depends provider {getattr(provider, "__name__", provider)!r} '
+                f'must take no parameters; it declares '
+                f'{sorted(sig.parameters)!r}.')
+
+        self.provider = provider
+        self.use_cache = use_cache
+        self._acm_factory = None
+        if inspect.isasyncgenfunction(provider):
+            self._kind = self._ASYNC_GEN
+            # asynccontextmanager gives the exact lifecycle wanted: one yield
+            # (a second yield raises RuntimeError), exceptions thrown into
+            # the generator at the yield point, cleanup via AsyncExitStack.
+            self._acm_factory = asynccontextmanager(provider)
+        elif inspect.iscoroutinefunction(provider):
+            self._kind = self._ASYNC_FN
+        elif inspect.isgeneratorfunction(provider):
+            raise TypeError(
+                f'Depends provider {getattr(provider, "__name__", provider)!r} '
+                f'is a sync generator; use an async generator '
+                f'(``async def`` + ``yield``) for value-plus-cleanup providers.')
+        else:
+            self._kind = self._SYNC_FN
+
+    def __repr__(self) -> str:
+        name = getattr(self.provider, '__name__', repr(self.provider))
+        cache = '' if self.use_cache else ', use_cache=False'
+        return f'Depends({name}{cache})'
+
+
+async def _resolve_depends(dep: Depends, stack, cache: dict) -> Any:
+    """Resolve one ``Depends`` parameter inside the per-request *stack*.
+
+    *cache* maps provider → value for ``use_cache=True`` sharing within a
+    single request; it is created per request by the handler wrapper.
+    """
+    provider = dep.provider
+    if dep.use_cache and provider in cache:
+        return cache[provider]
+    if dep._kind == Depends._ASYNC_GEN:
+        value = await stack.enter_async_context(dep._acm_factory())
+    elif dep._kind == Depends._ASYNC_FN:
+        value = await provider()
+    else:
+        value = provider()
+    if dep.use_cache:
+        cache[provider] = value
+    return value

--- a/blackbull/openapi.py
+++ b/blackbull/openapi.py
@@ -100,6 +100,36 @@ def _path_parameters(param_specs: dict[str, str]) -> list[dict]:
     return out
 
 
+def _query_parameters(handler, param_specs: dict[str, str]) -> list[dict]:
+    """Build ``in: query`` parameter entries for a simplified handler.
+
+    Minimal tier (Sprint 74): name, schema from the annotation's scalar type,
+    ``required`` from default-presence.  Reuses the router's registration-time
+    classifier so this walk can never disagree with what the wrapper actually
+    resolves; ``Depends`` params are not request inputs and carry no entry.
+    Full-ASGI handlers (and anything the classifier rejects) emit nothing.
+    """
+    from .router import _handler_param_plan, _is_simplified_handler
+
+    if not _is_simplified_handler(handler):
+        return []
+    try:
+        _, _, categories = _handler_param_plan(handler, set(param_specs))
+    except (TypeError, ValueError):
+        return []
+    out = []
+    for name, (kind, payload) in categories.items():
+        if kind != 'query':
+            continue
+        out.append({
+            'name': name,
+            'in': 'query',
+            'required': payload.required,
+            'schema': _type_to_schema(payload.type),
+        })
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Type → JSON-schema synthesis (v2)
 #
@@ -238,11 +268,16 @@ def _find_body_type(handler, param_specs: dict[str, str]) -> Any:
         sig = inspect.signature(handler)
     except (TypeError, ValueError):
         return None
+    from .di import Depends
+
     hints = _resolved_hints(handler)
     for name, param in sig.parameters.items():
         if name in param_specs:
             continue
         if name in ('scope', 'receive', 'send', 'call_next', 'inner', 'self'):
+            continue
+        if isinstance(param.default, Depends):
+            # DI-provided value, not a request body — never a schema source.
             continue
         ann = hints.get(name, param.annotation)
         if ann is inspect.Parameter.empty:
@@ -287,7 +322,7 @@ def _operation(handler, param_specs: dict[str, str],
     if description:
         op['description'] = description
 
-    params = _path_parameters(param_specs)
+    params = _path_parameters(param_specs) + _query_parameters(handler, param_specs)
     if params:
         op['parameters'] = params
 

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -12,6 +12,7 @@ import; this module re-exports it lazily through ``__getattr__``.
 """
 from collections import OrderedDict
 from collections.abc import Iterable
+from contextlib import AsyncExitStack
 import dataclasses
 from dataclasses import dataclass, field
 import typing
@@ -22,7 +23,10 @@ import json
 import re
 import inspect
 import types
+from urllib.parse import parse_qsl
 import uuid as _uuid
+import warnings
+from .di import Depends, _resolve_depends
 from .utils import Scheme, do_nothing
 
 # RouteGroup is defined in app.py to avoid a circular import;
@@ -532,6 +536,177 @@ async def _send_converted(value, scope, receive, send) -> None:
         f'bytes, str, dict, list, dataclass, or None; got {type(value).__name__!r}')
 
 
+async def _finish_result(result, scope, receive, send, converters, fn_name: str) -> None:
+    """Send a simplified handler's return value — native shapes first, then
+    the app's converter registry, then the loud ``TypeError``.
+
+    Same tail as the basic wrapper's inline version; kept as a module
+    function so the extended (query/``Depends``) wrapper shares it without
+    the basic wrapper gaining a per-request call.
+    """
+    if await _send_native(result, scope, receive, send):
+        return
+    if converters and (conv := _lookup_converter(converters, type(result))) is not None:
+        await _send_converted(conv(result), scope, receive, send)
+        return
+    raise TypeError(
+        f"Simplified handler {fn_name!r} returned unsupported type "
+        f"{type(result).__name__!r}.  Return a Response, str, bytes, "
+        f"dict, list, or None, or register a converter with "
+        f"app.register_converter({type(result).__name__}, ...)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simplified-handler parameter classification (Sprint 74)
+# ---------------------------------------------------------------------------
+
+# RFC-agnostic textual boolean forms accepted for ``param: bool`` query params.
+_QUERY_BOOL_STRINGS: dict[str, bool] = {
+    '1': True, 'true': True, 'yes': True, 'on': True,
+    '0': False, 'false': False, 'no': False, 'off': False,
+}
+
+
+def _coerce_query_bool(raw: str) -> bool:
+    try:
+        return _QUERY_BOOL_STRINGS[raw.lower()]
+    except KeyError:
+        raise ValueError(f'not a boolean: {raw!r}') from None
+
+
+def _identity_str(raw: str) -> str:
+    return raw
+
+
+# Scalar annotation → coercer for query params.  Mirrors the path-param
+# converter idea (annotation drives the coercion) with ``bool`` added —
+# ``bool('false')`` would be truthy, so it needs the textual-form table.
+_QUERY_COERCERS: dict[type, Callable[[str], Any]] = {
+    str: _identity_str,
+    int: int,
+    float: float,
+    bool: _coerce_query_bool,
+}
+
+
+def _unwrap_optional(ann: Any) -> Any:
+    """``T | None`` / ``Optional[T]`` → ``T``; anything else unchanged."""
+    origin = get_origin(ann)
+    if origin is Union or origin is types.UnionType:
+        non_none = [a for a in get_args(ann) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+    return ann
+
+
+class _QuerySpec(NamedTuple):
+    """Registration-time plan for one query parameter."""
+    name: str
+    type: type
+    coercer: Callable[[str], Any]
+    required: bool
+    default: Any
+
+
+# Sentinel distinguishing "key absent from the query string" from any value.
+_QUERY_MISSING = object()
+
+
+def _handler_param_plan(fn, path_param_names: set) -> tuple:
+    """Classify every parameter of simplified handler *fn* — once, at
+    registration time.
+
+    Returns ``(params, annotations, categories)`` where *categories* maps
+    parameter name → ``(kind, payload)`` with kind one of ``'path'``,
+    ``'scope'``, ``'body'``, ``'request'``, ``'dataclass'``, ``'depends'``
+    (payload: the :class:`~blackbull.di.Depends` instance), or ``'query'``
+    (payload: :class:`_QuerySpec`).  Precedence: path params first, then the
+    reserved names ``body``/``scope``, then a ``Depends`` default, then
+    ``Request`` recognition, then a dataclass body annotation; anything left
+    is a query param — the fallback category.
+
+    Raises ``TypeError`` (fail fast, at registration) for a ``Depends``
+    default on a reserved/path name, a second body-consuming parameter, or a
+    leftover parameter whose annotation is not a supported query scalar.
+    """
+    from .request import Request as _Request
+
+    params = inspect.signature(fn).parameters
+    annotations = {n: p.annotation for n, p in params.items()}
+
+    # Resolve PEP 563 / string-form annotations once, here, so the wrappers
+    # below can rely on real types in their isinstance / get_origin calls.
+    try:
+        resolved_hints = typing.get_type_hints(fn)
+        for n in annotations:
+            if n in resolved_hints:
+                annotations[n] = resolved_hints[n]
+    except Exception:
+        pass  # unresolved forward refs / bad annotations → keep the raw annotations.
+
+    categories: dict[str, tuple] = {}
+    for name, p in params.items():
+        ann = annotations.get(name, inspect.Parameter.empty)
+        default = p.default
+        is_dep = isinstance(default, Depends)
+
+        if name in path_param_names:
+            if is_dep:
+                raise TypeError(
+                    f"Simplified handler {fn.__name__!r}: parameter {name!r} "
+                    f"is a path param of {sorted(path_param_names)!r} and "
+                    f"cannot carry a Depends default.")
+            categories[name] = ('path', None)
+        elif name in ('body', 'scope'):
+            if is_dep:
+                raise TypeError(
+                    f"Simplified handler {fn.__name__!r}: parameter {name!r} "
+                    f"is reserved for the request {name} and cannot carry a "
+                    f"Depends default — rename the parameter.")
+            categories[name] = (name, None)
+        elif is_dep:
+            categories[name] = ('depends', default)
+        elif ann is _Request or (name == 'request' and ann is inspect.Parameter.empty):
+            categories[name] = ('request', None)
+        elif _is_body_dataclass_annotation(ann):
+            categories[name] = ('dataclass', None)
+        else:
+            # Fallback category: resolve from the query string.
+            target = str if ann is inspect.Parameter.empty else _unwrap_optional(ann)
+            coercer = _QUERY_COERCERS.get(target) if isinstance(target, type) else None
+            if coercer is None:
+                raise TypeError(
+                    f"Simplified handler {fn.__name__!r}: cannot resolve "
+                    f"parameter {name!r}. Expected a path param of "
+                    f"{sorted(path_param_names)!r}, 'body', 'scope', a "
+                    f"parameter annotated with Request (or named 'request'), "
+                    f"a dataclass body param, a Depends(...) default, or a "
+                    f"query param annotated str/int/float/bool "
+                    f"(optionally `| None`)."
+                )
+            required = default is inspect.Parameter.empty
+            categories[name] = ('query', _QuerySpec(
+                name=name, type=target, coercer=coercer, required=required,
+                default=None if required else default))
+
+    # A handler may have **at most one** body parameter — either a literal
+    # name ``body`` or a dataclass-typed parameter (or both, if they're the
+    # same parameter).  Trying to consume the body twice would hang the
+    # second ``read_body`` call indefinitely.  A ``Request`` param does not
+    # count: it drains lazily through the same cache the wrappers use.
+    body_param_count = sum(
+        1 for kind, _ in categories.values() if kind in ('body', 'dataclass'))
+    if body_param_count > 1:
+        raise TypeError(
+            f"Simplified handler {fn.__name__!r}: more than one parameter would "
+            f"consume the request body.  Pick one of 'body' or a dataclass-typed "
+            f"parameter, not both."
+        )
+
+    return params, annotations, categories
+
+
 def _adapt_handler(fn, path: str, converters: dict | None = None):
     """Wrap a simplified handler in an ASGI (scope, receive, send) coroutine.
 
@@ -540,7 +715,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     When a handler returns a value that is none of the natively supported
     shapes, a matching converter — if any — maps it to a sendable.
 
-    Parameter resolution:
+    Parameter resolution (classified once, by :func:`_handler_param_plan`):
     - Name matches a {param} in the path pattern → scope['path_params'][name],
       coerced to the annotated type if one is given.
     - Annotation is a Python ``@dataclass`` → request body parsed as JSON and
@@ -552,7 +727,16 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
       annotation → a per-request ``Request(scope, receive)`` context object.
       Its ``body()`` cache is the drain point for 'body' / dataclass params
       too, so the body is read at most once per request.
-    - Anything else → TypeError raised at registration time (fail fast).
+    - Default value is ``Depends(provider)`` → the provider's value, with
+      ``AsyncExitStack``-backed teardown after the response is sent.
+    - Anything else → a **query param**: resolved from scope['query_string'],
+      coerced to the annotation (str/int/float/bool, optionally ``| None``).
+      A default makes it optional; missing-required or failed coercion is a
+      400 via :class:`HTTPException`.  An unsupported annotation is a
+      TypeError at registration time (fail fast).
+
+    Handlers using neither query params nor ``Depends`` compile to the same
+    basic wrapper as before Sprint 74 — the zero-overhead pin.
 
     Return values: Response → send(result); bytes → send(Response(result));
     str → send(Response(result.encode())); dict → send(JSONResponse(result));
@@ -561,62 +745,23 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     from .request import Request as _Request, read_body as _read_body
 
     path_param_names: set[str] = {m.group(1) for m in Router._param_pattern.finditer(path)}
-    params = inspect.signature(fn).parameters
-    annotations = {n: p.annotation for n, p in params.items()}
+    params, annotations, categories = _handler_param_plan(fn, path_param_names)
 
-    # Resolve PEP 563 / string-form annotations once, here, so the wrapper
-    # below can rely on real types in its isinstance / get_origin calls.
-    try:
-        resolved_hints = typing.get_type_hints(fn)
-        for n in annotations:
-            if n in resolved_hints:
-                annotations[n] = resolved_hints[n]
-    except Exception:
-        pass  # unresolved forward refs / bad annotations → keep the raw annotations.
-
-    # Request-param recognition happens here, at registration time, so the
-    # wrapper below never reflects per request.  Path params keep precedence;
-    # a dataclass annotation on a param named 'request' stays a body param.
     request_param_names: frozenset[str] = frozenset(
-        n for n, ann in annotations.items()
-        if n not in path_param_names and n not in ('body', 'scope') and (
-            ann is _Request
-            or (n == 'request' and ann is inspect.Parameter.empty)
-        )
-    )
+        n for n, (kind, _) in categories.items() if kind == 'request')
 
-    # A handler may have **at most one** body parameter — either a literal
-    # name ``body`` or a dataclass-typed parameter (or both, if they're the
-    # same parameter).  Trying to consume the body twice would hang the
-    # second ``read_body`` call indefinitely.  A ``Request`` param does not
-    # count: it drains lazily through the same cache the branches below use.
-    body_param_count = sum(
-        1 for n, p in params.items()
-        if n not in path_param_names and n != 'scope' and (
-            n == 'body' or _is_body_dataclass_annotation(annotations.get(n))
-        )
-    )
-
-    for name in params:
-        if name in path_param_names or name in ('body', 'scope'):
-            continue
-        if name in request_param_names:
-            continue
-        if _is_body_dataclass_annotation(annotations.get(name)):
-            continue
-        raise TypeError(
-            f"Simplified handler {fn.__name__!r}: cannot resolve parameter {name!r}. "
-            f"Expected path params {sorted(path_param_names)!r}, 'body', "
-            f"'scope', a parameter annotated with Request (or named "
-            f"'request'), or a parameter annotated with a dataclass."
-        )
-
-    if body_param_count > 1:
-        raise TypeError(
-            f"Simplified handler {fn.__name__!r}: more than one parameter would "
-            f"consume the request body.  Pick one of 'body' or a dataclass-typed "
-            f"parameter, not both."
-        )
+    # A path param always resolves from the path, so a declared default can
+    # never apply — and any same-named query-string key is shadowed.  The
+    # default is the one registration-time signal that the author may have
+    # meant a query param, so say so now rather than 404-by-surprise later.
+    for name, p in params.items():
+        if categories[name][0] == 'path' and p.default is not inspect.Parameter.empty:
+            warnings.warn(
+                f"Simplified handler {fn.__name__!r}: parameter {name!r} matches "
+                f"a path placeholder in {path!r}; its default is never used and "
+                f"the path value shadows any '?{name}=' query key. Rename the "
+                f"parameter (or the placeholder) if you meant a query param.",
+                UserWarning, stacklevel=3)
 
     is_async = inspect.iscoroutinefunction(fn)
     has_request_param = bool(request_param_names)
@@ -672,7 +817,93 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
             f"app.register_converter({type(result).__name__}, ...)."
         )
 
-    return _wrapper
+    has_query = any(kind == 'query' for kind, _ in categories.values())
+    depends_plan = tuple(
+        (n, payload) for n, (kind, payload) in categories.items() if kind == 'depends')
+
+    if not has_query and not depends_plan:
+        # Zero-overhead pin: neither new parameter category is in play, so
+        # this handler gets the exact wrapper it got before Sprint 74.
+        return _wrapper
+
+    # Extended wrapper — query params and/or Depends.  The plan below was
+    # fully computed at registration; the per-request work is only what the
+    # declared parameters require.
+    plan = tuple((n, kind, payload) for n, (kind, payload) in categories.items()
+                 if kind != 'depends')
+    fn_name = fn.__name__
+
+    @wraps(fn)
+    async def _extended_wrapper(scope, receive, send):
+        req = _Request(scope, receive) if has_request_param else None
+        kwargs: dict = {}
+        if has_query:
+            raw_qs = scope.get('query_string') or b''
+            query_values = (
+                dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
+                if raw_qs else {})
+        for name, kind, payload in plan:
+            if kind == 'query':
+                raw = query_values.get(name, _QUERY_MISSING)
+                if raw is _QUERY_MISSING:
+                    if payload.required:
+                        raise HTTPException(
+                            HTTPStatus.BAD_REQUEST,
+                            f'missing required query parameter {name!r} '
+                            f'for handler {fn_name!r}')
+                    kwargs[name] = payload.default
+                else:
+                    try:
+                        kwargs[name] = payload.coercer(raw)
+                    except (ValueError, TypeError) as exc:
+                        raise HTTPException(
+                            HTTPStatus.BAD_REQUEST,
+                            f'query parameter {name!r}: cannot coerce {raw!r} '
+                            f'to {payload.type.__name__}',
+                        ) from exc
+            elif kind == 'scope':
+                kwargs[name] = scope
+            elif kind == 'body':
+                raw = await req.body() if req is not None else await _read_body(receive)
+                ann = annotations.get(name, inspect.Parameter.empty)
+                if _is_body_dataclass_annotation(ann):
+                    kwargs[name] = _decode_json_body(ann, raw, fn_name)
+                else:
+                    kwargs[name] = raw
+            elif kind == 'request':
+                kwargs[name] = req
+            elif kind == 'dataclass':
+                raw = await req.body() if req is not None else await _read_body(receive)
+                kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
+            else:  # 'path'
+                raw = scope.get('path_params', {}).get(name, '')
+                ann = annotations.get(name, inspect.Parameter.empty)
+                if (ann is not inspect.Parameter.empty and isinstance(ann, type)
+                        and not isinstance(raw, ann)):
+                    try:
+                        kwargs[name] = ann(raw)
+                    except (ValueError, TypeError) as exc:
+                        raise TypeError(
+                            f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
+                        ) from exc
+                else:
+                    kwargs[name] = raw
+
+        if not depends_plan:
+            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
+            await _finish_result(result, scope, receive, send, converters, fn_name)
+            return
+
+        async with AsyncExitStack() as stack:
+            cache: dict = {}
+            for name, dep in depends_plan:
+                kwargs[name] = await _resolve_depends(dep, stack, cache)
+            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
+            # Send inside the stack's scope so provider teardown runs after
+            # the client has the response (LIFO on the stack).
+            await _finish_result(result, scope, receive, send, converters, fn_name)
+
+    return _extended_wrapper
 
 
 # RFC 9110 §5.6.2: token = 1*tchar (visible US-ASCII, no separators)

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -1,0 +1,98 @@
+# Dependency injection
+
+`Depends` (since v0.56.0) lets a route handler *declare* a per-request
+resource — a database connection, an HTTP client, a config view — and have
+the framework construct it before the handler runs and tear it down after
+the response has been sent.
+
+```python
+from blackbull import BlackBull, Depends
+
+app = BlackBull()
+
+async def get_db():                    # a "provider": async generator
+    conn = await pool.acquire()
+    try:
+        yield conn                     # ← injected value
+    finally:
+        await pool.release(conn)      # ← runs after the response is sent
+
+@app.route(path='/items/{id:int}')
+async def get_item(id: int, db=Depends(get_db)):
+    return await db.fetch_item(id)
+```
+
+Use `Depends(provider)` as the parameter's **default value**.  Simplified
+handlers only — middleware and full `(scope, receive, send)` handlers are
+unchanged, the same rule as every other simplified-model feature.
+
+## Provider forms
+
+| Provider | Injected value | Cleanup |
+|---|---|---|
+| `async def p(): yield v` | `v` (must yield exactly once) | code after `yield` / `finally`, after the response is sent |
+| `async def p(): return v` | `v` | none |
+| `def p(): return v` | `v` | none |
+
+Providers take **no parameters**.  A provider that itself declares
+`Depends` (a nested dependency) is a registration-time `TypeError` —
+compose inside the provider body instead (call or close over the other
+provider).  Sync generator providers are rejected; use an async generator.
+
+## Lifetimes
+
+| Lifetime | Mechanism |
+|---|---|
+| per-request | `Depends(provider)` — fresh value each request |
+| per-parameter | `Depends(provider, use_cache=False)` |
+| per-app | `@app.on('startup')` / `AppConfig`; a provider closes over it |
+
+By default (`use_cache=True`), two parameters of one handler naming the
+*same* provider share a single instance for that request:
+
+```python
+async def audit(a=Depends(get_db), b=Depends(get_db)):
+    assert a is b          # one acquire, one release
+```
+
+There is no app-scoped container: an application-lifetime singleton is an
+object you create at startup and *capture* in a provider —
+
+```python
+engine: Engine | None = None
+
+@app.on('startup')
+async def boot(event):
+    global engine
+    engine = await create_engine(dsn)
+
+async def get_conn():
+    async with engine.connect() as conn:   # engine: app-scoped, conn: per-request
+        yield conn
+```
+
+## Ordering and errors
+
+- Providers resolve in signature order; cleanup runs LIFO (last provider
+  up, first down), the `AsyncExitStack` discipline.
+- Cleanup runs **after the response bytes are sent** — a client can hold
+  the full response while the DB connection is already back in the pool.
+  (FastAPI behaves the same way.)
+- A handler exception unwinds the stack: every provider's `finally` runs,
+  then the exception routes through [error handling](error-handling.md)
+  as usual (500, or the registered `error_handler`).
+- A provider exception before `yield` aborts the request the same way —
+  the handler never runs.
+
+## Zero cost when unused
+
+Everything is resolved at **registration time**: a handler that declares
+no `Depends` parameter compiles to exactly the wrapper it compiled to
+before this feature existed — no per-request stack, no empty dependency
+loop, no reflection.  (FastAPI, by contrast, runs `solve_dependencies()`
+and enters two `AsyncExitStack`s on every request even with no
+dependencies declared.)  Handlers that do use `Depends` pay only for what
+they declared.
+
+`Depends` parameters are not request inputs, so they are excluded from the
+generated [OpenAPI](openapi.md) spec.

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -37,6 +37,15 @@ For 404 / 405 / other client-error statuses without an exception,
 the body is just the status code + phrase (with the `Allow` header
 on 405).
 
+**4xx `HTTPException`s carry their detail, not a traceback** (since
+v0.56.0): when the framework itself diagnoses a client fault — a
+missing required query parameter, a malformed JSON body — the dev
+page shows the status and the human-readable detail line
+(`missing required query parameter 'q' for handler 'search'`) and
+omits the Python traceback.  The frames would only show framework
+internals; the detail line is the actionable part.  5xx
+`HTTPException`s and unexpected exceptions keep the full traceback.
+
 ### `production`
 
 ```bash

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -22,6 +22,9 @@ first — it covers installation and the shape of a minimal app.
   reading the body and headers, cookies, query parameters,
   forms; `Response` / `JSONResponse` / `StreamingResponse`;
   detecting client disconnection.
+- [**Dependency injection**](dependency-injection.md) —
+  `Depends` providers for simplified handlers: per-request
+  resources with teardown after the response is sent.
 - [**WebSockets**](websockets.md) — the WebSocket route, the
   `websocket` middleware, `permessage-deflate`, RFC 8441
   (WebSocket over HTTP/2), subprotocols, fragmented messages.

--- a/docs/guide/openapi.md
+++ b/docs/guide/openapi.md
@@ -38,6 +38,7 @@ and the docs page.
 | Handler docstring — first line | Operation `summary` |
 | Handler docstring — rest | Operation `description` |
 | HTTP-only (no `scheme=Scheme.websocket`) | Included.  WebSocket routes are skipped. |
+| Simplified-handler [query params](requests-and-responses.md#query-parameters) (`q: str, page: int = 1`) | `in: query` parameter entries — schema from the annotation, `required` from default-presence.  `Depends` params are not request inputs and are excluded. |
 | `POST` / `PUT` / `PATCH` route | A placeholder `requestBody: {type: object}` — replaced by a real schema when the handler is annotated with a dataclass (below) |
 
 ## `app.enable_openapi(...)` parameters
@@ -238,11 +239,6 @@ responses if the default 500 isn't what you want.
 
 ## What's not yet automated
 
-- **Query parameters.**  The simplified handler signature
-  resolves parameters from the URL path, the request body, or
-  the raw scope — there is no annotation source for query
-  parameters yet, so none are emitted in the spec.  Read them
-  manually from `scope['query_string']` inside the handler.
 - **Security schemes.**  Auth is application-defined, so no
   global `securitySchemes` are emitted.  Add them post-hoc by
   editing the spec returned by `generate_spec()` and serving

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -197,6 +197,43 @@ to know how the client delivered the cookies.
 
 ## Query parameters
 
+Declare them as handler parameters (since v0.56.0).  Any simplified-handler
+parameter that is not a path param, `body`, `scope`, `Request`, a dataclass
+body, or [`Depends`](dependency-injection.md) resolves from the query
+string, coerced to its annotation:
+
+```python
+@app.route(path='/search')
+async def search(q: str, page: int = 1, exact: bool = False):
+    ...   # /search?q=bull&page=2 → q='bull', page=2, exact=False
+```
+
+- **Types**: `str` (default for unannotated params), `int`, `float`, and
+  `bool` (`1/true/yes/on` and `0/false/no/off`, case-insensitive).
+  `T | None` of a supported scalar also works.  Anything else — containers,
+  models — is a registration-time `TypeError`; drop to `Request` or the raw
+  scope for those.
+- **Required vs optional**: a parameter with a default is optional; without
+  one, a request missing the key is answered with **400**.  A value that
+  fails coercion (`?page=abc` for `page: int`) is also a 400 — client
+  errors never surface as 500s.
+- **Repeated keys** (`?tag=a&tag=b`): the last occurrence wins.  For
+  list-valued keys, parse the raw query string as shown below.
+- **Precedence**: a parameter that matches a `{placeholder}` in the path is
+  always a path param — the path value shadows any same-named query key
+  (declaring a default on a path param draws a registration-time warning,
+  since that usually means a query param was intended).
+- **OpenAPI**: query params appear in the generated spec (`in: query`,
+  schema from the annotation, `required` from default-presence) — see
+  [OpenAPI](openapi.md).
+
+Coercion and required-ness are resolved when the route is registered, not
+per request — handlers that declare no query params keep the exact adapted
+form they had before.
+
+### Raw query strings
+
+For repeated keys, unusual encodings, or full control,
 `scope['query_string']` contains the raw query string as bytes.
 Parse it with the standard library:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ nav:
     - Middleware: guide/middleware.md
     - Error handling: guide/error-handling.md
     - Requests and responses: guide/requests-and-responses.md
+    - Dependency injection: guide/dependency-injection.md
     - WebSockets: guide/websockets.md
     - HTTP/2: guide/http2.md
     - Structured Fields: guide/structured-fields.md

--- a/tests/unit/test_adapt_zero_overhead.py
+++ b/tests/unit/test_adapt_zero_overhead.py
@@ -1,0 +1,57 @@
+"""The Sprint 74 zero-overhead pin for ``_adapt_handler``.
+
+The anti-FastAPI design point: query params and ``Depends`` are resolved at
+registration time, so a handler using *neither* feature compiles to exactly
+the wrapper it compiled to before Sprint 74 — the same (shared) code object,
+with no reference to the DI or query machinery.  FastAPI, by contrast, runs
+``solve_dependencies()`` + two ``AsyncExitStack``s per request even with no
+dependencies declared.
+"""
+from dataclasses import dataclass
+
+from blackbull import Depends, Request
+from blackbull.router import _adapt_handler
+
+
+@dataclass
+class _Item:
+    name: str
+
+
+async def _plain(): return 'x'
+async def _path_only(item_id: int): return item_id
+async def _full_legacy(item_id: int, body: bytes, scope, request: Request): pass
+async def _dataclass_body(item: _Item): pass
+async def _with_query(q: str, page: int = 1): pass
+def _provider(): return 'db'
+async def _with_depends(db=Depends(_provider)): pass
+
+
+def test_handlers_without_new_features_share_one_wrapper_code_object():
+    # Every closure the basic path emits shares the same code object —
+    # the strongest form of "byte-identical adapted functions".
+    basics = [
+        _adapt_handler(_plain, '/'),
+        _adapt_handler(_path_only, '/items/{item_id}'),
+        _adapt_handler(_full_legacy, '/items/{item_id}'),
+        _adapt_handler(_dataclass_body, '/items'),
+    ]
+    codes = {w.__code__ for w in basics}
+    assert len(codes) == 1
+
+
+def test_query_and_depends_handlers_use_a_different_wrapper():
+    basic = _adapt_handler(_plain, '/')
+    query = _adapt_handler(_with_query, '/search')
+    depends = _adapt_handler(_with_depends, '/')
+    assert query.__code__ is not basic.__code__
+    assert depends.__code__ is not basic.__code__
+
+
+def test_basic_wrapper_never_references_di_or_query_machinery():
+    basic = _adapt_handler(_full_legacy, '/items/{item_id}')
+    names = set(basic.__code__.co_names) | set(basic.__code__.co_freevars)
+    assert 'AsyncExitStack' not in names
+    for symbol in names:
+        assert 'depends' not in symbol.lower()
+        assert 'query' not in symbol.lower()

--- a/tests/unit/test_depends.py
+++ b/tests/unit/test_depends.py
@@ -1,0 +1,308 @@
+"""``Depends`` provider injection for simplified handlers (Sprint 74).
+
+Registration-time resolution on the ``_adapt_handler`` seam: a parameter
+whose *default value* is a ``Depends`` instance receives the provider's
+value per request.  Async-generator providers get ``AsyncExitStack``-backed
+teardown that runs *after* the response has been sent; plain async/sync
+callables inject a value with no cleanup.  v1 fences: providers take no
+parameters, and nested ``Depends`` is a registration-time ``TypeError``.
+"""
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+import pytest
+
+from blackbull import BlackBull, Depends, Response
+from blackbull.router import _adapt_handler
+from blackbull.testing import TestClient
+
+try:
+    from beartype.roar import BeartypeCallHintParamViolation as _BeartypeViolation
+except ImportError:  # pragma: no cover
+    _BeartypeViolation = None
+_TYPE_ERRORS = (TypeError,) if _BeartypeViolation is None else (TypeError, _BeartypeViolation)
+
+
+def _scope(query: bytes = b'') -> dict:
+    return {'type': 'http', 'method': 'GET', 'path': '/', 'headers': [],
+            'query_string': query}
+
+
+class TestDependsConstruction:
+    def test_non_callable_provider_raises(self):
+        # Plain TypeError from Depends itself, or beartype's violation (a
+        # TypeError subclass) when --beartype-packages=blackbull is active.
+        with pytest.raises(_TYPE_ERRORS):
+            Depends(42)
+
+    def test_provider_with_parameters_raises(self):
+        async def provider(x): pass
+        with pytest.raises(TypeError, match='parameter'):
+            Depends(provider)
+
+    def test_nested_depends_raises(self):
+        async def inner(): return 1
+        async def outer(db=Depends(inner)): return db
+        with pytest.raises(TypeError, match='[Nn]ested'):
+            Depends(outer)
+
+    def test_sync_generator_provider_raises(self):
+        def provider():
+            yield 1
+        with pytest.raises(TypeError, match='async generator'):
+            Depends(provider)
+
+
+class TestDependsRegistrationConflicts:
+    def test_path_param_with_depends_default_raises(self):
+        async def provider(): return 1
+        async def fn(item_id=Depends(provider)): pass
+        with pytest.raises(TypeError, match="item_id"):
+            _adapt_handler(fn, '/items/{item_id}')
+
+    def test_scope_name_with_depends_default_raises(self):
+        async def provider(): return 1
+        async def fn(scope=Depends(provider)): pass
+        with pytest.raises(TypeError, match="scope"):
+            _adapt_handler(fn, '/')
+
+    def test_body_name_with_depends_default_raises(self):
+        async def provider(): return 1
+        async def fn(body=Depends(provider)): pass
+        with pytest.raises(TypeError, match="body"):
+            _adapt_handler(fn, '/')
+
+
+class TestDependsInjection:
+    @pytest.mark.asyncio
+    async def test_async_function_provider_value_injected(self):
+        captured = {}
+        async def provider(): return {'conn': 1}
+        async def fn(db=Depends(provider)): captured['db'] = db
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert captured['db'] == {'conn': 1}
+
+    @pytest.mark.asyncio
+    async def test_sync_function_provider_value_injected(self):
+        captured = {}
+        def provider(): return 'cfg'
+        async def fn(cfg=Depends(provider)): captured['cfg'] = cfg
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert captured['cfg'] == 'cfg'
+
+    @pytest.mark.asyncio
+    async def test_async_generator_provider_value_injected(self):
+        captured = {}
+        async def provider():
+            yield 'pool'
+        async def fn(db=Depends(provider)): captured['db'] = db
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert captured['db'] == 'pool'
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_after_response_send(self):
+        events = []
+
+        async def provider():
+            events.append('setup')
+            try:
+                yield 'db'
+            finally:
+                events.append('cleanup')
+
+        async def fn(db=Depends(provider)):
+            events.append('handler')
+            return Response(b'ok')
+
+        async def recording_send(event):
+            events.append('send')
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, recording_send)
+        assert events == ['setup', 'handler', 'send', 'cleanup']
+
+    @pytest.mark.asyncio
+    async def test_two_providers_clean_up_lifo(self):
+        events = []
+
+        async def first():
+            try:
+                yield 'a'
+            finally:
+                events.append('first-cleanup')
+
+        async def second():
+            try:
+                yield 'b'
+            finally:
+                events.append('second-cleanup')
+
+        async def fn(a=Depends(first), b=Depends(second)):
+            return Response(b'ok')
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert events == ['second-cleanup', 'first-cleanup']
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_on_handler_exception(self):
+        events = []
+
+        async def provider():
+            try:
+                yield 'db'
+            finally:
+                events.append('cleanup')
+
+        async def fn(db=Depends(provider)):
+            raise RuntimeError('boom')
+
+        wrapper = _adapt_handler(fn, '/')
+        with pytest.raises(RuntimeError, match='boom'):
+            await wrapper(_scope(), None, AsyncMock())
+        assert events == ['cleanup']
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_propagates(self):
+        async def provider():
+            raise ValueError('no pool')
+            yield  # pragma: no cover
+
+        async def fn(db=Depends(provider)):
+            return Response(b'never')
+
+        wrapper = _adapt_handler(fn, '/')
+        with pytest.raises(ValueError, match='no pool'):
+            await wrapper(_scope(), None, AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_use_cache_shares_one_instance_per_request(self):
+        calls = []
+
+        async def provider():
+            calls.append(True)
+            return object()
+
+        captured = {}
+        async def fn(a=Depends(provider), b=Depends(provider)):
+            captured.update(a=a, b=b)
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert captured['a'] is captured['b']
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_use_cache_false_calls_provider_per_param(self):
+        calls = []
+
+        async def provider():
+            calls.append(True)
+            return object()
+
+        captured = {}
+        async def fn(a=Depends(provider, use_cache=False),
+                     b=Depends(provider, use_cache=False)):
+            captured.update(a=a, b=b)
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        assert captured['a'] is not captured['b']
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_fresh_instance_per_request(self):
+        calls = []
+
+        async def provider():
+            calls.append(True)
+            return object()
+
+        seen = []
+        async def fn(db=Depends(provider)): seen.append(db)
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), None, AsyncMock())
+        await wrapper(_scope(), None, AsyncMock())
+        assert len(calls) == 2
+        assert seen[0] is not seen[1]
+
+    @pytest.mark.asyncio
+    async def test_dataclass_annotated_depends_param_is_di_not_body(self):
+        @dataclass
+        class Pool:
+            dsn: str
+
+        def provider(): return Pool(dsn='x')
+
+        captured = {}
+        called = []
+
+        async def should_not_be_called():
+            called.append(True)
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+        async def fn(db: Pool = Depends(provider)): captured['db'] = db
+
+        wrapper = _adapt_handler(fn, '/')
+        await wrapper(_scope(), should_not_be_called, AsyncMock())
+        assert captured['db'] == Pool(dsn='x')
+        assert called == []
+
+    @pytest.mark.asyncio
+    async def test_depends_alongside_path_query_and_body(self):
+        def provider(): return 'svc'
+        captured = {}
+
+        async def fn(item_id: int, q: str, body: bytes, svc=Depends(provider)):
+            captured.update(item_id=item_id, q=q, body=body, svc=svc)
+
+        async def receive():
+            return {'type': 'http.request', 'body': b'payload', 'more_body': False}
+
+        wrapper = _adapt_handler(fn, '/items/{item_id}')
+        scope = _scope(b'q=bull')
+        scope['path_params'] = {'item_id': '5'}
+        await wrapper(scope, receive, AsyncMock())
+        assert captured == {'item_id': 5, 'q': 'bull', 'body': b'payload', 'svc': 'svc'}
+
+
+class TestDependsEndToEnd:
+    def test_db_pool_pattern_through_the_full_stack(self):
+        app = BlackBull()
+        events = []
+
+        async def get_db():
+            events.append('setup')
+            try:
+                yield {'users': {1: 'ada'}}
+            finally:
+                events.append('cleanup')
+
+        @app.route(path='/users/{uid:int}')
+        async def get_user(uid: int, db=Depends(get_db)):
+            return {'name': db['users'][uid]}
+
+        with TestClient(app) as client:
+            r = client.get('/users/1')
+            assert r.status_code == 200
+            assert r.json() == {'name': 'ada'}
+        assert events == ['setup', 'cleanup']
+
+    def test_provider_exception_maps_to_500(self):
+        app = BlackBull()
+
+        async def get_db():
+            raise ValueError('no pool')
+            yield  # pragma: no cover
+
+        @app.route(path='/broken')
+        async def broken(db=Depends(get_db)):
+            return 'never'
+
+        with TestClient(app, raise_app_exceptions=False) as client:
+            r = client.get('/broken')
+            assert r.status_code == 500

--- a/tests/unit/test_error_routing.py
+++ b/tests/unit/test_error_routing.py
@@ -276,6 +276,92 @@ class TestDevErrorPageTraceback:
             reset_settings_cache()
 
 
+class TestDevClientErrorPage:
+    """DEV mode, 4xx HTTPException: the framework already diagnosed the
+    client's mistake, so the page carries the status + detail line but no
+    Python traceback (Sprint 74).  Tracebacks are for *unexpected* server
+    faults — 5xx and non-HTTPException — which keep the full frames."""
+
+    @staticmethod
+    def _client_error():
+        from blackbull.router import HTTPException
+        try:
+            raise HTTPException(
+                HTTPStatus.BAD_REQUEST,
+                "missing required query parameter 'q' for handler 'search'")
+        except HTTPException as e:
+            return e
+
+    @pytest.mark.asyncio
+    async def test_dev_4xx_shows_detail_but_no_traceback(self):
+        from blackbull.env import reset_settings_cache
+        import os
+        os.environ['BLACKBULL_ENV'] = 'development'
+        reset_settings_cache()
+        try:
+            exc = self._client_error()
+            scope = _make_scope()
+            scope['state']['error_status'] = HTTPStatus.BAD_REQUEST
+            scope['state']['error_exception'] = exc
+            send = _CaptureSend()
+            await _default_error_handler(scope, None, send)
+            assert send.status == 400
+            # The actionable diagnosis stays…
+            assert b'Bad Request' in send.body
+            assert b"missing required query parameter 'q'" in send.body
+            # …the server-internals noise goes.
+            assert b'Traceback' not in send.body
+            assert b'File "' not in send.body
+        finally:
+            os.environ.pop('BLACKBULL_ENV', None)
+            reset_settings_cache()
+
+    @pytest.mark.asyncio
+    async def test_dev_4xx_html_shows_detail_but_no_traceback(self):
+        from blackbull.env import reset_settings_cache
+        import os
+        os.environ['BLACKBULL_ENV'] = 'development'
+        reset_settings_cache()
+        try:
+            exc = self._client_error()
+            scope = _make_scope()
+            scope['headers'] = [(b'accept', b'text/html,application/xhtml+xml')]
+            scope['state']['error_status'] = HTTPStatus.BAD_REQUEST
+            scope['state']['error_exception'] = exc
+            send = _CaptureSend()
+            await _default_error_handler(scope, None, send)
+            assert b"missing required query parameter" in send.body
+            assert b'<pre>' not in send.body       # the traceback block
+            assert b'Traceback' not in send.body
+        finally:
+            os.environ.pop('BLACKBULL_ENV', None)
+            reset_settings_cache()
+
+    @pytest.mark.asyncio
+    async def test_dev_5xx_httpexception_keeps_traceback(self):
+        from blackbull.env import reset_settings_cache
+        from blackbull.router import HTTPException
+        import os
+        os.environ['BLACKBULL_ENV'] = 'development'
+        reset_settings_cache()
+        try:
+            try:
+                raise HTTPException(HTTPStatus.BAD_GATEWAY, 'upstream died')
+            except HTTPException as e:
+                exc = e
+            scope = _make_scope()
+            scope['state']['error_status'] = HTTPStatus.BAD_GATEWAY
+            scope['state']['error_exception'] = exc
+            send = _CaptureSend()
+            await _default_error_handler(scope, None, send)
+            assert send.status == 502
+            assert b'Traceback' in send.body
+            assert b'upstream died' in send.body
+        finally:
+            os.environ.pop('BLACKBULL_ENV', None)
+            reset_settings_cache()
+
+
 class TestProductionErrorPage:
     """Production mode keeps the response terse — no exception class or
     message is leaked to the network."""

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -493,3 +493,80 @@ def test_extension_emits_spec_that_validates(_spec_validator):
     OpenAPIExtension(app, title='Validator', version='1.0.0')
     spec = generate_spec(app, title='Validator', version='1.0.0')
     _spec_validator(spec)
+
+
+class TestQueryParamEmission:
+    """Sprint 74: query params of simplified handlers appear in the minimal
+    tier — ``in: query``, schema from the annotation, ``required`` from
+    default-presence.  ``Depends`` params are not request inputs and are
+    excluded."""
+
+    def _spec_for(self, app):
+        return generate_spec(app, title='Q', version='1.0.0')
+
+    def test_query_params_emitted_with_schema_and_required(self):
+        app = BlackBull()
+
+        @app.route(methods=HTTPMethod.GET, path='/search')
+        async def search(q: str, page: int = 1):  # noqa: ARG001
+            return {}
+
+        params = self._spec_for(app)['paths']['/search']['get']['parameters']
+        by_name = {p['name']: p for p in params}
+        assert by_name['q'] == {
+            'name': 'q', 'in': 'query', 'required': True,
+            'schema': {'type': 'string'},
+        }
+        assert by_name['page'] == {
+            'name': 'page', 'in': 'query', 'required': False,
+            'schema': {'type': 'integer'},
+        }
+
+    def test_query_params_alongside_path_params(self):
+        app = BlackBull()
+
+        @app.route(methods=HTTPMethod.GET, path='/items/{item_id:int}')
+        async def get_item(item_id: int, verbose: bool = False):  # noqa: ARG001
+            return {}
+
+        params = self._spec_for(app)['paths']['/items/{item_id}']['get']['parameters']
+        by_name = {p['name']: p for p in params}
+        assert by_name['item_id']['in'] == 'path'
+        assert by_name['verbose'] == {
+            'name': 'verbose', 'in': 'query', 'required': False,
+            'schema': {'type': 'boolean'},
+        }
+
+    def test_depends_params_excluded(self):
+        from blackbull import Depends
+
+        def provider():
+            return 'db'
+
+        app = BlackBull()
+
+        @app.route(methods=HTTPMethod.GET, path='/users')
+        async def users(q: str, db=Depends(provider)):  # noqa: ARG001
+            return {}
+
+        params = self._spec_for(app)['paths']['/users']['get']['parameters']
+        assert [p['name'] for p in params] == ['q']
+
+    def test_full_asgi_handler_emits_no_query_params(self):
+        app = BlackBull()
+
+        @app.route(methods=HTTPMethod.GET, path='/raw')
+        async def raw(scope, receive, send):  # noqa: ARG001
+            pass
+
+        op = self._spec_for(app)['paths']['/raw']['get']
+        assert 'parameters' not in op
+
+    def test_spec_with_query_params_validates(self, _spec_validator):
+        app = BlackBull()
+
+        @app.route(methods=HTTPMethod.GET, path='/search')
+        async def search(q: str, limit: int = 10):  # noqa: ARG001
+            return {}
+
+        _spec_validator(self._spec_for(app))

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -1,0 +1,278 @@
+"""Query-param resolution in the simplified handler model (Sprint 74).
+
+Handler parameters that are neither path params, ``body``, ``scope``,
+``Request``, a dataclass body, nor ``Depends(...)`` resolve from
+``scope['query_string']`` with the same annotation-coercion rules path
+params use.  A default makes the param optional; a missing required param
+or a failed coercion surfaces as a 400 (``HTTPException``), never a 500.
+"""
+import warnings
+from http import HTTPStatus
+from unittest.mock import AsyncMock
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.router import HTTPException, _adapt_handler
+from blackbull.testing import TestClient
+
+
+def _scope(query: bytes = b'') -> dict:
+    return {'type': 'http', 'method': 'GET', 'path': '/', 'headers': [],
+            'query_string': query}
+
+
+class TestQueryParamResolution:
+    @pytest.mark.asyncio
+    async def test_str_param(self):
+        captured = {}
+        async def fn(q: str): captured['q'] = q
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=bull'), None, AsyncMock())
+        assert captured['q'] == 'bull'
+
+    @pytest.mark.asyncio
+    async def test_unannotated_param_resolves_as_str(self):
+        captured = {}
+        async def fn(q): captured['q'] = q
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=42'), None, AsyncMock())
+        assert captured['q'] == '42'
+        assert isinstance(captured['q'], str)
+
+    @pytest.mark.asyncio
+    async def test_int_param(self):
+        captured = {}
+        async def fn(page: int): captured['page'] = page
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'page=7'), None, AsyncMock())
+        assert captured['page'] == 7
+        assert isinstance(captured['page'], int)
+
+    @pytest.mark.asyncio
+    async def test_float_param(self):
+        captured = {}
+        async def fn(ratio: float): captured['ratio'] = ratio
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'ratio=0.5'), None, AsyncMock())
+        assert captured['ratio'] == 0.5
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('raw', ['1', 'true', 'yes', 'on', 'True', 'YES'])
+    async def test_bool_true_forms(self, raw):
+        captured = {}
+        async def fn(active: bool): captured['active'] = active
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(f'active={raw}'.encode()), None, AsyncMock())
+        assert captured['active'] is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('raw', ['0', 'false', 'no', 'off', 'False', 'NO'])
+    async def test_bool_false_forms(self, raw):
+        captured = {}
+        async def fn(active: bool): captured['active'] = active
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(f'active={raw}'.encode()), None, AsyncMock())
+        assert captured['active'] is False
+
+    @pytest.mark.asyncio
+    async def test_default_used_when_absent(self):
+        captured = {}
+        async def fn(q: str, page: int = 1): captured.update(q=q, page=page)
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=bull'), None, AsyncMock())
+        assert captured == {'q': 'bull', 'page': 1}
+
+    @pytest.mark.asyncio
+    async def test_default_overridden_when_present(self):
+        captured = {}
+        async def fn(page: int = 1): captured['page'] = page
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'page=3'), None, AsyncMock())
+        assert captured['page'] == 3
+
+    @pytest.mark.asyncio
+    async def test_optional_annotation_missing_gives_none(self):
+        captured = {}
+        async def fn(limit: int | None = None): captured['limit'] = limit
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b''), None, AsyncMock())
+        assert captured['limit'] is None
+
+    @pytest.mark.asyncio
+    async def test_optional_annotation_present_coerces(self):
+        captured = {}
+        async def fn(limit: int | None = None): captured['limit'] = limit
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'limit=9'), None, AsyncMock())
+        assert captured['limit'] == 9
+
+    @pytest.mark.asyncio
+    async def test_repeated_key_last_occurrence_wins(self):
+        captured = {}
+        async def fn(q: str): captured['q'] = q
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=first&q=second'), None, AsyncMock())
+        assert captured['q'] == 'second'
+
+    @pytest.mark.asyncio
+    async def test_blank_value_is_empty_string(self):
+        captured = {}
+        async def fn(q: str): captured['q'] = q
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q='), None, AsyncMock())
+        assert captured['q'] == ''
+
+    @pytest.mark.asyncio
+    async def test_percent_and_plus_decoding(self):
+        captured = {}
+        async def fn(q: str): captured['q'] = q
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=hello%20big+world'), None, AsyncMock())
+        assert captured['q'] == 'hello big world'
+
+    @pytest.mark.asyncio
+    async def test_query_alongside_path_params(self):
+        captured = {}
+        async def fn(item_id: int, q: str, page: int = 1):
+            captured.update(item_id=item_id, q=q, page=page)
+        wrapper = _adapt_handler(fn, '/items/{item_id}')
+        scope = _scope(b'q=bull&page=2')
+        scope['path_params'] = {'item_id': '5'}
+        await wrapper(scope, None, AsyncMock())
+        assert captured == {'item_id': 5, 'q': 'bull', 'page': 2}
+
+    @pytest.mark.asyncio
+    async def test_missing_query_string_key_entirely(self):
+        # scope without a 'query_string' key at all (defensive parity with
+        # minimal test scopes) — defaults still apply.
+        captured = {}
+        async def fn(page: int = 4): captured['page'] = page
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper({'type': 'http', 'headers': []}, None, AsyncMock())
+        assert captured['page'] == 4
+
+
+class TestQueryParam400s:
+    @pytest.mark.asyncio
+    async def test_missing_required_raises_400(self):
+        async def fn(q: str): pass
+        wrapper = _adapt_handler(fn, '/search')
+        with pytest.raises(HTTPException) as exc_info:
+            await wrapper(_scope(b''), None, AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+        assert 'q' in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_int_coercion_failure_raises_400(self):
+        async def fn(page: int): pass
+        wrapper = _adapt_handler(fn, '/search')
+        with pytest.raises(HTTPException) as exc_info:
+            await wrapper(_scope(b'page=abc'), None, AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_blank_int_value_raises_400(self):
+        async def fn(page: int): pass
+        wrapper = _adapt_handler(fn, '/search')
+        with pytest.raises(HTTPException) as exc_info:
+            await wrapper(_scope(b'page='), None, AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+    @pytest.mark.asyncio
+    async def test_bool_bad_value_raises_400(self):
+        async def fn(active: bool): pass
+        wrapper = _adapt_handler(fn, '/search')
+        with pytest.raises(HTTPException) as exc_info:
+            await wrapper(_scope(b'active=maybe'), None, AsyncMock())
+        assert exc_info.value.status == HTTPStatus.BAD_REQUEST
+
+
+class TestQueryParamRegistration:
+    def test_unsupported_annotation_raises_at_registration(self):
+        async def fn(x: dict): pass
+        with pytest.raises(TypeError, match="cannot resolve parameter 'x'"):
+            _adapt_handler(fn, '/search')
+
+    def test_container_annotation_raises_at_registration(self):
+        async def fn(tags: list[str]): pass
+        with pytest.raises(TypeError, match="cannot resolve parameter 'tags'"):
+            _adapt_handler(fn, '/search')
+
+    def test_path_param_with_default_warns_shadowing(self):
+        async def fn(item_id: int = 3): pass
+        with pytest.warns(UserWarning, match='shadow'):
+            _adapt_handler(fn, '/items/{item_id}')
+
+    def test_path_param_without_default_does_not_warn(self):
+        async def fn(item_id: int): pass
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            _adapt_handler(fn, '/items/{item_id}')
+
+    def test_query_param_never_warns(self):
+        async def fn(page: int = 1): pass
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            _adapt_handler(fn, '/search')
+
+    @pytest.mark.asyncio
+    async def test_request_name_with_scalar_annotation_is_query_param(self):
+        # Spec change (Sprint 74): a param named 'request' with a scalar
+        # annotation used to be a registration-time TypeError; it is now an
+        # ordinary query param.  Request injection still requires the Request
+        # annotation or the bare name 'request' (unannotated).
+        captured = {}
+        async def fn(request: int): captured['request'] = request
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'request=8'), None, AsyncMock())
+        assert captured['request'] == 8
+
+    @pytest.mark.asyncio
+    async def test_query_params_do_not_touch_receive(self):
+        async def fn(q: str): pass
+        called = []
+
+        async def should_not_be_called():
+            called.append(True)
+            return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+        wrapper = _adapt_handler(fn, '/search')
+        await wrapper(_scope(b'q=x'), should_not_be_called, AsyncMock())
+        assert called == []
+
+
+class TestQueryParamsEndToEnd:
+    def test_query_params_through_the_full_stack(self):
+        app = BlackBull()
+
+        @app.route(path='/search')
+        async def search(q: str, page: int = 1, active: bool = False):
+            return {'q': q, 'page': page, 'active': active}
+
+        with TestClient(app) as client:
+            r = client.get('/search?q=bull&page=2&active=yes')
+            assert r.status_code == 200
+            assert r.json() == {'q': 'bull', 'page': 2, 'active': True}
+
+    def test_missing_required_is_400_not_500(self):
+        app = BlackBull()
+
+        @app.route(path='/search')
+        async def search(q: str):
+            return {'q': q}
+
+        with TestClient(app) as client:
+            r = client.get('/search')
+            assert r.status_code == 400
+
+    def test_coercion_failure_is_400_not_500(self):
+        app = BlackBull()
+
+        @app.route(path='/search')
+        async def search(page: int):
+            return {'page': page}
+
+        with TestClient(app) as client:
+            r = client.get('/search?page=xyz')
+            assert r.status_code == 400

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -573,15 +573,18 @@ class TestSimplifiedHandlerDetection:
 
 
 class TestSimplifiedHandlerFailFast:
-    def test_unknown_param_raises_at_registration(self):
-        async def fn(x): pass
+    # Spec change (Sprint 74): a scalar param that matches no path
+    # placeholder is now a *query param*, not a registration error — the
+    # fail-fast contract holds only for annotations no category can resolve.
+    def test_unresolvable_annotation_raises_at_registration(self):
+        async def fn(x: dict): pass
         with pytest.raises(TypeError, match="cannot resolve parameter 'x'"):
             _adapt_handler(fn, '/items/{id}')
 
-    def test_unknown_param_raises_when_not_a_path_param(self):
-        async def fn(name): pass
+    def test_container_annotation_raises_at_registration(self):
+        async def fn(name: list[str]): pass
         with pytest.raises(TypeError, match="cannot resolve parameter 'name'"):
-            # path has {id}, not {name}
+            # path has {id}, not {name} — and list[str] is not a query scalar
             _adapt_handler(fn, '/items/{id}')
 
 
@@ -758,8 +761,12 @@ class TestSimplifiedHandlerRequestInjection:
         assert captured['raw'] == b'{"name": "spanner"}'
         assert len(calls) == 1
 
-    def test_request_name_with_foreign_annotation_raises(self):
-        async def fn(request: int): pass
+    def test_request_name_with_foreign_annotation_is_not_request_injected(self):
+        # Spec change (Sprint 74): 'request' with a scalar annotation used to
+        # be a registration TypeError; it is now an ordinary query param
+        # (asserted in test_query_params.py).  An unresolvable annotation on
+        # the name still fails fast — proving no Request fallback kicks in.
+        async def fn(request: dict): pass
         with pytest.raises(TypeError, match="cannot resolve parameter 'request'"):
             _adapt_handler(fn, '/')
 


### PR DESCRIPTION
## Summary

Sprint 74 — the two remaining request-parameter categories of the simplified handler model, both landing on the `_adapt_handler` seam. Target release: v0.56.0 (MINOR).

### Query params (deferred since Sprint 41)

```python
@app.route(path='/search')
async def search(q: str, page: int = 1, active: bool = False):
    ...   # /search?q=bull&page=2 → q='bull', page=2, active=False
```

- Fallback category: any leftover scalar param (`str`/`int`/`float`/`bool`, optionally `| None`; unannotated → `str`) resolves from `scope['query_string']`.
- Default → optional; missing required key or failed coercion → **400** (`HTTPException`), never a 500. Repeated keys: last occurrence wins.
- OpenAPI minimal tier: `in: query`, schema from the annotation, `required` from default-presence.
- New registration-time `UserWarning` when a path param declares a default (the path value always shadows a same-named query key).

### `Depends` (new module `blackbull.di`)

```python
async def get_db():
    conn = await pool.acquire()
    try:
        yield conn                 # injected
    finally:
        await pool.release(conn)  # after the response is sent

@app.route(path='/items/{id:int}')
async def get_item(id: int, db=Depends(get_db)):
    return await db.fetch_item(id)
```

- Provider forms: async generator (value + teardown after send, `AsyncExitStack`-backed, LIFO, exception-safe), async function, sync function.
- `use_cache=True` (default) shares one instance per request across params naming the same provider.
- v1 fences: zero-parameter providers; nested `Depends` → registration-time `TypeError`; simplified handlers only. Excluded from the OpenAPI spec.

### Zero-overhead pin (the anti-FastAPI design point)

All classification happens once at registration (`_handler_param_plan`, shared with `openapi.py` so spec and wrapper can never disagree). Handlers using neither feature compile to the pre-Sprint-74 wrapper — all such closures share one code object, pinned by `tests/unit/test_adapt_zero_overhead.py`. FastAPI runs `solve_dependencies()` + two `AsyncExitStack`s per request even with no dependencies declared.

### Spec change (existing tests)

"Unknown scalar param → registration `TypeError`" is replaced by the query-param fallback. The fail-fast `TypeError` remains for unsupported annotations (`dict`, `list[str]`, arbitrary classes); the three affected tests in `test_router.py` now assert that narrower contract.

## Testing

- 106 new tests: coercion matrix, 400 paths, shadowing warning, provider lifecycle (teardown-after-send ordering, LIFO, exception paths, `use_cache`), zero-overhead pin, OpenAPI emission + validator round-trip.
- Full suite green with `--beartype-packages=blackbull` (5189 passed); `mkdocs build --strict` clean.
- Verified end-to-end on the real server (curl against `app.run()`): happy paths, all 400 paths, teardown ordering after send, OpenAPI JSON, dev-vs-production error bodies, non-int path segment still 404.

## Docs

New guide page *Dependency injection*; *Requests and responses → Query parameters* rewritten to lead with the declarative form; OpenAPI guide coverage table updated ("query params not automated" limitation removed); README + CLAUDE.md simplified-handler sections extended; CHANGELOG under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)