### PR TITLE
perf: router trie fast path — static-path map + iterative DFS lookup (Sprint 77, router-cache Phase 2)

### DIFF
--- a/bench/router_microbench.py
+++ b/bench/router_microbench.py
@@ -1,0 +1,99 @@
+"""Router `_resolve` microbenchmark — Sprint 77 (router-cache Phase 2/3).
+
+Measures the per-call cost of ``Router._resolve`` (cache bypassed) and
+``Router.__getitem__`` (cache path) across the regimes the proposal names:
+
+- fixed-route hit          (trie walk, no params)
+- param-route hit          (trie walk + converter + injector)
+- deep param-route hit     (5 segments)
+- miss → PathNotRegistered (trie miss + regex-fallback scan)
+- miss → MethodNotApplicable
+
+Run:  python bench/router_microbench.py [--repeat 7] [--number 20000]
+
+Numbers print as ns/call (min of repeats — standard timeit discipline).
+Results for sprint records go under bench/results/router-microbench/.
+"""
+import argparse
+import timeit
+from http import HTTPMethod
+
+from blackbull.router import (
+    MethodNotApplicable, PathNotRegistered, Router,
+)
+from blackbull.utils import Scheme
+
+
+async def _h(scope, receive, send):
+    return None
+
+
+def build_router(n_fixed: int = 30, n_param: int = 10) -> Router:
+    """A route table shaped like a realistic small API (like Sprint 68 W2)."""
+    r = Router()
+    for i in range(n_fixed):
+        r[(f'/api/resource{i}/list', HTTPMethod.GET)] = _h
+    for i in range(n_param):
+        r[(f'/api/resource{i}/{{item_id:int}}', HTTPMethod.GET)] = _h
+    r[('/api/deep/{a}/{b}/{c}/{d:int}/{e}', HTTPMethod.GET)] = _h
+    r[('/', HTTPMethod.GET)] = _h
+    return r
+
+
+CASES = {
+    'fixed_hit':        ('/api/resource7/list', HTTPMethod.GET),
+    'param_hit':        ('/api/resource7/12345', HTTPMethod.GET),
+    'deep_param_hit':   ('/api/deep/a/b/c/42/e', HTTPMethod.GET),
+    'miss_404':         ('/nope/not/here', HTTPMethod.GET),
+    'miss_405':         ('/api/resource7/list', HTTPMethod.POST),
+}
+
+
+def bench(fn, number: int, repeat: int) -> float:
+    best = min(timeit.repeat(fn, number=number, repeat=repeat))
+    return best / number * 1e9
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--number', type=int, default=20000)
+    ap.add_argument('--repeat', type=int, default=7)
+    args = ap.parse_args()
+
+    r = build_router()
+    r.validate()
+    scheme = Scheme.http
+
+    print(f'{"case":<18} {"_resolve ns":>12} {"__getitem__ ns":>15}')
+    for name, (path, method) in CASES.items():
+        key = (path, method, scheme)
+        if name.startswith('miss'):
+            exc = (PathNotRegistered, MethodNotApplicable)
+
+            def resolve_call(key=key, exc=exc):
+                try:
+                    r._resolve(key)
+                except exc:
+                    pass
+
+            def getitem_call(key=key, exc=exc):
+                try:
+                    r[key]
+                except exc:
+                    pass
+        else:
+            def resolve_call(key=key):
+                r._resolve(key)
+
+            def getitem_call(key=key):
+                r[key]
+
+        resolve_ns = bench(resolve_call, args.number, args.repeat)
+        # Prime the cache, then measure the cached path.
+        getitem_call()
+        getitem_ns = bench(getitem_call, args.number, args.repeat)
+        print(f'{name:<18} {resolve_ns:>12.0f} {getitem_ns:>15.0f}')
+
+
+if __name__ == '__main__':
+    main()

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -66,6 +66,10 @@ _SAMPLE_INPUTS: dict[str, str] = {
 # literal paths ('/openapi.json') and harmless.
 _REGEX_METACHARS = frozenset('^$*+?()[]|\\')
 
+# Shared empty allowed-methods set returned on trie-lookup hits — hits never
+# read it, so one immutable instance avoids a per-hit set() allocation.
+_NO_METHODS: frozenset = frozenset()
+
 
 # ---------------------------------------------------------------------------
 # Module-level route-matching helpers (reused by Router and _RouteTrie)
@@ -85,7 +89,7 @@ def _route_method_matches(key_method, registered_methods: tuple) -> bool:
 # Routing trie — O(path-depth) lookup for string-path routes
 # ---------------------------------------------------------------------------
 
-@dataclass
+@dataclass(slots=True)
 class _TrieNode:
     children: dict[str, '_TrieNode'] = field(default_factory=dict)
     param_child: Optional['_TrieNode'] = None   # matches any single segment
@@ -100,6 +104,12 @@ class _RouteTrie:
 
     def __init__(self) -> None:
         self.root = _TrieNode()
+        # Fully-static registered paths → terminal node, keyed on both the
+        # raw registered path and its normalized ('/'-joined segments) form.
+        # Lets a canonical request path resolve with one dict probe instead
+        # of a segment walk; non-canonical forms (dup/trailing slashes) fall
+        # through to the walk, which drops empty segments.
+        self._static_full: dict[str, _TrieNode] = {}
 
     def insert(self, path: str, methods: tuple, scheme_key: Any, handler: Any) -> None:
         segments = [s for s in path.split('/') if s]
@@ -141,6 +151,9 @@ class _RouteTrie:
                 node = node.children[seg]
 
         node.entries.append((methods, scheme_key, handler, tuple(param_specs)))
+        if not param_specs:
+            self._static_full[path] = node
+            self._static_full['/' + '/'.join(segments)] = node
 
     def lookup(self, path: str, method: Any, scheme: Any) -> tuple:
         """Return (handler, params, allowed_methods).
@@ -148,8 +161,106 @@ class _RouteTrie:
         handler is None on miss; allowed_methods is non-empty when the path
         matched but the method was not registered (enables MethodNotApplicable).
         """
-        segments = [s for s in path.split('/') if s]
-        return self._lookup(self.root, segments, 0, [], method, scheme)
+        # Fast path 0: fully-static route + canonical request path — one dict
+        # probe replaces the whole segment walk.  A probe hit whose entries
+        # don't match (method/scheme) still falls through: a param branch may
+        # serve the same path with a different method.
+        node = self._static_full.get(path)
+        if node is not None:
+            hit = self._match_entries(node.entries, (), method, scheme)
+            if hit is not None:
+                return (hit[0], hit[1], _NO_METHODS)
+
+        # Canonical paths ('/a/b': leading slash, no duplicate or trailing
+        # slashes — the overwhelmingly common case) skip the filtering
+        # listcomp: split()'s only empty segment is the leading one, stepped
+        # over via *start*.  Non-canonical forms take the filtered build.
+        if not path or path.endswith('/') or '//' in path:
+            segments = [s for s in path.split('/') if s]
+            start = 0
+        else:
+            segments = path.split('/')
+            start = 1 if path[0] == '/' else 0
+        n = len(segments)
+
+        # Fast path 1: iterative depth-first walk for the hit case.  Same
+        # priority order as _lookup (static > param > wildcard at every node,
+        # with cross-level backtracking via an explicit stack) but with no
+        # recursion frames and no per-level set allocations.  The stack is
+        # created lazily — an unambiguous walk allocates nothing.  A miss
+        # falls through to the recursive walk, whose remaining job is
+        # collecting the allowed-methods set for MethodNotApplicable.
+        node = self.root
+        idx = start
+        caps: tuple = ()
+        stack = None
+        match_entries = self._match_entries
+        while True:
+            if idx == n:
+                hit = match_entries(node.entries, caps, method, scheme)
+                if hit is not None:
+                    return (hit[0], hit[1], _NO_METHODS)
+            else:
+                seg = segments[idx]
+                child = node.children.get(seg)
+                pc = node.param_child
+                wc = node.wildcard_child
+                if child is not None:
+                    # Record the lower-priority alternatives before
+                    # descending, so a dead end below can backtrack to them.
+                    if wc is not None:
+                        if stack is None:
+                            stack = []
+                        stack.append((wc, n, caps + ('/'.join(segments[idx:]),)))
+                    if pc is not None:
+                        if stack is None:
+                            stack = []
+                        stack.append((pc, idx + 1, caps + (seg,)))
+                    node = child
+                    idx += 1
+                    continue
+                if pc is not None:
+                    if wc is not None:
+                        if stack is None:
+                            stack = []
+                        stack.append((wc, n, caps + ('/'.join(segments[idx:]),)))
+                    node = pc
+                    idx += 1
+                    caps = caps + (seg,)
+                    continue
+                if wc is not None:
+                    caps = caps + ('/'.join(segments[idx:]),)
+                    node = wc
+                    idx = n
+                    continue
+            if not stack:
+                break
+            node, idx, caps = stack.pop()
+
+        return self._lookup(self.root, segments, start, [], method, scheme)
+
+    @staticmethod
+    def _match_entries(entries: list, caps: tuple, method: Any, scheme: Any):
+        """First entry whose method, scheme, and converters all accept →
+        (handler, params); None when nothing at this terminal matches."""
+        for ms, ss, handler, param_specs in entries:
+            if method not in ms:
+                continue
+            if not (isinstance(ss, _AnyScheme) or scheme in ss):
+                continue
+            try:
+                if not param_specs:
+                    params = {}
+                elif len(param_specs) == 1:
+                    name, conv, _ = param_specs[0]
+                    params = {name: conv(caps[0])}
+                else:
+                    params = {name: conv(caps[j])
+                              for j, (name, conv, _) in enumerate(param_specs)}
+            except (ValueError, TypeError):
+                continue
+            return (handler, params)
+        return None
 
     def _lookup(self, node: _TrieNode, segments: list, idx: int,
                 raw_caps: list, method: Any, scheme: Any) -> tuple:
@@ -1145,14 +1256,17 @@ class Router:
         self,
         key: Tuple[str, str | HTTPMethod, Scheme],
     ):
