### PR TITLE
feat: MQTT 5 shared subscriptions (§4.8.2) + TLS raw bindings (Sprint 75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,38 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **MQTT 5 shared subscriptions** (§4.8.2, Sprint 75). Subscribers naming the
+  same `$share/{ShareName}/{filter}` pair form a share group; each matching
+  message is delivered to exactly **one** connected member, round-robin per
+  group, at that member's granted QoS. Non-shared subscriptions keep broadcast
+  semantics; disconnected members are skipped while any member is connected
+  (§4.8.2.3); shared subscriptions never receive retained messages; `No Local`
+  on a shared subscription is a Protocol Error (DISCONNECT `0x82`, §3.8.3.1).
+  This also resolves the standing CONNACK wrinkle: the
+  `shared_subscription_available` property (0x2A) stays absent, which per
+  MQTT 5 means *supported* — now true.
+- **Retain Handling 1** (§3.3.1.3, Sprint 75). `retain_handling=1` now delivers
+  retained messages on SUBSCRIBE only when the subscription did not previously
+  exist (it previously behaved like 0).
+- **TLS for raw protocol bindings** (Sprint 75).
+  `app.raw_handler(name, port=…, tls=True)` /
+  `MQTTExtension(port=8883, tls=True)` serve the binding's port through the
+  server's TLS machinery (`mqtts://` without a fronting proxy). Cleartext
+  remains the default; `tls=True` with no certificate configured fails fast at
+  startup.
+
+### Changed
+
+- **Spec change**: a well-formed `$share/…` SUBSCRIBE is now granted instead of
+  rejected with `0x9E SHARED_SUBSCRIPTIONS_NOT_SUPPORTED` (the deliberate
+  Sprint 70 fence). Malformed `$share` forms (missing/empty ShareName or filter
+  portion, wildcard ShareName) are rejected per-entry with `0x8F`;
+  `validate_topic_filter` now rejects an empty filter portion (`$share/g/`).
+- Several raw bindings registered with `port=0` (OS-assigned) each now get
+  their own listener; previously the port-keyed view collapsed them to one.
+
 ## [0.56.0] — 2026-07-16
 
 ### Added

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -104,7 +104,7 @@ appears.
 
 ## Deployment notes
 
-### Raw protocol handlers: single-owner, HTTP still scales, cleartext-only
+### Raw protocol handlers: single-owner, HTTP still scales, cleartext by default
 
 When a non-ASGI protocol handler is registered via `app.raw_handler()` or
 `app.register_protocol_handler()`, BlackBull applies these constraints:
@@ -128,19 +128,22 @@ queue (best load distribution); without it the workers share the master's
 listening socket.  The protocol port is always bound without `SO_REUSEPORT`
 — a single owner is the point.
 
-**Cleartext only** — raw protocol sockets are bound without TLS regardless
-of whether a TLS certificate is configured.  Adding TLS support for raw
-protocols requires `ssl_context` plumbing through `RawBinding` → `Server`.
-For MQTT-over-TLS or similar, put a TLS-terminating proxy in front of the
-raw socket.
+**Cleartext by default; TLS is opt-in per binding (Sprint 75)** — a raw
+protocol socket is bound without TLS unless the binding is registered with
+`tls=True` (`app.raw_handler(name, port=…, tls=True)` /
+`MQTTExtension(port=8883, tls=True)`), in which case it is served through
+the same TLS machinery as the HTTPS listener (certificate from
+`certfile`/`keyfile` or `ssl_context`; startup fails fast when `tls=True`
+has no certificate to use).  A TLS-terminating proxy in front of the raw
+socket remains a fine alternative.
 
 ### MQTT broker: best-effort taps, in-memory single-process state
 
 The MQTT 5 broker (`blackbull.mqtt`, opt-in via `blackbull[mqtt]`) rides
 the raw-protocol bridge above, so it inherits its constraints —
 **single-owner** (the broker runs on worker 0; HTTP still scales across all
-workers) and **cleartext only** (front a TLS terminator for
-MQTT-over-TLS).  Beyond those:
+workers) and **cleartext unless registered with `tls=True`**
+(`MQTTExtension(port=8883, tls=True)` for `mqtts://`).  Beyond those:
 
 **Why a single broker owner is a protocol requirement, not an
 implementation limitation.**  The MQTT 5.0 specification (OASIS Committee Specification

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -983,6 +983,7 @@ class BlackBull:
         *,
         detector: object | None = None,
         port: int | None = None,
+        tls: bool = False,
     ) -> None:
         """Register a handler for a non-ASGI (raw) protocol (Sprint 50).
 
@@ -997,15 +998,18 @@ class BlackBull:
             detector: Reserved for first-byte sniffing on shared ports
                 (Sprint 51); unused today.
             port: Dedicated listening port for this protocol.
+            tls: Serve this port through the server's TLS machinery (e.g.
+                ``mqtts://``).  Requires the server to be configured with a
+                certificate; startup fails fast otherwise (Sprint 75).
         """
         if self._protocol_registry is None:
             from .server.protocol_registry import ProtocolRegistry  # noqa: PLC0415
             self._protocol_registry = ProtocolRegistry()
         self._protocol_registry.register(name, handler,
-                                         detector=detector, port=port)
+                                         detector=detector, port=port, tls=tls)
 
     def raw_handler(self, name: str, *, port: int | None = None,
-                    detector: object | None = None):
+                    detector: object | None = None, tls: bool = False):
         """Decorator form of :meth:`register_protocol_handler`.
 
         ::
@@ -1017,7 +1021,8 @@ class BlackBull:
         """
         def decorator(handler):
             self.register_protocol_handler(name, handler,
-                                           detector=detector, port=port)
+                                           detector=detector, port=port,
+                                           tls=tls)
             return handler
         return decorator
 

--- a/blackbull/mqtt/broker.py
+++ b/blackbull/mqtt/broker.py
@@ -112,6 +112,21 @@ def _valid_filter(topic_filter: str) -> bool:
         return False
 
 
