### PR TITLE
chore(peers): add native BlackBull app, Sanic peer, and server support

### DIFF
--- a/bench/peers/compare_servers.sh
+++ b/bench/peers/compare_servers.sh
@@ -71,7 +71,7 @@ DURATION="${DURATION:-60}"
 # steady-state before the measured runs start.
 WARMUP="${WARMUP:-15}"
 
-STACKS_ALL="blackbull uvicorn hypercorn granian daphne nginx"
+STACKS_ALL="blackbull uvicorn hypercorn granian daphne nginx sanic"
 # Sprint 24 added Lane E (connection churn).  Defaulting it off in the
 # all-lanes set so existing AWS runs (and the cost envelope they assume)
 # don't grow without intent — opt in with LANES="A B-wrk B-oha C D E-wrk".

--- a/bench/peers/native_app.py
+++ b/bench/peers/native_app.py
@@ -1,0 +1,90 @@
+"""Native BlackBull benchmark app — wire-compatible with bench/peers/asgi_app.py.
+
+Uses BlackBull's native Connection API (no ASGI scope dict, no compat shim).
+Same endpoints, same response bodies, same content-types as asgi_app.py.
+
+Loaded by BlackBull's own server:
+    blackbull bench.peers.native_app:app --bind 127.0.0.1:8443 ...
+"""
+import os
+from http import HTTPMethod
+
+from blackbull import BlackBull, Response
+
+app = BlackBull()
+
+# -- pre-encoded bodies (same as asgi_app.py) -------------------------------
+_PLAINTEXT = b"Hello, World!"
+_JSON = b'{"message":"Hello, World!"}'
+_PONG = b"pong"
+_1KB = os.urandom(1024)
+_16KB = os.urandom(16000)
+_64KB = os.urandom(65536)
+_1MB = os.urandom(1024 * 1024)
+
+_PLAIN_CT = "text/plain; charset=utf-8"
+_HTML_CT = "text/html; charset=utf-8"
+_JSON_CT = "application/json"
+_OCTET_CT = "application/octet-stream"
+
+
+@app.route(path="/ping", methods=[HTTPMethod.GET])
+async def ping():
+    return Response(_PONG, content_type=_HTML_CT)
+
+
+@app.route(path="/plaintext", methods=[HTTPMethod.GET])
+async def plaintext():
+    return Response(_PLAINTEXT, content_type=_PLAIN_CT)
+
+
+@app.route(path="/json", methods=[HTTPMethod.GET])
+async def json_endpoint():
+    return Response(_JSON, content_type=_JSON_CT)
+
+
+@app.route(path="/1kb", methods=[HTTPMethod.GET])
+async def _1kb_endpoint():
+    return Response(_1KB, content_type=_HTML_CT)
+
+
+@app.route(path="/16kb", methods=[HTTPMethod.GET])
+async def _16kb_endpoint():
+    return Response(_16KB, content_type=_HTML_CT)
+
+
+@app.route(path="/64kb", methods=[HTTPMethod.GET])
+async def _64kb_endpoint():
+    return Response(_64KB, content_type=_HTML_CT)
+
+
+@app.route(path="/1mb", methods=[HTTPMethod.GET])
+async def _1mb_endpoint():
+    return Response(_1MB, content_type=_HTML_CT)
+
+
+@app.route(path="/echo", methods=[HTTPMethod.POST])
+async def echo(body: bytes):
+    return Response(body, content_type=_OCTET_CT)
+
+
+@app.route(path="/ws", methods=[HTTPMethod.GET])
+async def ws_echo(conn, receive, send):
+    """WebSocket echo — full-form handler (conn, receive, send)."""
+    event = await receive()
+    if event.get("type") != "websocket.connect":
+        return
+    await send({"type": "websocket.accept"})
+    while True:
+        event = await receive()
+        t = event.get("type", "")
+        if t == "websocket.disconnect":
+            break
+        if t != "websocket.receive":
+            continue
+        text = event.get("text")
+        if text is not None:
+            await send({"type": "websocket.send", "text": text})
+        else:
+            await send({"type": "websocket.send",
+                        "bytes": event.get("bytes") or b""})

--- a/bench/peers/run_peer.sh
+++ b/bench/peers/run_peer.sh
@@ -42,7 +42,7 @@ BIND_HOST="${BIND_HOST:-127.0.0.1}"
 
 if [ -z "$stack" ]; then
     echo "Usage: $0 <stack> [port] [cert] [key]" >&2
-    echo "Bases: blackbull, uvicorn, hypercorn, granian, daphne, nginx" >&2
+    echo "Bases: blackbull, uvicorn, hypercorn, granian, daphne, nginx, sanic" >&2
     echo "Variants (Sprint 14): <base>-cleartext, <base>-nginx, uvicorn-h11" >&2
     echo "Variants (Sprint 16): blackbull-w<N> (N workers, e.g. blackbull-w4)" >&2
     exit 1
@@ -157,7 +157,7 @@ case "$base" in
                 BB_H2_CONNECTION_WINDOW_SIZE=65535
                 BB_H2_MAX_CONCURRENT_STREAMS=100
                 BB_ACCESS_LOG=0
-            blackbull bench.peers.asgi_app:app
+            blackbull bench.peers.native_app:app
                 --bind "${BIND_HOST}:${upstream_port}"
                 "${bb_tls_args[@]}"
         )
