### PR TITLE
feat: HTTP QUERY method support (RFC 10008) — Sprint 78

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ so the editable install's metadata catches up.
 
 ### Added
 
+- **QUERY normative response semantics (RFC 10008, Sprint 78 P2).** New
+  `accept_query=[...]` route option declaring the request media types a
+  QUERY route accepts. It drives an **`Accept-Query`** response header (an
+  RFC 9651 Structured Field list, serialized once at registration) on the
+  route's responses, and **Content-Type enforcement** on QUERY requests:
+  **400** when the media type is missing, **415** when unaccepted (the 415
+  carries `Accept-Query` so the client can correct). Media-type matching
+  ignores parameters and is case-insensitive. New `blackbull.UnprocessableQuery`
+  exception (an `HTTPException` subclass) for handlers to raise → **422**.
+  All three statuses flow through the normal error-router path; enforcement
+  targets QUERY only, while other methods on the route still receive the
+  header. Guide section extended; 16 new tests (unit + HTTP/1.1 wire).
 - **HTTP QUERY method support (RFC 10008, Sprint 78 P1).** First-mover
   support for the first new standard HTTP method since PATCH — safe,
   idempotent, cacheable, with a request body.  New `blackbull.QUERY`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,35 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **HTTP QUERY method support (RFC 10008, Sprint 78 P1).** First-mover
+  support for the first new standard HTTP method since PATCH — safe,
+  idempotent, cacheable, with a request body.  New `blackbull.QUERY`
+  plain-string constant (`http.HTTPMethod` has no member before Python
+  3.16; `StrEnum` equality keeps string-registered routes matching a
+  future enum member with no migration).  Routing, body access
+  (`body: bytes` / `Request.json()`), 405 `Allow` advertisement, and the
+  four request-lifecycle events are pinned by tests over HTTP/1.1,
+  HTTP/2, and `TestClient`; the experimental clients round-trip
+  `request('QUERY', ...)` on both protocols.  New guide section
+  *The QUERY method (RFC 10008)* in [Routing](docs/guide/routing.md).
+  QUERY routes stay out of the generated OpenAPI document — 3.1 has no
+  `query` operation (3.2 does; revisit when the emitter moves) — and are
+  never faked as another operation.
+
+### Fixed
+
+- **HTTP/2: spurious `http.disconnect` on body-less requests.** When
+  HEADERS carried END_STREAM and the connection closed before the
+  handler's first `receive()`, `HTTP2Recipient.put_disconnect()`
+  allocated the event queue and thereby disabled the synthetic
+  empty-body fast path — a body-reading handler (QUERY/POST with an
+  empty body) saw `http.disconnect` instead of the complete empty
+  `http.request`.  The synthetic event is now delivered first; the
+  disconnect follows it.  Invisible for GET handlers, which never read
+  the body.
+
 ## [0.58.0] — 2026-07-19
 
 ### Added

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -10,6 +10,7 @@ Public API exports:
 - `serve`: synchronous entry point that runs any ASGI 3.0 callable (also used by the ``blackbull`` console script).
 - `Response`, `JSONResponse`, `RedirectResponse`, `StreamingResponse`, `EventSourceResponse`, `WebSocketResponse`: response helpers.
 - `RouteInfo`: immutable ``(method, path, name)`` snapshot returned by ``app.get_routes()``.
+- `QUERY`: the HTTP QUERY method (RFC 10008) as a plain string — ``http.HTTPMethod`` lacks the member until Python ≥3.16.
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
 - `Request`: opt-in context object for HTTP handlers (headers/cookies/client/``body()``/``json()``), injected by signature.
 - `Depends`: per-request provider injection for simplified handlers (async-generator providers get teardown after the response is sent).
@@ -45,7 +46,7 @@ except PackageNotFoundError:
 
 from .app import BlackBull, serve
 from .di import Depends
-from .router import RouteInfo, HTTPException
+from .router import RouteInfo, HTTPException, QUERY
 from .config import AppConfig
 from .headers import Headers
 from .request import Request, read_body, read_json, read_text, parse_cookies, ClientDisconnected

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -11,6 +11,7 @@ Public API exports:
 - `Response`, `JSONResponse`, `RedirectResponse`, `StreamingResponse`, `EventSourceResponse`, `WebSocketResponse`: response helpers.
 - `RouteInfo`: immutable ``(method, path, name)`` snapshot returned by ``app.get_routes()``.
 - `QUERY`: the HTTP QUERY method (RFC 10008) as a plain string — ``http.HTTPMethod`` lacks the member until Python ≥3.16.
+- `UnprocessableQuery`: raise from a QUERY handler for ``422`` when the (accepted) request media type carries a semantically unprocessable query (RFC 10008).
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
 - `Request`: opt-in context object for HTTP handlers (headers/cookies/client/``body()``/``json()``), injected by signature.
 - `Depends`: per-request provider injection for simplified handlers (async-generator providers get teardown after the response is sent).
@@ -46,7 +47,7 @@ except PackageNotFoundError:
 
 from .app import BlackBull, serve
 from .di import Depends
-from .router import RouteInfo, HTTPException, QUERY
+from .router import RouteInfo, HTTPException, UnprocessableQuery, QUERY
 from .config import AppConfig
 from .headers import Headers
 from .request import Request, read_body, read_json, read_text, parse_cookies, ClientDisconnected

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -29,7 +29,7 @@ import logging
 from .event import Event, EventDispatcher, EventHandler
 from .headers import Headers
 from .utils import Scheme, is_client_error, is_server_error
-from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param, request_media_type
+from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param
 from .request import ClientDisconnected
 from .config import AppConfig
 logger = logging.getLogger(__name__)
@@ -77,19 +77,21 @@ def _wrap_send(raw_send):
     return _send
 
 
-def _accept_query_send(raw_send, header_value: bytes):
-    """Wrap *raw_send* to add the RFC 10008 ``Accept-Query`` response header.
+def _inject_response_headers(raw_send, extra_headers):
+    """Wrap *raw_send* to append *extra_headers* to the response.
 
