### PR TITLE
feat(websocket): inject path params, query params, and Depends (Sprint 83)

### DIFF
--- a/.github/skills
+++ b/.github/skills
@@ -1,1 +1,0 @@
-../.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,11 @@ venv.bak/
 .claude
 # CLAUDE.md is a symlink to AGENTS.md — create locally: ln -s AGENTS.md CLAUDE.md
 CLAUDE.md
+# Convenience link so GitHub-side tooling finds the skills locally — create
+# with: ln -s ../.claude/skills .github/skills
+# Untracked deliberately: it resolves through .claude above, which is ignored,
+# so a committed symlink would arrive dangling in every clone and in CI.
+.github/skills
 
 # benchmark result files (keep directory + READMEs, ignore data)
 bench/results/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,72 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **WebSocket handlers inject from their signature.**  Path params, query
+  params, and `Depends` now resolve into a WebSocket handler the way they
+  already did for HTTP, alongside the `WebSocket` object:
+
+  ```python
+  @app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+  async def chat(ws: WebSocket, room: str, since: int = 0,
+                 db=Depends(get_db)):
+      ...
+  ```
+
+  This completes injection parity across handler surfaces — no first-party
+  handler form now requires the raw `(conn, receive, send)` triplet, which
+  stays supported and undeprecated.  A lone `ws` parameter keeps the
+  allocation-free Sprint 82 fast path; injection is paid for only by
+  signatures that ask for it.
+
+  Two deliberate differences from the HTTP form: a WebSocket query param
+  **must carry its annotation** (a bare name stays a registration-time
+  `TypeError`, because `chat(socket)` means the socket rather than a query
+  param named `socket`), and there is no body parameter, a WebSocket having
+  no request body.
+
+  A parameter that cannot be bound at connect time — required query param
+  missing, value that will not coerce — **refuses the handshake with close
+  code 1008** and never runs the handler; no dependency is resolved for a
+  connection that is about to be rejected.
+
+  `Depends` resolves **once per connection** and tears down when the handler
+  exits, by any route — clean close, `WebSocketDisconnect`, or exception.
+  Because that means a socket holds its dependency for its whole lifetime,
+  the guide documents the pool-exhaustion hazard and the app-scoped-pool
+  pattern that avoids it.  Note that cleanup written after a bare `yield` is
+  skipped on the exception paths (ordinary `@asynccontextmanager`
+  semantics) — providers should use `try`/`finally`.
+
+- **`Depends` providers are warned when cleanup would be silently skipped.**
+  Code written after a bare `yield` never runs when the handler raises — the
+  exception is re-raised *at* the `yield` — so the resource leaks exactly
+  when something went wrong.  BlackBull now emits a `UserWarning` at
+  registration naming the provider and showing the `try`/`finally` fix.
+
+  The check is deliberately narrow, and stays quiet for every shape that is
+  already correct: a `yield` inside any `try` (`finally` covers all paths;
+  `except`/`else` means the author is deliberately telling success from
+  failure), a provider with nothing after the `yield`, and a `yield` inside
+  an `async with`.  It never fails registration — a provider whose source is
+  unavailable is left alone.
+
+  The semantics themselves are unchanged and intentionally so: the exception
+  must reach the generator, or a commit-or-rollback provider would commit on
+  error.  Applies to HTTP and WebSocket alike.
+
+### Docs
+
+- `docs/guide/dependency-injection.md` gains a **Write cleanup in a
+  `finally`** section; the provider-forms table no longer implies that "code
+  after `yield`" and `finally` are equivalent.
+- `docs/guide/websockets.md` gains an **Injected parameters** section with a
+  dependency-lifetime warning; `KNOWN_LIMITATIONS.md`'s "WebSocket handlers
+  take no injected parameters" entry is replaced by the two narrower fences
+  that remain.  `examples/websocket_object.py` reads `room` from the
+  signature instead of `conn.path_params`.
+
 ## [0.63.0] — 2026-07-29
 
 ### Added

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -18,6 +18,14 @@ Every item here is something the project knows about and has a
 position on.  Behaviours that aren't listed below — anything that
 would surprise us as well — belong on the GitHub issue tracker.
 
+**A limitation is not the same as a missing feature.** This file lists
+things that could *surprise* you: a default that is not what you would
+guess, a cost you would not predict, a surface that is narrower than its
+equivalent elsewhere.  Capabilities BlackBull simply doesn't aim to
+provide — HTTP/3, an ORM, a gRPC client — are not limitations; they are
+scope, and they live in [Deliberate non-goals](#deliberate-non-goals--not-limitations)
+at the end so they don't pad the list above.
+
 ---
 
 ## Protocol-level
@@ -207,9 +215,13 @@ capacity against `nproc / 2` on typical SMT-enabled hardware.
 
 ---
 
-## What BlackBull doesn't do
+## Deliberately narrow surfaces
 
-### Static-file serving is not a production CDN
+These are implemented and supported, but fenced tighter than the
+equivalent surface in a larger framework.  Each fence is lifted on
+demonstrated demand, not speculatively.
+
+### Static-file serving: know the per-request cost
 
 [`blackbull/middleware/static.py`](blackbull/middleware/static.py)
 serves files three ways at runtime:
@@ -237,16 +249,8 @@ in to keep prior performance.
 
 `StaticFiles` itself emits no `ETag`; pair it with the `Cache`
 middleware for ETag / `If-None-Match` revalidation (`blackbull serve`
-does this for you).  What's still missing across all paths:
-byte-range-multipart and CDN edge-cache invalidation glue.  For
-anything user-visible, front a real static-file server (nginx,
-S3 + CloudFront).
-
-### No internal database layer
-
-BlackBull is a protocol-layer framework.  There is no built-in
-ORM, no connection pool, no migration tool.  Apps should bring
-their own (`asyncpg`, `databases`, `tortoise-orm`, etc.).
+does this for you).  Byte-range-multipart responses are not
+implemented across any of the three paths.
 
 ### `Depends` is deliberately minimal; query params are scalars only
 
@@ -288,18 +292,7 @@ per-frame dispatch seam, and the handler owns its receive loop.  A
 declared-scope API is unlocked on demonstrated demand, not
 speculatively.
 
-### Optional `[speed-h1]` C parser stub not implemented
-
-`pyproject.toml` lists no `[speed-h1]` extra today.  The
-pure-Python HTTP/1 parser is fast enough that swapping in a C
-parser (e.g. `httptools`) isn't on the critical path; a future
-opt-in knob is sketched in the roadmap but not built.
-
-### No HTTP/3 / QUIC
-
-Out of scope.  Revisit if a real user need appears.
-
-### gRPC: core handlers exchange raw bytes; reflection is v1alpha-only
+### gRPC: reflection is v1alpha-only
 
 All four gRPC RPC shapes — unary, server-streaming, client-streaming, and
 bidirectional — ship in `blackbull.grpc` (`app.enable_grpc`), with `gzip`
