### PR TITLE
fix(http2): replay un-consumed connection credit on Python 3.13+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,25 @@ so the editable install's metadata catches up.
 
 ### Fixed
 
+- **HTTP/2 connection-window leak on Python 3.13+ (un-drained request
+  bodies).**  When a handler responded without draining its request body —
+  an early `401`/`413`, a validation reject, or simply ignoring the body —
+  the un-consumed DATA bytes were meant to be credited back to the shared
+  connection window as `WINDOW_UPDATE(0)` when the stream was released.  That
+  replay is scheduled from a synchronous done-callback, preferring the
+  connection `TaskGroup` and falling back to a bare loop task once the group
+  is closing.  Both paths were handed the *same* coroutine object, and since
+  CPython 3.13 `TaskGroup.create_task()` closes the coroutine before raising
+  `RuntimeError` for an exiting/aborting group — so the fallback scheduled an
+  already-closed coroutine, the task died with `cannot reuse already awaited
+  coroutine`, and the credit was silently dropped on exactly the teardown
+  path the fallback exists to serve.  The loss is cumulative: after 65535
+  un-drained bytes the connection window is shut and every later request on
+  that connection stalls.  Each `create_task` now gets its own coroutine.
+  Unaffected on 3.11/3.12, where the interpreter does not close the
+  coroutine — which is also why the repository's CI matrix (3.11 + 3.12)
+  never saw it, despite 3.13 and 3.14 being declared-supported.
+
 - `tests/integration/test_nginx.py` imported the optional `docker` /
   `testcontainers` extras at module scope, so a missing extra became a
   collection error that interrupted the whole pytest session instead of

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -533,13 +533,21 @@ class HTTP2Actor(Actor):
         # Callers may be sync done-callbacks — schedule the replay.  Prefer
         # the connection TaskGroup so run() awaits it; fall back to a bare
         # loop task when the group is already closing (teardown).
-        coro = _replay()
-        try:
-            if self._task_group is not None:
-                task = self._task_group.create_task(coro)
-            else:
-                task = asyncio.get_running_loop().create_task(coro)
-        except RuntimeError:
+        #
+        # Each create_task gets its OWN coroutine object.  Since CPython 3.13
+        # TaskGroup.create_task() closes the coroutine before raising when the
+        # group is exiting/aborting, so handing the same object to the fallback
+        # schedules an already-closed coroutine: the task dies with "cannot
+        # reuse already awaited coroutine" and the credit is silently never
+        # replayed — on exactly the teardown path this fallback exists for.
+        task = None
+        if self._task_group is not None:
+            try:
+                task = self._task_group.create_task(_replay())
+            except RuntimeError:
+                task = None
+        if task is None:
+            coro = _replay()
             try:
                 task = asyncio.get_running_loop().create_task(coro)
             except RuntimeError:

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -522,3 +522,44 @@ async def test_window_overrun_is_rst_enhance_your_calm():
              if f.FrameType() == FrameTypes.RST_STREAM
              and f.error_code == ErrorCodes.ENHANCE_YOUR_CALM]
     assert calms, 'window overrun must trip the ENHANCE_YOUR_CALM backstop'