-    Installed **below** :func:`_wrap_send`, so it only ever observes plain
-    ASGI dicts — convenience shapes (``Response``, 3-arg) have already been
-    normalised by the time an event reaches here.  The header is appended to
-    the ``http.response.start`` event (success and error responses alike);
-    every other event passes straight through.
+    A route may declare headers (via the ``_bb_response_headers`` hook) that
+    must appear on all of its responses — success and the centrally-rendered
+    error alike.  Installed **below** :func:`_wrap_send`, so it only ever
+    observes plain ASGI dicts: convenience shapes (``Response``, 3-arg) have
+    already been normalised by the time an event reaches here.  The headers
+    are appended to the ``http.response.start`` event; every other event
+    passes straight through.
     """
     async def _send(event):
         if isinstance(event, dict) and event.get('type') == 'http.response.start':
             headers: list = list(event.get('headers') or [])
-            headers.append((b'accept-query', header_value))
+            headers.extend(extra_headers)
             event = {**event, 'headers': headers}
         await raw_send(event)
 
@@ -672,31 +674,36 @@ class BlackBull:
                 await handler(scope, receive, send)
             return
 
-        # RFC 10008 — a route declared with ``accept_query=[...]`` advertises
-        # the ``Accept-Query`` header on its responses and enforces the QUERY
-        # request Content-Type.  The header injector is installed below
-        # _wrap_send (it sees only ASGI dicts); enforcement short-circuits to
-        # the error router (like 405/404) so 400/415 skip the handler and the
-        # lifecycle events, exactly as an unroutable request does.
-        accept_query = getattr(function, '_bb_accept_query', None)
-        if accept_query is not None:
-            scope.setdefault('state', {})['accept_query'] = accept_query.header
-            send = _wrap_send(_accept_query_send(raw_send, accept_query.header))
-            if scope['method'] == 'QUERY':
-                media = request_media_type(scope)
-                err_status = None
-                if not media:
-                    err_status = HTTPStatus.BAD_REQUEST
-                elif media not in accept_query.accepted:
-                    err_status = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
-                if err_status is not None:
-                    self._logger.info('%s on QUERY %s: content-type %r',
-                                      int(err_status), path, media or None)
-                    scope['state']['error_status'] = err_status
-                    handler = self._error_router[err_status]
-                    if handler is not None:
-                        await handler(scope, receive, send)
-                    return
+        # Per-route hooks (method-agnostic): a route may declare response
+        # headers to add to every response, and a request guard that rejects
+        # the request before dispatch.  The dispatcher applies both uniformly —
+        # it names no method and no feature.  ``accept_query`` (RFC 10008) is
+        # currently the only producer; its QUERY-specific logic lives inside
+        # the guard, not here.
+        resp_headers = getattr(function, '_bb_response_headers', None)
+        if resp_headers is not None:
+            # Installed below _wrap_send so it sees only ASGI dicts, and around
+            # raw_send so the header also lands on the centrally-rendered error
+            # response (e.g. a guard's 415).
+            send = _wrap_send(_inject_response_headers(raw_send, resp_headers))
+        guard = getattr(function, '_bb_request_guard', None)
+        if guard is not None:
+            try:
+                guard(scope)
+            except HTTPException as e:
+                # Rejected before dispatch — routed like a 404/405: by status
+                # (so an @app.on_error(status) handler is honoured, exactly as
+                # for those), no handler body and no lifecycle events.
+                self._logger.info('%s on %s %s: %s', int(e.status),
+                                  scope.get('method', ''), path, e.detail or e)
+                scope.setdefault('state', {}).update({
+                    'error_status': e.status,
+                    'error_exception': e,
+                })
+                handler = self._error_router[e.status]
+                if handler is not None:
+                    await handler(scope, receive, send)
+                return
 
         self._logger.debug((self, function))
         exc_caught: Exception | None = None

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -613,9 +613,13 @@ class BlackBull:
 
         try:
             # RFC 9110 §9.1 — methods are case-sensitive tokens.  Prefer the
-            # HTTPMethod enum for IANA-registered methods; for non-IANA methods
-            # (BREW, PROPFIND, WHEN, …) keep the raw str so the router can
-            # still match a registered route and return the correct Allow header.
+            # HTTPMethod enum when it has a member; for methods outside the
+            # enum — whether IANA-registered ones it hasn't caught up with
+            # (QUERY, RFC 10008; no member before 3.16) or extension tokens
+            # (BREW, PROPFIND, WHEN, …) — keep the raw str so the router can
+            # still match a registered route and return the correct Allow
+            # header.  StrEnum equality makes the two forms interchangeable
+            # as router keys.
             method = HTTPMethod(scope['method'])
         except ValueError:
             method = scope['method']

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -218,6 +218,14 @@ class RouteGroup:
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               middlewares: list = [], name: str | None = None,
               accept_query: Iterable[str] | None = None):
+        """Register a route on this group, prepending the group middlewares.
+
+        Same parameters as :meth:`BlackBull.route`.  ``accept_query`` is the
+        RFC 10008 list of request **media types** the route accepts (the
+        ``Accept-Query`` response header + Content-Type enforcement) — it is a
+        content-negotiation policy, **not** a switch for the QUERY *method*
+        (a method is accepted purely by listing it in ``methods``).
+        """
         return self._app.route(
             methods=methods,
             path=path,
@@ -853,8 +861,12 @@ class BlackBull:
               accept_query: Iterable[str] | None = None):
         """Register a route handler, optionally wrapping it in middlewares.
 
-        ``accept_query`` (RFC 10008) — a list of request media types the route
-        accepts for the QUERY method.  When set, QUERY-route responses carry an
+        ``accept_query`` (RFC 10008) names the request **media types** the
+        route accepts — it is the value of the ``Accept-Query`` response
+        header, **not** a switch that enables the QUERY method.  (A method is
+        accepted purely by listing it in ``methods``; QUERY is no different
+        from GET there.)  It is meaningful for the QUERY method, which carries
+        a request body.  When set, the route's responses carry an
         ``Accept-Query`` header (an RFC 9651 Structured Field list of those
         media types), and QUERY requests are Content-Type-enforced: a missing
         media type is answered ``400``, an unaccepted one ``415`` (with the

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -29,7 +29,7 @@ import logging
 from .event import Event, EventDispatcher, EventHandler
 from .headers import Headers
 from .utils import Scheme, is_client_error, is_server_error
-from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param
+from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param, request_media_type
 from .request import ClientDisconnected
 from .config import AppConfig
 logger = logging.getLogger(__name__)
@@ -73,6 +73,25 @@ def _wrap_send(raw_send):
             # ASGI dict (the common path) or any other shape — passed through
             # so the underlying sender's type checking decides what to do.
             await raw_send(event)
+
+    return _send
+
+
+def _accept_query_send(raw_send, header_value: bytes):
+    """Wrap *raw_send* to add the RFC 10008 ``Accept-Query`` response header.
+
+    Installed **below** :func:`_wrap_send`, so it only ever observes plain
+    ASGI dicts — convenience shapes (``Response``, 3-arg) have already been
+    normalised by the time an event reaches here.  The header is appended to
+    the ``http.response.start`` event (success and error responses alike);
+    every other event passes straight through.
+    """
+    async def _send(event):
+        if isinstance(event, dict) and event.get('type') == 'http.response.start':
+            headers: list = list(event.get('headers') or [])
+            headers.append((b'accept-query', header_value))
+            event = {**event, 'headers': headers}
+        await raw_send(event)
 
     return _send
 
@@ -195,13 +214,15 @@ class RouteGroup:
 
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
-              middlewares: list = [], name: str | None = None):
+              middlewares: list = [], name: str | None = None,
+              accept_query: Iterable[str] | None = None):
         return self._app.route(
             methods=methods,
             path=path,
             scheme=scheme,
             middlewares=self._group_mw + list(middlewares),
             name=name,
+            accept_query=accept_query,
         )
 
 
@@ -609,6 +630,9 @@ class BlackBull:
         # at the handler boundary, after the WebSocket branch — so middleware
         # (which sees send before _dispatch is entered) always receives plain
         # ASGI dicts.  See _wrap_send for why outward placement is a bug.
+        # ``raw_send`` is retained so an RFC 10008 ``Accept-Query`` route can
+        # re-wrap with the header injector *below* _wrap_send (dict-only).
+        raw_send = send
         send = _wrap_send(send)
 
         try:
@@ -647,6 +671,32 @@ class BlackBull:
             if handler is not None:
                 await handler(scope, receive, send)
             return
+
+        # RFC 10008 — a route declared with ``accept_query=[...]`` advertises
+        # the ``Accept-Query`` header on its responses and enforces the QUERY
+        # request Content-Type.  The header injector is installed below
+        # _wrap_send (it sees only ASGI dicts); enforcement short-circuits to
+        # the error router (like 405/404) so 400/415 skip the handler and the
+        # lifecycle events, exactly as an unroutable request does.
+        accept_query = getattr(function, '_bb_accept_query', None)
+        if accept_query is not None:
+            scope.setdefault('state', {})['accept_query'] = accept_query.header
+            send = _wrap_send(_accept_query_send(raw_send, accept_query.header))
+            if scope['method'] == 'QUERY':
+                media = request_media_type(scope)
+                err_status = None
+                if not media:
+                    err_status = HTTPStatus.BAD_REQUEST
+                elif media not in accept_query.accepted:
+                    err_status = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+                if err_status is not None:
+                    self._logger.info('%s on QUERY %s: content-type %r',
+                                      int(err_status), path, media or None)
+                    scope['state']['error_status'] = err_status
+                    handler = self._error_router[err_status]
+                    if handler is not None:
+                        await handler(scope, receive, send)
+                    return
 
         self._logger.debug((self, function))
         exc_caught: Exception | None = None
@@ -792,8 +842,20 @@ class BlackBull:
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               functions: list = [], middlewares: list = [],
-              name: str | None = None):
-        """Register a route handler, optionally wrapping it in middlewares."""
+              name: str | None = None,
+              accept_query: Iterable[str] | None = None):
+        """Register a route handler, optionally wrapping it in middlewares.
+
+        ``accept_query`` (RFC 10008) — a list of request media types the route
+        accepts for the QUERY method.  When set, QUERY-route responses carry an
+        ``Accept-Query`` header (an RFC 9651 Structured Field list of those
+        media types), and QUERY requests are Content-Type-enforced: a missing
+        media type is answered ``400``, an unaccepted one ``415`` (with the
+        ``Accept-Query`` header so the client can correct).  A handler may raise
+        :class:`~blackbull.UnprocessableQuery` for ``422`` on a well-formed but
+        unprocessable query.  Enforcement applies only to QUERY requests; other
+        methods on the same route still receive the ``Accept-Query`` header.
+        """
         return self._router.route(
             methods=methods,
             path=path,
@@ -801,6 +863,7 @@ class BlackBull:
             functions=functions,
             middlewares=middlewares,
             name=name,
+            accept_query=accept_query,
             )
 
     def group(self, middlewares=[]) -> 'RouteGroup':

