### PR TITLE
fix(sender): auto-flush trailers-coalesced body to prevent streaming deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.59.1] — 2026-07-20
+
+### Fixed
+
+- **gRPC server-streaming Watch flakiness (DEADLINE_EXCEEDED).** The
+  H2 sender's trailers-coalescing optimisation buffered the first DATA
+  frame when `trailers: True` was set on the response start, deferring
+  the write until trailers arrived (the unary-gRPC fast path).  For
+  server-streaming handlers that park after the first yield (health
+  Watch, chat streams), the buffered frame was never flushed, starving
+  the client.  Added a `call_soon` auto-flush: if trailers (or a
+  second body chunk) don't arrive within the same event-loop iteration,
+  the buffered body is flushed immediately.  The unary coalescing path
+  is preserved — synchronous trailers still combine into a single
+  write.  (#TBD)
+
 ## [0.59.0] — 2026-07-19
 
 ### Added

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -835,6 +835,33 @@ class HTTP2Sender(BaseSender):
         if set_end_stream:
             self._end_stream_sent = True
 
+    def _auto_flush_buffered_body(self) -> None:
+        """``call_soon`` callback — if the buffered body hasn't been consumed
+        by a synchronous trailers or second-body event, flush it now.
+
+        ``call_soon`` callbacks fire at the start of the next event-loop
+        iteration, *after* any synchronous ASGI events emitted in the same
+        coroutine.  This gives trailers (or a second body chunk) a chance to
+        coalesce before the auto-flush fires."""
+        if self._buffered_body is None:
+            return
+        asyncio.ensure_future(self._do_auto_flush())
+
+    async def _do_auto_flush(self) -> None:
+        """Flush the buffered body + headers.  Called as a task when the
+        event loop detects the producer has parked (no synchronous trailers
+        or second body arrived within the same event-loop iteration)."""
+        body = self._buffered_body
+        status = self._buffered_status
+        headers = self._buffered_headers
+        expect = self._expect_trailers
+        if body is None or status is None:
+            return
+        self._buffered_body = None
+        self._buffered_status = None
+        self._buffered_headers = None
+        await self._flush_buffered_start(body, False, status, headers, expect)
+
     async def send_response_headers(
         self, status: HTTPStatus, headers: list[tuple[bytes, bytes]],
     ) -> None:
@@ -1019,6 +1046,8 @@ class HTTP2Sender(BaseSender):
                             and len(payload) <= self.stream_window_size
                             and len(payload) <= self._conn_window.size):
                         self._buffered_body = payload
+                        asyncio.get_running_loop().call_soon(
+                            self._auto_flush_buffered_body)
                     else:
                         # A second body chunk (or a multi-frame / terminal one):
                         # flush any deferred first chunk with the HEADERS, then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.59.0"
+version = "0.59.1"
 description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Fixes intermittent `DEADLINE_EXCEEDED` on gRPC server-streaming Watch calls (`test_health_watch_observes_status_flip`).

## Root cause

The H2 sender's trailers-coalescing optimisation (Sprint 59) buffered the first DATA frame when `trailers: True` was set, deferring the write until trailers arrived. For server-streaming handlers that park after the first yield (health Watch, chat streams), the buffered frame was never flushed — the client waited 5 seconds then hit DEADLINE_EXCEEDED.

## Fix

Added a `call_soon` auto-flush callback: if trailers (or a second body chunk) don't arrive within the same event-loop iteration, the buffered body is flushed immediately. The unary coalescing path is preserved — synchronous trailers still combine into a single write.

## Verification

- `test_health_watch_observes_status_flip`: 0/20 failures (was ~40% failure rate)
- Full gRPC + H2 test suite: 587 passed, 9 skipped
- Performance: no measurable regression on both H2 /json and gRPC GetSum benchmarks

## Release

v0.59.1 patch — CHANGELOG + version bump included.