+
+
+@pytest.mark.asyncio
+async def test_credit_replay_survives_a_task_group_that_refuses_the_task():
+    """The connection-credit replay must still reach the wire when the
+    connection TaskGroup refuses the task.
+
+    Since CPython 3.13 ``TaskGroup.create_task()`` *closes* the coroutine
+    before raising ``RuntimeError`` for a group that is exiting or aborting.
+    A fallback that re-submits the same coroutine object therefore schedules
+    an already-closed coroutine: the task dies with "cannot reuse already
+    awaited coroutine" and the un-consumed balance is never credited back to
+    stream 0, so the shared connection window leaks shut for every later
+    stream on the connection — on exactly the teardown path the fallback
+    exists to serve.
+
+    The refusing group is faked rather than driven through a real teardown so
+    the contract is pinned on every supported Python, including 3.11/3.12
+    where the interpreter does not close the coroutine and the bug is
+    therefore invisible.
+    """
+    handler = _make_actor()
+
+    class _RefusingTaskGroup:
+        """asyncio.TaskGroup.create_task() on a shutting-down group."""
+
+        def create_task(self, coro, **kwargs):
+            coro.close()          # CPython >= 3.13 closes before it raises
+            raise RuntimeError(
+                'TaskGroup <TaskGroup cancelling> is shutting down')
+
+    handler._task_group = _RefusingTaskGroup()
+
+    recipient = MagicMock()
+    recipient.take_uncredited = MagicMock(return_value=1234)
+
+    handler._release_recipient_credit(recipient)
+    for _ in range(10):           # let the fallback task reach the wire
+        await asyncio.sleep(0)
+
+    assert _window_updates(handler) == [(0, 1234)]


### PR DESCRIPTION
## Summary

A handler that responds **without draining its request body** — an early
`401`/`413`, a validation reject, or simply ignoring the body — leaves DATA
bytes that the peer has already debited from the shared HTTP/2 **connection**
window. Those bytes are credited back as `WINDOW_UPDATE(0)` when the stream is
released.

That replay is scheduled from a synchronous done-callback: it prefers the
connection `TaskGroup` so `run()` awaits it, and falls back to a bare loop task
once the group is closing (teardown). Both paths were handed the **same
coroutine object**:

```python
coro = _replay()
try:
    task = self._task_group.create_task(coro)   # raises AND closes coro
except RuntimeError:
    task = asyncio.get_running_loop().create_task(coro)   # ← already closed
```

Since CPython 3.13, `TaskGroup.create_task()` calls `coro.close()` **before**
raising `RuntimeError` for a group that is exiting or aborting. The fallback
therefore scheduled an already-closed coroutine; the task died with
`RuntimeError: cannot reuse already awaited coroutine` and the credit was
silently dropped — on exactly the teardown path the fallback exists to serve.

**The loss is cumulative.** Each un-drained request permanently shrinks the
connection window, so after 65535 such bytes the window is shut and every later
request on that connection stalls.

Each `create_task` now gets its own coroutine object.

## Why CI never caught it

`pyproject.toml` declares support for **3.11–3.14**, but the CI matrix in
`.github/workflows/test.yml` is `['3.11', '3.12']` — the two versions where the
interpreter does *not* close the coroutine and the fallback still works. The
bug is structurally invisible to the current matrix.

`test_unread_body_balance_flushes_to_connection_window` already asserted the
correct end state and has been failing locally on 3.14 since the interpreter
bump (it fails identically at the `v0.61.0` tag — verified in a clean worktree,
so this is not a Sprint 81 regression).

The new regression test fakes a refusing `TaskGroup` that closes the coroutine,
pinning the contract on **every** supported Python rather than only where the
interpreter exhibits the behaviour.

## Test plan

- [x] `tests/conformance/http2/` — 264 passed, 9 skipped, 0 failed (3.14, beartype)
- [x] New test fails without the fix, passes with it (verified by reverting the source change and keeping the test)
- [x] `test_unread_body_balance_flushes_to_connection_window` passes again
- [x] Full beartype suite: 5267 passed, 261 skipped, 1 xfailed, **0 failed**
- [x] Confirmed the same failure at `v0.61.0` in a detached worktree — pre-existing, not introduced by #192

### Note on the 36 pre-existing suite errors

Unrelated and unchanged by this PR (identical count before and after): on
Python 3.14 `multiprocessing` defaults to `forkserver` on Linux, so fixtures
that hand a locally-defined lambda to `Process(target=…)` fail to pickle at
`p.start()` — all 36 are `PicklingError: Can't pickle local object`. They do not
occur on the CI matrix. Worth its own fix; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)