--- a/blackbull/openapi.py
+++ b/blackbull/openapi.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import json
+import logging
 import types
 import typing
 from http import HTTPMethod
@@ -43,6 +44,8 @@ from typing import Any
 
 from .extension import Extension
 from .router import _AnyScheme
+
+logger = logging.getLogger(__name__)
 from .utils import Scheme
 
 
@@ -381,6 +384,13 @@ def generate_spec(app, *, title: str = 'BlackBull API',
                 try:
                     method = HTTPMethod(method)
                 except ValueError:
+                    # Methods outside the stdlib enum (QUERY per RFC 10008,
+                    # extension tokens) have no OpenAPI 3.1 operation — 3.2
+                    # adds `query`/`additionalOperations`; revisit when the
+                    # emitter moves.  Never fake them as another operation.
+                    logger.debug(
+                        'OpenAPI: skipping method %r on %r — not an OpenAPI '
+                        '3.1 operation', method, ri.template)
                     continue
             if method not in _OPENAPI_METHODS:
                 continue

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1021,6 +1021,25 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
 _HTTP_TOKEN_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 
 
+QUERY: str = 'QUERY'
+"""The HTTP QUERY method (RFC 10008) — safe, idempotent, cacheable, with a
+request body.
+
+``http.HTTPMethod`` has no ``QUERY`` member (RFC 10008 postdates the 3.15
+feature freeze; earliest stdlib arrival is 3.16), so BlackBull exports the
+method as a plain string usable anywhere a method is accepted::
+
+    from blackbull import QUERY
+
+    @app.route(path='/search', methods=[QUERY])
+    async def search(body: bytes): ...
+
+Because ``http.HTTPMethod`` is a ``StrEnum``, this string stays equal- and
+hash-compatible with a future ``HTTPMethod.QUERY`` member — routes
+registered with it need no migration.
+"""
+
+
 def _validate_method_token(method: str) -> None:
     if not _HTTP_TOKEN_RE.match(method):
         raise ValueError(

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1074,24 +1074,54 @@ def _to_tuple(value: Any) -> tuple:
     return (value,)
 
 
-class _AcceptQuery(NamedTuple):
-    """Precomputed RFC 10008 ``accept_query`` plan attached to a handler.
+# ---------------------------------------------------------------------------
+# Per-route hooks — generic request/response metadata a handler can carry.
+#
+# The dispatcher (``BlackBull._dispatch``) treats every method identically.
+# A route may attach two optional, method-agnostic hooks that the dispatcher
+# applies uniformly — it does not know (or name) any specific method or
+# feature:
+#
+#   ``_bb_response_headers`` — extra headers appended to every response the
+#       route produces (success *and* the centrally-rendered error), e.g. the
+#       RFC 10008 ``Accept-Query`` header.
+#   ``_bb_request_guard`` — a ``(scope) -> None`` callable run before the
+#       handler; it raises :class:`HTTPException` to reject the request
+#       pre-dispatch (routed like a 404/405).
+#
+# ``accept_query`` (below) is currently the only producer of these hooks; the
+# QUERY-specific logic lives entirely inside the guard it builds, never in the
+# dispatcher.  A future feature (e.g. a rate-limit guard, other declared
+# response headers) reuses the same two hooks with no dispatcher change.
+# ---------------------------------------------------------------------------
 
-    ``header`` is the serialised ``Accept-Query`` field value (an RFC 9651
-    Structured Field list of media-type tokens, computed once at
-    registration); ``accepted`` is the frozenset of normalised (lowercased)
-    media types used for the O(1) Content-Type membership check.
+_ROUTE_HOOK_ATTRS = ('_bb_response_headers', '_bb_request_guard')
+
+
+def _copy_route_hooks(dst: Callable, src: Callable) -> None:
+    """Propagate any route hooks from *src* onto *dst*.
+
+    Used when the router re-wraps a handler (e.g. the path-param ``_inject``
+    closure in :meth:`Router._resolve`) so the hooks survive to the
+    dispatcher.
     """
-    header: bytes
-    accepted: frozenset
+    for attr in _ROUTE_HOOK_ATTRS:
+        value = getattr(src, attr, None)
+        if value is not None:
+            setattr(dst, attr, value)
 
 
-def _make_accept_query(media_types: Iterable[str]) -> _AcceptQuery:
-    """Build the :class:`_AcceptQuery` plan from declared media types.
+def _accept_query_hooks(media_types: Iterable[str]):
+    """Build the ``(response_headers, request_guard)`` hooks for the RFC 10008
+    ``accept_query`` route option.
 
-    Serialising through :func:`serialize_list` validates each media type as
-    an RFC 9651 token at registration time — an invalid entry raises
-    ``ValueError`` up front rather than emitting a malformed header later.
+    ``response_headers`` carries the ``Accept-Query`` field (an RFC 9651
+    Structured Field list of media-type tokens; serialising through
+    :func:`serialize_list` validates each token at registration, so an invalid
+    entry raises ``ValueError`` up front).  ``request_guard`` enforces the
+    request ``Content-Type`` on QUERY requests only — 400 when absent, 415
+    when unaccepted — while other methods sharing the route still receive the
+    header but are not media-type gated.
     """
     from .protocol.structured_fields import Token, serialize_list  # noqa: PLC0415
 
@@ -1100,7 +1130,20 @@ def _make_accept_query(media_types: Iterable[str]) -> _AcceptQuery:
         raise ValueError('accept_query must list at least one media type')
     header = serialize_list([(Token(mt), {}) for mt in types])
     accepted = frozenset(mt.strip().lower() for mt in types)
-    return _AcceptQuery(header=header, accepted=accepted)
+    response_headers = ((b'accept-query', header),)
+
+    def guard(scope: dict) -> None:
+        if scope['method'] != 'QUERY':
+            return
+        media = request_media_type(scope)
+        if not media:
+            raise HTTPException(HTTPStatus.BAD_REQUEST,
+                                'QUERY request requires a Content-Type')
+        if media not in accepted:
+            raise HTTPException(HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                                f'unsupported query media type {media!r}')
+
+    return response_headers, guard
 
 
 def request_media_type(scope: dict) -> str:
@@ -1350,11 +1393,9 @@ class Router:
                                   _fn=_fn, _params=_params):
                     scope.setdefault('path_params', {}).update(_params)
                     return await _fn(scope, receive, send)
-                # Preserve the RFC 10008 accept_query plan across the
-                # path-param wrapper so _dispatch still finds it.
-                _aq = getattr(_fn, '_bb_accept_query', None)
-                if _aq is not None:
-                    _inject._bb_accept_query = _aq
+                # Preserve any route hooks across the path-param wrapper so
+                # the dispatcher still finds them.
+                _copy_route_hooks(_inject, _fn)
                 return _inject
             return h
 
@@ -1382,9 +1423,7 @@ class Router:
                                       _fn=_fn, _params=_params):
                         scope.setdefault('path_params', {}).update(_params)
                         return await _fn(scope, receive, send)
-                    _aq = getattr(_fn, '_bb_accept_query', None)
-                    if _aq is not None:
-                        _inject._bb_accept_query = _aq
+                    _copy_route_hooks(_inject, _fn)
                     return _inject
                 return fn
 
@@ -1456,7 +1495,7 @@ class Router:
         for m in methods:
             if isinstance(m, str):
                 _validate_method_token(m)
-        aq = _make_accept_query(accept_query) if accept_query is not None else None
+        hooks = _accept_query_hooks(accept_query) if accept_query is not None else None
 
         def register(fn):
             logger.debug(f'Router.route_fn.register() is called. {fn}')
@@ -1465,8 +1504,8 @@ class Router:
             if _is_simplified_handler(fn):
                 fn = _adapt_handler(fn, path, self._converters)
 
-            if aq is not None:
-                fn._bb_accept_query = aq
+            if hooks is not None:
+                fn._bb_response_headers, fn._bb_request_guard = hooks
 
             logger.debug((path, methods, scheme))
             self[(path, methods, scheme)] = fn
@@ -1506,7 +1545,8 @@ class Router:
             return await _ic(scope, receive, send)
 
         if accept_query is not None:
-            _chain_wrapper._bb_accept_query = _make_accept_query(accept_query)
+            _chain_wrapper._bb_response_headers, _chain_wrapper._bb_request_guard = \
+                _accept_query_hooks(accept_query)
 
         self[(path, methods, scheme)] = _chain_wrapper
         self._record_route(path, original_handler or fns[-1], name,

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1489,7 +1489,14 @@ class Router:
                  scheme: Scheme | Iterable[Scheme] = Scheme.http,
                  name: str | None = None,
                  accept_query: Iterable[str] | None = None):