-        """Core route lookup — trie first, regex fallback.  Raises on miss."""
+        """Core route lookup — trie first, regex fallback.  Raises on miss.
+
+        No logging on the hit path: even a disabled ``logger.debug`` costs
+        ~100 ns/call, a measurable slice of the <1000 ns ``_resolve`` budget
+        (Sprint 77).  Miss-path logging is retained below.
+        """
         key_path, key_method, key_scheme = key
-        logger.debug("getitem key=%r", key)
 
         # --- 1. Trie lookup (all string-path routes) ----------------------
         h, params, trie_allowed = self._trie.lookup(key_path, key_method, key_scheme)
         if h is not None:
-            logger.debug("trie hit: handler=%r params=%r", h, params)
             if params:
                 _fn, _params = h, params
                 async def _inject(scope, receive, send,
@@ -1163,6 +1277,13 @@ class Router:
             return h
 
         # --- 2. Regex scan (fallback: raw re.Pattern routes only) ----------
+        # Skipped entirely when no re.Pattern routes are registered (the
+        # common case) — a miss then raises straight from the trie result.
+        if not self._raw_regex:
+            if trie_allowed:
+                raise MethodNotApplicable(trie_allowed)
+            raise PathNotRegistered(key_path)
+
         allowed_methods: set = set(trie_allowed)
         for (pattern, ms, ss), fn in self._raw_regex.items():
             m = pattern.match(key_path)

--- a/tests/unit/test_router_trie.py
+++ b/tests/unit/test_router_trie.py
@@ -112,6 +112,79 @@ def test_trie_multiple_params():
 
 
 # ---------------------------------------------------------------------------
+# Backtracking pins (Sprint 77) — behaviours the lookup fast path must keep
+# ---------------------------------------------------------------------------
+
+def test_trie_backtracks_to_param_when_static_dead_ends_deeper():
+    """A static branch that dead-ends below must fall back to a param branch
+    taken at an earlier level."""
+    static_h, param_h = object(), object()
+    trie = _RouteTrie()
+    trie.insert('/x/static/other', (HTTPMethod.GET,), Scheme.http, static_h)
+    trie.insert('/x/{a}/target', (HTTPMethod.GET,), Scheme.http, param_h)
+
+    h, params, _ = trie.lookup('/x/static/target', HTTPMethod.GET, Scheme.http)
+    assert h is param_h
+    assert params == {'a': 'static'}
+
+
+def test_trie_backtracks_on_method_mismatch_in_static_branch():
+    """Static-first priority is per-entry-match, not per-path: a method miss
+    on the static entry still lets a param sibling serve the request."""
+    get_h, post_h = object(), object()
+    trie = _RouteTrie()
+    trie.insert('/x/fixed', (HTTPMethod.GET,), Scheme.http, get_h)
+    trie.insert('/x/{a}', (HTTPMethod.POST,), Scheme.http, post_h)
+
+    h, params, _ = trie.lookup('/x/fixed', HTTPMethod.POST, Scheme.http)
+    assert h is post_h
+    assert params == {'a': 'fixed'}
+
+
+def test_trie_405_aggregates_allowed_methods_across_branches():
+    trie = _RouteTrie()
+    trie.insert('/x/fixed', (HTTPMethod.GET,), Scheme.http, object())
+    trie.insert('/x/{a}', (HTTPMethod.POST,), Scheme.http, object())
+
+    h, _, allowed = trie.lookup('/x/fixed', HTTPMethod.DELETE, Scheme.http)
+    assert h is None
+    assert HTTPMethod.GET in allowed and HTTPMethod.POST in allowed
+
+
+def test_trie_backtracks_to_wildcard_when_param_dead_ends():
+    param_h, wild_h = object(), object()
+    trie = _RouteTrie()
+    trie.insert('/f/{a}/b', (HTTPMethod.GET,), Scheme.http, param_h)
+    trie.insert('/f/{rest:path}', (HTTPMethod.GET,), Scheme.http, wild_h)
+
+    h, params, _ = trie.lookup('/f/q/z', HTTPMethod.GET, Scheme.http)
+    assert h is wild_h
+    assert params == {'rest': 'q/z'}
+
+
+def test_trie_converter_rejection_falls_back_to_wildcard_sibling():
+    int_h, wild_h = object(), object()
+    trie = _RouteTrie()
+    trie.insert('/i/{n:int}', (HTTPMethod.GET,), Scheme.http, int_h)
+    trie.insert('/i/{rest:path}', (HTTPMethod.GET,), Scheme.http, wild_h)
+
+    h, params, _ = trie.lookup('/i/abc', HTTPMethod.GET, Scheme.http)
+    assert h is wild_h
+    assert params == {'rest': 'abc'}
+
+
+def test_trie_slash_normalization_matches_static_route():
+    """Empty segments are dropped: trailing and duplicate slashes match the
+    canonical registered path."""
+    trie = _RouteTrie()
+    trie.insert('/api/x', (HTTPMethod.GET,), Scheme.http, _handler)
+    for variant in ('/api/x/', '//api//x', '/api/x//'):
+        h, params, _ = trie.lookup(variant, HTTPMethod.GET, Scheme.http)
+        assert h is _handler, variant
+        assert params == {}
+
+
+# ---------------------------------------------------------------------------
 # Router integration: trie is created and used
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Phase 2 of `router-cache-optimization.md` (Sprint 77 bench-window batch). Local microbench gate **met**: param-route `_resolve` **1555 → 959 ns** (<1000 ns gate), fixed **1244 → 232 ns**, deep-5-param 2617 → 1594 ns (WSL2, CPython 3.12.3; full numbers + methodology in `bench/results/router-microbench/sprint-77-phase2.md`, script at `bench/router_microbench.py`).

- **Static full-path map**: fully-static registered paths (raw + normalized keys) → terminal node; canonical request paths resolve with one dict probe. Probe hits whose entries don't match fall through — a param sibling may serve the same path with another method.
- **Iterative DFS hit path** in `_RouteTrie.lookup`: lazily-created backtrack stack, identical static > param > wildcard priority and cross-level backtracking; no recursion frames, no per-level set allocations; canonical paths skip the segment-filter listcomp. The recursive `_lookup` remains for misses only (allowed-methods collection). Trade-off: a 405 pays a double walk (3555 → 3969 ns) — rare error path, accepted.
- `_TrieNode` → `@dataclass(slots=True)`; Phase 2c regex-fallback skip when no `re.Pattern` routes; hot-path `logger.debug` removed from `_resolve` (~100 ns per disabled call); shared frozenset for hit returns.
- **Phase 2a parked by measurement**: closure creation (69 ns) beats a `__slots__`-class instantiation (93 ns) on CPython 3.12 — the proposal's estimate is inverted; fails its own ≥5% gate.
- **Phase 3 decided**: LRU cache retained — fixed trie-only (232 ns) still loses to a cache hit (~128 ns).

## Testing

- New behavior pins (pass before *and* after the rewrite): cross-level backtracking static→param, method-mismatch fallback, 405 allowed-set aggregation across branches, converter rejection → wildcard sibling, slash normalization.
- Full suite green (5220 passed); beartype-instrumented run green (one pre-existing flake: gRPC health-watch timing test, passes in isolation).
- End-to-end verified against a live server: static/param/wildcard/regex routes, slash variants, 404/405, method backtracking.

## Gate status

Local microbench half of the gate is met. The **no-throughput-regression** half rides the Sprint 77 EC2 window (HttpArena json + baseline profiles) before this ships in a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)