### PR TITLE
feat(bench): ARM64/Graviton support for the AWS bench harness

### DIFF
--- a/bench/app.py
+++ b/bench/app.py
@@ -30,7 +30,6 @@ import asyncio
 import json
 import os
 import sys
-import tracemalloc
 from http import HTTPStatus
 
 # Allow running as `python bench/app.py` from the repo root
@@ -49,6 +48,12 @@ from bench.lag_monitor import LoopLagMonitor
 # instrumentation; production users keep tracemalloc off by default.
 _BB_TRACEMALLOC = os.environ.get('BB_TRACEMALLOC', '0') == '1'
 if _BB_TRACEMALLOC:
+    # Imported lazily, only when the soak hook is on: ``tracemalloc`` needs
+    # the ``_tracemalloc`` C module, which PyPy does not ship — an
+    # unconditional import at module top breaks ``bench/app.py`` under PyPy
+    # (the PyPy vs CPython+uvloop bench arm).  The /tracemalloc endpoint
+    # below is likewise guarded on ``_BB_TRACEMALLOC``.
+    import tracemalloc
     tracemalloc.start(int(os.environ.get('BB_TRACEMALLOC_FRAMES', '10')))
 
 # ---------------------------------------------------------------------------

--- a/bench/aws/config.sh
+++ b/bench/aws/config.sh
@@ -61,8 +61,13 @@ SSH_OPTS=(
 # --- AMI selection --------------------------------------------------------
 # Ubuntu 24.04 LTS (Noble) — owner 099720109477 is Canonical.
 # Filter resolved at runtime in up.sh via aws ec2 describe-images.
+# Architecture-overridable (default x86_64).  Set AMI_ARCH=arm64 for
+# Graviton instances (c8g, c7g, …); the AMI name token and the
+# describe-images architecture filter (up.sh) both follow AMI_ARCH.
 AMI_OWNER="099720109477"
-AMI_NAME_PATTERN="ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
+: "${AMI_ARCH:=x86_64}"
+_ami_arch_name=$([ "$AMI_ARCH" = "arm64" ] && echo arm64 || echo amd64)
+: "${AMI_NAME_PATTERN:=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${_ami_arch_name}-server-*}"
 
 # --- aws CLI defaults -----------------------------------------------------
 # Honour AWS_PROFILE if set; otherwise use whatever `aws configure` did.

--- a/bench/aws/up.sh
+++ b/bench/aws/up.sh
@@ -45,7 +45,7 @@ AMI_ID=$("${AWS_BASE[@]}" ec2 describe-images \
     --filters \
         "Name=name,Values=$AMI_NAME_PATTERN" \
         "Name=state,Values=available" \
-        "Name=architecture,Values=x86_64" \
+        "Name=architecture,Values=${AMI_ARCH:-x86_64}" \
     --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
     --output text)
 if [ -z "$AMI_ID" ] || [ "$AMI_ID" = "None" ]; then

--- a/bench/install.sh
+++ b/bench/install.sh
@@ -84,29 +84,26 @@ echo ""
 echo "=== Installing oha (Rust HTTP load tool, granian-style) ==="
 if ! command -v oha >/dev/null 2>&1; then
     # Prefer apt (Debian ≥13, some PPAs); fall back to the upstream GitHub
-    # release binary (single static x86_64 ELF, works on Ubuntu 22.04/24.04);
-    # last resort cargo if a Rust toolchain is around.
+    # release binary (static ELF for amd64 or arm64); last resort cargo.
+    # oha is an OPTIONAL load tool (Lane B-oha) — never fatal, so an ARM box
+    # without it still completes install for the wrk / h2load lanes.
+    case "$(uname -m)" in x86_64) _oha_arch=amd64;; aarch64) _oha_arch=arm64;; *) _oha_arch="";; esac
     if apt-cache show oha >/dev/null 2>&1; then
-        sudo apt-get install -y oha
-    elif [ "$(uname -s)-$(uname -m)" = "Linux-x86_64" ] && command -v curl >/dev/null 2>&1; then
-        echo "  apt has no 'oha' package; downloading static binary from GitHub releases ..."
+        sudo apt-get install -y oha || echo "  oha apt install failed (optional; skipping)"
+    elif [ -n "$_oha_arch" ] && command -v curl >/dev/null 2>&1; then
+        echo "  downloading oha-linux-$_oha_arch from GitHub releases ..."
         tmp_oha=$(mktemp)
         if curl -fsSL -o "$tmp_oha" \
-                "https://github.com/hatoo/oha/releases/latest/download/oha-linux-amd64"; then
+                "https://github.com/hatoo/oha/releases/latest/download/oha-linux-$_oha_arch"; then
             sudo install -m 0755 "$tmp_oha" /usr/local/bin/oha
-            rm -f "$tmp_oha"
         else
-            rm -f "$tmp_oha"
-            echo "  failed to download oha from GitHub releases" >&2
-            exit 1
+            echo "  oha download failed (optional; skipping)" >&2
         fi
+        rm -f "$tmp_oha"
     elif command -v cargo >/dev/null 2>&1; then
-        cargo install oha
+        cargo install oha || echo "  oha cargo build failed (optional; skipping)"
     else
-        echo "  oha not packaged, no x86_64 release binary path, and cargo not installed." >&2
-        echo "  Install Rust (curl https://sh.rustup.rs | sh) or fetch manually from" >&2
-        echo "    https://github.com/hatoo/oha/releases" >&2
-        exit 1
+        echo "  oha unavailable on $(uname -m) (optional; skipping — Lane B-oha disabled)" >&2
     fi
 else
     echo "oha already installed, skipping."
