### PR TITLE
feat: type the receive/send message channel (Sprint 81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,51 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **Typed `receive`/`send` message channel.**  The 19 ASGI 3.0 message
+  shapes are now declared as `TypedDict`s keyed by a `Literal` `type` tag,
+  with a union per direction — `ASGIReceiveEvent` (7 members) and
+  `ASGISendEvent` (12) — and a callable alias per direction,
+  `ASGIReceiveCallable` / `ASGISendCallable`.  All four are exported from
+  `blackbull`; the individual shapes (`HTTPResponseStartEvent`,
+  `WebSocketReceiveEvent`, …) are importable from `blackbull.asgi`.
+
+  Because the unions are discriminated on `type`, comparing or `match`-ing
+  against `event['type']` narrows to a single member, so a type checker can
+  reject a wrong key, a wrong value type, or an event sent in the wrong
+  direction.  It also catches the 0.43.2-class type-confusion bug — a
+  `Response` object reaching a middleware `send` wrapper, which fails at
+  runtime on `event['type']` — statically rather than at runtime.
+
+  **This is a declaration-only change.**  The dicts on the wire are
+  unchanged, nothing is validated or converted at runtime, and unannotated
+  application code keeps working exactly as before.
+
+- **Static type-check gate.**  `tests/architecture/test_typing_gate.py` runs
+  pyright over a deliberately narrow scope (`blackbull/asgi.py` +
+  `tests/typing/`) and asserts both directions: the narrowing proofs produce
+  zero diagnostics, and every `# EXPECT-ERROR` line in the negative proof
+  draws at least one.  Requires the `[testing]` extra (pyright is pinned
+  exactly); skips cleanly when pyright is unavailable.
+
+### Changed
+
+- Project description and overview no longer call BlackBull an "ASGI 3.0
+  framework".  Since Sprint 79/80 the internal representation is a native,
+  typed `Connection` threaded end to end, and ASGI is an interop boundary
+  (external ASGI hosts, `BB_FORCE_ASGI_SCOPE=1`) — the prose now says so.
+  ASGI-prefixed *type names* are kept deliberately: they mark the boundary
+  vocabulary, and the values they carry are spec-defined ASGI strings.
+
+### Fixed
+
+- `tests/integration/test_nginx.py` imported the optional `docker` /
+  `testcontainers` extras at module scope, so a missing extra became a
+  collection error that interrupted the whole pytest session instead of
+  skipping one file.  Now guarded with `pytest.importorskip`, matching the
+  sibling differential test.
+
 ## [0.61.0] — 2026-07-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ so the editable install's metadata catches up.
   ASGI-prefixed *type names* are kept deliberately: they mark the boundary
   vocabulary, and the values they carry are spec-defined ASGI strings.
 
+### Internal
+
+- Per-request `send` wrapper closures are deliberately left unannotated.  A
+  nested `async def` created inside a per-request factory rebuilds an
+  `__annotate__` closure on every creation — measured at ~93 ns per closure
+  on CPython 3.14, or ~0.23 µs/req (~3.4 % of in-process dispatch) across the
+  three wrappers on the HTTP/1.1 path.  Annotations are only free on
+  definitions evaluated once at import.  The accepted event shapes are
+  documented in a comment at each site instead; `Compression`'s two wrappers
+  are now covered by the same rule, making them slightly cheaper than in
+  0.61.0.
+
 ### Fixed
 
 - `tests/integration/test_nginx.py` imported the optional `docker` /

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BlackBull
 
-**BlackBull** is a Python ASGI 3.0 web framework for developers who
+**BlackBull** is a Python web framework — native typed `Connection`
+end to end, ASGI 3.0 kept as an interop boundary — for developers who
 want one `pip install`, zero C compilers, and the ability to
 programmatically test their HTTP clients and servers against
 deliberate protocol misbehaviour.
@@ -76,7 +77,10 @@ Hello, world!
   new safe, idempotent, cacheable method that carries a request body,
   with `Accept-Query` content negotiation.
 - **Typed throughout.** Your editor and `mypy` / `pyright` see
-  every parameter; PEP 561 typed distribution.
+  every parameter; PEP 561 typed distribution.  The `receive`/`send`
+  message channel is a discriminated union — all 19 ASGI event shapes
+  are `TypedDict`s keyed by a `Literal` tag, so `event['type']`
+  narrows and a malformed send is a type error, not a traceback.
 
 ## Install
 
@@ -131,8 +135,10 @@ async def search(q: str, page: int = 1, db=Depends(get_db)):
     return await db.find(q, page=page)   # /search?q=bull&page=2
 ```
 
-Drop down to full ASGI `(scope, receive, send)` whenever you need it
-— routes accept either shape.
+Drop down to the full `(conn, receive, send)` form whenever you need
+it — routes accept either shape.  `conn` is the native typed
+`Connection`; `receive`/`send` carry ASGI 3.0 events, declared as
+`TypedDict`s so a type checker narrows them on `event['type']`.
 
 ## TLS + HTTP/2
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.62.x  | :white_check_mark: |
 | 0.61.x  | :white_check_mark: |
-| 0.60.x  | :white_check_mark: |
-| < 0.60  | :x:                |
+| < 0.61  | :x:                |
 
 This table updates with each minor release.
 

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -60,7 +60,10 @@ from .response import (
     EventSourceResponse, WebSocketResponse, cookie_header,
 )
 from .event import Event, EventHandler
-from .asgi import ResponseStart, ResponseBody, parse_response_event
+from .asgi import (
+    ResponseStart, ResponseBody, parse_response_event,
+    ASGIReceiveEvent, ASGISendEvent, ASGIReceiveCallable, ASGISendCallable,
+)
 from .middleware.cors import CORS
 from .middleware.utils import as_middleware
 from .middleware.proxy import TrustedProxy

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -31,7 +31,7 @@ from .utils import Scheme, is_client_error, is_server_error
 from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param
 from .request import ClientDisconnected
 from .connection import Connection, disconnected, CONNECTION_STASH_KEY
-from .asgi import ASGIReceiveCallable, ASGISendCallable, ASGISendEvent
+from .asgi import ASGIReceiveCallable, ASGISendCallable
 from .config import AppConfig
 logger = logging.getLogger(__name__)
 

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -31,11 +31,12 @@ from .utils import Scheme, is_client_error, is_server_error
 from .router import Router, RouteInfo, ErrorRouter, MethodNotApplicable, PathNotRegistered, ConfigurationError, HTTPException, has_middleware_param
 from .request import ClientDisconnected
 from .connection import Connection, disconnected, CONNECTION_STASH_KEY
+from .asgi import ASGIReceiveCallable, ASGISendCallable, ASGISendEvent
 from .config import AppConfig
 logger = logging.getLogger(__name__)
 
 
-def _wrap_send(raw_send):
+def _wrap_send(raw_send: ASGISendCallable):
     """Adapt the handler-facing ``send`` to accept BlackBull convenience shapes.
 
     BlackBull lets a handler emit more than bare ASGI dicts: a ``Response``
@@ -61,6 +62,12 @@ def _wrap_send(raw_send):
     """
     from .response import Response as _Response, _emit_response
 
+    # Deliberately unannotated: this closure is rebuilt on every request, and
+    # a parameter annotation makes each rebuild construct an ``__annotate__``
+    # closure too — measured at ~+0.2 us/req (~3 % of in-process dispatch) on
+    # the micro-driver.  Annotations are only free on definitions evaluated
+    # once at import; the accepted shapes are documented above instead.
+    # Accepts: ASGISendEvent | Response | bytes | bytearray | memoryview.
     async def _send(event, status=HTTPStatus.OK, headers=[]):
         if isinstance(event, _Response):
             await event(None, None, raw_send)
@@ -77,7 +84,7 @@ def _wrap_send(raw_send):
     return _send
 
 
-def _inject_response_headers(raw_send, extra_headers):
+def _inject_response_headers(raw_send: ASGISendCallable, extra_headers):
     """Wrap *raw_send* to append *extra_headers* to the response.
 
     A route may declare headers (via the ``_bb_response_headers`` hook) that
@@ -88,6 +95,8 @@ def _inject_response_headers(raw_send, extra_headers):
     are appended to the ``http.response.start`` event; every other event
     passes straight through.
     """
+    # Unannotated for the same per-request-closure reason as _wrap_send;
+    # ``event`` is an ASGISendEvent.
     async def _send(event):
         if isinstance(event, dict) and event.get('type') == 'http.response.start':
             headers: list = list(event.get('headers') or [])
@@ -579,7 +588,8 @@ class BlackBull:
                 await send({'type': 'lifespan.shutdown.complete'})
                 return
 
-    async def _dispatch(self, conn, receive, send):
+    async def _dispatch(self, conn, receive: ASGIReceiveCallable | None,
+                        send: ASGISendCallable):
         """Route and dispatch a single non-lifespan request.
 
         Single emission point for the in-request Level B lifecycle events
@@ -636,7 +646,8 @@ class BlackBull:
             }))
         await self._dispatch_http(conn, receive, send, scheme)
 
-    async def _dispatch_http(self, conn, receive, send, scheme):
+    async def _dispatch_http(self, conn, receive: ASGIReceiveCallable | None,
+                             send: ASGISendCallable, scheme):
         """Route and run one HTTP request (the non-WebSocket half of _dispatch).
 
         Sprint 80: BlackBull is a native-Connection framework — the dispatch
@@ -794,7 +805,14 @@ class BlackBull:
             chain = functools.partial(mw, call_next=chain)
         self._chain = chain
 
-    async def __call__(self, conn, receive, send):
+    async def __call__(self, conn, receive: ASGIReceiveCallable | None,
+                       send: ASGISendCallable):
+        # ``receive`` is Optional because a handler that never reads a body
+        # never touches it: the router guards on ``conn._receive is None`` and
+        # dispatch completes normally.  A conforming ASGI host always passes a
+        # real callable, but the tolerance is load-bearing for direct drives,
+        # so the annotation states it rather than quietly outlawing it.
+        #
         # Native entry: BlackBull's own server calls ``app(conn, receive, send)``
         # with a typed :class:`Connection` — BlackBull is a native-Connection
         # framework, not an ASGI one, so the whole dispatch pipeline (middleware

--- a/blackbull/asgi.py
+++ b/blackbull/asgi.py
@@ -1,46 +1,263 @@
-"""ASGI protocol types: event-type string constants and typed event wrappers.
+"""ASGI protocol types: event-type string constants, typed message shapes,
+and typed event wrappers.
 
-Two responsibilities, both framework-side:
+Three responsibilities, all framework-side:
 
 - ``ASGIEvent``: namespace of ASGI 3.0 event-type strings, used for
   ``match``/``case`` dispatch and equality checks across both the
-  framework and (importing from here) the server stack.
+  framework and (importing from here) the server stack.  Every constant is
+  ``Final``, so a type checker infers a ``Literal`` and comparisons against
+  them narrow the event unions below.
+- The 19 ``TypedDict`` message shapes and the two direction unions
+  (``ASGIReceiveEvent`` / ``ASGISendEvent``) plus the two channel callable
+  aliases (``ASGIReceiveCallable`` / ``ASGISendCallable``).  These are
+  declarations only — erased at runtime, no wire or dispatch change.
 - ``ResponseStart`` / ``ResponseBody``: dict-subclass wrappers for the
   two outgoing response event shapes so middleware can dispatch on
   Python type rather than string comparison.  Both subclass ``dict``
   so ``isinstance(e, dict)`` remains True — required for beartype and
   any ASGI send callable annotated ``event: dict``.
+
+**Naming rule**: an ``ASGI`` prefix marks boundary vocabulary and is
+quarantined to this module; unprefixed names (``Connection``, ``Headers``,
+``Request``, ``Response``) are BlackBull's native layer.  The dicts on the
+channel are ASGI 3.0 events verbatim — the spec is free documentation for
+every key — so ``rg "from .asgi import"`` stays a literal map of the
+remaining ASGI surface.
 """
-from .headers import Headers
+from collections.abc import Awaitable, Callable
+from typing import Final, Literal, NotRequired, TypedDict
+
+from .headers import HeaderList, Headers
 
 
 class ASGIEvent:
     """Namespace for ASGI protocol event type strings (ASGI 3.0 spec)."""
 
     # HTTP
-    HTTP_REQUEST           = 'http.request'
-    HTTP_DISCONNECT        = 'http.disconnect'
-    HTTP_RESPONSE_START    = 'http.response.start'
-    HTTP_RESPONSE_BODY     = 'http.response.body'
-    HTTP_RESPONSE_TRAILERS = 'http.response.trailers'
-    HTTP_RESPONSE_PUSH     = 'http.response.push'
-    HTTP_RESPONSE_PATHSEND = 'http.response.pathsend'
+    HTTP_REQUEST:           Final = 'http.request'
+    HTTP_DISCONNECT:        Final = 'http.disconnect'
+    HTTP_RESPONSE_START:    Final = 'http.response.start'
+    HTTP_RESPONSE_BODY:     Final = 'http.response.body'
+    HTTP_RESPONSE_TRAILERS: Final = 'http.response.trailers'
+    HTTP_RESPONSE_PUSH:     Final = 'http.response.push'
+    HTTP_RESPONSE_PATHSEND: Final = 'http.response.pathsend'
 
     # WebSocket
-    WS_CONNECT    = 'websocket.connect'
-    WS_ACCEPT     = 'websocket.accept'
-    WS_RECEIVE    = 'websocket.receive'
-    WS_SEND       = 'websocket.send'
-    WS_CLOSE      = 'websocket.close'
-    WS_DISCONNECT = 'websocket.disconnect'
+    WS_CONNECT:    Final = 'websocket.connect'
+    WS_ACCEPT:     Final = 'websocket.accept'
+    WS_RECEIVE:    Final = 'websocket.receive'
+    WS_SEND:       Final = 'websocket.send'
+    WS_CLOSE:      Final = 'websocket.close'
+    WS_DISCONNECT: Final = 'websocket.disconnect'
 
     # Lifespan
-    LIFESPAN_STARTUP           = 'lifespan.startup'
-    LIFESPAN_STARTUP_COMPLETE  = 'lifespan.startup.complete'
-    LIFESPAN_STARTUP_FAILED    = 'lifespan.startup.failed'
-    LIFESPAN_SHUTDOWN          = 'lifespan.shutdown'
-    LIFESPAN_SHUTDOWN_COMPLETE = 'lifespan.shutdown.complete'
-    LIFESPAN_SHUTDOWN_FAILED   = 'lifespan.shutdown.failed'
+    LIFESPAN_STARTUP:           Final = 'lifespan.startup'
+    LIFESPAN_STARTUP_COMPLETE:  Final = 'lifespan.startup.complete'
+    LIFESPAN_STARTUP_FAILED:    Final = 'lifespan.startup.failed'
+    LIFESPAN_SHUTDOWN:          Final = 'lifespan.shutdown'
+    LIFESPAN_SHUTDOWN_COMPLETE: Final = 'lifespan.shutdown.complete'
+    LIFESPAN_SHUTDOWN_FAILED:   Final = 'lifespan.shutdown.failed'
+
+
+# --------------------------------------------------------------------------
+# Message shapes (ASGI 3.0 §HTTP, §WebSocket, §Lifespan)
+#
+# The ``type`` key must be spelled as a literal string, not as
+# ``Literal[ASGIEvent.X]`` — ``Literal[...]`` only accepts literal
+# expressions, never a name, even a ``Final`` one.  The constants above and
+# the tags below are kept in the same order so drift is visible in a diff.
+#
+# ``headers`` fields use ``HeaderList`` (``Iterable[tuple[bytes, bytes]]``),
+# which a ``Headers`` instance satisfies — so the sender's
+# place-``Headers``-as-is idiom stays typeable without a conversion.
+# --------------------------------------------------------------------------
+
+# --- HTTP: receive direction ----------------------------------------------
+
+class HTTPRequestEvent(TypedDict):
+    """Incoming request body chunk."""
+
+    type: Literal['http.request']
+    body: NotRequired[bytes]
+    more_body: NotRequired[bool]
+
+
+class HTTPDisconnectEvent(TypedDict):
+    """Client went away before the response completed."""
+
+    type: Literal['http.disconnect']
+
+
+# --- HTTP: send direction -------------------------------------------------
+
+class HTTPResponseStartEvent(TypedDict):
+    """Response status line + headers."""
+
+    type: Literal['http.response.start']
+    status: int
+    headers: NotRequired[HeaderList]
+    trailers: NotRequired[bool]
+
+
+class HTTPResponseBodyEvent(TypedDict):
+    """Response body chunk; ``more_body`` keeps the response open."""
+
+    type: Literal['http.response.body']
+    body: NotRequired[bytes]
+    more_body: NotRequired[bool]
+
+
+class HTTPResponseTrailersEvent(TypedDict):
+    """Trailing headers, sent after the final body chunk."""
+
+    type: Literal['http.response.trailers']
+    headers: NotRequired[HeaderList]
+    more_trailers: NotRequired[bool]
+
+
+class HTTPResponsePushEvent(TypedDict):
+    """HTTP/2 server push (ASGI *extension*, not baseline ASGI 3.0)."""
+
+    type: Literal['http.response.push']
+    path: str
+    headers: NotRequired[HeaderList]
+
+
+class HTTPResponsePathsendEvent(TypedDict):
+    """Hand a file path to the server to send (ASGI *extension*)."""
+
+    type: Literal['http.response.pathsend']
+    path: str
+
+
+# --- WebSocket ------------------------------------------------------------
+
+class WebSocketConnectEvent(TypedDict):
+    """Handshake offered; the app answers with accept or close."""
+
+    type: Literal['websocket.connect']
+
+
+class WebSocketAcceptEvent(TypedDict):
+    """Complete the handshake."""
+
+    type: Literal['websocket.accept']
+    subprotocol: NotRequired[str | None]
+    headers: NotRequired[HeaderList]
+
+
+class WebSocketReceiveEvent(TypedDict):
+    """One complete message from the client.
+
+    BlackBull's recipient always sets *both* keys, one of them ``None``
+    (``FragmentAssembler`` has already reassembled any fragments), so the
+    value types are optional rather than the keys being mutually exclusive.
+    """
+
+    type: Literal['websocket.receive']
+    bytes: NotRequired[bytes | None]
+    text: NotRequired[str | None]
+
+
+class WebSocketSendEvent(TypedDict):
+    """One complete message to the client."""
+
+    type: Literal['websocket.send']
+    bytes: NotRequired[bytes | None]
+    text: NotRequired[str | None]
+
+
+class WebSocketCloseEvent(TypedDict):
+    """Close the connection (app-initiated)."""
+
+    type: Literal['websocket.close']
+    code: NotRequired[int]
+    reason: NotRequired[str | None]
+
+
+class WebSocketDisconnectEvent(TypedDict):
+    """Connection closed (peer- or transport-initiated)."""
+
+    type: Literal['websocket.disconnect']
+    code: NotRequired[int]
+    reason: NotRequired[str | None]
+
+
+# --- Lifespan -------------------------------------------------------------
+
+class LifespanStartupEvent(TypedDict):
+    """Server is starting; run startup hooks."""
+
+    type: Literal['lifespan.startup']
+
+
+class LifespanStartupCompleteEvent(TypedDict):
+    """Startup hooks finished successfully."""
+
+    type: Literal['lifespan.startup.complete']
+
+
+class LifespanStartupFailedEvent(TypedDict):
+    """Startup hooks raised; ``message`` carries the reason."""
+
+    type: Literal['lifespan.startup.failed']
+    message: NotRequired[str]
+
+
+class LifespanShutdownEvent(TypedDict):
+    """Server is stopping; run shutdown hooks."""
+
+    type: Literal['lifespan.shutdown']
+
+
+class LifespanShutdownCompleteEvent(TypedDict):
+    """Shutdown hooks finished successfully."""
+
+    type: Literal['lifespan.shutdown.complete']
+
+
+class LifespanShutdownFailedEvent(TypedDict):
+    """Shutdown hooks raised; ``message`` carries the reason."""
+
+    type: Literal['lifespan.shutdown.failed']
+    message: NotRequired[str]
+
+
+# --------------------------------------------------------------------------
+# Direction unions and channel callables — 7 + 12 = 19.
+# --------------------------------------------------------------------------
+
+ASGIReceiveEvent = (
+    HTTPRequestEvent
+    | HTTPDisconnectEvent
+    | WebSocketConnectEvent
+    | WebSocketReceiveEvent
+    | WebSocketDisconnectEvent
+    | LifespanStartupEvent
+    | LifespanShutdownEvent
+)
+
+ASGISendEvent = (
+    HTTPResponseStartEvent
+    | HTTPResponseBodyEvent
+    | HTTPResponseTrailersEvent
+    | HTTPResponsePushEvent
+    | HTTPResponsePathsendEvent
+    | WebSocketAcceptEvent
+    | WebSocketSendEvent
+    | WebSocketCloseEvent
+    | LifespanStartupCompleteEvent
+    | LifespanStartupFailedEvent
+    | LifespanShutdownCompleteEvent
+    | LifespanShutdownFailedEvent
+)
+
+# Never reference these two aliases from a NamedTuple field — beartype's
+# forward-reference resolver rejects a module-level ``Callable`` alias used
+# that way.  Inline the ``Callable[...]`` form there instead.
+ASGIReceiveCallable = Callable[[], Awaitable[ASGIReceiveEvent]]
+ASGISendCallable = Callable[[ASGISendEvent], Awaitable[None]]
 
 
 class ResponseStart(dict):
@@ -68,12 +285,19 @@ class ResponseBody(dict):
         return self.get('more_body', False)     # type: ignore[return-value]
 
 
-def parse_response_event(event: dict) -> ResponseStart | ResponseBody | dict:
+def parse_response_event(
+    event: ASGISendEvent,
+) -> ResponseStart | ResponseBody | ASGISendEvent:
     """Wrap *event* in the appropriate typed subclass for dispatch.
 
     The returned object IS the event dict (shallow copy) — pass it directly
     to downstream send callables without re-serialisation.
     Trailers and unknown event types are returned unchanged.
+
+    ``ResponseStart``/``ResponseBody`` are dict subclasses, not statically
+    members of ``ASGISendEvent``; a caller threading the result back into a
+    typed send callable casts at that seam (a runtime no-op) rather than
+    widening the public union.
     """
     match event.get('type'):
         case ASGIEvent.HTTP_RESPONSE_START:

--- a/blackbull/client/websocket.py
+++ b/blackbull/client/websocket.py
@@ -21,6 +21,8 @@ from hashlib import sha1
 from http import HTTPStatus
 from typing import Iterable
 
+from ..asgi import WebSocketDisconnectEvent, WebSocketReceiveEvent
+
 import logging
 from ..headers import Headers
 from ..server.recipient import (AbstractReader, AsyncioReader,
@@ -85,7 +87,7 @@ class WebSocketSession:
     async def ping(self, data: bytes = b'') -> None:
         await self._send_frame(data, WSOpcode.PING)
 
-    async def receive(self) -> dict:
+    async def receive(self) -> WebSocketReceiveEvent | WebSocketDisconnectEvent:
         """Read one ASGI ``websocket.*`` event from the connection.
 
         Returns one of:

--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from blackbull.asgi import WebSocketReceiveEvent
 from blackbull.event import Event, EventDispatcher
 
 
@@ -150,7 +151,7 @@ class EventAggregator:
         return self._ws_msg_cache_val
 
     async def on_websocket_message(
-        self, conn, message: dict[str, Any]
+        self, conn, message: WebSocketReceiveEvent
     ) -> None:
         """Fire Level B ``websocket_message`` (``conn`` is a Connection)."""
         await self._dispatcher.emit(

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from ..asgi import ASGIEvent
 from ..connection import Connection
 from ..headers import Headers
-from ..asgi import ASGISendEvent, ResponseStart, ResponseBody, parse_response_event
+from ..asgi import ResponseStart, ResponseBody, parse_response_event
 from ..server.cap_log import log_cap_hit
 from .utils import as_middleware
 
@@ -208,7 +208,9 @@ class Compression:
         (bug 1.21f, Branch 1).  Same predicate as the compress path's decision
         point: compressible Content-Type AND no pre-existing Content-Encoding.
         """
-        async def vary_send(event: ASGISendEvent) -> None:
+        # Unannotated on purpose: rebuilt per request (see _wrap_send in
+        # app.py).  ``event`` is an ASGISendEvent.
+        async def vary_send(event):
             parsed = parse_response_event(event)
             if isinstance(parsed, ResponseStart) and \
                     _is_compressible_content_type(parsed.headers) and \
@@ -245,7 +247,9 @@ class Compression:
         streaming = False
         skip_compression = False
 
-        async def intercepting_send(event: ASGISendEvent) -> None:
+        # Unannotated on purpose: rebuilt per request (see _wrap_send in
+        # app.py).  ``event`` is an ASGISendEvent.
+        async def intercepting_send(event):
             nonlocal streaming, skip_compression, start_forwarded
             # Fast path: once the start event has been forwarded under a
             # pass-through decision (already-encoded response, non-

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from ..asgi import ASGIEvent
 from ..connection import Connection
 from ..headers import Headers
-from ..asgi import ResponseStart, ResponseBody, parse_response_event
+from ..asgi import ASGISendEvent, ResponseStart, ResponseBody, parse_response_event
 from ..server.cap_log import log_cap_hit
 from .utils import as_middleware
 
@@ -208,7 +208,7 @@ class Compression:
         (bug 1.21f, Branch 1).  Same predicate as the compress path's decision
         point: compressible Content-Type AND no pre-existing Content-Encoding.
         """
-        async def vary_send(event: dict) -> None:
+        async def vary_send(event: ASGISendEvent) -> None:
             parsed = parse_response_event(event)
             if isinstance(parsed, ResponseStart) and \
                     _is_compressible_content_type(parsed.headers) and \
@@ -245,7 +245,7 @@ class Compression:
         streaming = False
         skip_compression = False
 
-        async def intercepting_send(event: dict) -> None:
+        async def intercepting_send(event: ASGISendEvent) -> None:
             nonlocal streaming, skip_compression, start_forwarded
             # Fast path: once the start event has been forwarded under a
             # pass-through decision (already-encoded response, non-

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -8,7 +8,7 @@ Public API:
 """
 from functools import wraps
 
-from ..asgi import ASGISendCallable, ASGISendEvent
+from ..asgi import ASGISendCallable
 from ..response import Response
 
 

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -8,10 +8,11 @@ Public API:
 """
 from functools import wraps
 
+from ..asgi import ASGISendCallable, ASGISendEvent
 from ..response import Response
 
 
-def _normalize_send(inner_send):
+def _normalize_send(inner_send: ASGISendCallable | None):
     """Return a wrapper around *inner_send* that expands Response objects.
 
     Handlers that use the simplified return-value form call ``send`` with a
@@ -30,6 +31,12 @@ def _normalize_send(inner_send):
     there is a single source of truth for the start/body event shape (shared
     with ``app._wrap_send`` and the simplified-handler dispatch).
     """
+    # ``inner_send`` is Optional because a middleware may be driven with no
+    # send channel at all on pass-through paths (a websocket or lifespan
+    # scope a middleware declines to touch).  The wrapper is built either
+    # way; it is simply never invoked in that case.
+    # Unannotated on purpose: rebuilt per request (see _wrap_send in app.py).
+    # ``event`` is an ASGISendEvent or a Response.
     async def normalized(event):
         if isinstance(event, Response):
             # Response is ASGI-callable and ignores conn/receive (it is a pure

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -19,7 +19,7 @@ module holds only the transport-agnostic free functions, which
 import json
 from typing import Any, AsyncIterator
 
-from .asgi import ASGIEvent
+from .asgi import ASGIEvent, ASGIReceiveCallable
 
 
 class ClientDisconnected(Exception):
@@ -38,7 +38,7 @@ class ClientDisconnected(Exception):
         self.partial = partial
 
 
-async def read_body(receive) -> bytes:
+async def read_body(receive: ASGIReceiveCallable) -> bytes:
     """Read the complete request body from the ASGI receive channel.
 
     Collects chunks in a list and joins once, rather than the O(n²) ``+=``
@@ -69,7 +69,7 @@ async def read_body(receive) -> bytes:
     return b''.join(chunks)
 
 
-async def stream_body(receive) -> AsyncIterator[bytes]:
+async def stream_body(receive: ASGIReceiveCallable) -> AsyncIterator[bytes]:
     """Yield the request body one ``http.request`` chunk at a time.
 
     The streaming counterpart to :func:`read_body`: it never accumulates the
@@ -96,7 +96,7 @@ async def stream_body(receive) -> AsyncIterator[bytes]:
             break
 
 
-async def read_json(receive) -> Any:
+async def read_json(receive: ASGIReceiveCallable) -> Any:
     """Read the request body and parse it as JSON.
 
     Returns the parsed JSON value (``dict``, ``list``, ``str``, ``int``,
@@ -131,7 +131,7 @@ def _json_or_none(body: bytes) -> Any:
         return None
 
 
-async def read_text(receive, encoding: str = 'utf-8') -> str:
+async def read_text(receive: ASGIReceiveCallable, encoding: str = 'utf-8') -> str:
     """Read the request body and decode it as text.
 
     Uses ``errors='replace'`` so undecodable bytes become U+FFFD rather than

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -16,7 +16,7 @@ from urllib.parse import unquote
 from ..actor import Actor, Message
 from ..event import Event
 from ..event_aggregator import EventAggregator
-from ..asgi import ASGIEvent
+from ..asgi import ASGIEvent, ASGIReceiveCallable, ASGISendCallable
 from ..connection import (
     Connection, bind_receive_channel, disconnected, mark_disconnected)
 from ..headers import Headers
@@ -294,8 +294,8 @@ class RequestActor(Actor):
     def __init__(
         self,
         conn: dict | Connection,
-        receive: Callable[..., Awaitable[Any]],
-        send: Callable[..., Awaitable[Any]],
+        receive: ASGIReceiveCallable,
+        send: ASGISendCallable,
         app: Callable[..., Awaitable[None]],
         aggregator: EventAggregator,
     ) -> None:

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -34,7 +34,8 @@ from .access_log import (
     request_record_needed as _request_record_needed,
     disconnect_events_observed as _disconnect_events_observed,
 )
-from ..asgi import ASGIEvent
+from ..asgi import (ASGIEvent, ASGIReceiveCallable, ASGISendCallable,
+                    HTTPResponsePushEvent)
 from .http1_actor import RequestActor
 
 logger = logging.getLogger(__name__)
@@ -196,8 +197,8 @@ class StreamActor(Actor):
         self,
         stream_id: int,
         conn: 'dict | Connection',
-        receive: Callable[..., Awaitable[Any]],
-        send: Callable[..., Awaitable[Any]],
+        receive: ASGIReceiveCallable,
+        send: ASGISendCallable,
         app: Callable[..., Awaitable[None]],
         aggregator: EventAggregator,
         http2_actor: 'HTTP2Actor',
@@ -1506,7 +1507,8 @@ class HTTP2Actor(Actor):
         task.add_done_callback(
             self._make_done_cb(stream.stream_id, is_ws=True))
 
-    async def _handle_push(self, event: dict, parent_stream_id: int) -> None:
+    async def _handle_push(self, event: HTTPResponsePushEvent,
+                           parent_stream_id: int) -> None:
         """Handle an 'http.response.push' ASGI event.
 
         RFC 9113 §8.4 (server push) — the pushed request MUST be safe,

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -10,7 +10,7 @@ from .ws_codec import (
     read_payload,
 )
 from .constants import WSCloseCode
-from ..asgi import ASGIEvent
+from ..asgi import ASGIEvent, ASGIReceiveEvent
 from ..headers import Headers
 from ..connection import (
     CONNECTION_STASH_KEY, Connection, disconnected, mark_disconnected,
@@ -811,7 +811,7 @@ class HTTP2Recipient(BaseRecipient):
                         protocol='http2')
             return False
 
-    def put_event(self, event: dict) -> bool:
+    def put_event(self, event: ASGIReceiveEvent) -> bool:
         """Enqueue a pre-built event dict. Returns False if the queue is full."""
         try:
             self._ensure_queue().put_nowait((event, 0))

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -14,7 +14,8 @@ from .cap_log import log_cap_hit
 from .constants import WSCloseCode
 from .ws_codec import WSOpcode, encode_frame, encode_frame_header
 import logging
-from ..asgi import ASGIEvent
+from ..asgi import (ASGIEvent, ASGISendEvent, HTTPDisconnectEvent,
+                    WebSocketAcceptEvent, WebSocketCloseEvent, WebSocketSendEvent)
 from ..headers import Headers, HeaderList
 
 logger = logging.getLogger(__name__)
@@ -296,6 +297,23 @@ class AsyncioWriter(AbstractWriter):
 # Sender hierarchy
 # ---------------------------------------------------------------------------
 
+# The senders accept strictly more than the public ASGI send contract, so
+# they get a private widening rather than polluting ``ASGISendEvent``:
+#
+# - ``http.disconnect`` arrives on the *send* side as an internal signal from
+#   the actor (an IncompleteReadError on the read side), not as an ASGI send
+#   event — see the ``HTTP_DISCONNECT`` case in ``HTTP1Sender.__call__``.
+# - raw ``bytes`` is the ``send(body, status, headers)`` convenience form.
+#
+# Keeping the public alias honestly ASGI-shaped is the point: an app or
+# middleware author holding an ``ASGISendCallable`` should not be told that
+# sending a disconnect or a bare byte string is legal, because through the
+# app-facing channel it is not.
+_SenderEvent = ASGISendEvent | HTTPDisconnectEvent
+_SenderBody = _SenderEvent | bytes
+_WSSenderEvent = WebSocketSendEvent | WebSocketCloseEvent | WebSocketAcceptEvent
+
+
 class BaseSender(ABC):
     """Abstract base for ASGI-event → wire-format senders.
 
@@ -323,7 +341,9 @@ class BaseSender(ABC):
         self._closed = False
 
     @abstractmethod
-    async def __call__(self, body, status: HTTPStatus = HTTPStatus.OK, headers: HeaderList = []): pass
+    async def __call__(self, body: _SenderBody,
+                       status: HTTPStatus = HTTPStatus.OK,
+                       headers: HeaderList = []): pass
 
     async def _guarded_write(self, write_fn, arg) -> None:
         """Run *write_fn(arg)* tolerant of peer-closed transports.
@@ -431,7 +451,7 @@ class HTTP1Sender(BaseSender):
         # (~7% of HTTP/1.1 CPU in the profile).  When None, no capture.
         self._log_record = None
 
-    async def __call__(self, body,
+    async def __call__(self, body: _SenderBody,
                        status: HTTPStatus = HTTPStatus.OK,
                        headers: HeaderList = ()):
         """Dispatch on *body* and write the resulting HTTP/1.1 bytes.
@@ -1002,7 +1022,9 @@ class HTTP2Sender(BaseSender):
         if delta > 0:
             self.wake_window()
 
-    async def __call__(self, body, status: HTTPStatus = HTTPStatus.OK, headers: HeaderList = []):
+    async def __call__(self, body: _SenderBody | FrameBase,
+                       status: HTTPStatus = HTTPStatus.OK,
+                       headers: HeaderList = []):
         # Control-plane: raw frame object (SETTINGS, PING ACK, WINDOW_UPDATE, …)
         if isinstance(body, FrameBase):
             logger.debug('HTTP2Sender raw frame: %r', body)
@@ -1180,7 +1202,9 @@ class WebSocketSender(BaseSender):
         # outbound frames are sent verbatim (RSV1=0).
         self._compressor = compressor
 
-    async def __call__(self, body, _status: HTTPStatus | None = None, _headers: HeaderList = []):
+    async def __call__(self, body: _WSSenderEvent,
+                       _status: HTTPStatus | None = None,
+                       _headers: HeaderList = []):
         if not isinstance(body, dict):
             raise TypeError(f'WebSocketSender expected a dict, got {type(body)!r}')
 

--- a/blackbull/server/websocket_actor.py
+++ b/blackbull/server/websocket_actor.py
@@ -7,7 +7,8 @@ from typing import Any
 from ..actor import Actor, Message
 from ..connection import Connection
 from ..event_aggregator import EventAggregator
-from ..asgi import ASGIEvent
+from ..asgi import (ASGIEvent, WebSocketAcceptEvent, WebSocketCloseEvent,
+                    WebSocketSendEvent)
 from .conn_id import new_connection_id
 from .constants import WSCloseCode
 from .permessage_deflate import (
@@ -107,7 +108,9 @@ class WebSocketActor(Actor):
             self._disconnect_code = event.get('code', WSCloseCode.ABNORMAL)
         return event
 
-    async def _send(self, event: dict[str, Any], _status=None, _headers=None) -> None:
+    async def _send(self,
+                    event: WebSocketSendEvent | WebSocketCloseEvent | WebSocketAcceptEvent,
+                    _status=None, _headers=None) -> None:
         if isinstance(event, dict) and event.get('type') == ASGIEvent.WS_ACCEPT:
             ws_bag = self._conn._ws or {}
             send_101 = ws_bag.pop('send_101', None)

--- a/blackbull/testing.py
+++ b/blackbull/testing.py
@@ -36,6 +36,8 @@ import threading
 from typing import Any
 from urllib.parse import unquote
 
+from .asgi import ASGIReceiveEvent
+
 import httpx
 
 
@@ -372,7 +374,7 @@ class WebSocketTestSession:
                 pass  # best-effort disconnect notification during teardown.
         self._teardown()
 
-    def _send_client_event(self, event: dict) -> None:
+    def _send_client_event(self, event: ASGIReceiveEvent) -> None:
         self._loop_thread.run_coro(
             self._loop_thread.client_to_server.put(event),
             timeout=self.timeout,

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -30,6 +30,39 @@ Signature: `async def mw(scope, receive, send, call_next)`.
 Middleware functions keep the full `(scope, receive, send, call_next)`
 shape; the simplified handler form does **not** apply to them.
 
+## Typing the message channel
+
+The events crossing `receive` and `send` are ASGI 3.0 dicts — that wire
+contract is unchanged and always will be.  What BlackBull adds is a set of
+`TypedDict` *declarations* for them, so a type checker can tell which keys
+are legal on which event:
+
+```python
+from blackbull import ASGIReceiveCallable, ASGISendCallable, ASGISendEvent
+
+async def add_header_mw(conn, receive: ASGIReceiveCallable,
+                        send: ASGISendCallable, call_next):
+    async def wrapped(event: ASGISendEvent) -> None:
+        if event['type'] == 'http.response.start':
+            # Narrowed here: pyright/mypy know `status` and `headers` exist
+            # on this branch, and that `body` does not.
+            event = {**event,
+                     'headers': list(event.get('headers', [])) + [(b'x-custom', b'1')]}
+        await send(event)
+    await call_next(conn, receive, wrapped)
+```
+
+`ASGISendEvent` and `ASGIReceiveEvent` are unions discriminated on the
+`type` key, so comparing or `match`-ing against it narrows the union to a
+single member.  A checker then rejects the classic mistake this guards —
+passing a `Response` object where an event dict belongs, which fails at
+runtime on `event['type']`.
+
+The individual shapes (`HTTPResponseStartEvent`, `WebSocketReceiveEvent`, …)
+are importable from `blackbull.asgi` if you want to name one directly.
+Everything here is annotation-only: nothing is validated or converted at
+runtime, and unannotated middleware keeps working exactly as before.
+
 ## The `@as_middleware` decorator
 
 Route handlers can return `Response` / `JSONResponse` objects

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -50,6 +50,32 @@ async def chat(scope, receive, send):
         await send({'type': 'websocket.send', 'text': event.get('text', '')})
 ```
 
+## Typed WebSocket events
+
+The events are plain ASGI dicts on the wire, but their shapes are declared
+as `TypedDict`s, so a type checker can narrow them on the `type` key:
+
+```python
+from blackbull import ASGIReceiveCallable, ASGISendCallable
+from blackbull.asgi import ASGIEvent
+
+async def chat(conn, receive: ASGIReceiveCallable, send: ASGISendCallable):
+    while True:
+        event = await receive()
+        if event['type'] == ASGIEvent.WS_DISCONNECT:
+            break
+        if event['type'] == ASGIEvent.WS_RECEIVE:
+            # Narrowed to WebSocketReceiveEvent: `text` and `bytes` are known
+            # keys here, and both are Optional — BlackBull always sets both,
+            # with one of them None.
+            await send({'type': 'websocket.send', 'text': event.get('text') or ''})
+```
+
+`FragmentAssembler` has already reassembled fragments by this point, so a
+`websocket.receive` event is always one complete message — which is why the
+declared type has `text: str | None` and `bytes: bytes | None` rather than
+modelling a partial frame.  The declarations change nothing at runtime.
+
 ## permessage-deflate (RFC 7692)
 
 `permessage-deflate` compression is negotiated automatically when

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,23 @@
 # BlackBull
 
-BlackBull is a Python web framework that speaks the
+BlackBull is a Python web framework with pure-Python implementations of
+HTTP/1.1, HTTP/2 (with ALPN), WebSocket, gRPC, and an MQTT 5 broker — all
+on one process, no reverse proxy or sidecar required.  No required C
+extensions outside the standard library, one `pip install`, one
+deployable.
+
+Internally it threads its own typed `Connection` end to end; the
 [**ASGI 3.0**](https://asgi.readthedocs.io/en/latest/specs/main.html)
-interface[^asgi], with pure-Python implementations of HTTP/1.1, HTTP/2
-(with ALPN), WebSocket, gRPC, and an MQTT 5 broker — all on one process,
-no reverse proxy or sidecar required.  No required C extensions outside
-the standard library, one `pip install`, one deployable.
+interface[^asgi] is kept as an interop boundary, so a BlackBull app also
+runs unchanged under uvicorn, Hypercorn, or `httpx.ASGITransport`.
 
 [^asgi]: ASGI is the async successor to WSGI — a single small interface
     that lets the same app object speak HTTP and WebSocket without
-    separate adapters.  Apps written against
-    [Starlette](https://www.starlette.io/),
-    [Quart](https://quart.palletsprojects.com/),
-    [FastAPI](https://fastapi.tiangolo.com/),
-    or any other ASGI 3.0 framework work on BlackBull.
+    separate adapters.  BlackBull apps are ASGI-callable, so any ASGI
+    host can serve them.  The reverse direction — hosting a *foreign*
+    ASGI app (Starlette, Quart, FastAPI) on BlackBull's own server —
+    needs `BB_FORCE_ASGI_SCOPE=1`, which makes the server emit a plain
+    ASGI `scope` dict instead of a `Connection`.
 
 !!! warning "Early Alpha"
     BlackBull is in **Early Alpha**.  The API may change between MINOR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,12 @@ testing = [
     # schema in tests/unit/test_openapi.py — proves the spec we emit is
     # consumable by the wider OpenAPI ecosystem.
     "openapi-spec-validator",
+    # Drives the static type-check gate in
+    # tests/architecture/test_typing_gate.py.  Pinned exactly: the gate
+    # asserts on diagnostic *positions*, so a version bump that re-words or
+    # re-anchors a diagnostic must be an explicit, reviewed change rather
+    # than something CI picks up on its own.
+    "pyright==1.1.408",
 ]
 
 docs = [
@@ -180,6 +186,19 @@ benchmark = []  # k6 and h2load are installed via bench/install.sh (not pip pack
 profiling = [
     "py-spy",
 ]
+
+[tool.pyright]
+# Deliberately narrow scope.  Whole-repo pyright drowns in pre-existing
+# diagnostics that predate any typing work; this gate exists to prove one
+# thing — that the ASGI message unions narrow on ``event['type']`` — so it
+# covers only the declarations and the proofs that exercise them.
+# `tests/architecture/test_typing_gate.py` is the runner.
+include = ["blackbull/asgi.py", "tests/typing"]
+strict = ["tests/typing"]
+# The floor from `requires-python`, not the interpreter the venv happens to
+# run: the narrowing must hold for the oldest Python we support.
+pythonVersion = "3.11"
+typeCheckingMode = "standard"
 
 [tool.coverage.run]
 source = ["blackbull"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ name = "blackbull"
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
 version = "0.61.0"
-description = "Async ASGI 3.0 framework with a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
+description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"
 

--- a/tests/architecture/test_typing_gate.py
+++ b/tests/architecture/test_typing_gate.py
@@ -1,0 +1,192 @@
+"""Static type-check gate for the ASGI message channel.
+
+Runs pyright over the narrow scope configured in `pyproject.toml`
+(`[tool.pyright]`: `blackbull/asgi.py` + `tests/typing`) and asserts both
+directions of the proof:
+
+- `tests/typing/assert_narrowing.py` — zero diagnostics.  Proves the
+  `ASGIEvent` constants are `Literal` (the `Final` keystone), that
+  `event['type']` narrows `ASGIReceiveEvent` / `ASGISendEvent` to a single
+  member by both `==` and `match`, and that all 19 shapes construct.
+- `tests/typing/expect_errors.py` — at least one diagnostic on **every** line
+  carrying an `# EXPECT-ERROR` comment, and none anywhere else.  Without this
+  half, the gate would still pass if the unions silently degraded to `Any`.
+
+The `# EXPECT-ERROR` tags are located by tokenising the file rather than by
+substring search, so prose mentioning the tag (in this docstring, or in
+`expect_errors.py`'s own) is never mistaken for a tagged line.
+
+Skips when pyright is unavailable rather than failing — the gate is
+authoritative in CI, and a contributor without the `[testing]` extra installed
+should not see a red suite.
+"""
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import tokenize
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TYPING_DIR = REPO_ROOT / 'tests' / 'typing'
+POSITIVE = TYPING_DIR / 'assert_narrowing.py'
+NEGATIVE = TYPING_DIR / 'expect_errors.py'
+
+EXPECT_ERROR_TAG = 'EXPECT-ERROR'
+
+
+def _expect_error_lines(path: pathlib.Path) -> set[int]:
+    """1-indexed lines carrying an ``# EXPECT-ERROR`` *comment*.
+
+    Tokenising means a docstring or string literal that merely mentions the
+    tag is not counted — only real comments are.
+    """
+    source = path.read_text()
+    tagged: set[int] = set()
+    for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+        if tok.type == tokenize.COMMENT and EXPECT_ERROR_TAG in tok.string:
+            tagged.add(tok.start[0])
+    return tagged
+
+
+@pytest.fixture(scope='module')
+def pyright_diagnostics() -> dict[str, dict[int, list[str]]]:
+    """Run pyright once; return {filename: {line: [rule, ...]}}."""
+    try:
+        proc = subprocess.run(
+            [sys.executable, '-m', 'pyright', '--outputjson'],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=600,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        pytest.skip(f'pyright unavailable or timed out: {exc!r}')
+
+    # pyright exits non-zero whenever diagnostics exist — which is the
+    # expected state here (expect_errors.py is full of them).  Only a missing
+    # module or an unparseable payload is a real failure.
+    if 'No module named pyright' in proc.stderr:
+        pytest.skip('pyright not installed (pip install -e ".[testing]")')
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        pytest.fail(
+            f'pyright produced no JSON (exit {proc.returncode})\n'
+            f'stdout: {proc.stdout[:2000]}\nstderr: {proc.stderr[:2000]}'
+        )
+
+    by_file: dict[str, dict[int, list[str]]] = {}
+    for diag in payload['generalDiagnostics']:
+        name = pathlib.Path(diag['file']).name
+        line = diag['range']['start']['line'] + 1        # pyright is 0-indexed
+        label = diag.get('rule') or diag['severity']
+        by_file.setdefault(name, {}).setdefault(line, []).append(label)
+    return by_file
+
+
+def test_positive_proof_is_clean(pyright_diagnostics):
+    """`assert_narrowing.py` must type-check with zero diagnostics.
+
+    A failure here means the unions stopped narrowing — most likely because
+    the `Final` annotations on `ASGIEvent` were dropped, which silently
+    demotes every constant back to `str`.
+    """
+    found = pyright_diagnostics.get(POSITIVE.name, {})
+    assert not found, (
+        f'{POSITIVE.name} must be diagnostic-free; got: '
+        + '; '.join(f'line {ln}: {", ".join(rules)}'
+                    for ln, rules in sorted(found.items()))
+    )
+
+
+def test_declarations_are_clean(pyright_diagnostics):
+    """`blackbull/asgi.py` itself must type-check clean."""
+    found = pyright_diagnostics.get('asgi.py', {})
+    assert not found, (
+        'blackbull/asgi.py must be diagnostic-free; got: '
+        + '; '.join(f'line {ln}: {", ".join(rules)}'
+                    for ln, rules in sorted(found.items()))
+    )
+
+
+def test_every_expected_error_is_reported(pyright_diagnostics):
+    """Each `# EXPECT-ERROR` line must draw at least one diagnostic.
+
+    This is the half that proves the types have teeth — including the 0.43.2
+    regression (a `Response` object passed to an `ASGISendCallable`), which
+    `tests/unit/test_middleware_decorator.py` catches at runtime.
+    """
+    tagged = _expect_error_lines(NEGATIVE)
+    assert tagged, f'no {EXPECT_ERROR_TAG} comments found in {NEGATIVE.name}'
+
+    found = pyright_diagnostics.get(NEGATIVE.name, {})
+    missing = sorted(tagged - found.keys())
+    assert not missing, (
+        f'{NEGATIVE.name}: no diagnostic on {EXPECT_ERROR_TAG} line(s) '
+        f'{missing} — these unsound cases now type-check'
+    )
+
+
+def test_no_unexpected_errors_in_negative_file(pyright_diagnostics):
+    """Nothing in `expect_errors.py` errors *except* the tagged lines.
+
+    Guards the sanctioned `cast` escape hatch that Phase 2's annotation sweep
+    relies on, and keeps stray breakage from masquerading as expected failure.
+    """
+    tagged = _expect_error_lines(NEGATIVE)
+    found = pyright_diagnostics.get(NEGATIVE.name, {})
+    unexpected = sorted(set(found) - tagged)
+    assert not unexpected, (
+        f'{NEGATIVE.name}: unexpected diagnostic(s) on untagged line(s) '
+        + '; '.join(f'{ln}: {", ".join(found[ln])}' for ln in unexpected)
+    )
+
+
+def test_every_asgi_event_constant_is_final():
+    """Every `ASGIEvent` constant carries a `Final` annotation.
+
+    This is asserted structurally, from the AST, because **pyright cannot
+    catch its absence**: pyright infers `Literal['http.request']` for a bare
+    class-body assignment, so the narrowing proofs in `assert_narrowing.py`
+    keep passing with every `Final` stripped.  mypy does not — it infers plain
+    `str` there, and every `event['type'] == ASGIEvent.X` comparison stops
+    narrowing.  So `Final` is load-bearing for mypy users, invisible to the
+    pyright gate, and would otherwise rot silently.
+    """
+    import ast
+
+    tree = ast.parse((REPO_ROOT / 'blackbull' / 'asgi.py').read_text())
+    cls = next(n for n in ast.walk(tree)
+               if isinstance(n, ast.ClassDef) and n.name == 'ASGIEvent')
+
+    bare = [n.targets[0].id for n in cls.body
+            if isinstance(n, ast.Assign) and isinstance(n.targets[0], ast.Name)]
+    assert not bare, (
+        f'ASGIEvent constants missing `Final`: {bare} — mypy will infer `str` '
+        'and no comparison against them narrows the event unions'
+    )
+
+    annotated = [n for n in cls.body if isinstance(n, ast.AnnAssign)]
+    non_final = [n.target.id for n in annotated
+                 if not (isinstance(n.annotation, ast.Name)
+                         and n.annotation.id == 'Final')]
+    assert not non_final, f'ASGIEvent constants not annotated `Final`: {non_final}'
+    assert len(annotated) == 19, (
+        f'expected 19 ASGI event constants, found {len(annotated)}'
+    )
+
+
+def test_pyright_scope_is_narrow():
+    """The gate's scope stays deliberately small.
+
+    Whole-repo pyright would drown in pre-existing diagnostics; if someone
+    widens `include`, this gate stops meaning "the message channel narrows"
+    and starts meaning "the repo is pyright-clean", which it is not.
+    """
+    import tomllib
+
+    with open(REPO_ROOT / 'pyproject.toml', 'rb') as fh:
+        config = tomllib.load(fh)
+
+    include = config['tool']['pyright']['include']
+    assert set(include) == {'blackbull/asgi.py', 'tests/typing'}, include

--- a/tests/architecture/test_typing_gate.py
+++ b/tests/architecture/test_typing_gate.py
@@ -109,6 +109,23 @@ def test_declarations_are_clean(pyright_diagnostics):
     )
 
 
+def test_only_the_negative_file_has_diagnostics(pyright_diagnostics):
+    """`expect_errors.py` is the *only* file in scope allowed to error.
+
+    Named-file assertions alone would let a newly added `tests/typing/`
+    module sit in the gate's scope failing silently, since nothing would
+    look at it.
+    """
+    offenders = sorted(set(pyright_diagnostics) - {NEGATIVE.name})
+    assert not offenders, (
+        f'unexpected diagnostics outside {NEGATIVE.name}: '
+        + '; '.join(
+            f'{name} (line(s) {sorted(pyright_diagnostics[name])})'
+            for name in offenders
+        )
+    )
+
+
 def test_every_expected_error_is_reported(pyright_diagnostics):
     """Each `# EXPECT-ERROR` line must draw at least one diagnostic.
 

--- a/tests/integration/test_nginx.py
+++ b/tests/integration/test_nginx.py
@@ -4,12 +4,20 @@ from http import HTTPMethod
 import json
 from pathlib import Path
 import time
-import docker as _docker
 import httpx
 import pytest
 import pytest_asyncio
 from multiprocessing import Process
-from testcontainers.core.container import DockerContainer
+
+# --- Module-level skip when the Docker stack isn't available ----------------
+# The docker/testcontainers packages are optional extras; importing them at
+# module scope turns a missing extra into a collection error that breaks the
+# whole run rather than skipping this file.
+pytest.importorskip('docker')
+pytest.importorskip('testcontainers')
+
+import docker as _docker  # noqa: E402  (after importorskip)
+from testcontainers.core.container import DockerContainer  # noqa: E402
 
 # Test targets
 from blackbull import BlackBull

--- a/tests/typing/assert_narrowing.py
+++ b/tests/typing/assert_narrowing.py
@@ -1,0 +1,178 @@
+"""Positive static proof: the ASGI message unions narrow, and all 19 shapes
+construct.
+
+This file is **never executed** — it is input to pyright, driven by
+`tests/architecture/test_typing_gate.py`, and must produce **zero**
+diagnostics.  Its companion `expect_errors.py` proves the converse.
+
+What is being proven, in order:
+
+1. ``ASGIEvent`` constants are ``Literal``, not ``str`` — without this no
+   comparison or ``match`` case against them narrows anything, and the whole
+   typing slice would be decorative.
+2. ``event['type'] == ASGIEvent.X`` narrows the union to exactly one member.
+3. ``match`` mapping patterns narrow the same way (the dispatch idiom the
+   server stack actually uses).
+4. Every one of the 19 shapes is constructible in its well-formed form and
+   accepted by the matching channel callable — a static check of the
+   ~100 construction sites' idiom.
+"""
+from typing import Literal, assert_type
+
+from blackbull.asgi import (
+    ASGIEvent,
+    ASGIReceiveCallable,
+    ASGIReceiveEvent,
+    ASGISendCallable,
+    ASGISendEvent,
+    HTTPDisconnectEvent,
+    HTTPRequestEvent,
+    HTTPResponseBodyEvent,
+    HTTPResponsePathsendEvent,
+    HTTPResponsePushEvent,
+    HTTPResponseStartEvent,
+    HTTPResponseTrailersEvent,
+    LifespanShutdownCompleteEvent,
+    LifespanShutdownEvent,
+    LifespanShutdownFailedEvent,
+    LifespanStartupCompleteEvent,
+    LifespanStartupEvent,
+    LifespanStartupFailedEvent,
+    WebSocketAcceptEvent,
+    WebSocketCloseEvent,
+    WebSocketConnectEvent,
+    WebSocketDisconnectEvent,
+    WebSocketReceiveEvent,
+    WebSocketSendEvent,
+)
+from blackbull.headers import Headers
+
+
+# --- 1. The keystone: constants are Literal, not str -----------------------
+# `Final` in the class body is what buys this.  If someone drops the `Final`
+# annotations, these lines fail and the gate reports it before any of the
+# narrowing checks below get a chance to.
+
+def constants_are_literals() -> None:
+    assert_type(ASGIEvent.HTTP_REQUEST, Literal['http.request'])
+    assert_type(ASGIEvent.HTTP_RESPONSE_START, Literal['http.response.start'])
+    assert_type(ASGIEvent.WS_RECEIVE, Literal['websocket.receive'])
+    assert_type(ASGIEvent.LIFESPAN_STARTUP, Literal['lifespan.startup'])
+
+
+# --- 2. Equality narrowing on the receive union ----------------------------
+
+def narrow_receive_by_equality(event: ASGIReceiveEvent) -> None:
+    if event['type'] == ASGIEvent.HTTP_REQUEST:
+        assert_type(event, HTTPRequestEvent)
+        # ...and the narrowed member's own keys are then typed:
+        body: bytes = event.get('body', b'')
+        more: bool = event.get('more_body', False)
+        _ = body, more
+    elif event['type'] == ASGIEvent.HTTP_DISCONNECT:
+        assert_type(event, HTTPDisconnectEvent)
+    elif event['type'] == ASGIEvent.WS_CONNECT:
+        assert_type(event, WebSocketConnectEvent)
+    elif event['type'] == ASGIEvent.WS_RECEIVE:
+        assert_type(event, WebSocketReceiveEvent)
+        text: str | None = event.get('text')
+        _ = text
+    elif event['type'] == ASGIEvent.WS_DISCONNECT:
+        assert_type(event, WebSocketDisconnectEvent)
+    elif event['type'] == ASGIEvent.LIFESPAN_STARTUP:
+        assert_type(event, LifespanStartupEvent)
+    else:
+        assert_type(event, LifespanShutdownEvent)
+
+
+# --- 3. `match` mapping-pattern narrowing on the send union ----------------
+# This is the shape `server/sender.py` dispatches with, so it is the case
+# that actually matters for the production hubs.
+
+def narrow_send_by_match(event: ASGISendEvent) -> None:
+    match event['type']:
+        case ASGIEvent.HTTP_RESPONSE_START:
+            assert_type(event, HTTPResponseStartEvent)
+            status: int = event['status']
+            _ = status
+        case ASGIEvent.HTTP_RESPONSE_BODY:
+            assert_type(event, HTTPResponseBodyEvent)
+        case ASGIEvent.HTTP_RESPONSE_TRAILERS:
+            assert_type(event, HTTPResponseTrailersEvent)
+        case ASGIEvent.HTTP_RESPONSE_PUSH:
+            assert_type(event, HTTPResponsePushEvent)
+        case ASGIEvent.HTTP_RESPONSE_PATHSEND:
+            assert_type(event, HTTPResponsePathsendEvent)
+            path: str = event['path']
+            _ = path
+        case ASGIEvent.WS_ACCEPT:
+            assert_type(event, WebSocketAcceptEvent)
+        case ASGIEvent.WS_SEND:
+            assert_type(event, WebSocketSendEvent)
+        case ASGIEvent.WS_CLOSE:
+            assert_type(event, WebSocketCloseEvent)
+        case ASGIEvent.LIFESPAN_STARTUP_COMPLETE:
+            assert_type(event, LifespanStartupCompleteEvent)
+        case ASGIEvent.LIFESPAN_STARTUP_FAILED:
+            assert_type(event, LifespanStartupFailedEvent)
+            message: str = event.get('message', '')
+            _ = message
+        case ASGIEvent.LIFESPAN_SHUTDOWN_COMPLETE:
+            assert_type(event, LifespanShutdownCompleteEvent)
+        case ASGIEvent.LIFESPAN_SHUTDOWN_FAILED:
+            assert_type(event, LifespanShutdownFailedEvent)
+
+
+# --- 4. All 19 shapes construct and are accepted by the channel ------------
+
+async def construct_all_receive(receive: ASGIReceiveCallable) -> None:
+    """Every receive-direction shape is a valid ``ASGIReceiveEvent``."""
+    _ = await receive()
+
+    events: list[ASGIReceiveEvent] = [
+        {'type': 'http.request'},
+        {'type': 'http.request', 'body': b'chunk', 'more_body': True},
+        {'type': 'http.disconnect'},
+        {'type': 'websocket.connect'},
+        # Both keys present with one None — the recipient's actual idiom.
+        {'type': 'websocket.receive', 'text': 'hi', 'bytes': None},
+        {'type': 'websocket.receive', 'text': None, 'bytes': b'\x01'},
+        {'type': 'websocket.disconnect', 'code': 1000},
+        {'type': 'websocket.disconnect', 'code': 1002, 'reason': 'protocol'},
+        {'type': 'lifespan.startup'},
+        {'type': 'lifespan.shutdown'},
+    ]
+    _ = events
+
+
+async def construct_all_send(send: ASGISendCallable) -> None:
+    """Every send-direction shape is accepted by an ``ASGISendCallable``.
+
+    ``Headers`` is passed where a ``headers`` key appears, proving the
+    sender's place-``Headers``-as-is idiom types without conversion.
+    """
+    hdrs = Headers([(b'content-type', b'text/plain')])
+
+    await send({'type': 'http.response.start', 'status': 200})
+    await send({'type': 'http.response.start', 'status': 200, 'headers': hdrs})
+    await send({'type': 'http.response.start', 'status': 204,
+                'headers': [(b'x-trace', b'1')], 'trailers': True})
+    await send({'type': 'http.response.body'})
+    await send({'type': 'http.response.body', 'body': b'hello', 'more_body': False})
+    await send({'type': 'http.response.trailers', 'headers': hdrs,
+                'more_trailers': False})
+    await send({'type': 'http.response.push', 'path': '/style.css'})
+    await send({'type': 'http.response.push', 'path': '/app.js', 'headers': hdrs})
+    await send({'type': 'http.response.pathsend', 'path': '/srv/file.bin'})
+
+    await send({'type': 'websocket.accept'})
+    await send({'type': 'websocket.accept', 'subprotocol': None, 'headers': hdrs})
+    await send({'type': 'websocket.send', 'text': 'hi'})
+    await send({'type': 'websocket.send', 'bytes': b'\x01'})
+    await send({'type': 'websocket.close'})
+    await send({'type': 'websocket.close', 'code': 1001, 'reason': 'going away'})
+
+    await send({'type': 'lifespan.startup.complete'})
+    await send({'type': 'lifespan.startup.failed', 'message': 'boom'})
+    await send({'type': 'lifespan.shutdown.complete'})
+    await send({'type': 'lifespan.shutdown.failed', 'message': 'boom'})

--- a/tests/typing/expect_errors.py
+++ b/tests/typing/expect_errors.py
@@ -1,0 +1,95 @@
+"""Negative static proof: malformed message-channel traffic is a type error.
+
+The companion of `assert_narrowing.py`.  That file proves the good cases pass;
+this one proves the bad cases *fail* — a gate that only checks the positive
+direction would still pass if the unions were secretly `Any`.
+
+Every line tagged ``# EXPECT-ERROR`` must produce at least one pyright
+diagnostic.  `tests/architecture/test_typing_gate.py` asserts exactly that,
+line by line, so a diagnostic drifting to a neighbouring line fails the gate
+rather than passing silently.
+
+This file is **never executed**; several lines here would raise at runtime,
+which is the point.
+"""
+from typing import Any, cast
+
+from blackbull.asgi import ASGIReceiveEvent, ASGISendCallable, ASGISendEvent
+from blackbull.response import Response
+
+
+# --- The 0.43.2 type-confusion bug, caught statically ----------------------
+# A `Response` object leaked into a middleware `send` wrapper, which subscripts
+# `msg['type']` → `TypeError: 'Response' object is not subscriptable`.
+# `tests/unit/test_middleware_decorator.py` catches this at runtime through the
+# full app stack; here the same mistake is rejected before the code runs.
+
+async def response_object_is_not_a_send_event(send: ASGISendCallable) -> None:
+    await send(Response('<h1>Hello</h1>'))  # EXPECT-ERROR
+
+
+async def response_object_is_not_subscriptable(event: ASGISendEvent) -> None:
+    resp = Response(b'data')
+    _ = resp['type']  # EXPECT-ERROR
+    _ = event
+
+
+# --- Misspelled / unknown keys --------------------------------------------
+# TypedDict closed-ness is what makes the ~100 construction sites checkable.
+
+async def misspelled_notrequired_key(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.body', 'body': b'x', 'more_bodies': True})  # EXPECT-ERROR
+
+
+async def unknown_key_on_start(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.start', 'status': 200, 'statuss': 200})  # EXPECT-ERROR
+
+
+# --- Wrong value types -----------------------------------------------------
+
+async def status_must_be_int(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.start', 'status': '200'})  # EXPECT-ERROR
+
+
+async def body_must_be_bytes(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.body', 'body': 'not bytes'})  # EXPECT-ERROR
+
+
+# --- Missing required keys -------------------------------------------------
+
+async def start_requires_status(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.start'})  # EXPECT-ERROR
+
+
+async def pathsend_requires_path(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.pathsend'})  # EXPECT-ERROR
+
+
+# --- Direction confusion ---------------------------------------------------
+# The two unions are disjoint; sending a receive-direction event (or an event
+# string that exists but belongs to the other direction) is rejected.
+
+async def receive_event_is_not_sendable(send: ASGISendCallable) -> None:
+    await send({'type': 'http.request', 'body': b'x'})  # EXPECT-ERROR
+
+
+async def send_event_is_not_receivable() -> None:
+    event: ASGIReceiveEvent = {'type': 'http.response.start', 'status': 200}  # EXPECT-ERROR
+    _ = event
+
+
+# --- Unknown event type ----------------------------------------------------
+
+async def unknown_event_type(send: ASGISendCallable) -> None:
+    await send({'type': 'http.response.teapot'})  # EXPECT-ERROR
+
+
+# --- The escape hatch still exists -----------------------------------------
+# `cast` is deliberately *not* an error: the compression seam threads
+# `ResponseStart`/`ResponseBody` wrappers (dict subclasses, not statically
+# union members) through typed sends this way.  If this line ever started
+# erroring, Phase 2's annotation sweep would have no legal escape.
+
+async def cast_is_the_sanctioned_escape(send: ASGISendCallable) -> None:
+    wrapper: Any = {'type': 'http.response.start', 'status': 200}
+    await send(cast(ASGISendEvent, wrapper))


### PR DESCRIPTION
## Summary

Types the ASGI `receive`/`send` message channel. The 19 ASGI 3.0 message shapes
are declared as `TypedDict`s keyed by a `Literal` `type` tag, with a union per
direction (`ASGIReceiveEvent`, 7 members / `ASGISendEvent`, 12) and a callable
alias per direction (`ASGIReceiveCallable` / `ASGISendCallable`). Because the
unions are discriminated on `type`, comparing or `match`-ing `event['type']`
narrows to a single member — so a wrong key, a wrong value type, or an event
sent in the wrong direction is a type error.

This statically excludes the 0.43.2-class type-confusion bug (a `Response`
object reaching a middleware `send` wrapper, which fails at runtime on
`event['type']`), which until now was only caught at runtime by
`tests/unit/test_middleware_decorator.py`. That test is untouched — the bug is
now covered from both sides.

**Declaration-only.** The dicts on the wire are unchanged, nothing is validated
or converted at runtime, and unannotated application code is unaffected.

## The static gate

`tests/architecture/test_typing_gate.py` (7 tests, ~0.7 s) runs pyright over a
deliberately narrow scope — `blackbull/asgi.py` + `tests/typing/` — and asserts
**both** directions:

- `tests/typing/assert_narrowing.py` must produce zero diagnostics (narrowing
  by `==` and by `match`, plus one well-formed construction of all 19 shapes).
- `tests/typing/expect_errors.py` must draw at least one diagnostic on **every**
  `# EXPECT-ERROR` line and none anywhere else. Without this half the gate would
  still pass if the unions silently degraded to `Any`.

The gate is mutation-proven in both directions: widening `status: int` to
`int | str` fails it, and dropping a deliberately broken file into scope fails
it. pyright is pinned exactly in the `[testing]` extra because the gate asserts
on diagnostic *positions*; it skips cleanly when pyright is unavailable.

## Two places measurement contradicted the plan

**`Final` is not the keystone the plan assumed.** pyright infers
`Literal['http.request']` from a bare class-body assignment and narrows without
`Final`; mypy infers plain `str` and loses narrowing entirely. So stripping
every `Final` left the pyright gate fully green — the positive proof cannot see
the keystone it was meant to protect. `Final` is therefore guarded structurally
from the AST (`test_every_asgi_event_constant_is_final`), the only instrument
that catches it.

**"Annotations are erased at runtime" is false for per-request closures.** True
for definitions evaluated once at import; false for a nested `async def` created
inside a per-request factory, where each creation also builds an `__annotate__`
closure. Measured on CPython 3.14: plain `def` 76 ns, return-annotation-only
148 ns, parameter-annotated 169 ns — so a bare `-> None` costs ~78% of a full
annotation. End to end that was **+0.23 µs/req (+3.4%)** on the in-process
dispatch micro-driver, consistent across 5/5 interleaved min-of-5 pairs against
a directly measured ±1.2% noise floor (same tree in both A/B slots).

The three affected send wrappers (`_wrap_send`, `_inject_response_headers`,
`_normalize_send`) are deliberately left unannotated with a comment at each site
saying so; `Compression`'s two wrappers are now covered by the same rule, making
them marginally cheaper than in 0.61.0. The plan's `cast()` at the compression
seam was dropped for the same reason — `typing.cast` is a real per-event call,
and nothing in that file is in the gate's scope, so it would buy nothing.

## Test plan

- [x] Full suite, plain lane — matches master baseline exactly
- [x] Full suite, `--beartype-packages=blackbull` — `1 failed, 5265 passed, 261 skipped, 1 xfailed, 36 errors`, identical to master's own baseline. Beartype matters here: it turns every annotation added by this PR into a runtime `isinstance` check.
- [x] Full suite, `BB_FORCE_ASGI_SCOPE=1` lane — matches its own master baseline
- [x] Typing gate — 7 passed
- [x] `mkdocs build --strict` clean
- [x] Both published doc examples type-checked with pyright (0 errors), not eyeballed
- [x] Dispatch µs/req flat within noise; `getallocatedblocks`/req identical (+0.0001)

The 37 pre-existing failures/errors are environment-only and present on master:
Python 3.14 `spawn` pickling of local functions in test fixtures, and absent
`docker` / `testcontainers`.

## ⚠️ Merge conflict to resolve: `CLAUDE.md`

This branch is based on `fcb41ad`; master has since deleted `CLAUDE.md`
(#186, private assets migrated to the companion repo). One commit here
(`e9d9213`) edits `CLAUDE.md`'s overview paragraph, so the merge is a
modify/delete conflict.

**Resolve by accepting the deletion** — `AGENTS.md` on master already carries
the corrected identity prose ("Internally native; ASGI is kept only at the two
external boundaries"), so the edit is redundant. Nothing else in this branch
touches `CLAUDE.md`.

## Also included

- `tests/integration/test_nginx.py` imported the optional `docker` /
  `testcontainers` extras at module scope, so a missing extra became a
  **collection error that aborted the entire pytest session** rather than
  skipping one file. Now guarded with `pytest.importorskip`, matching the
  sibling differential test. (This was blocking every local test run.)
- Pre-release docs audit: README and `docs/index.md` no longer call BlackBull an
  "ASGI 3.0 web framework"; README's drop-down form corrected from the ASGI
  `(scope, receive, send)` triplet to `(conn, receive, send)`, stale since
  Sprint 80; the `docs/index.md` footnote no longer promises that foreign ASGI
  apps run on BlackBull's own server without `BB_FORCE_ASGI_SCOPE=1`.
- `SECURITY.md` supported-versions table shifted for the 0.62 minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
