### PR TITLE
fix(tests): restore the local commit gate on Python 3.14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ A personal learning project — wire correctness over API stability (ZeroVer).
   implementation internals.  → `.claude/patterns/testing.md`
 
 - **Type-check before committing.** `just typecheck` catches contract
-  violations statically.  → `.github/skills/type-check/SKILL.md`
+  violations statically.  → `.claude/skills/type-check/SKILL.md` [private]
 
 - **Comments explain *why*, never *when*.** If a comment contains a sprint
   number, a date, "still", "previously", "no longer", or "as of version X",
@@ -140,17 +140,18 @@ fallback where one exists.
 | When you are… | Read |
 |---|---|
 | Doing any framework change (workflow, testing, type rules) | `.claude/CLAUDE_DEV.md` [private] |
-| Writing/adjusting tests | `.claude/patterns/testing.md` [private] / `.github/skills/create-test/SKILL.md` |
-| Running benchmarks or profiling | `.claude/patterns/benchmarking.md` [private] / `.github/skills/bench-compare/SKILL.md` |
-| Running peer server comparisons (FastAPI / Sanic / etc.) locally | `.github/skills/peer-compare/SKILL.md` |
+| Writing/adjusting tests | `.claude/patterns/testing.md` + `.claude/skills/create-test/SKILL.md` [both private] |
+| Running benchmarks or profiling | `.claude/patterns/benchmarking.md` + `.claude/skills/bench-compare/SKILL.md` [both private] |
+| Running peer server comparisons (FastAPI / Sanic / etc.) locally | `.claude/skills/peer-compare/SKILL.md` [private] |
 | Tracing a regression across sprints | `.claude/sprint-logs/` [private] — per-sprint bottleneck-attribution logs.  `bench/CHARACTERIZATION.md` is the public summary; sprint-logs hold the raw diagnostic numbers |
-| Cutting a release / sprint close | `.claude/patterns/release.md` [private] / `.github/skills/sprint-close/SKILL.md` |
+| Cutting a release / sprint close | `.claude/patterns/release.md` + `.claude/skills/sprint-close/SKILL.md` [both private] |
 | Reasoning about actors / events | `.claude/design/actor-model.md` + `.claude/design/event-catalogue.md` [both private] |
 | Checking a known gotcha before acting | `.claude/patterns/cautions.md` [private] |
 | Picking/triaging what to build next | `.claude/planning/proposals/INDEX.md` [private] |
 | Reading a point-in-time design | `.claude/planning/designs/` [private] |
 
-**Skills** (invocable, harness-surfaced; `.github/skills/` is public):
+**Skills** (invocable, harness-surfaced; they live in `.claude/skills/` [private] —
+`.github/skills` is an optional local symlink, see `.gitignore`):
 `sprint-close`, `bench-compare`, `peer-compare`, `pre-release-docs`, `update-roadmap`,
 `create-test`, `type-check`, `add-event`, `new-http2-frame`, `protocol-handler`,
 `httparena-bench`, `run-http11probe`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,18 @@
+import multiprocessing
 import os
 import pathlib
 import pytest
 import pytest_asyncio
+
+
+# The live-server fixtures bind the listening socket in the parent and then
+# start a worker that serves on it, so the child needs the *inherited* socket
+# — plus an app whose handlers are locally-defined closures.  Neither can be
+# pickled, which is what any start method other than ``fork`` requires of a
+# process target.  CPython 3.14 made ``forkserver`` the POSIX default, which
+# turns every such fixture into a setup error; pin the method these fixtures
+# were written against instead of restating it at each call site.
+multiprocessing.set_start_method('fork', force=True)
 
 
 DEFAULT_SKIPPED_MARKERS = {


### PR DESCRIPTION
## Summary

The pre-commit hook could not pass on Python 3.14 at all, so local commits
needed `--no-verify` — which is to say the repo's own test gate was off for
anyone on the newest supported interpreter.

CPython 3.14 makes `forkserver` the default start method on POSIX. The
live-server fixtures bind the listening socket in the **parent** and start a
worker to serve on it, so the child needs the inherited socket plus an app
whose handlers are locally-defined closures. Neither survives the pickling
`forkserver` requires of a process target, so all 36 such fixtures errored at
setup and pytest exited non-zero.

Pin `fork` in the root `tests/conftest.py` rather than at each of the ~13 call
sites. The other option on the table — moving the process targets to module
level — does **not** work here: the closed-over `ASGIServer` is itself
unpicklable, so the fixtures would have to rebuild the app inside the child and
hand the port back, which is a rewrite of the live-server contract rather than a
fix for it. That rewrite is worth doing on its own terms (fork in a
multi-threaded process is deprecated since 3.12 and the warning is now visible
in the output), but it is not what unblocks the gate.

CI behaviour is unchanged: the 3.11/3.12 lanes already defaulted to `fork`.

Second commit: `AGENTS.md` — the only doc auto-loaded every session — pointed at
six `.github/skills/...` paths that stopped existing when that symlink was
untracked in 90b4db3, and called the directory public when all twelve skills
live in the private companion repo.

## Test plan

- [x] `pytest --beartype-packages=blackbull --timeout=30 -q` on 3.14 —
      **5415 passed, 261 skipped, 1 xfailed** (was: 36 setup errors, exit 1)
- [x] `tests/conformance/http1/` + `tests/architecture/` on 3.14 — 331 passed,
      137 skipped, 0 errors
- [x] The pre-commit hook itself passes end to end (both commits in this PR
      were made with it enabled — no `--no-verify`)
- [x] `mkdocs build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)