### PR TITLE
docs: edge inference API server positioning — guide page + runnable example (Sprint 76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,19 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **Edge inference API server positioning (Sprint 76).** New guide page
+  [Edge inference serving](docs/guide/edge-inference.md): the one-process
+  edge serving shape — SSE token streaming with HTTP/2 multiplexing for
+  interactive clients beside MQTT device ingest and `$share/…` work queues
+  for devices — including how to run a real (CPU-bound) model off-thread,
+  and an explicit when-this-fits / when-it-doesn't section. Ships with the
+  runnable, dependency-free `examples/edge_inference.py` (fake token model,
+  browser `EventSource` demo, tap-fed `/devices` + `/status`). README,
+  `docs/index.md`, the guide overview, and *Why BlackBull?* carry the
+  positioning hooks.
+
 ## [0.57.0] — 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Hello, world!
 - **Multi-protocol, one process.** A pure-Python MQTT 5 broker and
   gRPC ride beside HTTP/2 and WebSocket on the same runtime;
   extensions add new protocols without touching the core — still no
-  C extension.
+  C extension.  That combination is an
+  [edge inference API server](https://TOKUJI.github.io/BlackBull/guide/edge-inference/)
+  in one `python app.py`: SSE token streaming with HTTP/2
+  multiplexing for clients, MQTT ingest and `$share/…` work queues
+  for devices — on any box CPython runs on, ARM included.
 - **Actor-model internals.** Connection-level isolation without a
   single shared lock: a `ConnectionActor` spawns a per-connection
   protocol actor whose inbox loop owns its own state.  The same
@@ -293,6 +297,7 @@ for the full tutorial.
 | [`examples/ChatServer/`](examples/ChatServer/) | WebSocket, SSE, long polling side by side; `blackbull-session` + Compression + custom auth |
 | [`examples/mqtt_broker.py`](examples/mqtt_broker.py) | MQTT 5 broker beside HTTP; `on_message` taps with `{capture}` topic params |
 | [`examples/translation_hub.py`](examples/translation_hub.py) | Protocol translation hub — MQTT → WebSocket, MQTT → SSE, REST → gRPC in one process |
+| [`examples/edge_inference.py`](examples/edge_inference.py) | Edge inference API server — SSE token streaming (browser demo included) + MQTT telemetry + `$share` work queue, dependency-free fake model |
 | [`examples/grpc_greeter.py`](examples/grpc_greeter.py) | Canonical gRPC Greeter speaking real protobuf — works with stock `grpcurl` / `grpcio` clients unmodified |
 | [`examples/typed_routes_ok.py`](examples/typed_routes_ok.py) | `{param:converter}` syntax, `url_path_for` |
 | [`examples/scenario_h1_fault_injection.py`](examples/scenario_h1_fault_injection.py) | HTTP/1.1 fault scenarios driven against stdlib `http.server` |

--- a/docs/getting-started/why-blackbull.md
+++ b/docs/getting-started/why-blackbull.md
@@ -15,6 +15,15 @@ gRPC — all from a single `python app.py` on a small box. Most Python stacks
 need a reverse proxy plus a separate MQTT broker; BlackBull serves all of it
 in one runtime, on one process.
 
+### Streaming inference from an edge box
+
+You're serving a local model from a Raspberry-Pi-class device: browsers
+want tokens streamed as they're generated (SSE, multiplexed over HTTP/2),
+devices report telemetry and drop jobs over MQTT, and the box has no room
+for a proxy + broker + ASGI-server stack. One BlackBull process covers the
+whole surface — [Edge inference serving](../guide/edge-inference.md) walks
+it end to end.
+
 ### You want to see what your HTTP server is doing
 
 Every frame, every stream-state transition, every HPACK encoding is visible

--- a/docs/guide/edge-inference.md
+++ b/docs/guide/edge-inference.md
@@ -1,0 +1,216 @@
+# Edge inference serving
+
+A recurring deployment shape for local ML models: a
+Raspberry-Pi-class box (often ARM, often headless) runs a model and
+has to serve two very different kinds of traffic at once —
+
+- **interactive clients** — browser tabs, `curl`, `httpx` — that call
+  an HTTP endpoint and want the answer *streamed token by token* as
+  it is generated, and
+- **devices** — sensors, cameras, controllers — that report telemetry
+  and drop batch jobs over **MQTT**, the protocol they already speak.
+
+The conventional stack for this is three or four moving parts: an
+ASGI server for HTTP, a reverse proxy in front of it for HTTP/2, a
+separate MQTT broker, and whatever glue keeps them coordinated. On
+an edge box every extra part is another daemon to provision, another
+config file, and — on ARM or RISC-V — potentially another native
+dependency to cross-compile.
+
+BlackBull's bet is that one process can carry the whole surface:
+
+```
+                        one Python process
+┌──────────────────────────────────────────────────────────┐
+│  :8000   HTTP/1.1 · HTTP/2 (h2c, or ALPN with TLS)       │
+│     GET /generate   ──►  SSE token stream                │
+│     GET /devices    ──►  latest readings (JSON)          │
+│                                                          │
+│  :1883   MQTT 5 broker                                   │
+│     sensors/{device}/{metric}  ──►  tap → in-memory      │
+│     jobs/#          ──►  $share/… round-robin work queue │
+└──────────────────────────────────────────────────────────┘
+    browsers · curl · httpx           devices · workers
+```
+
+Everything above is pure Python — no C extensions, so `pip install
+blackbull` completes on any architecture CPython runs on, with no
+build step and nothing to cross-compile. The runnable version of
+this page is
+[`examples/edge_inference.py`](https://github.com/TOKUJI/BlackBull/blob/master/examples/edge_inference.py).
+
+## The serving surface: SSE token streaming
+
+Token-streaming inference is a plain streaming handler: iterate the
+model, yield one SSE event per token
+(see [Streaming](streaming.md) for the full surface):
+
+```python
+from blackbull import BlackBull, EventSourceResponse
+
+app = BlackBull()
+
+@app.route(path='/generate')
+async def generate(prompt: str = 'Hello, edge'):
+    async def events():
+        async for token in fake_model(prompt):
+            yield {'event': 'token', 'data': token}
+        yield {'event': 'done', 'data': ''}
+    return EventSourceResponse(events())
+```
+
+`prompt` resolves from the query string, which keeps the endpoint
+compatible with the browser's `EventSource` API (GET-only). Each
+`yield` is written to the wire as it happens — transport
+backpressure, not buffering, paces the stream — so the first token
+reaches the client while the rest are still being generated.
+
+Concurrent generations are where HTTP/2 earns its place: several
+`/generate` streams multiplex over one connection instead of
+queueing head-of-line behind each other. No extra setup is needed —
+cleartext **h2c** is detected from the connection preface:
+
+```bash
+curl --http2-prior-knowledge -N 'http://localhost:8000/generate?prompt=hi'
+```
+
+Browsers require HTTP/2 over TLS; pass `certfile=` / `keyfile=` to
+`app.run` and ALPN negotiates `h2` on the same port
+([TLS deployment](../deployment/tls.md)).
+
+### Swapping in a real model
+
+The example's `fake_model` is an async generator that sleeps between
+tokens. A real model is *CPU-bound* (or NPU/GPU-bound behind a
+blocking call), and running it inline would stall the event loop —
+every other stream, and the MQTT broker, would freeze between
+tokens. Keep the loop free by pushing inference off-thread and
+draining tokens through a queue:
+
+```python
+import asyncio
+
+async def real_model(prompt: str):
+    q: asyncio.Queue[str | None] = asyncio.Queue()
+    loop = asyncio.get_running_loop()
+
+    def run():                      # blocking generation, worker thread
+        for token in llm.generate(prompt):        # llama-cpp, ONNX, ...
+            loop.call_soon_threadsafe(q.put_nowait, token)
+        loop.call_soon_threadsafe(q.put_nowait, None)
+
+    task = asyncio.create_task(asyncio.to_thread(run))
+    try:
+        while (token := await q.get()) is not None:
+            yield token
+    finally:
+        task.cancel()
+```
+
+The serving code around it — the route, the SSE framing, the
+multiplexing — is unchanged.
+
+## Device ingest: the broker you already run
+
+`MQTTExtension` puts a full [MQTT 5 broker](mqtt.md) in the same
+process. Devices connect to `:1883` with any standard client;
+`on_message` taps let the application observe the traffic — here,
+keeping the latest reading per device for the HTTP side to report:
+
+```python
+from blackbull.mqtt import MQTTExtension, Message
+
+mqtt = app.add_extension(MQTTExtension(port=1883))
+_readings: dict[str, dict[str, str]] = {}
+
+@mqtt.on_message(topic='sensors/{device}/{metric}')
+async def on_reading(msg: Message, device: str, metric: str):
+    _readings.setdefault(device, {})[metric] = msg.payload.decode()
+
+@app.route(path='/devices')
+async def devices():
+    return _readings
+```
+
+`{device}` and `{metric}` are captures — they match one topic level
+like `+` and arrive as keyword arguments, the MQTT counterpart of
+HTTP path params. Taps observe routing; delivery to subscribed MQTT
+clients happens whether or not a tap matches.
+
+## Batch jobs: a work queue with no queue server
+
+Interactive requests take the HTTP door; batch work takes the MQTT
+door. **Shared subscriptions** (MQTT 5 §4.8.2) turn a topic into a
+load-balanced work queue: every worker that subscribes to the same
+`$share/{group}/{filter}` joins a share group, and the broker gives
+each matching message to exactly **one** member, round-robin.
+
+```bash
+mosquitto_sub -t '$share/workers/jobs/#' -p 1883 -V 5    # worker 1
+mosquitto_sub -t '$share/workers/jobs/#' -p 1883 -V 5    # worker 2
+mosquitto_pub -t 'jobs/generate' -m '{"prompt": "job-1"}' -p 1883 -V 5
+mosquitto_pub -t 'jobs/generate' -m '{"prompt": "job-2"}' -p 1883 -V 5
+```
+
+`job-1` and `job-2` land on different workers. Scaling the pool is
+starting another subscriber — no queue server, no client library
+beyond MQTT, and the broker is the process you already run. The
+[shared-subscriptions section of the MQTT guide](mqtt.md#shared-subscriptions)
+covers the exact semantics (QoS, skipped members, retained
+messages).
+
+Two honest caveats for queue duty:
+
+- **No offline buffering for an empty group.** If no member is
+  connected when a job is published, the job is dropped, not queued
+  (the broker's general no-offline-queue behaviour). Keep at least
+  one worker connected whenever producers are publishing.
+- **Queue state lives in this process.** A broker restart clears
+  in-flight session state; there is no persistence layer.
+
+## When this shape fits — and when it doesn't
+
+This is deliberately a *narrow* pitch. It fits when:
+
+- the deployment target is **one box** — an edge device, a
+  single-board computer, a small VM — and you want the whole serving
+  surface in one `python app.py`;
+- clients genuinely benefit from **streamed output** and **HTTP/2
+  multiplexing** (several consumers per connection);
+- devices already speak **MQTT** and you'd rather not operate a
+  separate broker for them;
+- the target is **ARM / RISC-V / anything without a C toolchain**,
+  where "no native dependencies" is the difference between `pip
+  install` and an afternoon of cross-compilation.
+
+It is *not* the right shape when:
+
+- **inference throughput is the bottleneck** — BlackBull moves the
+  bytes; it does not batch, schedule, or accelerate the model. A
+  dedicated inference server in front of the GPU does more for
+  throughput than any web framework choice;
+- you need a **fleet-scale message bus** — the broker runs on one
+  worker process, in memory ([limitations](mqtt.md#limitations));
+  it is a device-gateway broker, not a clustered one;
+- your stack needs **Trio/AnyIO**, or the other trade-offs in
+  [Is BlackBull right for your project?](../getting-started/why-blackbull.md)
+  cut against you.
+
+## Run it
+
+```bash
+pip install blackbull
+python examples/edge_inference.py
+```
+
+Then, in other terminals:
+
+```bash
+curl -N 'http://localhost:8000/generate?prompt=hello+edge'   # SSE tokens
+open http://localhost:8000/                                  # browser demo
+mosquitto_pub -t 'sensors/pi-cam-1/temperature' -m '41.2' -p 1883 -V 5
+curl http://localhost:8000/devices
+```
+
+The example is dependency-free — the "model" is canned tokens — so
+it runs anywhere, including the box you're about to deploy to.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -30,6 +30,10 @@ first — it covers installation and the shape of a minimal app.
   (WebSocket over HTTP/2), subprotocols, fragmented messages.
 - [**HTTP/2**](http2.md) — ALPN, priority hints,
   `http.response.push`, flow control, h2c.
+- [**Edge inference serving**](edge-inference.md) — the
+  one-process shape for serving a local model: SSE token
+  streaming over HTTP/2 beside MQTT device ingest and a
+  `$share` work queue.
 - [**Events**](events.md) — `@app.on` (observation) and
   `@app.intercept` (interception) for lifecycle hooks.
 - [**Logging**](logging.md) — access log, framework log,

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,10 @@ the standard library, one `pip install`, one deployable.
   (all four RPC shapes, `gzip` compression) over the same HTTP/2 port;
   `app.add_extension(MQTTExtension(...))` runs a pure-Python MQTT 5
   broker on its own port, in the same process.
+- **An edge inference serving shape** — SSE token streaming with
+  HTTP/2 multiplexing beside MQTT device ingest and `$share/…`
+  work queues, in one process that `pip install`s on ARM with no
+  C toolchain.  See [Edge inference serving](guide/edge-inference.md).
 - **Standards conformance** — RFC 9112 (HTTP/1.1), RFC 9113
   (HTTP/2 — h2spec passes), RFC 6455 (WebSocket — Autobahn passes),
   RFC 8441 (Extended CONNECT for WebSocket over HTTP/2).
@@ -90,6 +94,9 @@ ASGI-triplet form.
 - New to BlackBull? Start with [Installation](getting-started/installation.md).
 - Building something? The [Guide](guide/index.md) covers routing,
   middleware, WebSockets, error handling, HTTP/2, and configuration.
+- Serving a local model from a small box?
+  [Edge inference serving](guide/edge-inference.md) walks the
+  one-process shape end to end, with a runnable example.
 - Deploying? See [Deployment](deployment/running.md) for multi-worker,
   TLS, AF_UNIX, systemd activation, and behind-nginx topologies.
 - Curious about the design? [Architecture](about/architecture.md) covers

--- a/examples/edge_inference.py
+++ b/examples/edge_inference.py
@@ -1,0 +1,157 @@
+"""Edge inference API server — one Python process, one small box.
+
+The scenario: a Raspberry-Pi-class device runs a local model and has to
+serve two kinds of traffic at once —
+
+* **Interactive clients** (browser tabs, `curl`, httpx) call an HTTP
+  endpoint and want the answer *streamed token by token* as it is
+  generated, not buffered until the end.
+* **Devices** report telemetry and drop batch jobs over **MQTT**, the
+  protocol they already speak.
+
+One BlackBull process covers both: HTTP/1.1 + HTTP/2 with an SSE
+token-streaming endpoint on :8000, and a full MQTT 5 broker on :1883.
+No reverse proxy, no separate broker, no C extensions — the whole stack
+is Python you can step through.  The "model" here is fake (a canned
+token generator) so the example runs with no ML dependency; swap
+``fake_model`` for a real one and the serving surface is unchanged.
+
+Run it::
+
+    python examples/edge_inference.py
+
+Streaming inference (SSE):
+
+    curl -N 'http://localhost:8000/generate?prompt=hello+edge'
+    open http://localhost:8000/          # browser EventSource demo
+
+Device telemetry over MQTT (``apt install mosquitto-clients``)::
+
+    mosquitto_pub -t 'sensors/pi-cam-1/temperature' -m '41.2' -p 1883 -V 5
+    curl http://localhost:8000/devices   # latest reading per device
+
+Batch jobs as a shared-subscription work queue (MQTT 5 §4.8.2) — every
+worker that subscribes to the same ``$share/{group}/{filter}`` joins a
+share group, and the broker gives each job to exactly **one** member,
+round-robin::
+
+    mosquitto_sub -t '$share/workers/jobs/#' -p 1883 -V 5    # terminal 1
+    mosquitto_sub -t '$share/workers/jobs/#' -p 1883 -V 5    # terminal 2
+    mosquitto_pub -t 'jobs/generate' -m '{"prompt": "job-1"}' -p 1883 -V 5
+    mosquitto_pub -t 'jobs/generate' -m '{"prompt": "job-2"}' -p 1883 -V 5
+
+The two publishes land on different terminals — a load-balanced work
+queue with no queue server beyond the broker this process already runs.
+``curl http://localhost:8000/status`` shows what the process has seen.
+
+HTTP/2 works on the same port with no extra setup — cleartext h2c is
+detected from the connection preface, so several ``/generate`` streams
+multiplex over one connection::
+
+    curl --http2-prior-knowledge -N 'http://localhost:8000/generate?prompt=h2'
+
+(For browsers, which require HTTP/2 over TLS, pass ``certfile=`` /
+``keyfile=`` to ``app.run`` and ALPN negotiates ``h2``.)
+"""
+from __future__ import annotations
+
+import asyncio
+
+from blackbull import BlackBull, EventSourceResponse, Response
+from blackbull.mqtt import MQTTExtension, Message
+
+app = BlackBull()
+mqtt = app.add_extension(MQTTExtension(port=1883))
+
+
+# --- The "model" -----------------------------------------------------------
+# A stand-in for real inference: emits one token at a time with a small
+# delay, exactly the shape a local LLM runtime hands back.
+
+_CANNED = ("Tokens stream over SSE as they are produced , so a slow "
+           "generation is visible immediately instead of after the last "
+           "token .").split()
+
+
+async def fake_model(prompt: str):
+    yield f'{prompt} →'
+    for token in _CANNED:
+        await asyncio.sleep(0.15)          # simulated per-token compute
+        yield token
+
+
+# --- HTTP: the interactive inference surface -------------------------------
+
+@app.route(path='/generate')
+async def generate(prompt: str = 'Hello, edge'):
+    """Stream one SSE event per generated token; ``done`` terminates."""
+    async def events():
+        async for token in fake_model(prompt):
+            yield {'event': 'token', 'data': token}
+        yield {'event': 'done', 'data': ''}
+    return EventSourceResponse(events())
+
+
+_HTML = b"""<!doctype html>
+<title>BlackBull edge inference demo</title>
+<body style="font-family: ui-monospace, monospace; padding: 2rem;">
+<h1>BlackBull edge inference demo</h1>
+<form id="f"><input id="p" value="Hello, edge" size="40">
+<button>Generate</button></form>
+<pre id="out" style="background: #f4f4f4; padding: 1rem; min-height: 4rem;"></pre>
+<script>
+const out = document.getElementById('out');
+document.getElementById('f').addEventListener('submit', e => {
+  e.preventDefault();
+  out.textContent = '';
+  const es = new EventSource(
+    '/generate?prompt=' + encodeURIComponent(document.getElementById('p').value));
+  es.addEventListener('token', e => { out.textContent += e.data + ' '; });
+  es.addEventListener('done',  () => es.close());
+});
+</script>
+"""
+
+
+@app.route(path='/')
+async def index():
+    return Response(_HTML, content_type='text/html; charset=utf-8')
+
+
+# --- MQTT: device ingest on the same process -------------------------------
+# Taps observe the broker's routing; delivery to subscribed MQTT clients
+# (including the $share work-queue groups) happens whether or not a tap
+# matches.
+
+_readings: dict[str, dict[str, str]] = {}     # device -> metric -> latest
+_jobs_seen = 0
+
+
+@mqtt.on_message(topic='sensors/{device}/{metric}')
+async def on_reading(msg: Message, device: str, metric: str):
+    _readings.setdefault(device, {})[metric] = msg.payload.decode('utf-8', 'replace')
+
+
+@mqtt.on_message(topic='jobs/#')
+async def on_job(msg: Message):
+    global _jobs_seen
+    _jobs_seen += 1                # broker hands the job to one $share member
+
+
+@app.route(path='/devices')
+async def devices():
+    """Latest reading per device, fed by the MQTT tap above."""
+    return _readings
+
+
+@app.route(path='/status')
+async def status():
+    return {
+        'devices': len(_readings),
+        'jobs_dispatched': _jobs_seen,
+        'work_queue': 'subscribe $share/workers/jobs/# to join the pool',
+    }
+
+
+if __name__ == '__main__':
+    app.run(port=8000)   # HTTP/1.1 + h2c on 8000, MQTT broker on 1883

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - MQTT broker: guide/mqtt.md
     - gRPC: guide/grpc.md
     - Protocol translation hub: guide/translation-hub.md
+    - Edge inference serving: guide/edge-inference.md
     - Streaming: guide/streaming.md
     - Events: guide/events.md
     - Logging: guide/logging.md


### PR DESCRIPTION
## Summary

Sprint 76 (C2, content sprint): position BlackBull as an **edge inference API server** — *one Python process, HTTP/2 + SSE token streaming for interactive clients, MQTT 5 device ingest with `$share` work queues for devices, no C dependencies, ARM-friendly.*

- **`docs/guide/edge-inference.md`** — the pitch and architecture sketch, the SSE serving surface, the real-model off-thread pattern (CPU-bound generation via `asyncio.to_thread` + queue), the `$share` work-queue story, and an explicit when-this-fits / when-it-doesn't section. Per the humble-docs pin: BlackBull on its own terms, no peer-framework comparisons, honest caveats (no offline queueing for an empty share group, single-worker in-memory broker, "BlackBull moves the bytes; it does not accelerate the model").
- **`examples/edge_inference.py`** — runnable, dependency-free: fake token model streaming over SSE (browser `EventSource` demo page included), `sensors/{device}/{metric}` taps feeding `/devices`, `jobs/#` tap feeding `/status`, docstring walkthrough for the `$share/workers` pool via mosquitto.
- **Positioning hooks** — README (Why-bullet extension + examples-table row), `docs/index.md` (What-you-get bullet + next-steps line), guide overview row, *Why BlackBull?* scenario.
- **mkdocs**: nav entry added; `mkdocs build --strict` green.
- CHANGELOG `[Unreleased]` entry (folds into v0.58.0 at sprint close).

Launch-post draft (inter-sprint distribution material) lives in `.claude/planning/proposals/edge-inference-launch-draft.md` (git-ignored, not in this diff).

## Test plan

- Live smoke test of the example: SSE streams tokens (`curl -N`), **h2c** multiplexing works (`curl --http2-prior-knowledge`), browser demo page serves.
- MQTT side driven with a raw MQTT 5 client against the live broker: 4 jobs published to `jobs/generate` split **2/2 round-robin** across two `$share/workers/jobs/#` subscribers with no duplicates; sensor publishes appear in `/devices`; `/status` counts 4 dispatched jobs.
- Pre-commit hook ran the full beartype-instrumented pytest suite + strict mkdocs build: all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)