### PR TITLE
release: v0.63.0 — Sprint 82: high-level WebSocket API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.63.0] — 2026-07-29
+
 ### Added
 
 - **High-level WebSocket API.**  WebSocket handlers can now take a typed

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -259,8 +259,20 @@ binding, no interception (the event API covers cross-cutting concerns).
 Query params resolve scalars only (`str`/`int`/`float`/`bool`,
 optionally `| None`); repeated-key aggregation (`?tag=a&tag=b` →
 `list[str]`) and query-model objects are not supported — parse
-`scope['query_string']` yourself for those.  Fences are lifted on
+`conn.query_string` yourself for those.  Fences are lifted on
 demonstrated demand, not speculatively.
+
+### WebSocket handlers take no injected parameters
+
+The v0.63.0 `WebSocket` object is resolved by signature, but only
+two things can appear there: the socket itself (`ws: WebSocket`, or
+the bare name `ws`/`websocket`) and optionally `conn: Connection`.
+Path params, query params, and `Depends` are **not** injected into a
+WebSocket handler the way they are into an HTTP one — read them off
+the connection (`ws.path_params['room']`, `ws.query_string`).
+Anything else in the signature is a registration-time `TypeError`
+rather than a surprise on the first connection.  Injection parity is
+the subject of queued follow-up work, not a permanent fence.
 
 ### Optional `[speed-h1]` C parser stub not implemented
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Hello, world!
 - **Readable stack.** Every byte on the wire passes through Python
   you can step through with `pdb`.  No C extensions to debug.
 - **Declare, don't plumb.** Handlers name what they need — path
-  params, query params, the body, a `Connection` view, or a
-  `Depends(get_db)` resource with teardown after the response — and
+  params, query params, the body, a `Connection` view, a
+  `WebSocket` on a websocket route, or a `Depends(get_db)` resource
+  with teardown after the response — and
   the router resolves it all when the route is *registered*.  A
   handler that uses none of it compiles to the same bare wrapper:
   zero per-request cost for features you didn't ask for.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.63.x  | :white_check_mark: |
 | 0.62.x  | :white_check_mark: |
-| 0.61.x  | :white_check_mark: |
-| < 0.61  | :x:                |
+| < 0.62  | :x:                |
 
 This table updates with each minor release.
 
@@ -65,6 +65,12 @@ The following are in scope for security reports:
 - Middleware shipped in `blackbull/middleware/` (Compression,
   StaticFiles, CORS, etc.).
 - Routing, request parsing, and response handling.
+- The WebSocket handshake seam in `blackbull/websocket.py` and
+  `blackbull/middleware/websocket.py`.  Rejection is expressed by
+  closing *before* accepting, and the two layers coordinate through
+  handshake state recorded on the connection — so a defect that lets
+  a connection reach a handler as "accepted" when a middleware meant
+  to reject it is a security report, not a bug report.
 - The `blackbull` CLI and module-level boot path (`blackbull.app.serve`).
 - The async HTTP client under `blackbull/client/` (experimental,
   but in-scope).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.62.0"
+version = "0.63.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closes Sprint 82. Two commits: the pre-release docs audit, then the
two-file release commit (version bump + CHANGELOG heading rename).

## What ships

**A typed `WebSocket` object for WebSocket handlers**, alongside the raw
`(conn, receive, send)` form:

```python
@app.route(path='/ws', scheme=Scheme.websocket)
async def ws_echo(ws: WebSocket):
    await ws.accept()
    async for message in ws:
        await ws.send(message)
```

`accept()` / `close()` drive the handshake — `close()` **before**
`accept()` rejects the connection outright. `send_text` / `send_bytes` /
`send_json` / `send` write one complete message; `receive()` and its typed
variants return bare `str`/`bytes` rather than an event. Connection facts
and handshake state are properties.

**The raw form is not deprecated** and costs nothing. A route is classified
once, at registration, by whether its signature has both `receive` and
`send`, so raw handlers reach the router untouched. The object is built once
per *connection*, never per message, and emits exactly the events a raw
handler sends by hand.

**`blackbull.middleware.websocket` composes with the object.** The first cut
refused the combination with a `RuntimeError`; that was the wrong shape of
fix — the defect was that two layers both owned the handshake and neither
could see the other. Handshake completion is now published on the connection
and read by the rest.

Two states, deliberately **not** interchangeable:

| Middleware did | Records with | Object then |
|---|---|---|
| Read connect **and** sent accept | `mark_handshake_accepted` | Starts accepted; bare `accept()` is a no-op |
| Read connect only | `mark_connect_consumed` | Doesn't wait for connect, still sends accept |

Collapsing them would make a handler downstream of an auth middleware skip
its own `accept()` and leave the client hanging — a silent hang. That shape
is live in `examples/ChatServer/chatserver.py`.

## Verification

- **5339 passed, 0 failed** locally (36 errors are the known Python 3.14
  `forkserver` fixture baseline, unrelated).
- **Autobahn SUCCESS** on the final Sprint 82 commit — the gate for this
  sprint was "framing, fragmentation, and close semantics unchanged".
- pyright clean; `blackbull/websocket.py` is now inside the typing gate.
- `mkdocs build --strict` clean.
- The shipped WebSocket examples are driven end to end by
  `tests/integration/test_websocket_examples.py` (8 cases, new — the
  examples previously had no test coverage at all).

## Docs audit

`SECURITY.md` supported-versions table shifted to 0.63.x + 0.62.x, and the
handshake seam added to scope. `KNOWN_LIMITATIONS.md` records that WebSocket
handlers take no injected parameters (no path/query params, no `Depends`) —
that parity is queued follow-up work, not a permanent fence.

## Known gap

`tests/integration/` runs only in the Full tier (schedule / `workflow_dispatch`),
so the new example tests are **not** gated per-PR. Verified locally. Whether
integration deserves a per-PR lane is a CI-topology call, deliberately not made
at a sprint tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)