### PR TITLE
release: v0.56.0 — Sprint 74: simplified-handler completion — query params + Depends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.56.0] — 2026-07-16
+
 ### Added
 
 - **Query params in the simplified handler model** (Sprint 74). A handler

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -228,6 +228,20 @@ BlackBull is a protocol-layer framework.  There is no built-in
 ORM, no connection pool, no migration tool.  Apps should bring
 their own (`asyncpg`, `databases`, `tortoise-orm`, etc.).
 
+### `Depends` is deliberately minimal; query params are scalars only
+
+The v0.56.0 dependency-injection surface is fenced by design
+(see [`docs/guide/dependency-injection.md`](docs/guide/dependency-injection.md)):
+providers take **no parameters**, and a provider that itself declares
+`Depends` (nesting, common in FastAPI code) is a registration-time
+`TypeError` — compose inside the provider body instead.  No interface
+binding, no interception (the event API covers cross-cutting concerns).
+Query params resolve scalars only (`str`/`int`/`float`/`bool`,
+optionally `| None`); repeated-key aggregation (`?tag=a&tag=b` →
+`list[str]`) and query-model objects are not supported — parse
+`scope['query_string']` yourself for those.  Fences are lifted on
+demonstrated demand, not speculatively.
+
 ### Optional `[speed-h1]` C parser stub not implemented
 
 `pyproject.toml` lists no `[speed-h1]` extra today.  The

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Hello, world!
   `gunicorn` class path.
 - **Readable stack.** Every byte on the wire passes through Python
   you can step through with `pdb`.  No C extensions to debug.
+- **Declare, don't plumb.** Handlers name what they need — path
+  params, query params, the body, a `Request` view, or a
+  `Depends(get_db)` resource with teardown after the response — and
+  the router resolves it all when the route is *registered*.  A
+  handler that uses none of it compiles to the same bare wrapper:
+  zero per-request cost for features you didn't ask for.
 - **Break things on purpose.** The same protocol code that serves
   real traffic can drive a programmable misbehaving client or
   server.  Test your own HTTP/2 client against half-closed streams,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.56.x  | :white_check_mark: |
 | 0.55.x  | :white_check_mark: |
-| 0.54.x  | :white_check_mark: |
-| < 0.54  | :x:                |
+| < 0.55  | :x:                |
 
 This table updates with each minor release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.55.0"
+version = "0.56.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 74 close. Feature work merged in #156; this PR is the version bump + CHANGELOG heading + pre-release docs audit.

- **Added**: query params in the simplified handler model (registration-time classification, 400 semantics, OpenAPI emission); `Depends` provider injection (`blackbull.di`, teardown after response send, zero cost when unused — test-pinned).
- **Changed**: dev-mode 4xx `HTTPException` pages drop the traceback (keep status + detail); unknown scalar handler params are query params instead of registration `TypeError`s; path-param defaults warn about query shadowing.
- **Docs audit**: SECURITY.md supported versions → 0.56.x/0.55.x; README "Why BlackBull" bullet for the declarative handler signature; KNOWN_LIMITATIONS.md entry for the v1 DI fences.

## Test plan

- [x] Full suite green with `--beartype-packages=blackbull` (pre-commit hook, 5192 passed)
- [x] `mkdocs build --strict` clean
- [x] Editable-install smoke test: `blackbull.__version__` → `0.56.0`
- [ ] CodeQL / pip-audit / build checks green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)