+def _parse_share(topic_filter: str) -> tuple[str, str] | None:
+    """§4.8.2 — split ``$share/{ShareName}/{filter}`` into ``(share, filter)``.
+
+    Returns ``None`` for a non-shared filter or one too malformed to carry a
+    filter portion at all (validation proper is :func:`validate_topic_filter`;
+    this only extracts the group key).
+    """
+    if not topic_filter.startswith('$share/'):
+        return None
+    parts = topic_filter.split('/', 2)
+    if len(parts) < 3:
+        return None
+    return parts[1], parts[2]
+
+
 def _new_broker_session() -> dict[str, Any]:
     """Per-client session state owned by the broker (§3.1.2.11)."""
     return {
@@ -147,6 +162,11 @@ class BrokerActor(Actor):
         self._retained = {}         # topic -> MQTTPublish
         self._wills = {}            # client_id -> MQTTPublish (Will template)
         self._auto_seq = 0          # for server-assigned client ids
+        # §4.8.2 — round-robin cursor per share group.  Membership itself is
+        # derived from session subscriptions at routing time (correctness
+        # first: no registry to keep in sync across SUBSCRIBE / UNSUBSCRIBE /
+        # session expiry); only the rotation position is stored.
+        self._share_rotation: dict[tuple[str, str], int] = {}
 
     # -- dispatch -----------------------------------------------------------
 
@@ -307,27 +327,37 @@ class BrokerActor(Actor):
         reason_codes = []
         options = subscribe.subscription_options or []
         for index, (topic_filter, qos) in enumerate(subscribe.subscriptions):
-            # §4.8 — Shared Subscriptions are not implemented.  Reject them
-            # explicitly (0x9E) rather than silently broadcasting to every group
-            # member, which would violate the §4.8.2 load-balancing contract.
-            if topic_filter.startswith('$share/'):
-                reason_codes.append(ReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED)
-                continue
-            # §3.8.3 / §4.7 — a syntactically invalid Topic Filter is rejected
-            # per-entry with 0x8F; the SUBACK still carries one reason code per
+            # §3.8.3 / §4.7 / §4.8.2 — a syntactically invalid Topic Filter
+            # (including a malformed ``$share`` form) is rejected per-entry
+            # with 0x8F; the SUBACK still carries one reason code per
             # requested filter, so ordering with the remaining entries is kept.
             if not _valid_filter(topic_filter):
                 reason_codes.append(ReasonCode.TOPIC_FILTER_INVALID)
                 continue
             opts = dict(options[index]) if index < len(options) else {}
+            share = _parse_share(topic_filter)
+            # §3.8.3.1 [MQTT-3.8.3-4] — No Local on a Shared Subscription is a
+            # Protocol Error: per §4.13 the server sends DISCONNECT 0x82 and
+            # closes the connection (no SUBACK).
+            if share is not None and opts.get('no_local'):
+                await conn.send(Send(packet=MQTTDisconnect(
+                    reason_code=ReasonCode.PROTOCOL_ERROR)))
+                await conn.send(Close(reason_code=ReasonCode.PROTOCOL_ERROR))
+                return
             opts['qos'] = qos
             # §3.8.4 — a SUBSCRIBE for an existing Topic Filter replaces its
             # prior subscription (and its options) rather than adding a second.
+            existed = any(s[0] == topic_filter for s in session['subscriptions'])
             subs = [s for s in session['subscriptions'] if s[0] != topic_filter]
             subs.append((topic_filter, qos, opts))
             session['subscriptions'] = subs
             reason_codes.append(qos)  # granted QoS == requested QoS
-            if int(opts.get('retain_handling', 0)) != 2:
+            # §3.3.1.3 Retain Handling — 0: send retained on every SUBSCRIBE;
+            # 1: only when the subscription did not already exist; 2: never.
+            # Shared subscriptions never receive retained messages (§4.8.2).
+            retain_handling = int(opts.get('retain_handling', 0))
+            if share is None and retain_handling != 2 \
+                    and not (retain_handling == 1 and existed):
                 await self._deliver_retained(conn, session, topic_filter, qos)
         await conn.send(Send(packet=MQTTSuback(
             packet_id=subscribe.packet_id, reason_codes=reason_codes)))
@@ -337,6 +367,20 @@ class BrokerActor(Actor):
             if topic_matches_filter(topic, topic_filter):
                 await self._deliver(conn, session, retained, qos, retain=True)
 
+    def _prune_share_rotation(self, removed_filters) -> None:
+        """§4.8.2 — drop rotation cursors for share groups that no session
+        subscribes to any more, so the cursor dict cannot grow without bound
+        as groups come and go."""
+        stale = {share for f in removed_filters
+                 if (share := _parse_share(f)) is not None}
+        if not stale:
+            return
+        for session in self._sessions.values():
+            for topic_filter, _qos, _opts in session['subscriptions']:
+                stale.discard(_parse_share(topic_filter))
+        for share in stale:
+            self._share_rotation.pop(share, None)
+
     async def _on_unsubscribe(self, conn, unsubscribe) -> None:
         session = self._session_for(conn)
         if session is None:
@@ -345,6 +389,7 @@ class BrokerActor(Actor):
         session['subscriptions'] = [
             s for s in session['subscriptions'] if s[0] not in topics
         ]
+        self._prune_share_rotation(topics)
         await conn.send(Send(packet=MQTTUnsuback(
             packet_id=unsubscribe.packet_id,
             reason_codes=[ReasonCode.SUCCESS] * len(unsubscribe.topics))))
@@ -406,7 +451,17 @@ class BrokerActor(Actor):
 
         *source_conn* is the connection that published (``None`` for a Will),
         used to honour the No Local subscription option (§3.8.3.1).
+
+        Non-shared subscriptions broadcast (one merged copy per client).
+        Shared subscriptions (§4.8.2) are grouped by ``(ShareName, filter)``;
+        each group receives exactly one copy per message, round-robin across
+        its *connected* members — a member with a live session but no
+        connection is skipped while any other member is connected (§4.8.2.3).
+        When no member is connected the message is not queued, matching the
+        broker's existing no-offline-queue behaviour for non-shared
+        subscriptions.
         """
+        share_groups: dict[tuple[str, str], list] = {}
         for client_id, conn in list(self._clients.items()):
             session = self._sessions.get(client_id)
             if session is None:
@@ -415,6 +470,13 @@ class BrokerActor(Actor):
             rap = False
             for topic_filter, qos, opts in session['subscriptions']:
                 if not topic_matches_filter(publish.topic, topic_filter):
+                    continue
+                share = _parse_share(topic_filter)
+                if share is not None:
+                    # §4.8.2 — an independent delivery channel: collect the
+                    # connected members; exactly-one delivery happens below.
+                    share_groups.setdefault(share, []).append(
+                        (conn, session, qos, opts))
                     continue
                 # §3.8.3.1 No Local — do not echo a client's own message back to
                 # it on a subscription that set the No Local option.
@@ -428,6 +490,17 @@ class BrokerActor(Actor):
             # only when a matching subscription requested it; otherwise a routed
             # (non-retained-replay) message always carries RETAIN=0.
             await self._deliver(conn, session, publish, granted,
+                                retain=(rap and publish.retain))
+        # §4.8.2 — exactly one copy per share group, rotating across the
+        # members that are connected right now.  The cursor is normalised
+        # against the current member count, so membership churn between
+        # messages cannot index out of range.
+        for share, members in share_groups.items():
+            cursor = self._share_rotation.get(share, 0) % len(members)
+            self._share_rotation[share] = cursor + 1
+            conn, session, qos, opts = members[cursor]
+            rap = bool(opts.get('retain_as_published'))
+            await self._deliver(conn, session, publish, qos,
                                 retain=(rap and publish.retain))
 
     async def _deliver(self, conn, session, publish, granted_qos, *, retain=False) -> None:
@@ -483,3 +556,5 @@ class BrokerActor(Actor):
         session = self._sessions.get(client_id)
         if session is not None and session.get('_expiry', 0) <= 0:
             self._sessions.pop(client_id, None)
+            self._prune_share_rotation(
+                [s[0] for s in session['subscriptions']])

--- a/blackbull/mqtt/extension.py
+++ b/blackbull/mqtt/extension.py
@@ -77,11 +77,14 @@ class MQTTExtension(Extension):
 
     extension_key = 'mqtt'
 
-    def __init__(self, *, port: int = 1883, tap_mode: str = 'actor',
-                 tap_queue_size: int = 1024) -> None:
+    def __init__(self, *, port: int = 1883, tls: bool = False,
+                 tap_mode: str = 'actor', tap_queue_size: int = 1024) -> None:
         if tap_mode not in ('actor', 'inline'):
             raise ValueError(f"tap_mode must be 'actor' or 'inline', got {tap_mode!r}")
         self.port = port
+        # Sprint 75 — serve the broker port over TLS (mqtts://, conventionally
+        # port 8883).  Requires the server to have a certificate configured.
+        self.tls = tls
         self.tap_mode = tap_mode
         self.tap_queue_size = tap_queue_size
         self._handlers: list[Any] = []   # compiled Tap objects
@@ -124,7 +127,8 @@ class MQTTExtension(Extension):
                                    app_handlers=inline, tap=tap)
 
         app.register_protocol_handler(
-            'mqtt', _serve, detector=MQTTProtocolDetector(), port=self.port)
+            'mqtt', _serve, detector=MQTTProtocolDetector(), port=self.port,
+            tls=self.tls)
         self._register(app)
 
     async def startup(self, app: Any) -> None:

--- a/blackbull/mqtt/messages.py
+++ b/blackbull/mqtt/messages.py
@@ -1177,6 +1177,9 @@ def validate_topic_filter(filter_str: str) -> bool:
         if '+' in share_name or '#' in share_name:
             raise ValueError(
                 'Shared subscription share name must not contain wildcards (+ or #)')
+        if parts[2] == '':
+            raise ValueError(
+                'Shared subscription filter portion must not be empty')
         work = parts[2]
 
     if work.count('#') > 1:

--- a/blackbull/server/protocol_registry.py
+++ b/blackbull/server/protocol_registry.py
@@ -274,11 +274,15 @@ class RawBinding(ProtocolBinding):
         *,
         detector: ProtocolDetector | None = None,
         port: int | None = None,
+        tls: bool = False,
     ) -> None:
         self.name = name
         self.handler = handler
         self.detector = detector
         self.port = port
+        # Sprint 75 — serve this binding's port through the server's TLS
+        # machinery (mqtts:// and friends).  Cleartext remains the default.
+        self.tls = tls
 
     @property
     def detect_prefix_len(self) -> int:
@@ -340,17 +344,20 @@ class ProtocolRegistry:
         *,
         detector: ProtocolDetector | None = None,
         port: int | None = None,
+        tls: bool = False,
     ) -> RawBinding:
         """Register a non-ASGI protocol handler.  Raises on duplicate name.
 
         A ``detector`` enables shared-port sniffing (see
         :class:`ProtocolDetector`).  When several registered detectors could
         match the same first bytes, dispatch picks the **first registered**
-        one — ``raw_bindings`` preserves insertion order.
+        one — ``raw_bindings`` preserves insertion order.  ``tls=True`` serves
+        the binding's own port through the server's TLS machinery (Sprint 75).
         """
         if name in self._ports or name in {b.name for b in self._cleartext}:
             raise ValueError(f'Protocol {name!r} already registered')
-        binding = RawBinding(name, handler, detector=detector, port=port)
+        binding = RawBinding(name, handler, detector=detector, port=port,
+                             tls=tls)
         self._ports[name] = binding
         self._detection_order = (tuple(self._ports.values())
                                  + tuple(self._cleartext))

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -293,6 +293,25 @@ class Server:
             await self._serve_connection(reader, writer, bound_binding=binding)
         return _cb
 
+    def _raw_tls_context(self):
+        """TLS context for ``tls=True`` raw bindings (Sprint 75).
+
+        When cert/key paths are available a dedicated context is built without
+        the HTTP listener's ``h2``/``http/1.1`` ALPN list — a raw-protocol
+        client offering its own ALPN token (e.g. ``mqtt``) must not fail the
+        handshake on no-overlap.  A caller-supplied ``ssl_context`` is reused
+        as-is (there is nothing to rebuild it from).
+        """
+        if not (self.certfile and self.keyfile):
+            return self.ssl_context
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        context.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        context.options |= ssl.OP_NO_COMPRESSION
+        if hasattr(ssl, 'SESS_CACHE_SERVER'):
+            context.set_session_cache_mode(ssl.SESS_CACHE_SERVER)  # type: ignore[attr-defined]
+        return context
+
     async def _serve_connection(self, reader, writer, *, bound_binding=None):
         """Wrap the transport and run one :class:`ConnectionActor`.
 
@@ -517,10 +536,17 @@ class Server:
 
         Each :class:`RawBinding` registered with a ``port`` gets its own
         dual-stack socket set.  ``port=0`` lets the OS pick a free port (used by
-        tests); the bound port is recorded in :attr:`protocol_ports`.  Cleartext
-        only — TLS for raw protocols is out of scope for the PoC.
+        tests); the bound port is recorded in :attr:`protocol_ports`.  Sockets
+        are bound bare here; :meth:`run` layers TLS onto the listeners whose
+        binding set ``tls=True`` (Sprint 75), cleartext otherwise.
         """
-        for port, binding in self._protocol_registry.port_bindings.items():
+        # Iterate the bindings themselves, not the port-keyed view — several
+        # bindings may all ask for port=0 (OS-assigned, common in tests), and
+        # keying by port would silently collapse them to one listener.
+        for binding in self._protocol_registry.raw_bindings.values():
+            if binding.port is None:
+                continue
+            port = binding.port
             socks = create_dual_stack_sockets(
                 port,
                 backlog=_cfg.socket_backlog,
@@ -567,17 +593,33 @@ class Server:
         # SocketManager wraps each socket in asyncio.start_server and closes all
         # servers on exit.  The shared HTTP listener uses client_connected_cb;
         # each port-bound non-ASGI protocol uses its own raw callback.  Raw
-        # sockets are cleartext (no TLS) for the Sprint 50 PoC.
+        # sockets are cleartext unless the binding was registered with
+        # ``tls=True`` (Sprint 75), which serves them through the same TLS
+        # machinery as the HTTPS listener.
         # LifespanManager drives the ASGI lifespan protocol; nesting it inside
         # SocketManager guarantees: startup completes before serve_forever() is
         # called, and shutdown completes before sockets are closed.
         pairs = [(s, self.client_connected_cb) for s in self.raw_sockets]
+        raw_clear = [(s, self._raw_connected_cb(binding))
+                     for socks, binding in self._protocol_sockets
+                     if not binding.tls for s in socks]
+        raw_tls = [(s, self._raw_connected_cb(binding))
+                   for socks, binding in self._protocol_sockets
+                   if binding.tls for s in socks]
+        if raw_tls and self.ssl_context is None:
+            names = ', '.join(binding.name
+                              for _socks, binding in self._protocol_sockets
+                              if binding.tls)
+            raise RuntimeError(
+                f'Raw protocol binding(s) [{names}] require TLS (tls=True) '
+                f'but the server has no certificate configured — pass '
+                f'certfile/keyfile or an ssl_context.')
         async with SocketManager(pairs, self.ssl_context) as servers, \
-                SocketManager(
-                    [(s, self._raw_connected_cb(binding))
-                     for socks, binding in self._protocol_sockets for s in socks],
-                    None) as raw_servers:
-            servers = servers + raw_servers
+                SocketManager(raw_clear, None) as raw_servers, \
+                SocketManager(raw_tls,
+                              self._raw_tls_context() if raw_tls else None
+                              ) as raw_tls_servers:
+            servers = servers + raw_servers + raw_tls_servers
             async with LifespanManager(self.app):
                 logger.info(f'Server(s) created: {servers}')
                 try:

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -89,7 +89,8 @@ conformance matrix:
 | Area | Support |
 |------|---------|
 | Connection | CONNECT / CONNACK, protocol-level check (rejects non-5 with `0x84`), Clean Start, Session Present |
-| Subscriptions | SUBSCRIBE / SUBACK, UNSUBSCRIBE / UNSUBACK, `+` and `#` wildcards, `$`-topic rules; `No Local` and `Retain As Published` options honoured; invalid Topic Filters rejected (`0x8F`). Shared subscriptions (`$share/…`) are **not implemented** and are rejected with `0x9E` rather than silently broadcast |
+| Subscriptions | SUBSCRIBE / SUBACK, UNSUBSCRIBE / UNSUBACK, `+` and `#` wildcards, `$`-topic rules; `No Local`, `Retain As Published`, and `Retain Handling` (0/1/2, §3.3.1.3) options honoured; invalid Topic Filters rejected (`0x8F`) |
+| Shared subscriptions | `$share/{ShareName}/{filter}` groups (§4.8.2): each matching message goes to exactly **one** connected group member, round-robin — see below |
 | Publish | invalid Topic Names (wildcards / null) rejected (`0x90`), never routed or retained |
 | QoS 0 | fire-and-forget delivery |
 | QoS 1 | PUBACK round-trip |
@@ -113,6 +114,43 @@ wires the two; `blackbull.mqtt.tap` holds the `TapActor` and the `Message`
 read-model; and `blackbull.mqtt.extension` holds `MQTTExtension` and
 `MQTTProtocolDetector`, which recognises the MQTT CONNECT first byte (`0x10`) for
 shared-port sniffing.
+
+## Shared subscriptions
+
+Subscribers that name the same `$share/{ShareName}/{filter}` pair form a
+*share group* (MQTT 5 §4.8.2). Each application message matching the filter is
+delivered to exactly **one** member of the group — round-robin across the
+members currently connected — instead of every matching subscriber. This is
+the standard MQTT pattern for load-balancing a work queue across a pool of
+consumers:
+
+```bash
+# terminals 1 and 2 — two workers in the same share group
+mosquitto_sub -t '$share/pool/jobs/#' -p 1883 -V 5
+mosquitto_sub -t '$share/pool/jobs/#' -p 1883 -V 5
+
+# terminal 3 — publishes alternate between the two workers
+mosquitto_pub -t 'jobs/import' -m 'job-1' -p 1883 -V 5
+mosquitto_pub -t 'jobs/import' -m 'job-2' -p 1883 -V 5
+```
+
+Semantics worth knowing:
+
+- **Non-shared subscriptions are unaffected** — a client subscribed to a plain
+  `jobs/#` still receives every message, alongside whichever group member the
+  rotation picks. Shared and non-shared subscriptions held by the same client
+  are independent delivery channels.
+- **Delivery QoS** is the chosen member's granted QoS (capped by the publish
+  QoS, as usual).
+- **Disconnected members are skipped** while any member is connected
+  (§4.8.2.3). If *no* member is connected, the message is not queued for the
+  group — the same no-offline-queue behaviour the broker applies to non-shared
+  subscriptions.
+- **Retained messages are never delivered to a shared subscription** (§4.8.2).
+- **`No Local` cannot be combined with a shared subscription** — MQTT 5 makes
+  it a Protocol Error (§3.8.3.1), and the broker disconnects with `0x82`.
+- Malformed forms (`$share/g`, an empty ShareName, a wildcard in the ShareName,
+  or an empty filter portion) are rejected per-entry with `0x8F`.
 
 ## Trying it with Mosquitto
 
@@ -175,10 +213,18 @@ Three honest caveats — also stated in the document's `info.description`:
 - **Payloads are opaque bytes** (`application/octet-stream`) until a future
   opt-in `schema=` on `on_message` lands.
 
+## TLS (`mqtts://`)
+
+`MQTTExtension(port=8883, tls=True)` serves the broker port over TLS using the
+same certificate the HTTPS listener uses — pass `certfile`/`keyfile` (or an
+`ssl_context`) to `app.run()` as usual. The server refuses to start if
+`tls=True` is set with no certificate configured. Cleartext remains the
+default (`tls=False`), so existing deployments are unchanged.
+
 ## Limitations
 
-- **Cleartext only.** TLS / MQTT-over-WebSocket transport is not yet wired up,
-  matching the bridge's current limits.
+- **No MQTT-over-WebSocket transport.** TLS is supported via
+  `MQTTExtension(tls=True)`; the WebSocket binding is not yet wired up.
 - **Single owner (HTTP still scales).** The broker runs on **worker 0** only —
   its state (subscriptions, sessions, retained messages) lives in that one
   process and is neither shared across workers nor persisted across restarts.

--- a/tests/integration/test_raw_binding_tls.py
+++ b/tests/integration/test_raw_binding_tls.py
@@ -1,0 +1,132 @@
+"""Integration tests for TLS on raw protocol bindings (Sprint 75).
+
+A raw binding registered with ``tls=True`` is served through the same TLS
+machinery as the HTTPS listener (``mqtts://``-style deployments).  Bindings
+default to cleartext, so existing registrations are unaffected — including on
+an app that has certificates configured for HTTPS.
+"""
+import asyncio
+import socket
+import ssl
+import time
+from pathlib import Path
+from multiprocessing import Process
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.server import Server
+
+CERT = str(Path(__file__).parent.parent / 'cert.pem')
+KEY = str(Path(__file__).parent.parent / 'key.pem')
+
+
+def _make_app():
+    app = BlackBull()
+
+    @app.route(path='/')
+    async def index():
+        return "http-ok"
+
+    @app.raw_handler('echo-tls', port=0, tls=True)
+    async def echo_tls(reader, writer, ctx):
+        while True:
+            data = await reader.read(1024)
+            if not data:
+                break
+            await writer.write(data)
+
+    @app.raw_handler('echo-clear', port=0)
+    async def echo_clear(reader, writer, ctx):
+        while True:
+            data = await reader.read(1024)
+            if not data:
+                break
+            await writer.write(data)
+
+    return app
+
+
+@pytest.fixture
+def live_tls_bridge():
+    """HTTPS + one TLS and one cleartext raw binding on ephemeral ports."""
+    app = _make_app()
+    server = Server(app, certfile=CERT, keyfile=KEY)
+    server.open_socket(0)
+    tls_port = server.protocol_ports['echo-tls']
+    clear_port = server.protocol_ports['echo-clear']
+    p = Process(target=lambda: asyncio.run(server.run()))
+    p.start()
+    try:
+        server.wait_for_port(timeout=10.0)
+        yield tls_port, clear_port
+    finally:
+        server.close()
+        p.terminate()
+        p.join(timeout=5)
+
+
+def _connect(port, timeout=5.0):
+    deadline = time.time() + timeout
+    while True:
+        try:
+            return socket.create_connection(('127.0.0.1', port), timeout=2)
+        except OSError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.05)
+
+
+def _tls_connect(port):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    sock = _connect(port)
+    return ctx.wrap_socket(sock, server_hostname='localhost')
+
+
+def test_tls_raw_echo_round_trips(live_tls_bridge):
+    tls_port, _ = live_tls_bridge
+    with _tls_connect(tls_port) as tsock:
+        tsock.sendall(b'hello mqtts\n')
+        assert tsock.recv(1024) == b'hello mqtts\n'
+
+
+def test_cleartext_to_tls_port_fails(live_tls_bridge):
+    """A plain-TCP client on a tls=True port never reaches the handler."""
+    tls_port, _ = live_tls_bridge
+    with _connect(tls_port) as sock:
+        sock.sendall(b'not a tls hello\n')
+        # The handshake fails server-side; the client sees a close (b'') or a
+        # reset — never an echo of its bytes.
+        try:
+            data = sock.recv(1024)
+        except OSError:
+            data = b''
+    assert data != b'not a tls hello\n'
+
+
+def test_cleartext_binding_stays_cleartext_alongside_tls(live_tls_bridge):
+    """tls=False (the default) keeps serving plain TCP even when the app has
+    certificates configured — no behaviour change for existing registrations."""
+    _, clear_port = live_tls_bridge
+    with _connect(clear_port) as sock:
+        sock.sendall(b'still cleartext\n')
+        assert sock.recv(1024) == b'still cleartext\n'
+
+
+def test_tls_binding_without_certs_fails_fast():
+    """tls=True on a server with no TLS configured raises at serve time."""
+    app = BlackBull()
+
+    @app.raw_handler('needs-tls', port=0, tls=True)
+    async def h(reader, writer, ctx):
+        pass  # never reached — the server must refuse to start
+
+    server = Server(app)
+    server.open_socket(0)
+    try:
+        with pytest.raises(RuntimeError, match='needs-tls'):
+            asyncio.run(asyncio.wait_for(server.run(), timeout=5))
+    finally:
+        server.close()

--- a/tests/unit/test_mqtt_hardening.py
+++ b/tests/unit/test_mqtt_hardening.py
@@ -260,7 +260,7 @@ class TestSessionTakeover:
 
 
 # ===========================================================================
-# 1.19e — No Local, Retain As Published, and $share rejection
+# 1.19e — No Local and Retain As Published subscription options
 # ===========================================================================
 
 class TestSubscriptionOptions:
@@ -311,14 +311,19 @@ class TestSubscriptionOptions:
         delivered = [p for p in sub.packets() if isinstance(p, MQTTPublish)][0]
         assert delivered.retain is False
 
-    async def test_shared_subscription_rejected(self):
+    async def test_shared_subscription_granted(self):
+        """Spec change (Sprint 75): §4.8.2 shared subscriptions are now
+        implemented — a well-formed ``$share`` filter is granted, never 0x9E.
+        Full behaviour matrix: ``test_mqtt_shared_subscriptions.py``."""
         broker, conn = BrokerActor(), RecordingConn()
         await _attach(broker, conn)
         await _subscribe(broker, conn, 1, [('$share/g/t', 0)])
         suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
-        assert suback.reason_codes == [
-            ReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED]
-        assert broker._sessions['c1']['subscriptions'] == []
+        assert suback.reason_codes == [0]
+        assert ReasonCode.SHARED_SUBSCRIPTIONS_NOT_SUPPORTED not in \
+            suback.reason_codes
+        assert [s[0] for s in broker._sessions['c1']['subscriptions']] == \
+            ['$share/g/t']
 
 
 # ===========================================================================

--- a/tests/unit/test_mqtt_shared_subscriptions.py
+++ b/tests/unit/test_mqtt_shared_subscriptions.py
@@ -1,0 +1,353 @@
+"""MQTT 5 §4.8.2 Shared Subscriptions — BrokerActor unit tests (Sprint 75).
+
+Drives ``BrokerActor._handle`` directly with recording connection actors, same
+harness as ``test_mqtt_broker_actor.py``.  Covers the load-balanced fan-out
+contract: exactly-one delivery per share group per message, round-robin
+rotation, membership changes (UNSUBSCRIBE / detach), the no-connected-member
+case, the No Local protocol error (§3.8.3.1), retained-message exclusion
+(§4.8.2), and the Retain Handling 1 rider (§3.3.1.3).
+"""
+import pytest
+
+from blackbull.actor import Actor
+from blackbull.mqtt.broker import (
+    BrokerActor,
+    Attach, ClientSubscribe, ClientUnsubscribe, ClientPublish,
+    Detach, Send, Close,
+)
+from blackbull.mqtt.messages import (
+    MQTTConnect, MQTTDisconnect, MQTTPublish, MQTTSubscribe, MQTTSuback,
+    MQTTUnsubscribe, ReasonCode,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class RecordingConn(Actor):
+    """A fake connection actor that records what the broker sends it."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.outbox = []
+
+    async def send(self, msg) -> None:  # override: record instead of enqueue
+        self.outbox.append(msg)
+
+    def packets(self) -> list:
+        return [m.packet for m in self.outbox if isinstance(m, Send)]
+
+    def publishes(self) -> list:
+        return [p for p in self.packets() if isinstance(p, MQTTPublish)]
+
+
+def _connect(client_id='c1', clean_start=True, **kw):
+    return MQTTConnect(client_id=client_id, clean_start=clean_start,
+                       keep_alive=kw.pop('keep_alive', 60), **kw)
+
+
+async def _attach(broker, conn, **kw):
+    await broker._handle(Attach(connect=_connect(**kw), sender=conn))
+
+
+async def _subscribe(broker, conn, packet_id, subs, options=None):
+    await broker._handle(ClientSubscribe(
+        subscribe=MQTTSubscribe(packet_id=packet_id, subscriptions=subs,
+                                subscription_options=options),
+        sender=conn))
+
+
+async def _publish(broker, conn, topic='t', payload=b'x', qos=0, **kw):
+    await broker._handle(ClientPublish(
+        publish=MQTTPublish(topic=topic, payload=payload, qos=qos, **kw),
+        sender=conn))
+
+
+async def _group(broker, n, filter_='$share/pool/t', qos=0):
+    """Attach *n* clients subscribed to the same share group; returns them."""
+    members = []
+    for i in range(n):
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id=f'm{i}')
+        await _subscribe(broker, conn, i + 1, [(filter_, qos)])
+        conn.outbox.clear()
+        members.append(conn)
+    return members
+
+
+# ===========================================================================
+# SUBACK contract — the 0x9E fence is gone (spec change vs Sprint 70)
+# ===========================================================================
+
+class TestSharedSubscribeAccepted:
+    async def test_share_filter_granted_not_rejected(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('$share/g/t', 1)])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [1]  # granted QoS, not 0x9E
+        assert [s[0] for s in broker._sessions['c1']['subscriptions']] == \
+            ['$share/g/t']
+
+    async def test_malformed_share_filters_rejected_0x8f(self):
+        """§4.8.2 — no filter part, empty ShareName, wildcard ShareName, and
+        an empty filter portion are all 0x8F per-entry rejections."""
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [
+            ('$share/g', 0), ('$share//t', 0), ('$share/g+/t', 0),
+            ('$share/g/', 0),
+        ])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [ReasonCode.TOPIC_FILTER_INVALID] * 4
+        assert broker._sessions['c1']['subscriptions'] == []
+
+
+# ===========================================================================
+# §4.8.2 — exactly-one delivery, round-robin rotation
+# ===========================================================================
+
+class TestSharedDelivery:
+    async def test_round_robin_exactly_one_per_message(self):
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(4):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        # Each message reaches exactly one member; rotation alternates.
+        assert [p.payload for p in a.publishes()] == [b'0', b'2']
+        assert [p.payload for p in b.publishes()] == [b'1', b'3']
+
+    async def test_non_shared_subscriber_always_receives(self):
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        plain = RecordingConn()
+        await _attach(broker, plain, client_id='plain')
+        await _subscribe(broker, plain, 9, [('t', 0)])
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(4):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        assert len(plain.publishes()) == 4                       # broadcast
+        assert len(a.publishes()) + len(b.publishes()) == 4      # exactly one
+
+    async def test_groups_rotate_independently(self):
+        """Two share groups on the same filter each get one copy per message."""
+        broker = BrokerActor()
+        g1 = await _group(broker, 2, filter_='$share/g1/t')
+        g2a = RecordingConn()
+        await _attach(broker, g2a, client_id='g2a')
+        await _subscribe(broker, g2a, 1, [('$share/g2/t', 0)])
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(2):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        assert len(g1[0].publishes()) + len(g1[1].publishes()) == 2
+        assert len(g2a.publishes()) == 2   # sole member of its own group
+
+    async def test_client_with_shared_and_non_shared_gets_non_shared_copy(self):
+        broker = BrokerActor()
+        both, other = RecordingConn(), RecordingConn()
+        await _attach(broker, both, client_id='both')
+        await _subscribe(broker, both, 1, [('$share/g/t', 0), ('t', 0)])
+        await _attach(broker, other, client_id='other')
+        await _subscribe(broker, other, 1, [('$share/g/t', 0)])
+        both.outbox.clear()
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(2):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        # Non-shared copy every message, plus the shared copy when rotation
+        # picks this client (shared and non-shared are independent
+        # subscriptions).  Rotation: msg 0 -> both, msg 1 -> other.
+        assert [p.payload for p in both.publishes()] == [b'0', b'0', b'1']
+        assert [p.payload for p in other.publishes()] == [b'1']
+
+    async def test_delivery_at_member_granted_qos(self):
+        broker = BrokerActor()
+        a, b = RecordingConn(), RecordingConn()
+        await _attach(broker, a, client_id='a')
+        await _subscribe(broker, a, 1, [('$share/g/t', 1)])
+        await _attach(broker, b, client_id='b')
+        await _subscribe(broker, b, 1, [('$share/g/t', 0)])
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        await _publish(broker, pub, qos=1, packet_id=7)   # -> a (qos 1)
+        await _publish(broker, pub, qos=1, packet_id=8)   # -> b (qos 0)
+
+        (pa,), (pb,) = a.publishes(), b.publishes()
+        assert pa.qos == 1 and pa.packet_id is not None
+        assert pb.qos == 0 and pb.packet_id is None
+
+    async def test_wildcard_share_filter_matches(self):
+        broker = BrokerActor()
+        (a,) = await _group(broker, 1, filter_='$share/pool/sensors/+')
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub, topic='sensors/temp')
+        assert len(a.publishes()) == 1
+
+
+# ===========================================================================
+# §4.8.2 — membership changes and offline members
+# ===========================================================================
+
+class TestSharedMembership:
+    async def test_unsubscribe_removes_member_from_rotation(self):
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        await broker._handle(ClientUnsubscribe(
+            unsubscribe=MQTTUnsubscribe(packet_id=5, topics=['$share/pool/t']),
+            sender=b))
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(3):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        assert len(a.publishes()) == 3
+        assert b.publishes() == []
+
+    async def test_disconnected_member_skipped(self):
+        """§4.8.2.3 — while any member is connected, disconnected members
+        (even with a live session) receive nothing."""
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        await broker._handle(Detach(graceful=True, sender=b))
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        for i in range(3):
+            await _publish(broker, pub, payload=b'%d' % i)
+
+        assert len(a.publishes()) == 3
+        assert b.publishes() == []
+
+    async def test_no_connected_member_drops_message(self):
+        """Documented behaviour: with no group member connected the message is
+        not queued — matching the broker's existing no-offline-queue semantics
+        for non-shared subscriptions."""
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        await broker._handle(Detach(graceful=True, sender=a))
+        await broker._handle(Detach(graceful=True, sender=b))
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+
+        await _publish(broker, pub, payload=b'lost')   # must not raise
+
+        assert a.publishes() == [] and b.publishes() == []
+
+
+# ===========================================================================
+# §3.8.3.1 — No Local on a shared subscription is a Protocol Error
+# ===========================================================================
+
+class TestSharedNoLocal:
+    async def test_no_local_on_shared_disconnects_0x82(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        conn.outbox.clear()
+        await _subscribe(broker, conn, 1, [('$share/g/t', 0)],
+                         options=[{'no_local': True}])
+        # §4.13 — Protocol Error: DISCONNECT 0x82 then close; no SUBACK.
+        disconnects = [p for p in conn.packets() if isinstance(p, MQTTDisconnect)]
+        assert disconnects and disconnects[0].reason_code == ReasonCode.PROTOCOL_ERROR
+        assert [m for m in conn.outbox if isinstance(m, Close)]
+        assert not [p for p in conn.packets() if isinstance(p, MQTTSuback)]
+        assert broker._sessions['c1']['subscriptions'] == []
+
+    async def test_no_local_on_plain_filter_still_fine(self):
+        broker, conn = BrokerActor(), RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('t', 0)],
+                         options=[{'no_local': True}])
+        suback = [p for p in conn.packets() if isinstance(p, MQTTSuback)][0]
+        assert suback.reason_codes == [0]
+
+
+# ===========================================================================
+# §4.8.2 retained exclusion + §3.3.1.3 Retain Handling 1 rider
+# ===========================================================================
+
+class TestRetainedInteraction:
+    async def test_shared_subscription_never_receives_retained(self):
+        broker = BrokerActor()
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub, payload=b'r', retain=True)
+
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('$share/g/t', 0)])
+        assert conn.publishes() == []
+
+    async def test_rh1_delivers_retained_on_new_subscription(self):
+        broker = BrokerActor()
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub, payload=b'r', retain=True)
+
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('t', 0)],
+                         options=[{'retain_handling': 1}])
+        assert len(conn.publishes()) == 1
+
+    async def test_rh1_skips_retained_on_existing_subscription(self):
+        broker = BrokerActor()
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub, payload=b'r', retain=True)
+
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('t', 0)],
+                         options=[{'retain_handling': 1}])
+        conn.outbox.clear()
+        # Re-SUBSCRIBE to the same filter: subscription already exists.
+        await _subscribe(broker, conn, 2, [('t', 0)],
+                         options=[{'retain_handling': 1}])
+        assert conn.publishes() == []
+
+    async def test_rh0_redelivers_retained_on_resubscribe(self):
+        broker = BrokerActor()
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub, payload=b'r', retain=True)
+
+        conn = RecordingConn()
+        await _attach(broker, conn, client_id='c1')
+        await _subscribe(broker, conn, 1, [('t', 0)])
+        conn.outbox.clear()
+        await _subscribe(broker, conn, 2, [('t', 0)])   # RH defaults to 0
+        assert len(conn.publishes()) == 1
+
+
+# ===========================================================================
+# Rotation-state hygiene
+# ===========================================================================
+
+class TestRotationState:
+    async def test_rotation_state_pruned_when_group_empties(self):
+        broker = BrokerActor()
+        a, b = await _group(broker, 2)
+        pub = RecordingConn()
+        await _attach(broker, pub, client_id='pub')
+        await _publish(broker, pub)
+        assert ('pool', 't') in broker._share_rotation
+
+        await broker._handle(ClientUnsubscribe(
+            unsubscribe=MQTTUnsubscribe(packet_id=5, topics=['$share/pool/t']),
+            sender=a))
+        await broker._handle(Detach(graceful=True, sender=b))  # session dropped
+        assert ('pool', 't') not in broker._share_rotation