+        """Return a decorator that registers the decorated handler.
 
+        ``accept_query`` (RFC 10008) is the list of request **media types** the
+        route accepts — the ``Accept-Query`` header value driving Content-Type
+        enforcement on QUERY requests.  It is **not** a switch for the QUERY
+        *method* (methods are accepted by ``methods``); it installs the route
+        hooks in :func:`_accept_query_hooks`.  See ``BlackBull.route``.
+        """
         logger.debug('Router.route_fn() is called.')
         methods = _to_tuple(methods)
         for m in methods:
@@ -1519,7 +1526,13 @@ class Router:
     def _register_chain(self, functions, path, methods, scheme,
                         name: str | None = None, original_handler=None,
                         accept_query: Iterable[str] | None = None):
-        """Build a middleware chain from *functions* and register it."""
+        """Build a middleware chain from *functions* and register it.
+
+        ``accept_query`` (RFC 10008) — the request **media types** the route
+        accepts (the ``Accept-Query`` header value), attached to the chain as
+        route hooks; **not** a switch for the QUERY *method*.  See
+        ``BlackBull.route``.
+        """
         if not isinstance(functions, Iterable):
             raise TypeError(f'{functions} is not iterable.')
 
@@ -1712,9 +1725,11 @@ class Router:
 
         ``name`` registers the route for use with ``url_path_for()``.
 
-        ``accept_query`` (RFC 10008) declares the request media types a QUERY
-        route accepts.  It drives the ``Accept-Query`` response header and
-        Content-Type enforcement (400 missing / 415 unsupported) — see
+        ``accept_query`` (RFC 10008) declares the request **media types** the
+        route accepts — the value of the ``Accept-Query`` response header, and
+        **not** a switch for the QUERY *method* (methods are accepted by being
+        listed in ``methods``).  It drives that header plus Content-Type
+        enforcement (400 missing / 415 unsupported) on QUERY requests — see
         ``BlackBull.route``.
         """
         logger.debug('Router.route() is called. functions=%r middlewares=%r', functions, middlewares)

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -333,6 +333,21 @@ class HTTPException(Exception):
         self.detail = detail
 
 
+class UnprocessableQuery(HTTPException):
+    """RFC 10008 §2.2 — a well-formed QUERY whose contents cannot be processed.
+
+    Raise this from a QUERY handler when the request media type was accepted
+    (so 400/415 do not apply) but the query itself is semantically invalid —
+    references an unknown field, violates a constraint, etc.  The dispatcher
+    answers ``422 Unprocessable Content`` and, being an :class:`HTTPException`
+    subclass, it flows through the normal error-router path and quiet 4xx
+    logging.
+    """
+
+    def __init__(self, detail: str = ''):
+        super().__init__(HTTPStatus.UNPROCESSABLE_ENTITY, detail)
+
+
 @dataclass
 class _RouteInfo:
     template: str
@@ -1059,6 +1074,49 @@ def _to_tuple(value: Any) -> tuple:
     return (value,)
 
 
+class _AcceptQuery(NamedTuple):
+    """Precomputed RFC 10008 ``accept_query`` plan attached to a handler.
+
+    ``header`` is the serialised ``Accept-Query`` field value (an RFC 9651
+    Structured Field list of media-type tokens, computed once at
+    registration); ``accepted`` is the frozenset of normalised (lowercased)
+    media types used for the O(1) Content-Type membership check.
+    """
+    header: bytes
+    accepted: frozenset
+
+
+def _make_accept_query(media_types: Iterable[str]) -> _AcceptQuery:
+    """Build the :class:`_AcceptQuery` plan from declared media types.
+
+    Serialising through :func:`serialize_list` validates each media type as
+    an RFC 9651 token at registration time — an invalid entry raises
+    ``ValueError`` up front rather than emitting a malformed header later.
+    """
+    from .protocol.structured_fields import Token, serialize_list  # noqa: PLC0415
+
+    types = list(media_types)
+    if not types:
+        raise ValueError('accept_query must list at least one media type')
+    header = serialize_list([(Token(mt), {}) for mt in types])
+    accepted = frozenset(mt.strip().lower() for mt in types)
+    return _AcceptQuery(header=header, accepted=accepted)
+
+
+def request_media_type(scope: dict) -> str:
+    """Return the request's media type (``Content-Type`` sans parameters),
+    lowercased; ``''`` when no Content-Type is present.
+
+    ``scope['headers']`` is a :class:`~blackbull.headers.Headers` inside
+    ``_dispatch`` (normalised at the app entry point), so a plain ``.get``
+    suffices.
+    """
+    ct = scope['headers'].get(b'content-type', b'')
+    if not ct:
+        return ''
+    return ct.split(b';', 1)[0].strip().lower().decode('latin-1')
+
+
 class _LookupCache:
     """Bounded LRU for resolved route lookups.
 
@@ -1292,6 +1350,11 @@ class Router:
                                   _fn=_fn, _params=_params):
                     scope.setdefault('path_params', {}).update(_params)
                     return await _fn(scope, receive, send)
+                # Preserve the RFC 10008 accept_query plan across the
+                # path-param wrapper so _dispatch still finds it.
+                _aq = getattr(_fn, '_bb_accept_query', None)
+                if _aq is not None:
+                    _inject._bb_accept_query = _aq
                 return _inject
             return h
 
@@ -1319,6 +1382,9 @@ class Router:
                                       _fn=_fn, _params=_params):
                         scope.setdefault('path_params', {}).update(_params)
                         return await _fn(scope, receive, send)
+                    _aq = getattr(_fn, '_bb_accept_query', None)
+                    if _aq is not None:
+                        _inject._bb_accept_query = _aq
                     return _inject
                 return fn
 
@@ -1382,13 +1448,15 @@ class Router:
                  methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
                  path: str | re.Pattern = '/',
                  scheme: Scheme | Iterable[Scheme] = Scheme.http,
-                 name: str | None = None):
+                 name: str | None = None,
+                 accept_query: Iterable[str] | None = None):
 
         logger.debug('Router.route_fn() is called.')
         methods = _to_tuple(methods)
         for m in methods:
             if isinstance(m, str):
                 _validate_method_token(m)
+        aq = _make_accept_query(accept_query) if accept_query is not None else None
 
         def register(fn):
             logger.debug(f'Router.route_fn.register() is called. {fn}')
@@ -1396,6 +1464,9 @@ class Router:
             original = fn
             if _is_simplified_handler(fn):
                 fn = _adapt_handler(fn, path, self._converters)
+
+            if aq is not None:
+                fn._bb_accept_query = aq
 
             logger.debug((path, methods, scheme))
             self[(path, methods, scheme)] = fn
@@ -1407,7 +1478,8 @@ class Router:
         return register
 
     def _register_chain(self, functions, path, methods, scheme,
-                        name: str | None = None, original_handler=None):
+                        name: str | None = None, original_handler=None,
+                        accept_query: Iterable[str] | None = None):
         """Build a middleware chain from *functions* and register it."""
         if not isinstance(functions, Iterable):
             raise TypeError(f'{functions} is not iterable.')
@@ -1432,6 +1504,9 @@ class Router:
         _ic = inner_chain
         async def _chain_wrapper(scope, receive, send):
             return await _ic(scope, receive, send)
+
+        if accept_query is not None:
+            _chain_wrapper._bb_accept_query = _make_accept_query(accept_query)
 
         self[(path, methods, scheme)] = _chain_wrapper
         self._record_route(path, original_handler or fns[-1], name,
@@ -1583,7 +1658,8 @@ class Router:
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,
               functions: list = [], middlewares: list = [],
-              name: str | None = None):
+              name: str | None = None,
+              accept_query: Iterable[str] | None = None):
         """Register a function or middleware chain in the routing table.
 
         Three calling conventions:
@@ -1595,6 +1671,11 @@ class Router:
            appended to the middleware list before the chain is registered.
 
         ``name`` registers the route for use with ``url_path_for()``.
+
+        ``accept_query`` (RFC 10008) declares the request media types a QUERY
+        route accepts.  It drives the ``Accept-Query`` response header and
+        Content-Type enforcement (400 missing / 415 unsupported) — see
+        ``BlackBull.route``.
         """
         logger.debug('Router.route() is called. functions=%r middlewares=%r', functions, middlewares)
 