@@ -309,10 +302,9 @@ WebSocket, with `grpc-status` reported in trailers (a trailing HEADERS
 frame). Core handlers exchange raw message bytes by design; object-typed
 servicers, server reflection, `grpc.health.v1`, and rich error details ship
 in the optional [`blackbull-protobuf`](https://github.com/TOKUJI/blackbull-protobuf)
-package (`pip install 'blackbull[protobuf]'`). Remaining gaps: reflection
-serves `grpc.reflection.v1alpha` only (`v1` is a planned fast-follow;
-grpcurl and most clients fall back to v1alpha automatically), and BlackBull
-is server-side only — use `grpcio` for a client. See
+package (`pip install 'blackbull[protobuf]'`). The remaining gap: reflection
+serves `grpc.reflection.v1alpha` only — `v1` is a planned fast-follow, and
+grpcurl and most clients fall back to v1alpha automatically. See
 [`docs/guide/grpc.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/grpc.md).
 
 ### CLI `--bind` host is advisory
@@ -326,6 +318,23 @@ field on `AppConfig`) is advisory — the socket layer binds dual-stack
 on **all** interfaces, so `--bind 127.0.0.1:8000` still listens on
 every interface.  Use a `unix:` bind, `fd://` socket activation, or a
 fronting proxy when interface filtering matters.
+
+---
+
+## Deliberate non-goals — not limitations
+
+Capabilities BlackBull does not aim to provide.  Nothing here is a gap
+in an implemented feature; each is a scope decision with a supported
+alternative.  Listed so the question is answered once — not as a
+shortfall list.
+
+| Not provided | Why, and what to use |
+|---|---|
+| **HTTP/3 / QUIC** | Out of scope at Early Alpha. Revisit if a real user need appears. Front with a proxy that terminates H3 if you need it at the edge. |
+| **ORM / connection pool / migrations** | BlackBull is a protocol-layer framework, like Flask and Starlette. Bring `asyncpg`, `databases`, `tortoise-orm`, or `SQLAlchemy`. |
+| **A gRPC client** | Server-side only, by design. Use `grpcio` for clients. |
+| **CDN edge-cache invalidation glue** | For user-visible static assets, front a real static server or CDN (nginx, S3 + CloudFront). The built-in `StaticFiles` targets app-adjacent assets. |
+| **A C-accelerated HTTP/1 parser (`[speed-h1]`)** | No such extra exists. A pure-Python parser on every path is the project's identity; accelerating it with a C dependency would trade that away. Performance work targets the Python path instead. |
 
 ---
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -262,17 +262,31 @@ optionally `| None`); repeated-key aggregation (`?tag=a&tag=b` →
 `conn.query_string` yourself for those.  Fences are lifted on
 demonstrated demand, not speculatively.
 
-### WebSocket handlers take no injected parameters
+### WebSocket injection: annotated query params only, one lifetime
 
-The v0.63.0 `WebSocket` object is resolved by signature, but only
-two things can appear there: the socket itself (`ws: WebSocket`, or
-the bare name `ws`/`websocket`) and optionally `conn: Connection`.
-Path params, query params, and `Depends` are **not** injected into a
-WebSocket handler the way they are into an HTTP one — read them off
-the connection (`ws.path_params['room']`, `ws.query_string`).
-Anything else in the signature is a registration-time `TypeError`
-rather than a surprise on the first connection.  Injection parity is
-the subject of queued follow-up work, not a permanent fence.
+Since v0.64.0 a WebSocket handler resolves path params, query
+params, and `Depends` from its signature, as an HTTP handler does.
+Two deliberate differences remain.
+
+A WebSocket **query param must carry its annotation** — on an HTTP
+route a bare name is taken as a `str` query param, but the reserved
+names (`ws`, `websocket`, `conn`, `connection`) make bare parameters
+ambiguous on a socket, so `async def chat(socket)` stays a
+registration-time `TypeError` instead of silently becoming a query
+param named `socket`.  There is also no body parameter: a WebSocket
+has no request body, so the HTTP `body`/dataclass forms have no
+analogue.
+
+`Depends` resolves **once per connection**, with no way to ask for
+another lifetime.  That is correct for values and wrong for scarce
+resources — a socket pins its dependency for hours, so a pool of N
+serves N concurrent sockets.  Application-scope the pool
+(`@app.on_startup`) and borrow per use; see the dependency-lifetime
+section of `docs/guide/websockets.md`.  Per-message scope is not
+merely unimplemented but structurally unavailable: it needs a
+per-frame dispatch seam, and the handler owns its receive loop.  A
+declared-scope API is unlocked on demonstrated demand, not
+speculatively.
 
 ### Optional `[speed-h1]` C parser stub not implemented
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -86,107 +86,55 @@ it, so the header rides the QUERY route's own responses (including its
 
 ---
 
-## Deployment notes
+## Runtime constraints
 
-### Raw protocol handlers: single-owner, HTTP still scales, cleartext by default
+Behaviours that hold at run time regardless of how you deploy.  The
+operational how-to for each lives in the deployment guide; what's here is
+the part that can surprise you.
 
-When a non-ASGI protocol handler is registered via `app.raw_handler()` or
-`app.register_protocol_handler()`, BlackBull applies these constraints:
+### Raw protocol sockets are cleartext unless you ask for TLS
 
-**The protocol has a single owner, but HTTP scales (Sprint 55).** A stateful
-broker must have one owner (see the MQTT section below), so the master binds
-the protocol port once and hands it to **worker 0** only; the broker lives
-there.  HTTP is stateless, so `app.run(port=8000, workers=4)` alongside, say,
-`MQTTExtension(port=1883)` now runs HTTP on **all** workers while the broker
-runs on worker 0.  If worker 0 crashes the master respawns it and it
-re-inherits the still-open listening socket, so the broker resumes on the same
-port (clients reconnect; in-memory broker state is not preserved — see below).
+A socket bound by `app.raw_handler()` or `app.register_protocol_handler()`
+carries **no TLS by default**.  Register the binding with `tls=True`
+(`app.raw_handler(name, port=…, tls=True)`, `MQTTExtension(port=8883,
+tls=True)`) to serve it through the same TLS machinery as the HTTPS
+listener — certificate from `certfile`/`keyfile` or `ssl_context`, with
+startup failing fast when `tls=True` has no certificate to use.  A
+TLS-terminating proxy in front of the raw socket is a fine alternative.
 
-The one exception is **auto-reload** (`--reload`): it hands listening sockets
-across an `exec` via fd inheritance, and that handoff does not yet include the
-protocol listeners, so `reload=True` with a port-bound protocol still forces
-`workers=1`.  Run without reload to scale HTTP alongside the broker.
+A raw protocol also has a **single owner** — it is bound on worker 0 only,
+while HTTP scales across all workers.  See
+[Workers](docs/deployment/workers.md) for the mechanics, including why
+`--reload` forces `workers=1` when a protocol port is bound.
 
-`BB_SOCKET_REUSEPORT=1` makes each HTTP worker bind its own kernel accept
-queue (best load distribution); without it the workers share the master's
-listening socket.  The protocol port is always bound without `SO_REUSEPORT`
-— a single owner is the point.
+### MQTT broker state is in-memory and lost on restart
 
-**Cleartext by default; TLS is opt-in per binding (Sprint 75)** — a raw
-protocol socket is bound without TLS unless the binding is registered with
-`tls=True` (`app.raw_handler(name, port=…, tls=True)` /
-`MQTTExtension(port=8883, tls=True)`), in which case it is served through
-the same TLS machinery as the HTTPS listener (certificate from
-`certfile`/`keyfile` or `ssl_context`; startup fails fast when `tls=True`
-has no certificate to use).  A TLS-terminating proxy in front of the raw
-socket remains a fine alternative.
+The MQTT 5 broker (`blackbull.mqtt`, opt-in via `blackbull[mqtt]`) rides the
+raw-protocol bridge, so it inherits both constraints above.  Beyond those:
 
-### MQTT broker: best-effort taps, in-memory single-process state
+**State does not survive a restart.**  Subscriptions, sessions, and retained
+messages live in the one serving process — not shared across workers, not
+persisted.  A restart, or a worker-0 respawn after a crash, clears all
+session and retained state.  Sessions are kept for the process lifetime
+rather than expired on a timer.
 
-The MQTT 5 broker (`blackbull.mqtt`, opt-in via `blackbull[mqtt]`) rides
-the raw-protocol bridge above, so it inherits its constraints —
-**single-owner** (the broker runs on worker 0; HTTP still scales across all
-workers) and **cleartext unless registered with `tls=True`**
-(`MQTTExtension(port=8883, tls=True)` for `mqtts://`).  Beyond those:
-
-**Why a single broker owner is a protocol requirement, not an
-implementation limitation.**  The MQTT 5.0 specification (OASIS Committee Specification
-02, March 2019) defines semantics that depend on broker-side state visible
-to every connection: publish-subscribe matching (§3.3), retained messages
-(§3.3.2.3), session state across Clean Start = 0 reconnects (§3.1.2.11),
-Will messages (§3.1.2.5), and QoS 1/2 delivery tracking (§4.3).  All five
-break if that state is split across worker processes with no shared store.
-This is consistent with industry practice: the Eclipse Mosquitto
-reference implementation ([mosquitto.org](https://mosquitto.org/)) is
-single-threaded by architecture for the same reason, and EMQX clusters via
-Erlang distributed message passing rather than local worker splitting.
-(Confirmed 2026-06-25 against the OASIS MQTT 5.0 specification and
-Mosquitto's project documentation.)
+**Nothing is queued for offline sessions.**  A disconnected client with a
+live session (`Session Expiry Interval > 0`) gets §4.4 replay of its
+*unacknowledged in-flight* QoS 1/2 messages on reconnect, but messages
+**newly published while it was offline are not queued** and will never reach
+it.  The same applies to a shared-subscription group with no connected
+member.  If you need store-and-forward for offline consumers, use a broker
+with persistent offline queues.
 
 **`on_message` taps are best-effort observability, not a delivery path.**
-In the default `tap_mode='actor'`, each PUBLISH is *offered* to a
-bounded-inbox `TapActor` that **drops the newest message on overflow**
-(with a running dropped-count logged) so a slow tap can never
-back-pressure routing.  Use a real MQTT subscription when you need
-guaranteed delivery; treat a tap as a probe.
+In the default `tap_mode='actor'` each PUBLISH is *offered* to a
+bounded-inbox `TapActor` that drops the newest message on overflow (with a
+running dropped-count logged), so a slow tap can never back-pressure
+routing.  Use a real MQTT subscription when you need guaranteed delivery.
 
-**Broker state is in-memory and per-process.**  Subscriptions, sessions,
-and retained messages live in the one serving process (worker 0) — not
-shared across workers (hence the single-owner model) and not persisted
-across a restart.  A restart, or a worker-0 respawn after a crash, clears
-all session and retained state.  Sessions are also kept for the process
-lifetime rather than expired on a timer.
-
-**New messages are not queued for offline sessions.**  A disconnected
-client with a live session (`Session Expiry Interval > 0`) gets §4.4
-replay of its *unacknowledged in-flight* QoS 1/2 messages on reconnect,
-but messages **newly published while it was offline are not queued** and
-will never be delivered to it.  The same applies to a shared-subscription
-group with no connected member (see
-[`docs/guide/mqtt.md`](docs/guide/mqtt.md)).  If you need store-and-forward
-for offline consumers, use a broker with persistent offline queues.
-
-### HTTP/2 costs more per request than HTTP/1.1
-
-Not a BlackBull property — HTTP/2 carries per-stream state, framing,
-and flow control that HTTP/1.1 does not, in every implementation.
-Noted here only because the deployment consequence is easy to miss:
-if a workload needs maximum throughput on a single HTTP/2 connection
-at high multiplex, the usual production shape is a fronting HTTP/2
-terminator (nginx, Envoy) with BlackBull on HTTP/1.1 behind it.
-
-BlackBull's HTTP/2 is conformant (`h2spec`, RFC 9113).  How its
-per-stream cost compares to other servers is **not measured** — the
-`bench/CHARACTERIZATION.md` A-lane (h2load at n=1/10/50) is specified
-but has no recorded results, so no comparative claim is made here in
-either direction.
-
-### Multi-worker scaling tops out at physical core count
-
-Worker throughput scales roughly to the **physical core count**,
-not the logical (SMT-thread) count.  Multiplying workers past
-the physical-core ceiling does not multiply throughput.  Plan
-capacity against `nproc / 2` on typical SMT-enabled hardware.
+Why one owner is a *protocol* requirement rather than an implementation
+shortcut — and how Mosquitto and EMQX handle the same constraint — is
+explained in [the MQTT guide](docs/guide/mqtt.md).
 
 ---
 

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -57,20 +57,6 @@ with BlackBull on HTTP/1.1 behind it — eliminates this surface
 entirely because nginx does not forward RFC 8441 Extended
 CONNECT to the backend.
 
-### HTTP/2 multiplex overhead vs HTTP/1.1
-
-The HTTP/2 implementation is conformant (passes `h2spec`,
-RFC 9113) but each stream carries actor-machinery overhead — a
-per-stream queue, sender state, and priority-tree bookkeeping —
-that the HTTP/1.1 path doesn't pay.  Single-connection,
-high-multiplex workloads will spend more per request on HTTP/2
-than on HTTP/1.1; the difference grows with mux depth.
-
-If a workload needs maximum throughput on a single HTTP/2
-connection at high mux, a fronting HTTP/2 terminator (nginx,
-Envoy) is the usual production shape; BlackBull behind that
-terminator on HTTP/1.1 is the matched-cost path.
-
 ### h2c prior-knowledge shares the HTTP/1.1 port
 
 BlackBull's plaintext listener auto-detects the HTTP/2
@@ -89,40 +75,14 @@ the exact "with N slow connections, first new connection
 accepted within M ms" curve — only the qualitative claim "RFC
 9110 §15.5.9 compliant 408 plus the three timeouts work".
 
-### HTTP QUERY (RFC 10008) — two deliberate edges
+### HTTP QUERY (RFC 10008): `Accept-Query` is not synthesised on OPTIONS
 
 QUERY routing, `Accept-Query` content negotiation, and Content-Type
-enforcement ship (see the [routing guide](docs/guide/routing.md)), but
-two edges are out of scope for now:
-
-- **OpenAPI**: QUERY routes are excluded from the generated document.
-  OpenAPI 3.1 has no `query` operation; 3.2 adds one — revisit when the
-  emitter moves to 3.2.  QUERY is never faked as another operation.
-- **`Accept-Query` on OPTIONS**: RFC 10008 mentions emitting the header
-  on OPTIONS for a path; BlackBull only auto-handles OPTIONS when a route
-  is registered for it, so the header is emitted on the QUERY route's own
-  responses (including its 415), not synthesised on an unrouted OPTIONS.
-
-No browser implements QUERY; server + client + tests are the whole story.
-
----
-
-## RFC-defensible differential-corpus divergences
-
-The differential fuzz harness compares BlackBull's response to
-the same request against nginx.  Two captured divergences are
-**RFC-defensible**, kept in the corpus deliberately, and not
-treated as bugs:
-
-| Wire request | nginx | BlackBull | Why we're right |
-|---|---|---|---|
-| `GET&nbsp;&nbsp;http://localhost/x HTTP/1.0` (double-SP between method and target) | 200 | 400 | RFC 9112 §3 — request-line tokens are separated by exactly one SP.  nginx is lenient; we reject. |
-| `GET&nbsp;&nbsp;http://localhost/x HTTP/9.9` (double-SP **and** unknown version) | 505 | 400 | Validation-order choice: the request-line SP grammar (RFC 9112 §3) is checked before the HTTP version, so the malformed line is 400 first.  nginx reports the version problem (505) instead.  A *well-formed* request with an unsupported version does get 505 from BlackBull (RFC 9110 §15.6.6). |
-
-Both are documented in
-[`tests/conformance/http1/fuzz/user-corpus/diff_README.md`](tests/conformance/http1/fuzz/user-corpus/).
-We're not chasing nginx parity here unless a real user need
-appears.
+enforcement ship (see the [routing guide](docs/guide/routing.md)).  One
+edge: RFC 10008 mentions emitting `Accept-Query` on OPTIONS for a path,
+but BlackBull only auto-handles OPTIONS when a route is registered for
+it, so the header rides the QUERY route's own responses (including its
+415) rather than being synthesised on an unrouted OPTIONS.
 
 ---
 
@@ -205,6 +165,21 @@ will never be delivered to it.  The same applies to a shared-subscription
 group with no connected member (see
 [`docs/guide/mqtt.md`](docs/guide/mqtt.md)).  If you need store-and-forward
 for offline consumers, use a broker with persistent offline queues.
+
+### HTTP/2 costs more per request than HTTP/1.1
+
+Not a BlackBull property — HTTP/2 carries per-stream state, framing,
+and flow control that HTTP/1.1 does not, in every implementation.
+Noted here only because the deployment consequence is easy to miss:
+if a workload needs maximum throughput on a single HTTP/2 connection
+at high multiplex, the usual production shape is a fronting HTTP/2
+terminator (nginx, Envoy) with BlackBull on HTTP/1.1 behind it.
+
+BlackBull's HTTP/2 is conformant (`h2spec`, RFC 9113).  How its
+per-stream cost compares to other servers is **not measured** — the
+`bench/CHARACTERIZATION.md` A-lane (h2load at n=1/10/50) is specified
+but has no recorded results, so no comparative claim is made here in
+either direction.
 
 ### Multi-worker scaling tops out at physical core count
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ Hello, world!
 - **Declare, don't plumb.** Handlers name what they need — path
   params, query params, the body, a `Connection` view, a
   `WebSocket` on a websocket route, or a `Depends(get_db)` resource
-  with teardown after the response — and
-  the router resolves it all when the route is *registered*.  A
+  with teardown when the handler is done — and
+  the router resolves it all when the route is *registered*.  The
+  same signature means the same thing on an HTTP route and a
+  WebSocket one.  A
   handler that uses none of it compiles to the same bare wrapper:
   zero per-request cost for features you didn't ask for.
 - **Break things on purpose.** The same protocol code that serves
@@ -166,7 +168,21 @@ async def ws_echo(ws: WebSocket):
 The loop ends when the client disconnects.  `send_text` / `send_bytes` /
 `send_json` and `receive_text` / `receive_bytes` / `receive_json` are there
 when you want to be explicit, and `await ws.close(code, reason)` before
-`accept()` rejects the handshake outright.  The raw
+`accept()` rejects the handshake outright.
+
+A WebSocket handler declares what it needs the same way an HTTP one does —
+path params, query params, and `Depends` all resolve from the signature:
+
+```python
+@app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+async def chat(ws: WebSocket, room: str, since: int = 0, db=Depends(get_db)):
+    await ws.accept()
+    ...
+```
+
+A `Depends` on a socket is resolved once per *connection* and released when
+the handler exits, so give scarce resources application scope and borrow them
+per use — the guide explains why.  The raw
 `(conn, receive, send)` event form is still supported — see
 [WebSockets](https://tokuji.github.io/BlackBull/guide/websockets/).
 
@@ -314,7 +330,7 @@ for the full tutorial.
 | [`examples/scenario_h1_fault_injection.py`](examples/scenario_h1_fault_injection.py) | HTTP/1.1 fault scenarios driven against stdlib `http.server` |
 | [`examples/scenario_h2_fault_injection.py`](examples/scenario_h2_fault_injection.py) | HTTP/2 fault scenarios served against httpx |
 | [`examples/connection_object.py`](examples/connection_object.py) | Opt-in `Connection` context object — headers, cookies, client, `body()`/`json()`/`text()` |
-| [`examples/websocket_object.py`](examples/websocket_object.py) | High-level `WebSocket` object — `async for` messages, `send_json`, handshake rejection, and the raw event form side by side |
+| [`examples/websocket_object.py`](examples/websocket_object.py) | High-level `WebSocket` object — `async for` messages, `send_json`, path/query injection, handshake rejection, and the raw event form side by side |
 | [`examples/dependency_injection.py`](examples/dependency_injection.py) | `Depends` on a pseudo DB pool — per-request acquire/release with teardown after the response, query params, `use_cache` sharing |
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Hello, world!
   `gunicorn` class path.
 - **Readable stack.** Every byte on the wire passes through Python
   you can step through with `pdb`.  No C extensions to debug.
+- **New protocols, early.** HTTP QUERY (RFC 10008) — a safe,
+  idempotent, cacheable method with a request body — ships with
+  routing, `Accept-Query` negotiation, and Content-Type
+  enforcement, years before it reaches the standard library.
 - **Declare, don't plumb.** Handlers name what they need — path
   params, query params, the body, a `Connection` view, a
   `WebSocket` on a websocket route, or a `Depends(get_db)` resource
@@ -151,6 +155,28 @@ app.run(port=8443, certfile='cert.pem', keyfile='key.pem')
 
 ALPN negotiates `h2` automatically; HTTP/1.1 clients fall back via
 the same socket.
+
+## HTTP QUERY (RFC 10008)
+
+A safe, idempotent, **cacheable** method that carries a request body — for
+the searches that don't fit in a URL and shouldn't be a `POST`:
+
+```python
+from blackbull import QUERY
+
+@app.route(path='/search', methods=[QUERY])
+async def search(body: bytes):
+    return run_query(body)
+```
+
+BlackBull ships QUERY routing, `Accept-Query` content negotiation, and
+Content-Type enforcement.  `http.HTTPMethod` has no `QUERY` member — RFC
+10008 postdates the 3.15 feature freeze, so the earliest stdlib arrival is
+3.16 — and because `HTTPMethod` is a `StrEnum`, the exported string stays
+equal- and hash-compatible with a future `HTTPMethod.QUERY`.  Routes
+registered today need no migration.
+
+See the [routing guide](https://tokuji.github.io/BlackBull/guide/routing/).
 
 ## WebSocket
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.64.x  | :white_check_mark: |
 | 0.63.x  | :white_check_mark: |
-| 0.62.x  | :white_check_mark: |
-| < 0.62  | :x:                |
+| < 0.63  | :x:                |
 
 This table updates with each minor release.
 

--- a/blackbull/di.py
+++ b/blackbull/di.py
@@ -30,11 +30,57 @@ v1 scope fences (add on real demand, not speculatively):
 * no interface binding and no interception: duck typing and the event API
   (``@app.intercept``) already cover those.
 """
+import ast
 import inspect
+import textwrap
+import warnings
 from contextlib import asynccontextmanager
 from typing import Any, Callable
 
 __all__ = ['Depends']
+
+
+def _cleanup_after_bare_yield(provider) -> bool:
+    """True when *provider* has cleanup code that an exception would skip.
+
+    An async-generator provider is driven through
+    :func:`~contextlib.asynccontextmanager`, so an exception in the handler is
+    re-raised **at the yield**.  Statements written after a bare ``yield``
+    therefore never run on that path — the resource leaks precisely when
+    something went wrong.  A WebSocket makes this bite harder than HTTP,
+    because a socket ends by exception far more often than a request does.
+
+    The shape reported is narrow on purpose: a ``yield`` that is not inside a
+    ``try`` at all, with at least one statement after it.  A yield inside any
+    ``try`` is left alone — ``finally`` covers every path, and ``except`` /
+    ``else`` mean the author is deliberately telling success from failure (the
+    commit-or-rollback provider).  A yield with nothing after it has no
+    cleanup to lose, and an ``async with`` around the yield cleans up by
+    itself.  Returns False rather than guessing when the source is
+    unavailable (C-defined, REPL, ``exec``) — a diagnostic must never be the
+    reason registration fails.
+    """
+    try:
+        tree = ast.parse(textwrap.dedent(inspect.getsource(provider)))
+    except (OSError, TypeError, SyntaxError, IndentationError):
+        return False
+
+    fn = next((n for n in ast.walk(tree)
+               if isinstance(n, ast.AsyncFunctionDef)), None)
+    if fn is None:
+        return False
+
+    guarded = {id(y) for t in ast.walk(fn) if isinstance(t, ast.Try)
+               for stmt in t.body for y in ast.walk(stmt)
+               if isinstance(y, (ast.Yield, ast.YieldFrom))}
+
+    for y in (n for n in ast.walk(fn) if isinstance(n, (ast.Yield, ast.YieldFrom))):
+        if id(y) in guarded:
+            continue
+        end = getattr(y, 'end_lineno', y.lineno)
+        if any(isinstance(s, ast.stmt) and s.lineno > end for s in ast.walk(fn)):
+            return True
+    return False
 
 
 class Depends:
@@ -99,6 +145,24 @@ class Depends:
             # (a second yield raises RuntimeError), exceptions thrown into
             # the generator at the yield point, cleanup via AsyncExitStack.
             self._acm_factory = asynccontextmanager(provider)
+            # Registration-time signal, not a runtime one: cleanup after a bare
+            # yield is skipped on exactly the paths that need it most.  Warn
+            # rather than raise — the shape is legal, and a provider whose
+            # handler never fails works fine today.
+            if _cleanup_after_bare_yield(provider):
+                warnings.warn(
+                    f'Depends provider '
+                    f'{getattr(provider, "__name__", provider)!r} has cleanup '
+                    f'after a bare `yield`. It is skipped when the handler '
+                    f'raises — and on a WebSocket, when the peer disconnects. '
+                    f'Wrap the yield so cleanup always runs:\n'
+                    f'    try:\n'
+                    f'        yield value\n'
+                    f'    finally:\n'
+                    f'        ...  # release here\n'
+                    f'Use `except`/`else` instead if the cleanup needs to tell '
+                    f'success from failure (commit vs rollback).',
+                    UserWarning, stacklevel=2)
         elif inspect.iscoroutinefunction(provider):
             self._kind = self._ASYNC_FN
         elif inspect.isgeneratorfunction(provider):

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -909,6 +909,29 @@ def _set_path_params(target, receive, params: dict) -> None:
 #: when they carry no annotation.  ``ws: WebSocket`` works under any name.
 _WS_PARAM_NAMES = frozenset({'ws', 'websocket'})
 
+#: RFC 6455 §7.4.1 close code 1008 — "policy violation".  Used to refuse a
+#: handshake whose declared handler params could not be bound; the HTTP path
+#: answers the equivalent failure with 400, which a WebSocket cannot carry.
+_WS_POLICY_VIOLATION = 1008
+
+#: RFC 6455 §5.5 caps a Close frame payload at 125 bytes, of which the code
+#: takes 2 — so a close *reason* has 123 bytes to work with.
+_WS_MAX_CLOSE_REASON = 123
+
+
+def _path_param_names(path: str) -> set[str]:
+    """The ``{name}`` placeholders declared in a route *path*."""
+    return {m.group(1) for m in Router._param_pattern.finditer(path)}
+
+
+def _truncate_close_reason(detail: str) -> str:
+    """Clip *detail* to fit an RFC 6455 Close frame, without splitting a
+    multi-byte character (a lone surrogate would make the frame unsendable)."""
+    raw = detail.encode('utf-8')
+    if len(raw) <= _WS_MAX_CLOSE_REASON:
+        return detail
+    return raw[:_WS_MAX_CLOSE_REASON].decode('utf-8', errors='ignore')
+
 
 def _is_websocket_route(scheme) -> bool:
     """True when *scheme* selects the WebSocket surface and nothing else.
@@ -924,19 +947,26 @@ def _is_websocket_route(scheme) -> bool:
     return bool(schemes) and all(s == Scheme.websocket for s in schemes)
 
 
-def _websocket_param_plan(fn) -> tuple[str, ...]:
+def _websocket_param_plan(fn, path_param_names: set = frozenset()) -> tuple[tuple, ...]:
     """Classify an object-form WebSocket handler's parameters, once, at
     registration time.
 
-    Returns one category per parameter, in signature order: ``'ws'`` for the
-    :class:`~blackbull.websocket.WebSocket` and ``'conn'`` for the native
-    :class:`~blackbull.connection.Connection`.  Annotation wins over name, so
-    an explicitly annotated parameter always means what it says.
+    Returns ``(name, kind, payload)`` per parameter, in signature order, with
+    kind one of ``'ws'`` (the :class:`~blackbull.websocket.WebSocket`),
+    ``'conn'`` (the native :class:`~blackbull.connection.Connection`),
+    ``'path'`` (payload: the annotation to coerce to, or ``None``),
+    ``'query'`` (payload: :class:`_QuerySpec`), or ``'depends'`` (payload: the
+    :class:`~blackbull.di.Depends` instance).
 
-    Anything else raises ``TypeError`` at registration rather than failing on
-    the first connection.  Path params, query params, and ``Depends`` are the
-    subject of the simplified-handler work queued behind this object; until
-    then, "I don't know what to put here" has to be loud.
+    Annotation wins over name, so an explicitly annotated parameter always
+    means what it says.  Precedence after that mirrors
+    :func:`_handler_param_plan`: path params, then the bare reserved names,
+    then a ``Depends`` default, and query params as the fallback category.
+
+    A WebSocket has no request body, so the ``'body'``/``'dataclass'``
+    categories have no WebSocket analogue — such a parameter falls through to
+    the query branch and is rejected there.  Anything unresolvable raises
+    ``TypeError`` at registration rather than failing on the first connection.
     """
     from .connection import Connection as _Conn  # noqa: PLC0415 — cycle-safe
     from .websocket import WebSocket as _WS      # noqa: PLC0415 — cycle-safe
@@ -951,30 +981,68 @@ def _websocket_param_plan(fn) -> tuple[str, ...]:
     except Exception:
         pass  # unresolved forward refs → fall back to the raw annotations.
 
-    plan: list[str] = []
+    plan: list[tuple] = []
     for name, p in params.items():
         ann = annotations.get(name, inspect.Parameter.empty)
-        if ann is _WS:
-            plan.append('ws')
-        elif ann is _Conn:
-            plan.append('conn')
-        elif ann is inspect.Parameter.empty and name in _WS_PARAM_NAMES:
-            plan.append('ws')
-        elif ann is inspect.Parameter.empty and name in ('conn', 'connection'):
-            plan.append('conn')
+        default = p.default
+        is_dep = isinstance(default, Depends)
+        bare = ann is inspect.Parameter.empty
+
+        if ann is _WS or (bare and name in _WS_PARAM_NAMES):
+            if is_dep:
+                raise TypeError(
+                    f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
+                    f"reserved for the WebSocket object and cannot carry a "
+                    f"Depends default — rename the parameter.")
+            plan.append((name, 'ws', None))
+        elif ann is _Conn or (bare and name in ('conn', 'connection')):
+            if is_dep:
+                raise TypeError(
+                    f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
+                    f"reserved for the Connection and cannot carry a Depends "
+                    f"default — rename the parameter.")
+            plan.append((name, 'conn', None))
+        elif name in path_param_names:
+            if is_dep:
+                raise TypeError(
+                    f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
+                    f"a path param of {sorted(path_param_names)!r} and cannot "
+                    f"carry a Depends default.")
+            plan.append((name, 'path', None if bare else ann))
+        elif is_dep:
+            plan.append((name, 'depends', default))
         else:
-            got = ('no annotation' if ann is inspect.Parameter.empty
-                   else getattr(ann, '__name__', repr(ann)))
-            raise TypeError(
-                f"WebSocket handler {fn.__name__!r}: cannot resolve parameter "
-                f"{name!r} ({got}).  A WebSocket handler takes 'ws: WebSocket' "
-                f"(or the bare name 'ws'/'websocket'), optionally alongside "
-                f"'conn: Connection'.  For full control, declare the raw "
-                f"'(conn, receive, send)' signature instead.")
+            # Unlike the HTTP plan, a *bare* leftover name is not silently taken
+            # as a str query param.  On HTTP that fallback is load-bearing
+            # (`async def search(q)` is idiomatic); on a WebSocket query params
+            # are rare and the reserved-name space makes bare names genuinely
+            # ambiguous — `async def chat(socket)` means the socket, not a query
+            # param named "socket".  Requiring the annotation costs one word and
+            # keeps the Sprint 82 property that a typo fails at registration
+            # instead of rejecting every connection at runtime.
+            target = None if bare else _unwrap_optional(ann)
+            coercer = _QUERY_COERCERS.get(target) if isinstance(target, type) else None
+            if coercer is None:
+                got = 'no annotation' if bare else getattr(ann, '__name__', repr(ann))
+                raise TypeError(
+                    f"WebSocket handler {fn.__name__!r}: cannot resolve parameter "
+                    f"{name!r} ({got}).  Expected 'ws: WebSocket' (or the bare "
+                    f"name 'ws'/'websocket'), 'conn: Connection', a path param of "
+                    f"{sorted(path_param_names)!r}, a Depends(...) default, or a "
+                    f"query param annotated str/int/float/bool (optionally "
+                    f"`| None`) — a WebSocket query param must carry its "
+                    f"annotation, it is not inferred.  A WebSocket has no request "
+                    f"body, so body and dataclass params have no WebSocket form.  "
+                    f"For full control, declare the raw '(conn, receive, send)' "
+                    f"signature instead.")
+            required = default is inspect.Parameter.empty
+            plan.append((name, 'query', _QuerySpec(
+                name=name, type=target, coercer=coercer, required=required,
+                default=None if required else default)))
     return tuple(plan)
 
 
-def _adapt_websocket_handler(fn):
+def _adapt_websocket_handler(fn, path: str = ''):
     """Wrap an object-form WebSocket handler in a ``(conn, receive, send)``
     coroutine, building the :class:`~blackbull.websocket.WebSocket` per
     connection.
@@ -984,34 +1052,114 @@ def _adapt_websocket_handler(fn):
     ``async for`` loop over a long-lived socket allocates nothing extra per
     message.
 
+    **Dependency lifetime.**  A ``Depends`` parameter is resolved **once per
+    connection** and released when the handler returns, via an
+    :class:`~contextlib.AsyncExitStack` that unwinds on every exit — clean
+    close, ``WebSocketDisconnect``, or a handler exception alike.  That means a
+    dependency is held for the *whole socket lifetime*, which on a WebSocket
+    may be hours rather than the milliseconds an HTTP request holds one.  Do
+    not resolve a pooled or otherwise scarce resource this way: app-scope the
+    pool (``@app.on_startup``) and borrow per use inside the handler.  See
+    ``docs/guide/websockets.md``.
+
     Nothing is done to the wire: the wrapper's methods emit the same
     ``websocket.*`` events the raw form sends by hand.
     """
     from .websocket import WebSocket as _WS  # noqa: PLC0415 — cycle-safe
 
-    plan = _websocket_param_plan(fn)
+    plan = _websocket_param_plan(fn, _path_param_names(path))
 
     # The overwhelmingly common shape — a lone ``ws`` — gets a wrapper with no
-    # per-connection argument assembly at all.
-    if plan == ('ws',):
+    # per-connection argument assembly at all.  Unchanged since Sprint 82.
+    if len(plan) == 1 and plan[0][1] == 'ws':
         @wraps(fn)
         async def _ws_wrapper(conn, receive, send):
             await fn(_WS(conn, receive, send))
         return _ws_wrapper
 
+    depends_plan = tuple((n, payload) for n, kind, payload in plan if kind == 'depends')
+    bind_plan = tuple((n, kind, payload) for n, kind, payload in plan if kind != 'depends')
+    has_query = any(kind == 'query' for _, kind, _ in bind_plan)
+    fn_name = fn.__name__
+
     @wraps(fn)
     async def _ws_plan_wrapper(conn, receive, send):
         ws = None
-        args = []
-        for kind in plan:
+        kwargs: dict = {}
+        if has_query:
+            raw_qs = conn.query_string or b''
+            query_values = (
+                dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
+                if raw_qs else {})
+
+        # Bind everything that cannot fail on a resource *before* resolving any
+        # Depends: a connection we are about to reject should never acquire one.
+        for name, kind, payload in bind_plan:
             if kind == 'ws':
                 if ws is None:
                     ws = _WS(conn, receive, send)
-                args.append(ws)
-            else:
-                args.append(conn)
-        await fn(*args)
+                kwargs[name] = ws
+            elif kind == 'conn':
+                kwargs[name] = conn
+            elif kind == 'path':
+                raw = conn.path_params.get(name, '')
+                if (payload is not None and isinstance(payload, type)
+                        and not isinstance(raw, payload)):
+                    try:
+                        kwargs[name] = payload(raw)
+                    except (ValueError, TypeError):
+                        return await _ws_reject(
+                            _WS(conn, receive, send) if ws is None else ws,
+                            f'path param {name!r}: cannot coerce {raw!r} to '
+                            f'{payload.__name__}')
+                else:
+                    kwargs[name] = raw
+            else:  # 'query'
+                raw = query_values.get(name, _QUERY_MISSING)
+                if raw is _QUERY_MISSING:
+                    if payload.required:
+                        return await _ws_reject(
+                            _WS(conn, receive, send) if ws is None else ws,
+                            f'missing required query parameter {name!r} for '
+                            f'handler {fn_name!r}')
+                    kwargs[name] = payload.default
+                else:
+                    try:
+                        kwargs[name] = payload.coercer(raw)
+                    except (ValueError, TypeError):
+                        return await _ws_reject(
+                            _WS(conn, receive, send) if ws is None else ws,
+                            f'query parameter {name!r}: cannot coerce {raw!r} '
+                            f'to {payload.type.__name__}')
+
+        if not depends_plan:
+            await fn(**kwargs)
+            return
+
+        # One stack per connection.  Teardown is LIFO on handler exit and runs
+        # on an exception propagating out of the handler just as it does on a
+        # clean return — that is the whole point of binding it to the `async
+        # with` rather than to a close event.
+        async with AsyncExitStack() as stack:
+            cache: dict = {}
+            for name, dep in depends_plan:
+                kwargs[name] = await _resolve_depends(dep, stack, cache)
+            await fn(**kwargs)
+
     return _ws_plan_wrapper
+
+
+async def _ws_reject(ws, detail: str) -> None:
+    """Reject a WebSocket handshake whose declared params could not be bound.
+
+    The HTTP path answers a bad query param with 400; a WebSocket has no
+    response to put a status on, so the handshake is refused with close code
+    1008 (policy violation) — the same shape FastAPI uses for WebSocket
+    validation failures.  Called before the handler runs, so the client's
+    ``connect()`` fails rather than opening and immediately closing.
+    """
+    logger.info(f'WebSocket handshake rejected: {detail}')
+    await ws.close(code=_WS_POLICY_VIOLATION, reason=_truncate_close_reason(detail))
 
 
 def _adapt_handler(fn, path: str, converters: dict | None = None):
@@ -1052,7 +1200,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     """
     from .connection import Connection as _Conn
 
-    path_param_names: set[str] = {m.group(1) for m in Router._param_pattern.finditer(path)}
+    path_param_names: set[str] = _path_param_names(path)
     params, annotations, categories = _handler_param_plan(fn, path_param_names)
 
     request_param_names: frozenset[str] = frozenset(
@@ -1691,7 +1839,7 @@ class Router:
             original = fn
             if _is_simplified_handler(fn):
                 if _is_websocket_route(scheme):
-                    fn = _adapt_websocket_handler(fn)
+                    fn = _adapt_websocket_handler(fn, path)
                 else:
                     fn = _adapt_handler(fn, path, self._converters)
 
@@ -1926,7 +2074,7 @@ class Router:
             fns = list(functions)
             original = fns[-1]
             if _is_simplified_handler(fns[-1]):
-                fns[-1] = (_adapt_websocket_handler(fns[-1])
+                fns[-1] = (_adapt_websocket_handler(fns[-1], path)
                            if _is_websocket_route(scheme)
                            else _adapt_handler(fns[-1], path, self._converters))
             self._register_chain(fns, path, methods, scheme,
@@ -1939,7 +2087,7 @@ class Router:
                 if not _is_simplified_handler(fn):
                     adapted = fn
                 elif _is_websocket_route(scheme):
-                    adapted = _adapt_websocket_handler(fn)
+                    adapted = _adapt_websocket_handler(fn, path)
                 else:
                     adapted = _adapt_handler(fn, path, self._converters)
                 self._register_chain(list(middlewares) + [adapted], path, methods, scheme,

--- a/docs/about/conformance.md
+++ b/docs/about/conformance.md
@@ -162,9 +162,20 @@ same input, each categorised:
 | `BOTH_REJECTED` | Both servers reject the malformed input | 4 |
 | `OK` | Both servers respond identically | 1 |
 
-The two `STATUS_DIFFER` entries are documented as known
-divergences from nginx behaviour in
-[`KNOWN_LIMITATIONS.md`](https://github.com/TOKUJI/BlackBull/blob/master/KNOWN_LIMITATIONS.md).
+Both `STATUS_DIFFER` entries are **RFC-defensible** — BlackBull is
+the stricter reader — and are kept in the corpus deliberately rather
+than treated as bugs:
+
+| Wire request | nginx | BlackBull | Why we're right |
+|---|---|---|---|
+| `GET&nbsp;&nbsp;http://localhost/x HTTP/1.0` (double-SP between method and target) | 200 | 400 | RFC 9112 §3 — request-line tokens are separated by exactly one SP.  nginx is lenient; we reject. |
+| `GET&nbsp;&nbsp;http://localhost/x HTTP/9.9` (double-SP **and** unknown version) | 505 | 400 | Validation-order choice: the request-line SP grammar (RFC 9112 §3) is checked before the HTTP version, so the malformed line is 400 first.  nginx reports the version problem (505) instead.  A *well-formed* request with an unsupported version does get 505 from BlackBull (RFC 9110 §15.6.6). |
+
+Both are also recorded in
+[`tests/conformance/http1/fuzz/user-corpus/diff_README.md`](https://github.com/TOKUJI/BlackBull/blob/master/tests/conformance/http1/fuzz/user-corpus/).
+We are not chasing nginx parity unless a real user need appears —
+being stricter than a permissive server is a conformance result, not
+a defect.
 
 #### Docker-free regression replay
 

--- a/docs/deployment/behind-nginx.md
+++ b/docs/deployment/behind-nginx.md
@@ -146,6 +146,21 @@ The nginx upstream then looks like:
 upstream blackbull { server unix:/run/blackbull.sock; }
 ```
 
+## When fronting HTTP/2 is the right call
+
+HTTP/2 costs more per request than HTTP/1.1 in *every* implementation — each
+stream carries state, framing, and flow control that HTTP/1.1 does not.  That
+is the protocol, not a BlackBull property, but it has a deployment
+consequence worth naming: if a workload needs maximum throughput on a single
+HTTP/2 connection at high multiplex, the usual production shape is a fronting
+HTTP/2 terminator (nginx, Envoy) with BlackBull on HTTP/1.1 behind it — the
+arrangement this page describes.
+
+BlackBull's own HTTP/2 is conformant (`h2spec`, RFC 9113).  How its
+per-stream cost compares to other servers is **not measured**: the
+`bench/CHARACTERIZATION.md` A-lane (h2load at n=1/10/50) is specified but has
+no recorded results, so no comparative claim is made in either direction.
+
 ## Next
 
 - [Workers](workers.md) — multi-worker is a natural fit behind

--- a/docs/deployment/workers.md
+++ b/docs/deployment/workers.md
@@ -135,6 +135,38 @@ closed.  The defaults match Apache's `LimitRequestLine` /
 | `BB_MAX_CONNECTIONS` | `500` per worker | Connections beyond the cap are refused at accept time.  Combine with `BB_SOCKET_BACKLOG` for graceful overload.  `0` = unlimited. |
 | `BB_REQUEST_TIMEOUT` | `0` (off) | Per-HTTP/2-stream deadline in seconds.  Set in production (e.g. `30`) so an ASGI handler hung on an upstream call can't keep its stream slot indefinitely.  Stream is cancelled via `RST_STREAM CANCEL`. |
 
+## Scaling ceiling — plan against physical cores
+
+Worker throughput scales roughly to the **physical core count**, not the
+logical (SMT-thread) count.  Adding workers past the physical-core ceiling
+does not multiply throughput.  Plan capacity against `nproc / 2` on typical
+SMT-enabled hardware.
+
+## Workers alongside a raw protocol handler
+
+A non-ASGI protocol registered via `app.raw_handler()` or
+`app.register_protocol_handler()` follows a different rule from HTTP,
+because a stateful broker must have exactly one owner.
+
+**The protocol has a single owner; HTTP still scales.**  The master binds
+the protocol port once and hands it to **worker 0** only, so the broker
+lives there — while `app.run(port=8000, workers=4)` alongside, say,
+`MQTTExtension(port=1883)` still runs HTTP on **all** workers.  If worker 0
+crashes, the master respawns it and it re-inherits the still-open listening
+socket, so the broker resumes on the same port.  Clients reconnect;
+in-memory broker state does not survive (see
+[MQTT](../guide/mqtt.md)).
+
+**Auto-reload is the exception.**  `--reload` hands listening sockets across
+an `exec` via fd inheritance, and that handoff does not yet include the
+protocol listeners — so `reload=True` with a port-bound protocol still forces
+`workers=1`.  Run without reload to scale HTTP alongside the broker.
+
+**`SO_REUSEPORT` applies to HTTP only.**  `BB_SOCKET_REUSEPORT=1` gives each
+HTTP worker its own kernel accept queue (best load distribution); without it
+the workers share the master's listening socket.  The protocol port is always
+bound *without* `SO_REUSEPORT` — a single owner is the point.
+
 ## Production checklist
 
 A reasonable production environment:

--- a/docs/guide/dependency-injection.md
+++ b/docs/guide/dependency-injection.md
@@ -30,7 +30,7 @@ unchanged, the same rule as every other simplified-model feature.
 
 | Provider | Injected value | Cleanup |
 |---|---|---|
-| `async def p(): yield v` | `v` (must yield exactly once) | code after `yield` / `finally`, after the response is sent |
+| `async def p(): yield v` | `v` (must yield exactly once) | after the response is sent — but see [Write cleanup in a `finally`](#write-cleanup-in-a-finally) |
 | `async def p(): return v` | `v` | none |
 | `def p(): return v` | `v` | none |
 
@@ -87,6 +87,57 @@ acquire/release accounting — ships as
   as usual (500, or the registered `error_handler`).
 - A provider exception before `yield` aborts the request the same way —
   the handler never runs.
+
+### Write cleanup in a `finally`
+
+Cleanup written *after* a bare `yield` runs on the success path only.  When
+the handler raises, the exception is re-raised **at the `yield`**, so the
+trailing statements never execute — the resource leaks exactly when
+something went wrong:
+
+```python
+async def get_conn():
+    conn = await pool.acquire()
+    yield conn
+    await pool.release(conn)     # ✗ skipped when the handler raises
+
+async def get_conn():
+    conn = await pool.acquire()
+    try:
+        yield conn
+    finally:
+        await pool.release(conn)  # ✓ runs on every path
+```
+
+BlackBull **warns at registration** when it sees the first shape, naming the
+provider.  The warning is deliberately narrow: a `yield` inside any `try` is
+left alone, and so is a provider with nothing after the `yield` (there is no
+cleanup to lose) or one whose `yield` sits inside an `async with` (the
+context manager already handles every path).
+
+This is ordinary [`@asynccontextmanager`](https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager)
+behaviour, and it is not a wart to be fixed: the exception has to reach the
+generator so a provider can tell success from failure.
+
+```python
+async def get_tx():
+    tx = await db.begin()
+    try:
+        yield tx
+    except Exception:
+        await tx.rollback()      # knows it failed
+        raise
+    else:
+        await tx.commit()        # knows it succeeded
+```
+
+If the framework instead swallowed the exception to force cleanup to run,
+this provider would **commit on error**.  That is why the weak form is
+warned about rather than silently repaired.
+
+On a WebSocket the same rule matters more, because a socket ends by
+exception far more often than a request does — see
+[dependency lifetime](websockets.md#dependency-lifetime-read-this-before-injecting-a-database-handle).
 
 ## Zero cost when unused
 

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -221,6 +221,28 @@ same certificate the HTTPS listener uses — pass `certfile`/`keyfile` (or an
 `tls=True` is set with no certificate configured. Cleartext remains the
 default (`tls=False`), so existing deployments are unchanged.
 
+## Why the broker has a single owner
+
+The broker runs on **worker 0** only, while HTTP scales across all workers.
+That is a protocol requirement, not an implementation shortcut.
+
+MQTT 5.0 (OASIS Committee Specification 02, March 2019) defines semantics
+that depend on broker-side state visible to *every* connection:
+publish-subscribe matching (§3.3), retained messages (§3.3.2.3), session
+state across `Clean Start = 0` reconnects (§3.1.2.11), Will messages
+(§3.1.2.5), and QoS 1/2 delivery tracking (§4.3).  All five break if that
+state is split across worker processes with no shared store.
+
+This matches industry practice: the Eclipse Mosquitto reference
+implementation ([mosquitto.org](https://mosquitto.org/)) is single-threaded
+by architecture for the same reason, and EMQX clusters via Erlang
+distributed message passing rather than splitting state across local
+workers.  (Confirmed 2026-06-25 against the OASIS MQTT 5.0 specification and
+Mosquitto's project documentation.)
+
+See [Workers](../deployment/workers.md) for how the single-owner binding
+interacts with `--reload` and `SO_REUSEPORT`.
+
 ## Limitations
 
 - **No MQTT-over-WebSocket transport.** TLS is supported via

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -57,10 +57,92 @@ async def room(ws: WebSocket, conn: Connection):
     await ws.send_text(f'welcome to {conn.path_params["name"]}')
 ```
 
-A parameter that is neither is a `TypeError` **at registration**, not on the
-first connection.  Path params, query params, and `Depends` are not injected
-into WebSocket handlers yet — read them from `ws.path_params` and
-`ws.query_string` for now.
+A parameter that is none of the recognised kinds is a `TypeError` **at
+registration**, not on the first connection.
+
+### Injected parameters
+
+A WebSocket handler declares what it needs the same way an HTTP handler does
+— path params, query params, and `Depends` all resolve from the signature:
+
+```python
+@app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+async def chat(ws: WebSocket, room: str, since: int = 0,
+               db=Depends(get_db)):
+    await ws.accept()
+    await ws.send_text(f'{room} from {since}')
+```
+
+| Declared | Resolves to |
+|---|---|
+| Name matches a `{param}` in the path | `ws.path_params[name]`, coerced to the annotation if given |
+| Any other annotated `str`/`int`/`float`/`bool` (optionally `\| None`) | The query param of that name |
+| `Depends(provider)` default | The provider's value, once per connection |
+
+Two differences from the HTTP form are worth knowing:
+
+**A query param must carry its annotation.** On an HTTP route a bare name is
+taken as a `str` query param; on a WebSocket it is a `TypeError`. The reserved
+names make bare parameters ambiguous — `async def chat(socket)` almost
+certainly means the socket, not a query param called `socket` — so the
+annotation is required and a typo fails at registration instead of rejecting
+every connection at runtime.
+
+**There is no body parameter.** A WebSocket has no request body, so the HTTP
+`body` and dataclass-body forms have no WebSocket equivalent.
+
+When a declared parameter cannot be bound — a required query param missing, a
+value that will not coerce — the handshake is **refused with close code 1008**
+(policy violation) and the handler never runs. The HTTP path answers the same
+failure with `400`; a WebSocket has no response to put a status on.
+
+#### Dependency lifetime — read this before injecting a database handle
+
+A `Depends` on a WebSocket is resolved **once per connection** and released
+when the handler exits. That is the correct scope for values — an
+authenticated user, a parsed token, per-connection config — and the **wrong**
+scope for scarce resources:
+
+!!! warning "A socket holds its dependency for hours, not milliseconds"
+
+    An HTTP request holds a pooled connection for the duration of the
+    response.  A WebSocket holds it for the life of the socket.  A pool of 20
+    therefore serves 20 *concurrent sockets*, and the 21st client blocks
+    until someone disconnects.  Worse, a pinned connection sitting idle gets
+    reaped underneath you — MySQL `wait_timeout`, PgBouncer, and AWS NAT
+    idle timeouts all drop long-idle connections, so the handler wakes up
+    holding a dead one.
+
+Give the *pool* application scope and borrow from it per use instead:
+
+```python
+@app.on_startup
+async def open_pool():
+    app.state.pool = await asyncpg.create_pool(DSN)
+
+@app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+async def chat(ws: WebSocket, room: str, user=Depends(current_user)):
+    await ws.accept()
+    async for message in ws:                       # user: per connection ✓
+        async with app.state.pool.acquire() as db:  # db: per use ✓
+            await db.execute('insert into messages …', room, message)
+```
+
+**Write cleanup in a `finally`.** Teardown runs whenever the handler exits —
+clean close, `WebSocketDisconnect`, or an exception — but cleanup written
+*after* a bare `yield` is skipped on the exception paths, because the
+exception is thrown into the generator at the `yield`. This is ordinary
+`@asynccontextmanager` behaviour and it bites harder here, since a socket ends
+by exception far more often than a request does:
+
+```python
+async def get_conn():
+    conn = await pool.acquire()
+    try:
+        yield conn
+    finally:                    # runs on disconnect and on error alike
+        await pool.release(conn)
+```
 
 ### Rejecting a connection
 

--- a/examples/websocket_object.py
+++ b/examples/websocket_object.py
@@ -20,7 +20,7 @@ Try it:
     asyncio.run(main())
     "
 """
-from blackbull import BlackBull, Connection, WebSocket, WebSocketDisconnect
+from blackbull import BlackBull, WebSocket, WebSocketDisconnect
 from blackbull.utils import Scheme
 
 app = BlackBull()
@@ -49,17 +49,18 @@ async def json_stream(ws: WebSocket):
 
 
 @app.route(path='/rooms/{room}', scheme=Scheme.websocket)
-async def room(ws: WebSocket, conn: Connection):
-    """Path params are on the Connection — inject it alongside the object.
+async def room(ws: WebSocket, room: str, since: int = 0):
+    """Path and query params inject straight into the signature.
 
-    (Injecting them directly into the signature, the way HTTP handlers get
-    them, is the next step for this API.)
+    ``room`` matches the ``{room}`` placeholder; ``since`` has no placeholder,
+    so it comes from the query string (``/rooms/lobby?since=7``) with 0 as its
+    default.  A query param must carry its annotation — that is what tells the
+    router it is one.
     """
-    name = conn.path_params['room']
     await ws.accept()
-    await ws.send_text(f'welcome to {name}')
+    await ws.send_text(f'welcome to {room} (from {since})')
     async for message in ws:
-        await ws.send_text(f'[{name}] {message}')
+        await ws.send_text(f'[{room}] {message}')
 
 
 @app.route(path='/private', scheme=Scheme.websocket)

--- a/tests/integration/test_websocket_examples.py
+++ b/tests/integration/test_websocket_examples.py
@@ -67,12 +67,18 @@ def test_example_object_json_round_trips(websocket_object_app):
             assert ws.receive_json() == {'seen': 1, 'echo': {'a': 1}}
 
 
-def test_example_object_reads_path_params_off_the_connection(websocket_object_app):
+def test_example_object_injects_path_and_query_params(websocket_object_app):
     with TestClient(websocket_object_app) as client:
         with client.websocket_connect('/rooms/lobby') as ws:
-            assert ws.receive_text() == 'welcome to lobby'
+            assert ws.receive_text() == 'welcome to lobby (from 0)'
             ws.send_text('hi')
             assert ws.receive_text() == '[lobby] hi'
+
+
+def test_example_object_query_param_overrides_its_default(websocket_object_app):
+    with TestClient(websocket_object_app) as client:
+        with client.websocket_connect('/rooms/lobby?since=7') as ws:
+            assert ws.receive_text() == 'welcome to lobby (from 7)'
 
 
 def test_example_object_rejects_without_credentials(websocket_object_app):

--- a/tests/unit/test_depends.py
+++ b/tests/unit/test_depends.py
@@ -306,3 +306,97 @@ class TestDependsEndToEnd:
         with TestClient(app, raise_app_exceptions=False) as client:
             r = client.get('/broken')
             assert r.status_code == 500
+
+
+class TestBareYieldDiagnostic:
+    """Cleanup after a bare ``yield`` is skipped exactly when it matters.
+
+    The semantics are correct and must not change — an exception has to reach
+    the generator so a commit/rollback provider can tell success from failure
+    (``test_exception_aware_provider_is_not_flagged``). What the framework can
+    do is refuse to let the weak form be *silent*, so the gap surfaces at
+    registration rather than as a production leak.
+    """
+
+    def _warned(self, provider) -> bool:
+        import warnings
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            Depends(provider)
+        return any('bare `yield`' in str(w.message) for w in caught)
+
+    def test_cleanup_after_bare_yield_is_flagged(self):
+        async def get_db():
+            yield 'db'
+            print('release')
+
+        assert self._warned(get_db)
+
+    def test_try_finally_is_not_flagged(self):
+        async def get_db():
+            try:
+                yield 'db'
+            finally:
+                print('release')
+
+        assert not self._warned(get_db)
+
+    def test_exception_aware_provider_is_not_flagged(self):
+        """commit-or-rollback: the author is deliberately reading the exception,
+        which is the capability that forbids 'just always run the cleanup'."""
+        async def get_tx():
+            try:
+                yield 'tx'
+            except Exception:
+                print('rollback')
+                raise
+            else:
+                print('commit')
+
+        assert not self._warned(get_tx)
+
+    def test_provider_with_nothing_after_the_yield_is_not_flagged(self):
+        async def get_db():
+            yield 'db'
+
+        assert not self._warned(get_db)
+
+    def test_async_with_around_the_yield_is_not_flagged(self):
+        """The context manager already cleans up on every path."""
+        class _Pool:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return False
+
+        async def get_db():
+            async with _Pool() as pool:
+                yield pool
+
+        assert not self._warned(get_db)
+
+    def test_non_generator_providers_are_not_flagged(self):
+        async def a_value():
+            return 'v'
+
+        def a_sync_value():
+            return 'v'
+
+        assert not self._warned(a_value)
+        assert not self._warned(a_sync_value)
+
+    def test_unavailable_source_is_not_an_error(self):
+        """A diagnostic must never be the reason registration fails."""
+        ns: dict = {}
+        exec('async def dyn():\n    yield 1\n    print(2)\n', ns)
+        assert not self._warned(ns['dyn'])
+
+    def test_the_warning_names_the_provider_and_suggests_the_fix(self):
+        async def get_conn():
+            yield 'c'
+            print('release')
+
+        with pytest.warns(UserWarning, match='get_conn') as rec:
+            Depends(get_conn)
+        assert 'finally' in str(rec[0].message)

--- a/tests/unit/test_websocket_injection.py
+++ b/tests/unit/test_websocket_injection.py
@@ -1,0 +1,425 @@
+"""Signature injection into WebSocket handlers (Sprint 83).
+
+Sprint 82 gave a WebSocket handler its object; this covers what the *signature*
+may declare alongside it — path params, query params, and ``Depends`` — plus
+the registration-time errors that keep an unresolvable parameter loud.
+
+Two layers, same split as ``test_websocket_object.py``: the plan (classified
+once, at registration) and the wrapper (which only indexes it). The dependency
+**lifetime** contract — resolved once per connection, torn down when the
+handler exits by any route — is pinned here rather than e2e because the exit
+routes are easiest to drive deterministically against a scripted channel.
+"""
+import pytest
+
+from blackbull import (BlackBull, Connection, Depends, Headers, WebSocket,
+                       WebSocketDisconnect)
+from blackbull.router import _adapt_websocket_handler, _websocket_param_plan
+from blackbull.utils import Scheme
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+class _Channel:
+    """A scripted receive channel plus a recording send channel."""
+
+    def __init__(self, *inbound):
+        self._inbound = list(inbound)
+        self.sent = []
+
+    async def receive(self):
+        if not self._inbound:
+            return {'type': 'websocket.disconnect', 'code': 1006}
+        return self._inbound.pop(0)
+
+    async def send(self, event, *_args, **_kwargs):
+        self.sent.append(event)
+
+
+CONNECT = {'type': 'websocket.connect'}
+
+
+def _conn(path='/ws', *, query=b'', path_params=None) -> Connection:
+    conn = Connection(method='GET', path=path, raw_path=path.encode(),
+                      headers=Headers([]), type='websocket', query_string=query)
+    if path_params:
+        conn.path_params = dict(path_params)
+    return conn
+
+
+def _kinds(plan) -> tuple[str, ...]:
+    return tuple(kind for _, kind, _ in plan)
+
+
+def _closes(channel) -> list[dict]:
+    return [e for e in channel.sent if e['type'] == 'websocket.close']
+
+
+# ---------------------------------------------------------------------------
+# Registration-time classification
+# ---------------------------------------------------------------------------
+
+def test_path_param_is_classified_by_name():
+    async def handler(ws: WebSocket, room: str):
+        pass
+
+    assert _kinds(_websocket_param_plan(handler, {'room'})) == ('ws', 'path')
+
+
+def test_annotated_leftover_is_a_query_param():
+    async def handler(ws: WebSocket, since: int):
+        pass
+
+    assert _kinds(_websocket_param_plan(handler, set())) == ('ws', 'query')
+
+
+def test_query_param_must_be_annotated():
+    """The one place the WebSocket plan is deliberately stricter than HTTP.
+
+    HTTP takes a bare leftover name as a ``str`` query param, which is
+    load-bearing there (``async def search(q)``). On a WebSocket the reserved
+    names make bare parameters ambiguous — ``chat(socket)`` means the socket —
+    so the annotation is required and a typo stays a registration error.
+    """
+    async def handler(ws: WebSocket, since):
+        pass
+
+    with pytest.raises(TypeError, match='must carry its annotation'):
+        _websocket_param_plan(handler, set())
+
+
+def test_depends_default_is_classified():
+    async def provider():
+        return 'db'
+
+    async def handler(ws: WebSocket, db=Depends(provider)):
+        pass
+
+    assert _kinds(_websocket_param_plan(handler, set())) == ('ws', 'depends')
+
+
+@pytest.mark.parametrize('name', ['ws', 'websocket', 'conn', 'connection'])
+def test_depends_on_a_reserved_name_is_rejected(name):
+    """Silently ignoring the Depends would hand back the socket instead."""
+    async def provider():
+        return 'x'
+
+    fn = eval(f'lambda {name}=Depends(provider): None', {'Depends': Depends,
+                                                         'provider': provider})
+    with pytest.raises(TypeError, match='reserved'):
+        _websocket_param_plan(fn, set())
+
+
+def test_depends_on_a_path_param_is_rejected():
+    async def provider():
+        return 'x'
+
+    async def handler(ws: WebSocket, room=Depends(provider)):
+        pass
+
+    with pytest.raises(TypeError, match='path param'):
+        _websocket_param_plan(handler, {'room'})
+
+
+def test_body_shaped_annotation_is_rejected_with_a_websocket_specific_reason():
+    """A WebSocket has no request body, so the HTTP body/dataclass categories
+    have no analogue — say so rather than failing as 'bad query param'."""
+    async def handler(ws: WebSocket, payload: dict):
+        pass
+
+    with pytest.raises(TypeError, match='no request body'):
+        _websocket_param_plan(handler, set())
+
+
+def test_unresolvable_parameter_still_fails_at_registration_through_the_router():
+    app = BlackBull()
+
+    with pytest.raises(TypeError, match='cannot resolve parameter'):
+        @app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+        async def bad(ws: WebSocket, room: str, mystery: dict):  # noqa: F841
+            pass
+
+
+# ---------------------------------------------------------------------------
+# The ws-only fast path is untouched (Sprint 83 gate)
+# ---------------------------------------------------------------------------
+
+def test_lone_ws_still_compiles_to_the_fast_path_wrapper():
+    """``@wraps`` rewrites ``__name__``, so the code object's own name is what
+    identifies which wrapper was built."""
+    async def handler(ws: WebSocket):
+        pass
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    assert adapted.__code__.co_name == '_ws_wrapper'
+
+
+def test_any_injection_moves_to_the_plan_wrapper():
+    async def handler(ws: WebSocket, room: str):
+        pass
+
+    adapted = _adapt_websocket_handler(handler, '/rooms/{room}')
+    assert adapted.__code__.co_name == '_ws_plan_wrapper'
+
+
+# ---------------------------------------------------------------------------
+# Runtime binding
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_path_param_is_injected_and_coerced():
+    seen = {}
+
+    async def handler(ws: WebSocket, room: str, seat: int):
+        seen['room'], seen['seat'] = room, seat
+
+    adapted = _adapt_websocket_handler(handler, '/rooms/{room}/{seat}')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(path_params={'room': 'lobby', 'seat': '12'}),
+                  channel.receive, channel.send)
+
+    assert seen == {'room': 'lobby', 'seat': 12}
+
+
+@pytest.mark.asyncio
+async def test_query_param_is_injected_with_coercion_and_default():
+    seen = {}
+
+    async def handler(ws: WebSocket, since: int, tok: str | None = None):
+        seen['since'], seen['tok'] = since, tok
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(query=b'since=7'), channel.receive, channel.send)
+
+    assert seen == {'since': 7, 'tok': None}
+
+
+@pytest.mark.asyncio
+async def test_missing_required_query_param_rejects_the_handshake():
+    called = False
+
+    async def handler(ws: WebSocket, since: int):
+        nonlocal called
+        called = True
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(), channel.receive, channel.send)
+
+    assert not called, 'handler must not run when a declared param cannot bind'
+    assert [e['code'] for e in _closes(channel)] == [1008]
+
+
+@pytest.mark.asyncio
+async def test_uncoercible_query_param_rejects_the_handshake():
+    called = False
+
+    async def handler(ws: WebSocket, since: int):
+        nonlocal called
+        called = True
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(query=b'since=soon'), channel.receive, channel.send)
+
+    assert not called
+    assert [e['code'] for e in _closes(channel)] == [1008]
+
+
+@pytest.mark.asyncio
+async def test_rejection_never_resolves_a_dependency():
+    """A connection we are about to refuse must not acquire a resource first."""
+    log = []
+
+    async def provider():
+        log.append('setup')
+        try:
+            yield 'db'
+        finally:
+            log.append('teardown')
+
+    async def handler(ws: WebSocket, since: int, db=Depends(provider)):
+        log.append('handler')
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(), channel.receive, channel.send)
+
+    assert log == []
+    assert [e['code'] for e in _closes(channel)] == [1008]
+
+
+# ---------------------------------------------------------------------------
+# Dependency lifetime: once per connection, torn down on every exit route
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_depends_teardown_runs_on_clean_return():
+    log = []
+
+    async def provider():
+        log.append('setup')
+        yield 'db'
+        log.append('teardown')
+
+    with pytest.warns(UserWarning, match='bare `yield`'):
+        async def handler(ws: WebSocket, db=Depends(provider)):
+            log.append(f'handler:{db}')
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(), channel.receive, channel.send)
+
+    assert log == ['setup', 'handler:db', 'teardown']
+
+
+@pytest.mark.asyncio
+async def test_depends_teardown_runs_on_abrupt_disconnect():
+    """The sprint gate: teardown must not be tied to a *clean* close.
+
+    ``WebSocketDisconnect`` propagating out of the handler is what an abrupt
+    peer loss looks like from inside one. Note the ``try/finally`` — see
+    ``test_bare_yield_provider_does_not_tear_down_on_an_exception`` for why
+    that is the provider author's job and not something the framework fakes.
+    """
+    log = []
+
+    async def provider():
+        log.append('setup')
+        try:
+            yield 'db'
+        finally:
+            log.append('teardown')
+
+    async def handler(ws: WebSocket, db=Depends(provider)):
+        raise WebSocketDisconnect(1006, None)
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    with pytest.raises(WebSocketDisconnect):
+        await adapted(_conn(), channel.receive, channel.send)
+
+    assert log == ['setup', 'teardown']
+
+
+@pytest.mark.asyncio
+async def test_depends_teardown_runs_when_the_handler_raises():
+    log = []
+
+    async def provider():
+        log.append('setup')
+        try:
+            yield 'db'
+        finally:
+            log.append('teardown')
+
+    async def handler(ws: WebSocket, db=Depends(provider)):
+        raise RuntimeError('boom')
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    with pytest.raises(RuntimeError, match='boom'):
+        await adapted(_conn(), channel.receive, channel.send)
+
+    assert log == ['setup', 'teardown']
+
+
+@pytest.mark.asyncio
+async def test_bare_yield_provider_does_not_tear_down_on_an_exception():
+    """Pinned because it is the footgun, not because it is desirable.
+
+    Cleanup written *after* a bare ``yield`` never runs when an exception is
+    thrown into the generator — the exception surfaces at the yield and
+    propagates. This is ``@asynccontextmanager`` semantics, identical on the
+    HTTP path, and a WebSocket makes it bite harder because a socket ends by
+    exception far more often than a request does. The docs tell providers to
+    use ``try/finally``; this test is what makes that instruction load-bearing
+    rather than advisory.
+    """
+    log = []
+
+    async def provider():
+        log.append('setup')
+        yield 'db'
+        log.append('teardown')      # deliberately unreachable on the raise path
+
+    with pytest.warns(UserWarning, match='bare `yield`'):
+        async def handler(ws: WebSocket, db=Depends(provider)):
+            raise RuntimeError('boom')
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    with pytest.raises(RuntimeError, match='boom'):
+        await adapted(_conn(), channel.receive, channel.send)
+
+    assert log == ['setup'], 'a bare-yield provider skips cleanup on exception'
+
+
+@pytest.mark.asyncio
+async def test_dependency_is_resolved_once_per_connection_not_per_message():
+    """The Sprint 82 rule — object per connection — governs dependencies too."""
+    setups = []
+
+    async def provider():
+        setups.append(1)
+        return object()
+
+    async def handler(ws: WebSocket, db=Depends(provider)):
+        await ws.accept()
+        async for _ in ws:
+            pass
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT,
+                       {'type': 'websocket.receive', 'text': 'a', 'bytes': None},
+                       {'type': 'websocket.receive', 'text': 'b', 'bytes': None},
+                       {'type': 'websocket.disconnect', 'code': 1000})
+    await adapted(_conn(), channel.receive, channel.send)
+
+    assert len(setups) == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_dependency_is_shared_between_parameters():
+    calls = []
+
+    async def provider():
+        calls.append(1)
+        return 'shared'
+
+    async def handler(ws: WebSocket, a=Depends(provider), b=Depends(provider)):
+        assert a is b
+
+    adapted = _adapt_websocket_handler(handler, '/ws')
+    channel = _Channel(CONNECT)
+    await adapted(_conn(), channel.receive, channel.send)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_everything_together():
+    """The signature the sprint set out to make work."""
+    seen = {}
+
+    async def get_db():
+        yield 'DB'
+
+    async def chat(ws: WebSocket, conn: Connection, room: str,
+                   since: int = 0, db=Depends(get_db)):
+        seen.update(room=room, since=since, db=db, conn=conn, ws=ws)
+
+    adapted = _adapt_websocket_handler(chat, '/rooms/{room}')
+    conn = _conn(path='/rooms/lobby', query=b'since=7',
+                 path_params={'room': 'lobby'})
+    channel = _Channel(CONNECT)
+    await adapted(conn, channel.receive, channel.send)
+
+    assert seen['room'] == 'lobby'
+    assert seen['since'] == 7
+    assert seen['db'] == 'DB'
+    assert seen['conn'] is conn
+    assert seen['ws'].connection is conn

--- a/tests/unit/test_websocket_injection_e2e.py
+++ b/tests/unit/test_websocket_injection_e2e.py
@@ -1,0 +1,132 @@
+"""Signature injection over the real stack (Sprint 83).
+
+``test_websocket_injection.py`` pins the plan and the wrapper against a
+scripted channel. This file drives the same signatures through
+:class:`~blackbull.testing.TestClient` — router, WebSocket actor, recipient,
+codec, sender — so that what the handler receives is proven to come from a
+real handshake and a real query string rather than a hand-built
+:class:`~blackbull.connection.Connection`.
+
+The rejection tests matter most here: a refused handshake is a *wire*
+outcome, and 1008 has to reach the client as a close code.
+"""
+import pytest
+
+from blackbull import BlackBull, Depends, WebSocket
+from blackbull.testing import TestClient, WebSocketDisconnect
+from blackbull.utils import Scheme
+
+TEARDOWNS: list[str] = []
+
+
+def _make_app() -> BlackBull:
+    app = BlackBull()
+
+    @app.route(path='/rooms/{room}', scheme=Scheme.websocket)
+    async def chat(ws: WebSocket, room: str, since: int = 0):
+        await ws.accept()
+        await ws.send_text(f'room={room} since={since}')
+        await ws.close()
+
+    @app.route(path='/seats/{seat}', scheme=Scheme.websocket)
+    async def seat(ws: WebSocket, seat: int):
+        await ws.accept()
+        await ws.send_text(f'seat={seat} type={type(seat).__name__}')
+        await ws.close()
+
+    @app.route(path='/strict', scheme=Scheme.websocket)
+    async def strict(ws: WebSocket, token: str):
+        await ws.accept()
+        await ws.send_text(f'token={token}')
+        await ws.close()
+
+    @app.route(path='/held', scheme=Scheme.websocket)
+    async def held(ws: WebSocket, db=Depends(_provider)):
+        await ws.accept()
+        async for message in ws:
+            await ws.send_text(f'{db}:{message}')
+
+    return app
+
+
+async def _provider():
+    try:
+        yield 'DB'
+    finally:
+        TEARDOWNS.append('teardown')
+
+
+@pytest.fixture(autouse=True)
+def _clear_teardowns():
+    TEARDOWNS.clear()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Injection
+# ---------------------------------------------------------------------------
+
+def test_path_and_query_params_reach_the_handler():
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/rooms/lobby?since=7') as ws:
+            assert ws.receive_text() == 'room=lobby since=7'
+
+
+def test_query_param_default_applies_when_absent():
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/rooms/lobby') as ws:
+            assert ws.receive_text() == 'room=lobby since=0'
+
+
+def test_path_param_is_coerced_to_its_annotation():
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/seats/12') as ws:
+            assert ws.receive_text() == 'seat=12 type=int'
+
+
+# ---------------------------------------------------------------------------
+# Rejection reaches the client as a close code
+# ---------------------------------------------------------------------------
+
+def test_missing_required_query_param_is_refused_with_1008():
+    app = _make_app()
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect('/strict'):
+                pass
+    assert excinfo.value.code == 1008
+
+
+def test_uncoercible_path_param_is_refused_with_1008():
+    app = _make_app()
+    with TestClient(app) as client:
+        with pytest.raises(WebSocketDisconnect) as excinfo:
+            with client.websocket_connect('/seats/front-row'):
+                pass
+    assert excinfo.value.code == 1008
+
+
+# ---------------------------------------------------------------------------
+# Dependency lifetime over a real socket
+# ---------------------------------------------------------------------------
+
+def test_dependency_is_live_for_the_whole_socket_and_torn_down_after_it():
+    """One resolution serves every message, and release happens on disconnect.
+
+    The teardown assertion sits *outside* the client block: the handler only
+    exits when the peer goes away, which is exactly the lifetime this sprint
+    documents.
+    """
+    app = _make_app()
+    with TestClient(app) as client:
+        with client.websocket_connect('/held') as ws:
+            ws.send_text('one')
+            assert ws.receive_text() == 'DB:one'
+            ws.send_text('two')
+            assert ws.receive_text() == 'DB:two'
+            assert TEARDOWNS == [], 'released while the socket was still open'
+
+    assert TEARDOWNS == ['teardown']

--- a/tests/unit/test_websocket_object.py
+++ b/tests/unit/test_websocket_object.py
@@ -466,10 +466,15 @@ def test_raw_triplet_handler_is_not_wrapped_at_all():
     assert not hasattr(_registered(app, '/raw2'), '__wrapped__')
 
 
+def _kinds(plan) -> tuple[str, ...]:
+    """Just the categories of a param plan, in signature order."""
+    return tuple(kind for _, kind, _ in plan)
+
+
 @pytest.mark.parametrize('name', ['ws', 'websocket'])
 def test_bare_parameter_names_get_the_object(name):
     plan = _websocket_param_plan(eval(f'lambda {name}: None'))
-    assert plan == ('ws',)
+    assert _kinds(plan) == ('ws',)
 
 
 def test_annotation_wins_over_name():
@@ -477,14 +482,14 @@ def test_annotation_wins_over_name():
     async def handler(ws: Connection):
         pass
 
-    assert _websocket_param_plan(handler) == ('conn',)
+    assert _kinds(_websocket_param_plan(handler)) == ('conn',)
 
 
 def test_object_and_connection_together():
     async def handler(ws: WebSocket, conn: Connection):
         pass
 
-    assert _websocket_param_plan(handler) == ('ws', 'conn')
+    assert _kinds(_websocket_param_plan(handler)) == ('ws', 'conn')
 
 
 def test_unresolvable_parameter_fails_at_registration_not_at_connect_time():
@@ -506,7 +511,7 @@ def test_an_explicit_annotation_works_under_any_parameter_name():
     async def handler(sock: WebSocket):
         pass
 
-    assert _websocket_param_plan(handler) == ('ws',)
+    assert _kinds(_websocket_param_plan(handler)) == ('ws',)
 
 
 def test_http_route_is_unaffected_by_the_websocket_branch():


### PR DESCRIPTION
## Summary

A WebSocket handler now declares what it needs the way an HTTP handler already does, alongside the `WebSocket` object:

```python
@app.route(path='/rooms/{room}', scheme=Scheme.websocket)
async def chat(ws: WebSocket, room: str, since: int = 0, db=Depends(get_db)):
    ...
```

This completes **injection parity across handler surfaces** — no first-party handler form requires the raw `(conn, receive, send)` triplet or a scope dict. The raw form stays supported and undeprecated.

Closes the `KNOWN_LIMITATIONS.md` entry added at v0.63.0, which was filed as deliberate and temporary.

### Added

- `_websocket_param_plan` widened to `'path'` / `'query'` / `'depends'` beside `'ws'` / `'conn'`, reusing the HTTP plan's `_QuerySpec`, `_QUERY_COERCERS` and `_unwrap_optional` rather than reimplementing coercion.
- A lone `ws` keeps the Sprint 82 allocation-free fast path — asserted directly, since `@wraps` rewrites `__name__` but not `__code__.co_name`.
- `Depends` resolves **once per connection**, with `AsyncExitStack` teardown at handler exit on every route: clean close, `WebSocketDisconnect`, or a handler exception.
- A parameter that cannot bind refuses the handshake with **close code 1008** before the handler runs — and before any `Depends` is resolved, so a connection about to be rejected never acquires a pooled resource.
- Registration-time `UserWarning` when a `Depends` provider's cleanup sits after a bare `yield`, where an exception would skip it.

### Deliberately different from the HTTP form

- **A WebSocket query param must carry its annotation.** HTTP's bare-name fallback is load-bearing there (`async def search(q)`), but the reserved names make bare parameters ambiguous on a socket: `chat(socket)` means the socket, so it stays a registration-time `TypeError` instead of silently becoming a query param named `socket`.
- **No body parameter** — a WebSocket has no request body.

### On the `Depends` semantics

Unchanged on purpose. The exception must reach the generator, or a commit-or-rollback provider would **commit on error**. Measured, not assumed:

```
clean  : bare:setup, guard:setup, tx:COMMIT,   guard:finally, bare:after-yield
raises : bare:setup, guard:setup, tx:ROLLBACK, guard:finally
```

WebSocket matches HTTP exactly. Both are weaker than BlackBull's *own* teardowns, which are all written in `finally` — so the weak form is made **loud** rather than repaired. The diagnostic stays silent for a `yield` inside any `try`, a provider with nothing after the `yield`, and a `yield` inside an `async with`; it never fails registration.

## Test plan

- [x] 25 unit tests for injection (`tests/unit/test_websocket_injection.py`)
- [x] 6 e2e tests over the real stack (`tests/unit/test_websocket_injection_e2e.py`) — 1008 verified reaching the client
- [x] 8 tests for the bare-yield diagnostic, incl. the exception-aware provider and the unavailable-source case
- [x] Full suite: **1879 passed**, 115 skipped, 1 xfailed; **zero stray warnings**
- [x] beartype-instrumented run over the DI + WebSocket suites: 109 passed
- [x] `mkdocs build` clean; both new cross-page anchors verified against the generated HTML
- [ ] **Autobahn** — the sprint gate, CI-only

The 6 integration errors seen locally are the known Python 3.14 `forkserver` fixture issue; verified reproducing identically on a stashed clean tree.

## Second commit

`chore: untrack .github/skills` — it was committed as a symlink into gitignored `.claude`, so it arrived **dangling in every fresh clone and in CI** (verified by cloning). Kept locally, no longer shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)