### PR DESCRIPTION
## Summary

Sprint 75 — replaces the Sprint 70 `0x9E` fence with real MQTT 5 §4.8.2 shared subscriptions, plus both riders (Retain Handling 1, TLS for raw protocol bindings — neither ballooned, so neither was cut).

### Shared subscriptions (core)

- Subscribers naming the same `$share/{ShareName}/{filter}` pair form a share group; each matching message is delivered to **exactly one** connected member, round-robin per group, at that member's granted QoS. Non-shared subscriptions keep broadcast semantics; a client holding both gets the non-shared copy independently of rotation.
- Membership is **derived from session subscriptions at routing time** (the proposal's "keep it derived" latitude); only the per-group rotation cursor is stored, pruned when a group loses its last subscriber.
- Disconnected members with live sessions are skipped while any member is connected (§4.8.2.3). With **no member connected the message is not queued** — documented choice, consistent with the broker's existing no-offline-queue behaviour for non-shared subscriptions.
- `No Local` on a shared subscription → Protocol Error: DISCONNECT `0x82` + close (§3.8.3.1 [MQTT-3.8.3-4], §4.13). **Note**: the proposal said `0x9C`, but that code is *Use Another Server* — implemented per the spec instead (stub-spec-error convention: fix and report).
- Malformed `$share` forms reject per-entry with `0x8F`; `validate_topic_filter` now also rejects an empty filter portion (`$share/g/`), which previously validated.
- Shared subscriptions never receive retained messages (§4.8.2).
- Resolves the CONNACK conformance wrinkle: `shared_subscription_available` (0x2A) stays absent = *supported*, which is now true.

### Riders

- **Retain Handling 1** (§3.3.1.3): retained delivery on SUBSCRIBE only when the subscription did not previously exist; RH 0/2 unchanged.
- **TLS for raw bindings**: `app.raw_handler(name, port=…, tls=True)` / `MQTTExtension(port=8883, tls=True)` serve the binding's port through the server's TLS machinery (dedicated context without the HTTP ALPN list). Cleartext stays the default; `tls=True` with no certificate fails fast. Works single- and multi-worker (worker 0 path shares `Server.run()`). Also fixes multiple `port=0` bindings collapsing to one listener.

### Spec change on existing tests

`test_shared_subscription_rejected` (0x9E contract, `test_mqtt_hardening.py`) flips to `test_shared_subscription_granted` — old contract replaced per the sprint scope, recorded in the core commit.

## Verification

- 18 new broker-level unit tests (`test_mqtt_shared_subscriptions.py`): rotation, exactly-one, both-kinds client, per-member granted QoS, membership churn, no-connected-member, No Local `0x82`, malformed-`$share` `0x8F`, retained exclusion, RH0/RH1 matrix, cursor pruning.
- 4 new integration tests (`test_raw_binding_tls.py`): TLS echo round-trip, cleartext-to-TLS-port never reaches the handler, cleartext binding unaffected beside TLS, fail-fast without certs.
- Full suite + beartype green (5217 passed; one unrelated gRPC health-watch flake passed in isolation).
- Interop smoke with real `paho-mqtt 2.1.0` clients: two members in `$share/pool/jobs/#` received `job-0/2/4` vs `job-1/3/5` (exactly-one, balanced); `mqtts://` publish/subscribe round-trip via `MQTTExtension(tls=True)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)