@@ -114,15 +111,19 @@ fi
 
 echo ""
 echo "=== Installing k6 ==="
+# k6 is an OPTIONAL load tool (Lanes C/D) — non-fatal, so a box where the
+# k6 repo has no build for the arch still completes install.
 if ! command -v k6 >/dev/null 2>&1; then
-  sudo apt-get install -y gnupg curl
-  curl -fsSL https://dl.k6.io/key.gpg \
-    | sudo gpg --batch --yes --dearmor \
-        -o /usr/share/keyrings/k6-archive-keyring.gpg
-  echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
-    | sudo tee /etc/apt/sources.list.d/k6.list
-  sudo apt-get update -qq
-  sudo apt-get install -y k6
+  {
+    sudo apt-get install -y gnupg curl
+    curl -fsSL https://dl.k6.io/key.gpg \
+      | sudo gpg --batch --yes --dearmor \
+          -o /usr/share/keyrings/k6-archive-keyring.gpg
+    echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" \
+      | sudo tee /etc/apt/sources.list.d/k6.list
+    sudo apt-get update -qq
+    sudo apt-get install -y k6
+  } || echo "  k6 install failed (optional; skipping — Lanes C/D disabled)"
 else
   echo "k6 already installed, skipping."
 fi

--- a/bench/install.sh
+++ b/bench/install.sh
@@ -142,7 +142,7 @@ echo "=== Versions ==="
 h2load --version | head -1
 wrk --version 2>&1 | head -1 || true
 oha --version 2>/dev/null || echo "oha: not installed"
-k6 version
+k6 version 2>/dev/null || echo "k6: not installed"
 python3 -c "import uvicorn;  print('uvicorn   ', uvicorn.__version__)"
 python3 -c "import hypercorn; print('hypercorn ', getattr(hypercorn, '__version__', '(no __version__)'))"
 python3 -c "import granian;   print('granian   ', granian.__version__)"

--- a/bench/install.sh
+++ b/bench/install.sh
@@ -25,7 +25,13 @@ echo "=== Building wrk2 (Gil Tene's CO-corrected fork) ==="
 # against 0, which on fast servers (sub-ms first sample) yields +Inf and a
 # garbage uint64 that aborts the HDR histogram with
 # `bucket_index < h->bucket_count`. Patch the divisor guard before build.
-if [ ! -x "$HOME/.local/bin/wrk2" ]; then
+if [ "$(uname -m)" != "x86_64" ]; then
+    # wrk2 bundles LuaJIT, whose build errors "No support for this
+    # architecture" on aarch64 (Graviton).  wrk2 backs only the constant-rate
+    # Lane B2r; skip it on non-x86 so the rest of the toolchain (apt wrk,
+    # h2load, nginx) still installs.  Lane B2r is unavailable on this arch.
+    echo "wrk2 skipped on $(uname -m) (LuaJIT unsupported; Lane B2r x86-only)"
+elif [ ! -x "$HOME/.local/bin/wrk2" ]; then
     mkdir -p "$HOME/.local/src" "$HOME/.local/bin"
     cd "$HOME/.local/src"
     [ -d wrk2 ] || git clone --depth=1 https://github.com/giltene/wrk2.git


### PR DESCRIPTION
## Why

Sprint 77's PyPy/edge measurement wanted a **Graviton (c8g)** datapoint to test the pure-Python edge/ARM positioning. Getting the bench harness onto aarch64 surfaced a chain of toolchain gaps (none in BlackBull itself) — this branch fixes them so `bench/aws` runs end-to-end on ARM.

## Fixes (all backward-compatible; x86 runs unchanged)

1. **`AMI_ARCH` override** (`config.sh` + `up.sh`) — the AMI name token and describe-images architecture filter were hardcoded to x86. Now `AMI_ARCH=arm64 INSTANCE_TYPE=c8g.2xlarge bash bench/aws/up.sh` boots a Graviton arm64 AMI; default stays `x86_64`.
2. **wrk2 x86-gate** (`install.sh`) — wrk2 bundles LuaJIT, which errors "No support for this architecture" on aarch64 and aborted install. wrk2 backs only the constant-rate Lane B2r; plain `wrk` is apt (arm64 fine). Gated to x86.
3. **oha arm64 + non-fatal** — oha only fetched the amd64 GitHub binary and hard-exited otherwise. Now fetches `oha-linux-arm64` and every failure path is non-fatal (optional Lane B-oha).
4. **k6 non-fatal** (install + version report) — no arm64 build in the k6 repo; the install and the `k6 version` line now degrade gracefully (optional Lanes C/D).
5. **`bench/app.py` tracemalloc guard** — PyPy lacks `_tracemalloc`; guarded the import behind `BB_TRACEMALLOC` so the PyPy bench arm runs. *(Same change as #166 — this PR supersedes it; close #166 if you merge this.)*

## Validated

End-to-end on **c8g.2xlarge (Graviton4)**: provision → install (all essential tools: wrk, h2load, nginx; optional oha ok, k6 skipped cleanly) → the PyPy-vs-CPython+uvloop 3-arm measurement ran to completion. Result (recorded in `bench/results/pypy-nginx-h1/RESULT.md`): on ARM the PyPy advantage **flips** — CPython+uvloop wins outright (PyPy −2%), vs PyPy +87% on x86. Every ARM run torn down clean, zero orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)