### PR TITLE
docs: fix stale MQTT subscription-options block in KNOWN_LIMITATIONS

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -173,13 +173,14 @@ across a restart.  A restart, or a worker-0 respawn after a crash, clears
 all session and retained state.  Sessions are also kept for the process
 lifetime rather than expired on a timer.
 
-**Subscription options are persisted but not fully enforced.**  No Local
-and Retain As Published are parsed and stored in the session (and survive
-a Clean Start = 0 reconnect, §3.1.2.11) but are **not yet applied during
-delivery**.  Retain Handling is honoured only coarsely: `2` (don't send)
-suppresses the retained delivery on subscribe, while `0` and `1` both
-send it — the §3.8.3.1 "only on a *new* subscription" nuance of `1` is
-not yet distinguished.
+**New messages are not queued for offline sessions.**  A disconnected
+client with a live session (`Session Expiry Interval > 0`) gets §4.4
+replay of its *unacknowledged in-flight* QoS 1/2 messages on reconnect,
+but messages **newly published while it was offline are not queued** and
+will never be delivered to it.  The same applies to a shared-subscription
+group with no connected member (see
+[`docs/guide/mqtt.md`](docs/guide/mqtt.md)).  If you need store-and-forward
+for offline consumers, use a broker with persistent offline queues.
 
 ### Multi-worker scaling tops out at physical core count
 


### PR DESCRIPTION
## Summary

Pre-release audit follow-up (surfaced while checking KNOWN_LIMITATIONS.md for staleness after v0.57.0):

- The **"Subscription options are persisted but not fully enforced"** paragraph was stale on both claims: No Local and Retain As Published have been enforced at delivery since Sprint 70 (`BrokerActor._route`), and Retain Handling 1's new-subscription-only nuance shipped in Sprint 75 / v0.57.0 — RH 0/1/2 are now fully honoured, with tests.
- Replaced with the delivery gap that genuinely remains: **new messages are not queued for offline sessions** (only §4.4 in-flight replay on reconnect), consistent with the shared-subscription empty-group behaviour documented in the MQTT guide.

Docs-only; ships with the next release per the no-removal-only-releases convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)