### PR TITLE
ci(deps): sync all codeql-action steps to v4.37.1 (fixes #178 CodeQL failure)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0   # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9   # v4.37.0
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -50,7 +50,7 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9   # v4.37.0
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,6 @@ jobs:
         uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9   # v4.37.0
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9   # v4.37.0
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Problem

Dependabot PR #178 bumped **only** `github/codeql-action/analyze` to v4.37.1, leaving `init` and `autobuild` on v4.37.0. The CodeQL Action requires every step in a run to be the same version, so the `analyze` post-action step failed with a configuration error:

```
##[error]Loaded a configuration file for version '4.37.0', but running version '4.37.1'
CodeQL job status was configuration error.
```

This is why the **Analyze (python)** check on #178 fails.

## Fix

Bump `init` and `autobuild` to the same v4.37.1 commit (`7188fc363630916deb702c7fdcf4e481b751f97a`, verified as the deref of tag `v4.37.1`), matching the `analyze` step. All three CodeQL steps now run v4.37.1.

This supersedes #178, which should be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)