### PR TITLE
release: v0.58.0 — Sprint 77: router fast path, 3.11 restored, coalescer removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.58.0] — 2026-07-19
+
 ### Added
 
 - **Edge inference API server positioning (Sprint 76).** New guide page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.57.0"
+version = "0.58.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Two-file release commit (version bump + CHANGELOG stamp) closing **Sprint 77 — Bench-window batch**. All content landed during the sprint.

- **Added** — Edge inference API server positioning (Sprint 76): guide page + `examples/edge_inference.py`.
- **Changed** — Router trie fast path (static-path map + iterative DFS + regex-skip): param `_resolve` ~1555→959 ns, static ~1244→232 ns, no throughput regression (EC2-verified).
- **Removed** — `ConnCoalescer` / `BB_H2_CONN_BUFFER_US`. Its designed killer case (gRPC unary fan-out, split-topology real network) showed ~20% fewer TCP segments but **no** throughput/latency win (`TCP_NODELAY` → no delayed-ACK stall). Removed rather than kept as dormant opt-in. **Breaking**: the env var now has no effect (it defaulted off, so no behaviour change).
- **Fixed** — Python 3.11 compatibility restored (`HTTPStatus.is_client_error/.is_server_error` are 3.12-only — crashed on import since 0.48.1; int-range helpers + 3.11 CI lane). MQTT read-loop cancellation hang on 3.11 (`asyncio.wait_for` cancel-swallow → `asyncio.timeout`).

**MINOR** bump per ZeroVer (new behaviour + a removed env var).

## Test plan

- [x] `blackbull.__version__` → `0.58.0` after `pip install -e .`
- [x] Full pre-commit beartype suite green on the release commit
- [x] `mkdocs build --strict` passes
- [ ] CodeQL + Audit dependencies + Build checks green (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)