### PR TITLE
release: v0.57.0 — Sprint 75: MQTT 5 shared subscriptions + TLS raw bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.57.0] — 2026-07-17
+
 ### Added
 
 - **MQTT 5 shared subscriptions** (§4.8.2, Sprint 75). Subscribers naming the

--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ One process, more than one protocol. Extensions attach non-HTTP
 protocols through a single seam — `app.add_extension(...)` — while the
 HTTP core stays protocol-agnostic. The flagship is a **pure-Python
 MQTT 5 broker**: CONNECT / SUBSCRIBE / PUBLISH at QoS 0–2, retained
-messages, and Last-Will on the standard `:1883` port, beside your HTTP
-routes — no Mosquitto sidecar, no C extension.
+messages, Last-Will, and shared subscriptions (`$share/…` work queues)
+on the standard `:1883` port — or over TLS with
+`MQTTExtension(port=8883, tls=True)` — beside your HTTP routes, no
+Mosquitto sidecar, no C extension.
 
 ```python
 from blackbull import BlackBull

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 |---------|--------------------|
+| 0.57.x  | :white_check_mark: |
 | 0.56.x  | :white_check_mark: |
-| 0.55.x  | :white_check_mark: |
-| < 0.55  | :x:                |
+| < 0.56  | :x:                |
 
 This table updates with each minor release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.56.0"
+version = "0.57.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Sprint 75 close. Feature work landed in #159; this PR is the two-file release commit (version bump + CHANGELOG heading) plus the pre-release docs audit (README MQTT headline, SECURITY supported-versions table → 0.57.x/0.56.x).

- **MQTT 5 shared subscriptions** (§4.8.2): `$share/{ShareName}/{filter}` groups, exactly-one round-robin delivery per group, offline-member skipping, retained exclusion, No Local → `0x82`.
- **Retain Handling 1** (§3.3.1.3): retained delivery only on new subscriptions.
- **TLS for raw protocol bindings**: `tls=True` per binding / `MQTTExtension(port=8883, tls=True)` for `mqtts://`; fail-fast without a certificate.
- **Spec change**: well-formed `$share` grants replace the `0x9E` fence; malformed forms → `0x8F`.

## Test plan

- [x] Full suite + beartype green on master post-merge of #159 (5217 passed)
- [x] paho-mqtt interop smoke: alternating exactly-one delivery in a share group; `mqtts://` round-trip
- [x] `mkdocs build --strict` passes
- [x] Editable-install smoke: `blackbull.__version__` → 0.57.0
- [x] CodeQL / CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)