### PR TITLE
fix(bench): guard tracemalloc import so bench/app.py runs under PyPy

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -30,7 +30,6 @@ import asyncio
 import json
 import os
 import sys
-import tracemalloc
 from http import HTTPStatus
 
 # Allow running as `python bench/app.py` from the repo root
@@ -49,6 +48,12 @@ from bench.lag_monitor import LoopLagMonitor
 # instrumentation; production users keep tracemalloc off by default.
 _BB_TRACEMALLOC = os.environ.get('BB_TRACEMALLOC', '0') == '1'
 if _BB_TRACEMALLOC:
+    # Imported lazily, only when the soak hook is on: ``tracemalloc`` needs
+    # the ``_tracemalloc`` C module, which PyPy does not ship — an
+    # unconditional import at module top breaks ``bench/app.py`` under PyPy
+    # (the PyPy vs CPython+uvloop bench arm).  The /tracemalloc endpoint
+    # below is likewise guarded on ``_BB_TRACEMALLOC``.
+    import tracemalloc
     tracemalloc.start(int(os.environ.get('BB_TRACEMALLOC_FRAMES', '10')))
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`bench/app.py` imported `tracemalloc` unconditionally at module top, but `tracemalloc` needs the `_tracemalloc` C extension, which **PyPy does not ship**. So `bench/app.py` crashed with `ModuleNotFoundError: No module named '_tracemalloc'` under PyPy — which broke the PyPy arm of the Sprint 77 PyPy-vs-CPython+uvloop benchmark.

## Fix

The import is only needed for the `BB_TRACEMALLOC=1` soak hook, and the `/tracemalloc` endpoint already guards on `_BB_TRACEMALLOC` before touching the module. Moved the import inside the `if _BB_TRACEMALLOC:` block:
- `BB_TRACEMALLOC` unset (all PyPy bench runs): `tracemalloc` never imported → runs on PyPy.
- `BB_TRACEMALLOC=1` (CPython soak): unchanged — imported and started.

Verified both import paths on CPython; the PyPy 3-arm bench then ran arm C successfully (PyPy 3.11.15).

## Context

Part of the Sprint 77 bench-window batch. With this fix, the PyPy measurement completed: **PyPy 3.11 behind nginx beats CPython+uvloop by ~+87%** on the parse-bound H1 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)