@@ -282,12 +282,30 @@ json.dump(cfg, open(sys.argv[2], 'w'))
         nginx -c "$conf" -t 2>&1 || exit 1
         exec nginx -c "$conf"
         ;;
+    sanic)
+        # Sanic's built-in server (HTTP/1.1 + WebSocket).  No HTTP/2, no
+        # cleartext/nginx variants — this is a native-stack comparison
+        # against BlackBull's own server.
+        # Sanic 25.x: TLS via ssl={'cert': ..., 'key': ...}
+        if [ "$variant" = "tls" ]; then
+            ssl_args=(--cert "$cert" --key "$key")
+        else
+            ssl_args=()
+        fi
+        LAUNCH_CMD=(
+            python3 bench/peers/sanic_app.py
+                --host "$BIND_HOST" --port "$upstream_port"
+                "${ssl_args[@]}"
+        )
+        finalize
+        ;;
     *)
         echo "Unknown base stack: $base (from input '$stack')" >&2
-        echo "Valid bases: blackbull, uvicorn, hypercorn, granian, daphne, nginx" >&2
+        echo "Valid bases: blackbull, uvicorn, hypercorn, granian, daphne, nginx, sanic" >&2
         echo "Variants (blackbull|uvicorn|granian only): -cleartext, -nginx" >&2
         echo "Variants (uvicorn only): -h11" >&2
         echo "Variants (blackbull only):  -w<N>  (e.g. blackbull-w4)" >&2
+        echo "Sanic runs its built-in server (HTTP/1.1 + WS); TLS via ssl={...}." >&2
         exit 1
         ;;
 esac

--- a/bench/peers/sanic_app.py
+++ b/bench/peers/sanic_app.py
@@ -1,0 +1,89 @@
+"""Sanic benchmark app — wire-compatible with bench/peers/asgi_app.py.
+
+Same endpoints, same response bodies, same content-types.
+Runs on Sanic's built-in server (not ASGI).
+
+Usage:
+    python3 bench/peers/sanic_app.py [--port PORT] [--cert CERT] [--key KEY]
+"""
+import argparse
+import os
+
+from sanic import Sanic
+from sanic.response import text, json, raw
+
+app = Sanic("bench")
+
+# -- pre-encoded bodies (same as asgi_app.py) -------------------------------
+_PLAINTEXT = b"Hello, World!"
+_JSON_BODY = b'{"message":"Hello, World!"}'
+_PONG = b"pong"
+_1KB = os.urandom(1024)
+_16KB = os.urandom(16000)
+_64KB = os.urandom(65536)
+_1MB = os.urandom(1024 * 1024)
+
+
+@app.get("/ping")
+async def ping(_request):
+    return raw(_PONG, content_type="text/html; charset=utf-8")
+
+
+@app.get("/plaintext")
+async def plaintext(_request):
+    return raw(_PLAINTEXT, content_type="text/plain; charset=utf-8")
+
+
+@app.get("/json")
+async def json_endpoint(_request):
+    return raw(_JSON_BODY, content_type="application/json")
+
+
+@app.get("/1kb")
+async def _1kb_endpoint(_request):
+    return raw(_1KB, content_type="text/html; charset=utf-8")
+
+
+@app.get("/16kb")
+async def _16kb_endpoint(_request):
+    return raw(_16KB, content_type="text/html; charset=utf-8")
+
+
+@app.get("/64kb")
+async def _64kb_endpoint(_request):
+    return raw(_64KB, content_type="text/html; charset=utf-8")
+
+
+@app.get("/1mb")
+async def _1mb_endpoint(_request):
+    return raw(_1MB, content_type="text/html; charset=utf-8")
+
+
+@app.post("/echo")
+async def echo(request):
+    return raw(request.body or b"", content_type="application/octet-stream")
+
+
+@app.websocket("/ws")
+async def ws_echo(_request, ws):
+    while True:
+        data = await ws.recv()
+        await ws.send(data)
+
+
+# -- Entry point ------------------------------------------------------------
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Sanic benchmark app")
+    parser.add_argument("--port", type=int, default=8443)
+    parser.add_argument("--cert", default=None)
+    parser.add_argument("--key", default=None)
+    parser.add_argument("--host", default="127.0.0.1")
+    args = parser.parse_args()
+
+    kwargs = dict(host=args.host, port=args.port,
+                  access_log=False, motd=False, single_process=True)
+
+    if args.cert and args.key:
+        kwargs["ssl"] = {"cert": args.cert, "key": args.key}
+
+    app.run(**kwargs)


### PR DESCRIPTION
## Summary

Add `bench/peers/` files for native BlackBull and Sanic peer benchmarking.

### Added

| File | Purpose |
|---|---|
| `native_app.py` | BlackBull native `Connection` path benchmark entrypoint — replaces `asgi_app.py` for peer server comparisons |
| `sanic_app.py` | Sanic benchmark entrypoint for cross-framework comparison |

### Modified

| File | Change |
|---|---|
| `compare_servers.sh` | Add `sanic` to `STACKS_ALL` default server list |
| `run_peer.sh` | Switch BlackBull from `asgi_app` to `native_app`; add Sanic server launch case |

### Not included (gitignored)

- `compare.sh`, `httparena_calibrate.py` — in `.gitignore`
- `NOTES.private.md` — `*.private.md` pattern
- `bench/results/*` — runtime output
- `__pycache__/` — build artifacts

---
Inter-sprint work.