@@ -1608,18 +1689,21 @@ class Router:
             if _is_simplified_handler(fns[-1]):
                 fns[-1] = _adapt_handler(fns[-1], path, self._converters)
             self._register_chain(fns, path, methods, scheme,
-                                 name=name, original_handler=original)
+                                 name=name, original_handler=original,
+                                 accept_query=accept_query)
             return lambda fn: fn
 
         if middlewares:
             def decorator(fn):
                 adapted = _adapt_handler(fn, path, self._converters) if _is_simplified_handler(fn) else fn
                 self._register_chain(list(middlewares) + [adapted], path, methods, scheme,
-                                     name=name, original_handler=fn)
+                                     name=name, original_handler=fn,
+                                     accept_query=accept_query)
                 return fn
             return decorator
 
-        return self.route_fn(methods, path, scheme, name=name)
+        return self.route_fn(methods, path, scheme, name=name,
+                             accept_query=accept_query)
 
 
 class ErrorRouter:

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -836,11 +836,15 @@ class HTTP2Recipient(BaseRecipient):
         return n
 
     async def __call__(self) -> dict:
-        # Fast path: GET with END_STREAM on HEADERS and no body — synthesize the
-        # empty http.request event without allocating a queue.
-        if (self._end_of_stream_on_headers
-                and not self._initial_consumed
-                and self._queue is None):
+        # Fast path: END_STREAM on HEADERS and no body — synthesize the empty
+        # http.request event without allocating a queue.  Checked even when a
+        # queue exists: put_disconnect() may have raced ahead of the app's
+        # first read (connection closed right after the request), and the
+        # stream still ended cleanly at HEADERS — the complete (empty) body
+        # must be delivered before any disconnect event, otherwise a
+        # body-reading handler on a body-less request (QUERY, POST with
+        # END_STREAM on HEADERS) sees a spurious client disconnect.
+        if self._end_of_stream_on_headers and not self._initial_consumed:
             self._initial_consumed = True
             return {'type': ASGIEvent.HTTP_REQUEST, 'body': b'', 'more_body': False}
         event, credit = await self._ensure_queue().get()

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -30,6 +30,45 @@ async def healthz(scope, receive, send):
     await send(Response(b'ok'))
 ```
 
+Any valid method token is accepted, as a string or an `HTTPMethod`
+member — extension methods (`PROPFIND`, vendor tokens) route the same
+way as the standard ones, and appear in the 405 `Allow` header when
+another method hits the path.
+
+### The QUERY method (RFC 10008)
+
+QUERY — the first new standard HTTP method since PATCH — is a **safe,
+idempotent, cacheable** request that carries a **request body**, closing
+the "GET with a body" gap for complex read-only queries.  The stdlib
+`http.HTTPMethod` enum has no `QUERY` member until Python 3.16, so
+BlackBull exports the method as a plain-string constant:
+
+```python
+from blackbull import BlackBull, QUERY
+
+app = BlackBull()
+
+@app.route(path='/search', methods=[QUERY])
+async def search(body: bytes):
+    return run_query(body)          # the whole query rides in the body
+```
+
+Body access works exactly as for POST — `body: bytes`, `Request.json()`,
+or draining `receive` yourself.  By registering a QUERY handler you sign
+up for the method's contract: the handler **must not** have side effects
+the client could regret repeating (safe), and repeating the same request
+must give the same result (idempotent) — caches and retrying clients
+rely on it.
+
+Two RFC 10008 notes:
+
+- The response-cache rules (the cache key must incorporate the request
+  content) bind *caches*, not origin servers — BlackBull ships no
+  response cache, so nothing to configure.
+- OpenAPI 3.1 has no `query` operation, so QUERY routes are not emitted
+  in the [generated spec](openapi.md) (they are never faked as another
+  operation).
+
 ## Path parameters
 
 Use `{name}` segments in the path string.  Captured values are

--- a/docs/guide/routing.md
+++ b/docs/guide/routing.md
@@ -60,7 +60,43 @@ the client could regret repeating (safe), and repeating the same request
 must give the same result (idempotent) — caches and retrying clients
 rely on it.
 
-Two RFC 10008 notes:
+#### Declaring accepted media types
+
+RFC 10008 lets a QUERY route advertise the request media types it
+understands and enforce them.  Pass `accept_query=[...]` to `route()`:
+
+```python
+from blackbull import BlackBull, QUERY, UnprocessableQuery
+
+@app.route(path='/search', methods=[QUERY],
+           accept_query=['application/sql', 'text/plain'])
+async def search(body: bytes):
+    try:
+        plan = compile_query(body)
+    except UnknownField as e:
+        raise UnprocessableQuery(str(e))   # → 422
+    return run(plan)
+```
+
+With `accept_query` set, BlackBull:
+
+- emits an **`Accept-Query`** response header — an
+  [RFC 9651 Structured Field](structured-fields.md) list of those media
+  types (`application/sql, text/plain`) — on the route's responses, so a
+  client can discover what to send;
+- **enforces the request `Content-Type`** on QUERY requests: a missing
+  media type is answered **400**, an unaccepted one **415** (the 415 also
+  carries `Accept-Query` so the client can correct).  The media-type
+  match ignores parameters (`; charset=…`) and is case-insensitive.
+
+Raise **`UnprocessableQuery`** from the handler for **422** when the media
+type was accepted but the query itself is semantically invalid (an unknown
+field, a violated constraint). All three statuses flow through the normal
+[error-handling](error-handling.md) path, so custom error handlers apply.
+Enforcement targets the QUERY method; other methods registered on the same
+route still receive the `Accept-Query` header but are not Content-Type-gated.
+
+Two more RFC 10008 notes:
 
 - The response-cache rules (the cache key must incorporate the request
   content) bind *caches*, not origin servers — BlackBull ships no

--- a/tests/architecture/events/test_query_method_lifecycle.py
+++ b/tests/architecture/events/test_query_method_lifecycle.py
@@ -1,0 +1,94 @@
+"""Request-lifecycle events for HTTP QUERY requests (RFC 10008, Sprint 78).
+
+The four lifecycle events (`request_received`, `before_handler`,
+`after_handler`, `request_completed`) must fire exactly once per QUERY
+request, same as any IANA method — QUERY dispatches through the raw-str
+fallback in ``BlackBull._dispatch`` (no ``http.HTTPMethod`` member until
+≥3.16), and that path must not skip or double-fire the events.
+"""
+import asyncio
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.event import Event
+
+from blackbull.server.http1_actor import HTTP1Actor
+
+from .test_request_received_event import _FakeReader, _FakeWriter
+
+
+_LIFECYCLE_EVENTS = ('request_received', 'before_handler',
+                     'after_handler', 'request_completed')
+
+
+async def _run_query_request(app, path: str = '/search',
+                             body: bytes = b'select *') -> None:
+    # HTTP1Actor's ``request=`` carries the header block only; the body is
+    # read from the reader (mirrors the keep-alive loop's readuntil split).
+    head = (f'QUERY {path} HTTP/1.1\r\n'
+            f'Host: localhost:8000\r\n'
+            f'Content-Type: text/plain\r\n'
+            f'Content-Length: {len(body)}\r\n\r\n')
+    actor = HTTP1Actor(
+        _FakeReader(body), _FakeWriter(), app, None,
+        request=head.encode(),
+        peername=('127.0.0.1', 54321),
+        sockname=('0.0.0.0', 8000),
+    )
+    await actor.run()
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_events_fire_exactly_once_for_query():
+    app = BlackBull()
+    captured: dict[str, list[Event]] = {name: [] for name in _LIFECYCLE_EVENTS}
+    done = asyncio.Event()
+
+    for name in _LIFECYCLE_EVENTS:
+        @app.on(name)
+        async def observer(event: Event, _name=name):
+            captured[_name].append(event)
+            if _name == 'request_completed':
+                done.set()
+
+    @app.route(path='/search', methods=['QUERY'])
+    async def search(scope, receive, send):
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'ok', 'more_body': False})
+
+    await _run_query_request(app)
+    await asyncio.wait_for(done.wait(), timeout=2.0)
+    await asyncio.sleep(0.2)        # settle window for late duplicates
+
+    for name in _LIFECYCLE_EVENTS:
+        assert len(captured[name]) == 1, (
+            f'{name} fired {len(captured[name])} times for a QUERY request; '
+            f'expected exactly 1')
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_event_detail_reports_query_method():
+    app = BlackBull()
+    captured: list[Event] = []
+    seen = asyncio.Event()
+
+    @app.on('request_received')
+    async def observer(event: Event):
+        captured.append(event)
+        seen.set()
+
+    @app.route(path='/search', methods=['QUERY'])
+    async def search(scope, receive, send):
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        await send({'type': 'http.response.body', 'body': b'ok', 'more_body': False})
+
+    await _run_query_request(app)
+    await asyncio.wait_for(seen.wait(), timeout=2.0)
+    await asyncio.sleep(0.2)
+    assert len(captured) == 1
+
+    d = captured[0].detail
+    assert d['method'] == 'QUERY'
+    assert d['path'] == '/search'
+    assert d['scope']['method'] == 'QUERY'

--- a/tests/conformance/http1/conftest.py
+++ b/tests/conformance/http1/conftest.py
@@ -57,6 +57,11 @@ def _make_app() -> BlackBull:
                     'headers': [(b'content-type', b'application/octet-stream')]})
         await send({'type': 'http.response.body', 'body': body})
 
+    @app.route(path='/query-typed', methods=['QUERY'],
+               accept_query=['application/sql', 'text/plain'])
+    async def query_typed(body: bytes):
+        return body
+
     @app.route(path='/chunked')
     async def chunked(scope, receive, send):
         async def events():

--- a/tests/conformance/http1/conftest.py
+++ b/tests/conformance/http1/conftest.py
@@ -11,6 +11,9 @@ differences come from the framework, not the handler:
 * ``GET /``        — replies "ok" (text)
 * ``POST /echo``   — replies with the request body verbatim
 * ``GET /chunked`` — returns a streaming response (triggers chunked TE)
+* ``QUERY /query`` — replies with the request body verbatim (RFC 10008;
+  registered with QUERY only, so any other method on the path draws a 405
+  whose Allow header must advertise QUERY)
 """
 from __future__ import annotations
 
@@ -42,6 +45,13 @@ def _make_app() -> BlackBull:
 
     @app.route(path='/echo', methods=[HTTPMethod.GET, HTTPMethod.POST, HTTPMethod.PUT])
     async def echo(scope, receive, send):
+        body = await read_body(receive)
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'application/octet-stream')]})
+        await send({'type': 'http.response.body', 'body': body})
+
+    @app.route(path='/query', methods=['QUERY'])
+    async def query(scope, receive, send):
         body = await read_body(receive)
         await send({'type': 'http.response.start', 'status': 200,
                     'headers': [(b'content-type', b'application/octet-stream')]})

--- a/tests/conformance/http1/test_client.py
+++ b/tests/conformance/http1/test_client.py
@@ -260,6 +260,31 @@ class TestHTTP1Client:
 
 
 # ---------------------------------------------------------------------------
+# QUERY method (RFC 10008) — string-form methods round-trip on both clients
+# ---------------------------------------------------------------------------
+
+class TestQueryMethod:
+    """``request()`` accepts ``str | HTTPMethod``; QUERY (no enum member
+    before Python 3.16) exercises the plain-string path with a body over
+    both protocol clients (Sprint 78 P4 pin — no dedicated sugar, the
+    clients expose no per-verb helpers)."""
+
+    @pytest.mark.asyncio
+    async def test_http1_query_with_body(self, server_port):
+        async with HTTP1Client('127.0.0.1', server_port) as c:
+            res = await c.request('QUERY', '/echo', body=b'select *')
+        assert res.status == HTTPStatus.OK
+        assert res.body == b'select *'
+
+    @pytest.mark.asyncio
+    async def test_http2_query_with_body(self, server_port):
+        async with HTTP2Client('127.0.0.1', server_port) as c:
+            res = await c.request('QUERY', '/echo', body=b'select *')
+        assert res.status == HTTPStatus.OK
+        assert res.body == b'select *'
+
+
+# ---------------------------------------------------------------------------
 # Wire-level unit tests for HTTP1RequestSender — no server needed
 # ---------------------------------------------------------------------------
 

--- a/tests/conformance/http1/test_rfc10008_query.py
+++ b/tests/conformance/http1/test_rfc10008_query.py
@@ -1,0 +1,80 @@
+"""RFC 10008 — The HTTP QUERY method, over HTTP/1.1 wire bytes.
+
+QUERY is safe + idempotent + cacheable with a request body (the first new
+standard method since PATCH).  The fixture app registers ``QUERY /query``
+as a body echo, so these tests pin:
+
+* §2 — a QUERY request with a body dispatches and the handler sees the body;
+* RFC 9110 §9.1 — QUERY is a case-sensitive token (``query`` must not match);
+* RFC 9110 §15.5.6 — other methods on a QUERY-only path draw 405 with an
+  ``Allow`` header advertising QUERY.
+
+Note: RFC 10008's cache-key rules (§4.2) bind *caches*, not origin
+servers — BlackBull ships no response cache, so nothing here tests them.
+"""
+import pytest
+
+from .conftest import send_raw
+
+
+@pytest.mark.integration
+class TestQueryDispatch:
+    """QUERY requests route and carry a request body (RFC 10008 §2)."""
+
+    def test_query_with_body_echoes(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY /query HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Type: text/plain\r\n'
+                     b'Content-Length: 8\r\n\r\n'
+                     b'select *')
+        assert r.status == 200
+        assert r.body == b'select *'
+
+    def test_query_with_empty_body(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY /query HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Length: 0\r\n\r\n')
+        assert r.status == 200
+        assert r.body == b''
+
+    def test_lowercase_query_does_not_dispatch(self, h1_app):
+        """RFC 9110 §9.1 — methods are case-sensitive tokens."""
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'query /query HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Length: 0\r\n\r\n')
+        assert r.status != 200
+
+
+@pytest.mark.integration
+class TestQueryIn405Allow:
+    """405 responses for a QUERY-registered path advertise QUERY in Allow."""
+
+    def test_post_to_query_only_path_is_405(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'POST /query HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Length: 0\r\n\r\n')
+        assert r.status == 405
+
+    def test_allow_header_contains_query(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'GET /query HTTP/1.1\r\n'
+                     b'Host: localhost\r\n\r\n')
+        assert r.status == 405
+        allow = r.header(b'allow')
+        assert allow is not None, '405 must carry an Allow header'
+        tokens = {t.strip() for t in allow.split(b',')}
+        assert b'QUERY' in tokens, f'Allow must advertise QUERY; got {allow!r}'
+
+    def test_query_on_get_only_path_is_405_without_query_in_allow(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY / HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Length: 0\r\n\r\n')
+        assert r.status == 405
+        allow = r.header(b'allow') or b''
+        tokens = {t.strip() for t in allow.split(b',')}
+        assert b'QUERY' not in tokens

--- a/tests/conformance/http1/test_rfc10008_query.py
+++ b/tests/conformance/http1/test_rfc10008_query.py
@@ -78,3 +78,38 @@ class TestQueryIn405Allow:
         allow = r.header(b'allow') or b''
         tokens = {t.strip() for t in allow.split(b',')}
         assert b'QUERY' not in tokens
+
+
+@pytest.mark.integration
+class TestAcceptQueryOnWire:
+    """RFC 10008 §2.2/§3 — Accept-Query header + Content-Type enforcement
+    on a live QUERY route declared with ``accept_query=[...]``."""
+
+    def test_accept_query_header_on_success(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY /query-typed HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Type: application/sql\r\n'
+                     b'Content-Length: 8\r\n\r\n'
+                     b'select *')
+        assert r.status == 200
+        assert r.body == b'select *'
+        assert r.header(b'accept-query') == b'application/sql, text/plain'
+
+    def test_missing_content_type_is_400(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY /query-typed HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Length: 2\r\n\r\n'
+                     b'{}')
+        assert r.status == 400
+
+    def test_unsupported_media_type_is_415_with_accept_query(self, h1_app):
+        r = send_raw('127.0.0.1', h1_app.port,
+                     b'QUERY /query-typed HTTP/1.1\r\n'
+                     b'Host: localhost\r\n'
+                     b'Content-Type: application/json\r\n'
+                     b'Content-Length: 2\r\n\r\n'
+                     b'{}')
+        assert r.status == 415
+        assert r.header(b'accept-query') == b'application/sql, text/plain'

--- a/tests/conformance/http2/test_rfc10008_query.py
+++ b/tests/conformance/http2/test_rfc10008_query.py
@@ -1,0 +1,58 @@
+"""RFC 10008 — The HTTP QUERY method, over HTTP/2 framing.
+
+``:method`` is an arbitrary token in HTTP/2 (RFC 9113 §8.3.1), so QUERY
+needs no protocol-level support — these tests pin that a QUERY request
+dispatches through HTTP2Actor to a registered BlackBull route and that the
+DATA payload reaches the handler as the request body.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from blackbull import BlackBull, QUERY, read_body
+from blackbull.protocol.frame_types import FrameTypes, DataFrameFlags
+
+from .test_http2_dispatch import (_make_h2_frame, _make_headers_frame,
+                                  _make_h2_actor)
+
+
+def _query_app(captured: dict) -> BlackBull:
+    app = BlackBull()
+
+    @app.route(path='/search', methods=[QUERY])
+    async def search(scope, receive, send):
+        captured['method'] = scope['method']
+        captured['body'] = await read_body(receive)
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'text/plain')]})
+        await send({'type': 'http.response.body', 'body': b'ok'})
+
+    return app
+
+
+@pytest.mark.asyncio
+class TestQueryOverHTTP2:
+    async def test_query_dispatches_with_data_payload(self):
+        captured: dict = {}
+        h_frame = _make_headers_frame(stream_id=1, end_stream=False,
+                                      method=b'QUERY', path=b'/search')
+        d_frame = _make_h2_frame(FrameTypes.DATA, DataFrameFlags.END_STREAM,
+                                 1, b'select *')
+
+        handler, _ = _make_h2_actor(_query_app(captured))
+        handler.receive = AsyncMock(side_effect=[h_frame, d_frame, None])
+        await handler.run()
+
+        assert captured.get('method') == 'QUERY'
+        assert captured.get('body') == b'select *'
+
+    async def test_query_without_body_dispatches(self):
+        captured: dict = {}
+        h_frame = _make_headers_frame(stream_id=1, end_stream=True,
+                                      method=b'QUERY', path=b'/search')
+
+        handler, _ = _make_h2_actor(_query_app(captured))
+        handler.receive = AsyncMock(side_effect=[h_frame, None])
+        await handler.run()
+
+        assert captured.get('method') == 'QUERY'
+        assert captured.get('body') == b''

--- a/tests/unit/test_query_accept_query.py
+++ b/tests/unit/test_query_accept_query.py
@@ -1,0 +1,161 @@
+"""RFC 10008 §2.2 / §3 — QUERY normative response semantics (Sprint 78 P2).
+
+A QUERY route may declare the request media types it accepts via the
+``accept_query=[...]`` route option.  That drives two behaviours:
+
+* **`Accept-Query` response header** — an RFC 9651 Structured Field list of
+  the accepted media types, emitted on the route's responses (success and
+  the 415 rejection) so a client can discover what to send.
+* **Content-Type enforcement** on QUERY requests — 400 when the request
+  carries no media type, 415 when the media type is not accepted (with the
+  `Accept-Query` header so the client can correct), and 422 (raisable by the
+  handler as :class:`UnprocessableQuery`) for a well-formed but semantically
+  unprocessable query.
+
+The 4xx responses flow through the normal error-router path, so custom
+error handlers keep working.
+"""
+import pytest
+
+from blackbull import BlackBull, QUERY, UnprocessableQuery
+from blackbull.testing import TestClient
+
+
+def _app():
+    app = BlackBull()
+
+    @app.route(path='/search', methods=[QUERY],
+               accept_query=['application/sql', 'text/plain'])
+    async def search(body: bytes):
+        if body == b'BOOM':
+            raise UnprocessableQuery('query references an unknown field')
+        return body
+
+    return app
+
+
+class TestAcceptQueryHeader:
+    def test_header_on_successful_query_response(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'select 1',
+                               headers={'content-type': 'application/sql'})
+            assert r.status_code == 200
+            assert r.content == b'select 1'
+            assert r.headers.get('accept-query') == 'application/sql, text/plain'
+
+    def test_header_is_structured_field_list(self):
+        """RFC 9651 SF list: comma-space separated tokens, no parameters."""
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'x',
+                               headers={'content-type': 'text/plain'})
+            aq = r.headers['accept-query']
+            assert aq == 'application/sql, text/plain'
+
+
+class TestContentTypeEnforcement:
+    def test_missing_content_type_is_400(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'select 1')
+            assert r.status_code == 400
+
+    def test_unsupported_media_type_is_415(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'{}',
+                               headers={'content-type': 'application/json'})
+            assert r.status_code == 415
+
+    def test_415_carries_accept_query_header(self):
+        """A 415 MUST advertise Accept-Query so the client can correct."""
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'{}',
+                               headers={'content-type': 'application/json'})
+            assert r.status_code == 415
+            assert r.headers.get('accept-query') == 'application/sql, text/plain'
+
+    def test_supported_media_type_passes(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'select 1',
+                               headers={'content-type': 'application/sql'})
+            assert r.status_code == 200
+
+    def test_media_type_parameters_are_ignored(self):
+        """A charset parameter must not defeat the media-type match."""
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'select 1',
+                               headers={'content-type': 'application/sql; charset=utf-8'})
+            assert r.status_code == 200
+
+    def test_media_type_match_is_case_insensitive(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'select 1',
+                               headers={'content-type': 'Application/SQL'})
+            assert r.status_code == 200
+
+
+class TestUnprocessableQuery:
+    def test_handler_raises_422(self):
+        with TestClient(_app()) as client:
+            r = client.request('QUERY', '/search', content=b'BOOM',
+                               headers={'content-type': 'application/sql'})
+            assert r.status_code == 422
+
+    def test_422_is_httpexception_subclass(self):
+        from blackbull.router import HTTPException
+        from http import HTTPStatus
+        exc = UnprocessableQuery('nope')
+        assert isinstance(exc, HTTPException)
+        assert exc.status == HTTPStatus.UNPROCESSABLE_ENTITY
+
+
+class TestEnforcementScope:
+    def test_non_query_method_is_not_enforced(self):
+        """accept_query enforcement targets QUERY; other methods registered on
+        the path are not Content-Type-gated by it."""
+        app = BlackBull()
+
+        @app.route(path='/multi', methods=[QUERY, 'POST'],
+                   accept_query=['application/sql'])
+        async def multi(body: bytes):
+            return body
+
+        with TestClient(app) as client:
+            # POST with no Content-Type is not rejected by the QUERY gate.
+            r = client.post('/multi', content=b'hi')
+            assert r.status_code == 200
+
+    def test_route_without_accept_query_has_no_header(self):
+        app = BlackBull()
+
+        @app.route(path='/plain', methods=[QUERY])
+        async def plain(body: bytes):
+            return body
+
+        with TestClient(app) as client:
+            r = client.request('QUERY', '/plain', content=b'x')
+            assert r.status_code == 200
+            assert 'accept-query' not in r.headers
+
+
+class TestCustomErrorHandlerStillWorks:
+    def test_415_reaches_custom_error_handler(self):
+        from http import HTTPStatus
+
+        app = BlackBull()
+
+        @app.route(path='/search', methods=[QUERY],
+                   accept_query=['application/sql'])
+        async def search(body: bytes):
+            return body
+
+        @app.on_error(HTTPStatus.UNSUPPORTED_MEDIA_TYPE)
+        async def on_415(scope, receive, send):
+            await send(b'custom 415', HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                       [(b'content-type', b'text/plain')])
+
+        with TestClient(app) as client:
+            r = client.request('QUERY', '/search', content=b'{}',
+                               headers={'content-type': 'application/json'})
+            assert r.status_code == 415
+            assert r.content == b'custom 415'
+            # The injector still adds Accept-Query beneath a custom handler.
+            assert r.headers.get('accept-query') == 'application/sql'

--- a/tests/unit/test_query_method.py
+++ b/tests/unit/test_query_method.py
@@ -1,0 +1,167 @@
+"""HTTP QUERY method support (RFC 10008) — Sprint 78 P1.
+
+QUERY (RFC 10008, June 2026) is the first new standard HTTP method since
+PATCH: safe + idempotent + cacheable, **with a request body**.  The stdlib
+``http.HTTPMethod`` enum has no ``QUERY`` member (RFC 10008 postdates the
+3.15 feature freeze), so the package exports a plain-string constant
+``blackbull.QUERY`` usable anywhere a method is accepted.
+
+These tests pin the string-form routing path (register → dispatch → 405
+Allow) and the forward-compat contract: if CPython later grows
+``HTTPMethod.QUERY``, ``StrEnum`` equality must keep string-registered
+routes matching enum-coerced dispatch keys with no migration.
+"""
+from enum import StrEnum
+from http import HTTPMethod
+
+import pytest
+
+from blackbull import BlackBull, Request, QUERY
+from blackbull.router import Router, MethodNotApplicable
+from blackbull.utils import Scheme
+from blackbull.testing import TestClient
+
+
+class _FutureHTTPMethod(StrEnum):
+    """Stand-in for a future ``http.HTTPMethod.QUERY`` member (≥3.16)."""
+    QUERY = 'QUERY'
+
+
+# ---------------------------------------------------------------------------
+# The exported constant
+# ---------------------------------------------------------------------------
+
+class TestQueryConstant:
+    def test_value(self):
+        assert QUERY == 'QUERY'
+
+    def test_is_str(self):
+        # Plain str, not an enum: usable as a dict key interchangeably with
+        # a future StrEnum member of the same value.
+        assert isinstance(QUERY, str)
+
+    def test_equal_to_future_enum_member(self):
+        assert QUERY == _FutureHTTPMethod.QUERY
+        assert hash(QUERY) == hash(_FutureHTTPMethod.QUERY)
+
+
+# ---------------------------------------------------------------------------
+# Router registration + lookup (string form)
+# ---------------------------------------------------------------------------
+
+class TestRouterQuery:
+    def _router_with_query_route(self):
+        router = Router()
+        async def handler(scope, receive, send): ...
+        router[('/q', QUERY)] = handler
+        return router, handler
+
+    def test_register_and_lookup(self):
+        router, handler = self._router_with_query_route()
+        assert router[('/q', 'QUERY', Scheme.http)] is handler
+
+    def test_lookup_with_future_enum_member(self):
+        """Forward-compat: when CPython adds HTTPMethod.QUERY, _dispatch will
+        coerce 'QUERY' to the enum member; the string-registered route must
+        still match (StrEnum hash/eq contract)."""
+        router, handler = self._router_with_query_route()
+        assert router[('/q', _FutureHTTPMethod.QUERY, Scheme.http)] is handler
+
+    def test_register_with_enum_lookup_with_str(self):
+        """The reverse direction: enum-registered, string-dispatched."""
+        router = Router()
+        async def handler(scope, receive, send): ...
+        router[('/q', _FutureHTTPMethod.QUERY)] = handler
+        assert router[('/q', 'QUERY', Scheme.http)] is handler
+
+    def test_query_on_get_only_path_raises_405(self):
+        router = Router()
+        async def handler(scope, receive, send): ...
+        router[('/g', HTTPMethod.GET)] = handler
+        with pytest.raises(MethodNotApplicable) as exc:
+            router[('/g', QUERY, Scheme.http)]
+        assert QUERY not in exc.value.allowed_methods
+
+    def test_allowed_methods_includes_query(self):
+        """405 on a QUERY-registered path must advertise QUERY in Allow."""
+        router, handler = self._router_with_query_route()
+        with pytest.raises(MethodNotApplicable) as exc:
+            router[('/q', HTTPMethod.POST, Scheme.http)]
+        assert 'QUERY' in {str(m) for m in exc.value.allowed_methods}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end dispatch through TestClient
+# ---------------------------------------------------------------------------
+
+class TestQueryDispatch:
+    def _app(self):
+        app = BlackBull()
+
+        @app.route(path='/search', methods=[QUERY])
+        async def search(body: bytes):
+            return body
+
+        @app.route(path='/json', methods=[QUERY])
+        async def search_json(request: Request):
+            data = await request.json()
+            return {'echo': data}
+
+        @app.route(path='/getonly')
+        async def getonly():
+            return 'ok'
+
+        return app
+
+    def test_query_dispatches_with_body(self):
+        with TestClient(self._app()) as client:
+            r = client.request('QUERY', '/search', content=b'select *')
+            assert r.status_code == 200
+            assert r.content == b'select *'
+
+    def test_query_request_json(self):
+        with TestClient(self._app()) as client:
+            r = client.request('QUERY', '/json', json={'q': 'bull'})
+            assert r.status_code == 200
+            assert r.json() == {'echo': {'q': 'bull'}}
+
+    def test_query_on_get_only_route_is_405(self):
+        with TestClient(self._app()) as client:
+            r = client.request('QUERY', '/getonly')
+            assert r.status_code == 405
+
+    def test_405_allow_header_includes_query(self):
+        with TestClient(self._app()) as client:
+            r = client.post('/search')
+            assert r.status_code == 405
+            allow = r.headers.get('allow', '')
+            assert 'QUERY' in {m.strip() for m in allow.split(',')}
+
+    def test_get_routes_reports_query(self):
+        routes = {(ri.method, ri.path) for ri in self._app().get_routes()}
+        assert ('QUERY', '/search') in routes
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI: QUERY routes are excluded under the 3.1 emitter (Sprint 78 P3)
+# ---------------------------------------------------------------------------
+
+class TestQueryOpenAPI:
+    def test_query_route_excluded_from_31_spec(self):
+        """OpenAPI 3.1 has no `query` operation (3.2 does).  Until the
+        emitter moves to 3.2, QUERY routes stay out of the spec — and must
+        never be faked as another operation."""
+        from blackbull.openapi import generate_spec
+
+        app = BlackBull()
+
+        @app.route(path='/search', methods=[QUERY, HTTPMethod.GET])
+        async def search():
+            return 'ok'
+
+        spec = generate_spec(app)
+        assert spec['openapi'].startswith('3.1')
+        ops = set(spec['paths']['/search'])
+        assert 'get' in ops
+        assert 'query' not in ops
+        assert ops == {'get'}


### PR DESCRIPTION
## Summary

Sprint 78: first-mover support for the HTTP **QUERY** method (RFC 10008, Proposed Standard, June 2026) — the first new standard HTTP method since PATCH: safe + idempotent + cacheable, **with a request body**. As of July 2026 no Python framework ships native support.

Per `.claude/planning/proposals/query-method-rfc10008.md`, all four phases land here.

### P1 — routing + ergonomics
New `blackbull.QUERY` plain-string constant (`http.HTTPMethod` gains no member before Python 3.16; `StrEnum` equality keeps string-registered routes matching a future enum member — pinned by a forward-compat test). Routing already worked via the raw-str fallback in `BlackBull._dispatch`; this pins it with tests over HTTP/1.1 wire bytes, HTTP/2 framing, and `TestClient` — body params, 405 `Allow` advertisement, exactly-once lifecycle events. New routing-guide section.

### P2 — normative response semantics (`accept_query=[...]`)
New route option declaring the request media types a QUERY route accepts (API surface — a `route()` kwarg — approved by the maintainer). It drives:
- an **`Accept-Query`** response header (RFC 9651 Structured Field list, serialized once at registration; `serialize_list` validates each media type as an sf-token so bad entries fail fast at import) on the route's responses, injected at the ASGI-dict level *below* `_wrap_send`;
- **Content-Type enforcement** on QUERY requests: **400** (missing media type), **415** (unaccepted — carries `Accept-Query`), matching case-insensitively and ignoring parameters. Short-circuits to the error router like 405/404.

New `blackbull.UnprocessableQuery` (an `HTTPException` subclass) for handlers to raise → **422**. All three statuses flow the normal error-router path; custom error handlers keep working (verified). Enforcement targets QUERY only; other methods on the route still receive the header.

### P3 — OpenAPI decision (resolved)
The emitter targets OpenAPI 3.1, which has no `query` operation — QUERY routes stay excluded (with a debug log), never faked as another operation. Revisit if/when the emitter moves to 3.2.

### P4 — client
No `c.query()` sugar — the experimental clients expose no per-verb helpers at all, so a lone helper would be inconsistent. Both clients' `request('QUERY', ...)` string form is pinned by live round-trips instead.

## Bug found and fixed (test-driven, P1)

`HTTP2Recipient` delivered `http.disconnect` instead of the request body when HEADERS carried END_STREAM and the connection closed before the handler's first `receive()`: `put_disconnect()` allocated the event queue, which disabled the synthetic empty-body fast path in `__call__`. The stream had ended cleanly at HEADERS, so the complete (empty) `http.request` is now always delivered first; the disconnect follows. Invisible for GET handlers; surfaced by body-reading QUERY handlers.

## Hot path

Router method matching is unchanged (data-driven; Sprint 77 fast path untouched). `accept_query` costs nothing for routes that don't set it — the `_dispatch` check is a single `getattr(function, '_bb_accept_query', None)`. The `HTTP2Recipient.__call__` fast-path check drops one `is None` comparison.

## Test plan

- 41 new tests across `tests/unit/test_query_method.py`, `tests/unit/test_query_accept_query.py`, `tests/conformance/http1/test_rfc10008_query.py`, `tests/conformance/http2/test_rfc10008_query.py`, `tests/architecture/events/test_query_method_lifecycle.py`, and client round-trips in `test_client.py`
- Full suite green under `--beartype-packages=blackbull` (5247 passed); `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)