### PR TITLE
release: v0.64.0 — Sprint 83: WebSocket signature injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.64.0] — 2026-07-29
+
 ### Added
 
 - **WebSocket handlers inject from their signature.**  Path params, query
@@ -96,6 +98,35 @@ so the editable install's metadata catches up.
   take no injected parameters" entry is replaced by the two narrower fences
   that remain.  `examples/websocket_object.py` reads `room` from the
   signature instead of `conn.path_params`.
+
+- **`README.md` documents HTTP QUERY (RFC 10008)**, which shipped without ever
+  being named there — a reader met its caveats in `KNOWN_LIMITATIONS.md`
+  before meeting the feature.  The new section covers `from blackbull import
+  QUERY` and why routes registered against the exported string need no
+  migration when `http.HTTPMethod` eventually grows a `QUERY` member.
+
+- **`KNOWN_LIMITATIONS.md` separates limitations from deliberate non-goals.**
+  Absent capabilities that were never promised (HTTP/3, an ORM, a gRPC
+  client, CDN glue) moved to a "not limitations" table, and operational
+  how-to moved to where it is actionable: the worker-count ceiling and the
+  worker-0 raw-protocol rule to `docs/deployment/workers.md`, HTTP/2 fronting
+  to `docs/deployment/behind-nginx.md`, the single-broker-owner rationale
+  (an MQTT 5.0 session-state requirement) to `docs/guide/mqtt.md`, and the
+  nginx differential-corpus divergences to `docs/about/conformance.md`.
+  Nothing was dropped; 17 entries became 11 genuine ones.
+
+### Internal
+
+- **The test suite runs on Python 3.14 again.**  CPython 3.14 made
+  `forkserver` the default `multiprocessing` start method on POSIX, and the
+  live-server fixtures bind their listening socket in the parent before
+  starting a worker that serves on it — an inherited socket and an app of
+  locally-defined closures, neither of which pickles.  Every such fixture
+  became a setup error, and because the repo's pre-commit hook runs the
+  suite, the hook could not pass at all on 3.14.  `tests/conftest.py` now
+  pins the `fork` start method those fixtures were written against.  No
+  change to shipped code, and a no-op on 3.11/3.12 where `fork` is already
+  the default.
 
 ## [0.63.0] — 2026-07-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.63.0"
+version = "0.64.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Closes Sprint 83. Two-file release commit: `pyproject.toml` version bump and
the `CHANGELOG.md` heading rename, plus the Internal note for #198.

## What ships

**WebSocket handlers inject from their signature.** Path params, query params,
and `Depends(...)` resolve for WebSocket handlers the way they already did for
HTTP ones, so a handler declares what it needs instead of reaching into
`conn.path_params`.

**Docs.** `README.md` now documents HTTP QUERY (RFC 10008), which had shipped
without ever being named there — readers met its caveats in
`KNOWN_LIMITATIONS.md` before meeting the feature. `KNOWN_LIMITATIONS.md` was
restructured to separate genuine limitations from deliberate non-goals
(17 entries → 11 genuine), with operational how-to moved to where it is
actionable under `docs/`.

**Internal.** The suite runs on Python 3.14 again (#198) — CPython 3.14 made
`forkserver` the POSIX default, which turned every live-server fixture into a
setup error and left the repo's pre-commit hook unable to pass at all. No
shipped-code change; a no-op on 3.11/3.12.

## Verification

Release commit was made with the pre-commit hook **enabled**: 5415 passed,
261 skipped, 1 xfailed, plus a clean `mkdocs build`.

Editable-install smoke test: `blackbull.__version__` → `0.64.0`.

## Note for the reviewer

The green rollup on this PR does not exercise the integration tier —
`Full tier (+ integration + docker)` is `schedule || workflow_dispatch` only.
Running it locally on 3.14 surfaced 33 pre-existing failures, all one root
cause (test handlers written against the ASGI scope dict receiving a native
`Connection`). Verified pre-existing against a `master` worktree: the set
"fails here but not on master" is empty. Deliberately **not** fixed in this
release branch; written up as §7 of the coverage-gap proposal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)