### PR TITLE
fix(mqtt): read-loop cancellation swallowed by asyncio.wait_for on Python 3.11

### DIFF
--- a/blackbull/mqtt/connection.py
+++ b/blackbull/mqtt/connection.py
@@ -161,9 +161,16 @@ class MQTT5Actor(Actor):
         idle deadline (§3.1.2.10)."""
         if not self._keep_alive:
             return await reader.read(_READ_CHUNK)
+        # NB: ``asyncio.timeout``, not ``asyncio.wait_for``.  On Python 3.11 the
+        # latter can *swallow* an external ``CancelledError`` when the wrapped
+        # read completes in the same loop iteration the cancel arrives — the
+        # read-loop then never observes the cancellation and spins forever (the
+        # connection task wedges in the ``cancelling`` state).  ``asyncio.timeout``
+        # distinguishes its own deadline from an outer cancel and re-raises the
+        # latter, so ``serve_connection`` can be torn down deterministically.
         try:
-            return await asyncio.wait_for(
-                reader.read(_READ_CHUNK), self._keep_alive * 1.5)
+            async with asyncio.timeout(self._keep_alive * 1.5):
+                return await reader.read(_READ_CHUNK)
         except asyncio.TimeoutError:
             return b''
 


### PR DESCRIPTION
## What & why

The post-merge master CI for #167 went red on the **3.11 fast tier** ([run 29632893159](https://github.com/TOKUJI/BlackBull/actions/runs/29632893159)):

```
FAILED tests/unit/test_mqtt_connection_actor.py::test_two_connections_publish_subscribe_routing
       - Failed: Timeout (>60.0s) from pytest-timeout.
1 failed, 1971 passed
```

3.12 passed; only 3.11 failed. #167 itself only touched `bench/` scripts — this is a **pre-existing 3.11-only flaky hang** the merge run happened to surface.

### Root cause

`MQTT5Actor._read_with_keepalive` wrapped each keep-alive-bounded socket read in `asyncio.wait_for`. On **Python 3.11**, `wait_for` can *swallow an external `CancelledError`* when the wrapped read completes in the same event-loop iteration the cancel is delivered. The read-loop then never observes the cancel and spins on the 5 ms idle poll forever, leaving the `serve_connection` task stuck in the `cancelling` state and the awaiting teardown (`_drain` → `gather`) hung until pytest-timeout fires.

Python 3.12 reimplemented `wait_for` on top of `asyncio.timeout` and is immune — which is exactly why the failure was 3.11-only.

Confirmed with an all-tasks stack dump: the wedged task is a `serve_connection` in state `cancelling`, parked at `await conn.read_loop(reader)`.

### Fix

Use `asyncio.timeout()` (3.11+, our supported floor) instead of `wait_for`. It distinguishes its own deadline from an outer cancel and re-raises the latter, so the connection tears down deterministically.

## Verification (real CPython 3.11.15 — the CI version)

- Deterministic reproducer (dumps hung task stacks): failed on **iteration 0** before, **400/400 clean** after.
- Target test in isolation: **40/40 pass** (was ~1-in-25 hang).
- Full fast tier (`tests/unit tests/architecture tests/properties`, `--beartype-packages=blackbull`): **1972 passed, 1 xfailed** across 4 consecutive runs.
- 3.12 unaffected (MQTT module 10/10; pre-commit full suite green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)