### PR TITLE
release: v0.59.0 — Sprint 78 (HTTP QUERY / RFC 10008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.59.0] — 2026-07-19
+
 ### Added
 
 - **QUERY normative response semantics (RFC 10008, Sprint 78 P2).** New
@@ -71,6 +73,18 @@ so the editable install's metadata catches up.
   `http.request`.  The synthetic event is now delivered first; the
   disconnect follows it.  Invisible for GET handlers, which never read
   the body.
+
+### Internal
+
+- **Generic per-route hooks replace the QUERY dispatch special-case.**
+  `accept_query` enforcement is now implemented through two
+  method-agnostic handler hooks — `_bb_response_headers` (extra headers
+  injected on every response, success and central error alike) and
+  `_bb_request_guard` (a pre-dispatch callable that may reject with an
+  `HTTPException`) — which `BlackBull._dispatch` applies uniformly. The
+  dispatcher carries no method-specific branch; all QUERY-specific logic
+  lives in the guard built at registration. Reusable by any future
+  per-route response-header or request-guard feature. No behaviour change.
 
 ## [0.58.0] — 2026-07-19
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -81,6 +81,22 @@ the exact "with N slow connections, first new connection
 accepted within M ms" curve — only the qualitative claim "RFC
 9110 §15.5.9 compliant 408 plus the three timeouts work".
 
+### HTTP QUERY (RFC 10008) — two deliberate edges
+
+QUERY routing, `Accept-Query` content negotiation, and Content-Type
+enforcement ship (see the [routing guide](docs/guide/routing.md)), but
+two edges are out of scope for now:
+
+- **OpenAPI**: QUERY routes are excluded from the generated document.
+  OpenAPI 3.1 has no `query` operation; 3.2 adds one — revisit when the
+  emitter moves to 3.2.  QUERY is never faked as another operation.
+- **`Accept-Query` on OPTIONS**: RFC 10008 mentions emitting the header
+  on OPTIONS for a path; BlackBull only auto-handles OPTIONS when a route
+  is registered for it, so the header is emitted on the QUERY route's own
+  responses (including its 415), not synthesised on an unrouted OPTIONS.
+
+No browser implements QUERY; server + client + tests are the whole story.
+
 ---
 
 ## RFC-defensible differential-corpus divergences

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ Hello, world!
   message-passing concurrency runs your HTTP routes, the MQTT broker,
   and the gRPC handlers — one model across every protocol.
 - **RFC-grade correctness.** Passes the same external conformance
-  suites used to validate nginx and Envoy (`h2spec`, Autobahn).
+  suites used to validate nginx and Envoy (`h2spec`, Autobahn).  First
+  Python framework with native **HTTP QUERY** (RFC 10008) support — the
+  new safe, idempotent, cacheable method that carries a request body,
+  with `Accept-Query` content negotiation.
 - **Typed throughout.** Your editor and `mypy` / `pyright` see
   every parameter; PEP 561 typed distribution.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.59.x  | :white_check_mark: |
 | 0.58.x  | :white_check_mark: |
-| 0.57.x  | :white_check_mark: |
-| < 0.57  | :x:                |
+| < 0.58  | :x:                |
 
 This table updates with each minor release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.58.0"
+version = "0.59.0"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Closes **Sprint 78**. Ships first-mover native **HTTP QUERY** support (RFC 10008) — the first new standard HTTP method since PATCH: safe, idempotent, cacheable, with a request body. As of July 2026 no other Python framework has native support.

**Added**
- `blackbull.QUERY` constant; QUERY routing, body access, 405 `Allow`, and the four lifecycle events pinned over HTTP/1.1, HTTP/2, and TestClient; clients round-trip `request('QUERY', …)`.
- `accept_query=[...]` route option → `Accept-Query` response header (RFC 9651 Structured Field list) + Content-Type enforcement (400 missing / 415 unaccepted, header carried on the 415). `blackbull.UnprocessableQuery` → 422. Enforcement is QUERY-only; other methods on the route still receive the header; custom `@app.on_error(status)` handlers honoured.
- OpenAPI decision: 3.1 has no `query` operation → QUERY routes excluded (never faked), with a debug log.

**Fixed**
- HTTP/2 spurious `http.disconnect` on body-less requests — the END_STREAM-on-HEADERS synthetic empty body is delivered before any disconnect. Invisible for GET; surfaced by body-reading QUERY handlers.

**Internal**
- Generic per-route hooks (`_bb_response_headers` + `_bb_request_guard`) replace the QUERY-named dispatch special-case; `_dispatch` names no method or feature.

Feature work landed in #171; this is the two-file release commit (+ a pre-release docs-audit commit for README / SECURITY / KNOWN_LIMITATIONS).

## Test plan

- [x] Full suite green under `--beartype-packages=blackbull` (pre-commit hook, both commits)
- [x] `mkdocs build --strict` clean
- [x] Editable install reports `0.59.0`
- [ ] CodeQL + CI green on this PR