### PR TITLE
release: v0.65.0 — Sprint 84: test-gate repair + H/1.1 fast-path phases 1a/2

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -23,6 +23,16 @@ name: RFC conformance
 # index.json for Autobahn, pytest output for corpus-replay) carry
 # the detail.
 #
+# Interpreter pin: 3.12, under review.  Wire conformance is the layer
+# where an interpreter behaviour change does the most damage — the
+# HTTP/2 connection-window leak fixed in v0.62.0 was exactly that, a
+# CPython >=3.13 TaskGroup change silently disabling a credit replay —
+# so the argument for tracking the newest supported version here is
+# strong.  Held at 3.12 only until test.yml's newly widened 3.13/3.14
+# matrix has proven green in CI: moving both in one change would put
+# two unverified variables in the same run, which is the measurement
+# error this sprint exists to stop repeating.
+#
 # Third-party actions pinned to commit SHAs per the supply-chain
 # hygiene baseline (Sprint 30 Task 6); Dependabot tracks updates.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ jobs:
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97   # v7.0.0
         with:
+          # Deliberately pinned, not matrixed: this job renders Markdown and
+          # pushes to gh-pages.  Nothing it produces depends on the runtime
+          # interpreter, so version coverage belongs in test.yml, not here.
           python-version: '3.12'
 
       - name: Install docs dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97   # v7.0.0
         with:
+          # Deliberately pinned, not matrixed: BlackBull is pure Python and
+          # builds one `py3-none-any` wheel, so the building interpreter is
+          # not recorded in the artefact and a matrix here would produce
+          # identical files.  Runtime version coverage is test.yml's job.
           python-version: '3.12'
 
       - name: Install build tooling

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,9 +243,15 @@ jobs:
             --description 'Scheduled Full tier is red' --force
           existing=$(gh issue list --state open --label ci-full-tier \
             --json number --jq '.[0].number')
-          body="Scheduled Full tier failed on \`${GITHUB_SHA}\`.
-          Run: ${RUN_URL}
-          Logs age out after 90 days — triage before then."
+          # printf, not a quoted multi-line string: YAML block indentation
+          # would otherwise land in the body and Markdown would render the
+          # continuation lines as a code block.
+          body=$(printf '%s\n' \
+            "Scheduled Full tier failed on \`${GITHUB_SHA}\`." \
+            "" \
+            "Run: ${RUN_URL}" \
+            "" \
+            "Logs age out after 90 days — triage before then.")
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --body "$body"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,28 @@
 name: pytest
 
-# Two-tier pytest CI (Sprint 51 R8).
+# Four-lane pytest CI.
 #
-# Fast tier  — runs on every push/PR; no Docker, beartype enabled.
-#              Catches regressions in unit, architecture, and property tests.
-# Dual-path  — runs on every push/PR; the same Docker-free suites under
-#              BB_FORCE_ASGI_SCOPE=1, forcing Connection.as_scope()+from_scope()
-#              on every request so the ASGI compat conversion can't bitrot
-#              between sprints (native-connection-interface.md §4.3, Sprint 79 —
-#              previously a manual-only lane).
-# Full tier  — runs weekly (Saturday 05:00 UTC, offset from conformance.yml's
-#              Sunday 03:17 UTC) and on demand; adds --run-all (integration +
-#              docker-dependent tests).
+# Fast tier   — runs on every push/PR across the full supported interpreter
+#               matrix; no Docker, beartype enabled.  Catches regressions in
+#               unit, architecture, and property tests.
+# Integration — runs on every push/PR; tests/integration + tests/conformance
+#               under --run-integration.  The docker-dependent modules
+#               importorskip themselves out, so this lane needs no daemon.
+#               Exists because these suites were previously reachable only
+#               from the weekly Full tier, which is gated on schedule /
+#               workflow_dispatch and therefore gates nothing: 33 tests rotted
+#               red behind that gap before anyone noticed.
+# Dual-path   — runs on every push/PR; the same Docker-free suites under
+#               BB_FORCE_ASGI_SCOPE=1, forcing Connection.as_scope()+from_scope()
+#               on every request so the ASGI compat conversion can't bitrot
+#               between sprints (native-connection-interface.md §4.3, Sprint 79 —
+#               previously a manual-only lane).
+# Full tier   — runs weekly (Saturday 05:00 UTC, offset from conformance.yml's
+#               Sunday 03:17 UTC) and on demand; adds --run-all, which is now
+#               the docker-dependent tests on top of what the integration lane
+#               already gates.  It files an issue when it fails: an unattended
+#               scheduled job that nothing reports on is indistinguishable from
+#               a green one.
 #
 # Both tiers install the full [compression,testing] extras and generate a
 # self-signed TLS cert so TLS-aware tests don't fail due to missing key files.
@@ -40,12 +51,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The matrix must equal the classifiers in pyproject.toml.  Advertising
+        # a version we do not test is the defect that let an HTTP/2
+        # connection-window leak ship: CPython >=3.13 closes a coroutine before
+        # TaskGroup.create_task() raises, the credit-replay fallback then
+        # scheduled a dead coroutine, and the one test that noticed ran only on
+        # the versions where the old behaviour still held.
+        #
         # 3.11 is the declared floor (requires-python = ">=3.11"); running
         # the fast tier there is the *authoritative* check that the floor is
         # honest — a static audit missed HTTPStatus.is_client_error being
         # 3.12-only and let a 3.11 crash ship (fixed 2026-07-18).  Also the
         # compat level a PyPy arm targets in the bench-window plan.
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
@@ -81,6 +99,42 @@ jobs:
         run: |
           python -m pytest tests/unit tests/architecture tests/properties \
             --timeout=60 -q --beartype-packages=blackbull
+
+  integration:
+    name: Integration lane (integration + conformance)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97   # v7.0.0
+        with:
+          python-version: '3.12'
+
+      - name: Install BlackBull (with test-relevant extras)
+        run: pip install -e '.[compression,testing,fault-injection,reload,speed]'
+
+      - name: Generate self-signed TLS material
+        run: |
+          # subjectAltName must cover the loopback IP: the cert-verifying
+          # integration tests (test_http2_advanced) connect to 127.0.0.1 and
+          # validate the chain + hostname.  CN=localhost alone fails with
+          # "IP address mismatch".  Mirrors the committed tests/cert.pem SAN.
+          openssl req -x509 -newkey rsa:2048 \
+            -keyout tests/key.pem -out tests/cert.pem \
+            -days 365 -nodes -subj '/CN=localhost' \
+            -addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+
+      - name: Run integration + conformance suites
+        # --run-integration (not --run-all): the `docker` marker stays skipped,
+        # so no daemon is needed here and the docker-dependent modules
+        # importorskip out.  Measured at ~98s locally for 3526 tests, which is
+        # what made this lane cheap enough to gate every PR.
+        run: |
+          python -m pytest tests/integration tests/conformance \
+            --run-integration --timeout=120 -q --beartype-packages=blackbull
 
   dual-path:
     name: Dual-path lane (BB_FORCE_ASGI_SCOPE=1)
@@ -121,6 +175,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      issues: write   # the failure notification below files/updates an issue
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
@@ -168,3 +225,30 @@ jobs:
         run: |
           python -m pytest tests/ --run-all --timeout=120 -q \
             --beartype-packages=blackbull
+
+      - name: Report a scheduled failure
+        # Nothing watches a cron job.  Full tier ran 4 times before this step
+        # existed and 2 of those failed unattended; by the time it was noticed
+        # the logs had aged out.  Uses the preinstalled gh CLI rather than a
+        # third-party action so there is no new SHA to pin.  Reuses one open
+        # issue instead of filing a fresh one weekly.
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # `gh issue list/create --label` errors on a label that does not
+          # exist yet, so ensure it before either call.
+          gh label create ci-full-tier --color B60205 \
+            --description 'Scheduled Full tier is red' --force
+          existing=$(gh issue list --state open --label ci-full-tier \
+            --json number --jq '.[0].number')
+          body="Scheduled Full tier failed on \`${GITHUB_SHA}\`.
+          Run: ${RUN_URL}
+          Logs age out after 90 days — triage before then."
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title 'Full tier (scheduled) is failing' \
+              --label ci-full-tier --body "$body"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,11 @@ so the editable install's metadata catches up.
   be removed once that lands.  Both paths pass the same HTTP/1.1 conformance
   suite; the flag changes how bytes arrive, never what a request means.
 
+  `BufferedH1Reader` is registered as an `AbstractReader`.  Without that,
+  `RecipientFactory.http1` re-wrapped it in an `AsyncioReader` on **every**
+  request — the front end whose whole purpose is to remove per-request work was
+  adding an allocation to every request of every keep-alive connection.
+
 ### Removed
 
 - **The `scope` simplified-handler parameter alias.**  Naming a simplified
@@ -97,6 +102,28 @@ so the editable install's metadata catches up.
   the tests had drifted from it.
 
 ### Changed
+
+- **HTTP/1.1 keep-alive builds one recipient and one `RequestActor` per
+  connection, not per request.**  Both were rebuilt on every request even
+  though everything they hold that is expensive — the reader, the body
+  timeout, the connection deadline, the app, the aggregator — belongs to the
+  connection, not the request.  They are now rebound (`HTTP1Recipient.bind`,
+  `RequestActor.bind`), which is the trade the sender already made with
+  `reset_per_request_state`.  Safe for HTTP/1.1 specifically because a
+  connection dispatches one request at a time; HTTP/2 keeps building one
+  `RequestActor` per stream, since concurrent streams sharing an instance
+  would interleave their fields.
+
+  Measured on a same-session A/B over 400 serialized keep-alive requests:
+  **17.46 → 16.25 µs/req (−6.9%)** through `HTTP1Actor.run`, with every "after"
+  minimum below every "before" minimum across five runs each.  Rebinding turns
+  out to save more than the two constructors do, because it also skips
+  `RecipientFactory.http1`'s dispatch and the function-level
+  `from ..env import get_settings` that ran inside `__init__` on every request.
+  The 213-vector Http11Probe suite returns an identical per-test verdict before
+  and after (0 failed, 0 errors), which is the check that matters here: the
+  framing state a rebind must reset is exactly what request smuggling exploits
+  when it leaks between requests.
 
 - **The integration tier now gates pull requests.**  `tests/integration` and
   `tests/conformance` run under `--run-integration` on every push and PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.65.0] — 2026-07-29
+
 ### Added
 
 - **`BB_H1_PROTOCOL` — buffer-owning HTTP/1.1 read front end (experimental,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,34 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Removed
+
+- **The `scope` simplified-handler parameter alias.**  Naming a simplified
+  handler's parameter `scope` used to inject the native `Connection`.  That is
+  backwards: `scope` means a genuine ASGI scope dict everywhere else in the
+  codebase, so the alias handed back an object that answered to the wrong name
+  and made `scope['headers']` look correct — it compiled, registered, and
+  failed at request time with `AttributeError`.  That is precisely how the 33
+  tests below rotted.  It is now a `TypeError` **at registration**:
+
+  ```python
+  @app.route(path='/x')
+  async def h(scope):          # TypeError: parameter 'scope' is not supported
+      ...
+
+  @app.route(path='/x')
+  async def h(conn):           # use this — conn.headers, conn.query_string, …
+      ...
+  ```
+
+  `conn` and `connection` are unchanged.  **Full-form handlers and middleware
+  are unaffected** — `async def h(scope, receive, send)` takes its arguments
+  positionally, so the router never inspects those names; the 196 such handlers
+  in the test corpus and every documented example keep working.  Rejecting the
+  name rather than merely dropping the alias is deliberate: an unannotated
+  `scope` would otherwise fall through to the query-param fallback and silently
+  start receiving a query-string value instead of the request.
+
 ### Fixed
 
 - **33 rotted integration/conformance tests.**  Every one shared a root cause:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,30 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Added
+
+- **`BB_H1_PROTOCOL` — buffer-owning HTTP/1.1 read front end (experimental,
+  default off).**  Phase 1a of the H/1.1 fast path.  The header block is
+  located with a single `find(b'\r\n\r\n')` scan over an accumulated buffer
+  instead of one `readuntil(b'\r\n')` per header line, and any bytes read past
+  the delimiter are kept rather than discarded — so a keep-alive or pipelined
+  peer's next head is usually already in hand, and an await that resolves from
+  the buffer never yields to the loop.
+
+  The buffer is not an optimisation detail, it is what makes the scan possible
+  at all.  Two things block the obvious `readuntil(b'\r\n\r\n')` version: a
+  stream `readuntil` cannot see the bytes protocol detection already consumed
+  (a minimal `GET / HTTP/1.0\r\n\r\n` leaves only `\r\n` on the wire, and the
+  search blocks until the peer closes — the deadlock the line-by-line loop was
+  written to avoid), and any chunked scan over-reads into the body or the next
+  pipelined request.  Owning the buffer answers both: the scan starts from the
+  already-consumed prefix, and the surplus has somewhere to live.
+
+  This is a **measurement gate, not a supported switch** — it exists so both
+  read paths can be A/B'd on identical builds, and will become the default or
+  be removed once that lands.  Both paths pass the same HTTP/1.1 conformance
+  suite; the flag changes how bytes arrive, never what a request means.
+
 ### Removed
 
 - **The `scope` simplified-handler parameter alias.**  Naming a simplified

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,49 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Fixed
+
+- **33 rotted integration/conformance tests.**  Every one shared a root cause:
+  the test's handler was written against an ASGI scope dict while BlackBull's
+  native dispatch hands it a `Connection`, so the first mapping access raised
+  `AttributeError: 'Connection' object has no attribute 'get'`.  Ported to the
+  typed attributes (`conn.headers`, `conn.query_string`, `conn.cookies`,
+  `conn.state`, `conn.extensions`) across `test_http1_request_timeout.py` (13),
+  `test_middleware_composition.py` (6), `test_http2_advanced.py` (5),
+  `test_request_features.py` (4), `test_trusted_proxy.py` (3), and
+  `test_cookies.py` (2).  No library code changed — the framework was right and
+  the tests had drifted from it.
+
+### Changed
+
+- **The integration tier now gates pull requests.**  `tests/integration` and
+  `tests/conformance` run under `--run-integration` on every push and PR
+  (~98s locally for 3526 tests).  Previously the only job passing
+  `--run-integration` was the weekly Full tier, gated on
+  `schedule`/`workflow_dispatch`, so it gated nothing: the 33 tests above sat
+  red for weeks with no path to a human.
+- **The fast tier runs the full supported matrix** — 3.11, 3.12, 3.13, and
+  3.14, matching the classifiers in `pyproject.toml`.  Testing two of the four
+  versions we advertise is what let a 3.13 `TaskGroup` behaviour change ship an
+  HTTP/2 connection-window leak (fixed in v0.62.0) while CI stayed green.  Both
+  new interpreters were verified green before widening — no triage was needed.
+- **A failing scheduled Full tier now files an issue.**  It had run 4 times
+  and failed 2 of those unattended; by the time anyone looked, the logs had
+  aged out.  Reuses one open `ci-full-tier` issue rather than filing weekly
+  duplicates.
+
+### Tests
+
+- **`tests/architecture/test_native_handler_contract.py`** — a source scan
+  forbidding the shape that rotted: a registered handler or middleware using
+  its `Connection` as a mapping.  Turns a request-time `AttributeError` into a
+  collection-time failure, repo-wide, with no allowlist.  Verified against the
+  pre-fix sources, where it catches 23 of the 25 offending handler definitions
+  behind the 33 failures.  The two it misses passed the `Connection` to a
+  helper that subscripts it (`parse_cookies(conn)`) — indirect use needs
+  call-graph analysis, and the guard documents that gap rather than implying
+  coverage it does not have.
+
 ## [0.64.0] — 2026-07-29
 
 ### Added

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.65.x  | :white_check_mark: |
 | 0.64.x  | :white_check_mark: |
-| 0.63.x  | :white_check_mark: |
-| < 0.63  | :x:                |
+| < 0.64  | :x:                |
 
 This table updates with each minor release.
 

--- a/bench/h1_frontend_ab.py
+++ b/bench/h1_frontend_ab.py
@@ -1,0 +1,121 @@
+"""A/B the two H/1.1 read front ends by *transport reads per request*.
+
+Run: ``uv run python bench/h1_frontend_ab.py``
+
+Deterministic and machine-independent: it counts trips to the transport rather
+than timing a local throughput number that would mostly measure the laptop.
+Each underlying ``read``/``readuntil`` is one trip, i.e. at minimum one chance
+for the loop to suspend, and fewer of them is the whole claim behind
+``BB_H1_PROTOCOL``.
+
+What it established (Sprint 84): the per-line header loop runs only for the
+*first* request on a connection — ``run()`` already reads each subsequent head
+with a single ``readuntil(b'\r\n\r\n')`` — so the buffered front end wins on
+pipelined arrival (~1.1 → ~0.04 trips/req) and not on serialized keep-alive
+(~1.1 → ~1.02), which is the shape the baseline profile actually has.
+
+Caveat when reading the output: the fake reader's ``readuntil`` searches its
+whole byte string instead of respecting the simulated chunk boundary, so the
+*streams* rows are identical across both arrival shapes.  The buffered rows are
+faithful; the claim about where the per-line loop runs is read off the code.
+"""
+import asyncio
+import os
+
+N = 50  # pipelined requests on one connection
+
+REQ = (b'GET /baseline11?a=13&b=42 HTTP/1.1\r\n'
+       b'Host: localhost\r\n'
+       b'User-Agent: probe/1.0\r\n'
+       b'Accept: */*\r\n'
+       b'\r\n')
+
+
+class CountingReader:
+    """Serves a fixed byte stream, counting every transport touch."""
+
+    def __init__(self, data: bytes, chunk: int = 65536):
+        self._d = data
+        self._pos = 0
+        self._chunk = chunk
+        self.reads = 0
+        self.readuntils = 0
+
+    async def read(self, n: int = -1) -> bytes:
+        self.reads += 1
+        if self._pos >= len(self._d):
+            return b''
+        n = self._chunk if n < 0 else min(n, self._chunk)
+        out = self._d[self._pos:self._pos + n]
+        self._pos += len(out)
+        return out
+
+    async def readuntil(self, sep: bytes = b'\n') -> bytes:
+        self.readuntils += 1
+        idx = self._d.find(sep, self._pos)
+        if idx == -1:
+            from blackbull.server.recipient import IncompleteReadError
+            rest, self._pos = self._d[self._pos:], len(self._d)
+            raise IncompleteReadError(rest)
+        end = idx + len(sep)
+        out = self._d[self._pos:end]
+        self._pos = end
+        return out
+
+    async def readexactly(self, n: int) -> bytes:
+        from blackbull.server.recipient import IncompleteReadError
+        out = self._d[self._pos:self._pos + n]
+        if len(out) < n:
+            self._pos = len(self._d)
+            raise IncompleteReadError(out)
+        self._pos += n
+        return out
+
+
+class NullWriter:
+    def write(self, data): pass
+    async def drain(self): pass
+    def close(self): pass
+    async def wait_closed(self): pass
+    def get_extra_info(self, name, default=None): return default
+    def is_closing(self): return False
+    def can_write_eof(self): return False
+
+
+async def run_arm(flag: str, chunk: int = 65536) -> tuple[int, int, int]:
+    os.environ['BB_H1_PROTOCOL'] = flag
+    from blackbull import env
+    env.get_settings.cache_clear() if hasattr(env.get_settings, 'cache_clear') else None
+    from blackbull.server.http1_actor import HTTP1Actor
+
+    calls = 0
+
+    async def app(conn, receive, send):
+        nonlocal calls
+        calls += 1
+        await send({'type': 'http.response.start', 'status': 200,
+                    'headers': [(b'content-type', b'text/plain')]})
+        await send({'type': 'http.response.body', 'body': b'ok'})
+
+    reader = CountingReader(REQ * N, chunk)
+    actor = HTTP1Actor(reader, NullWriter(), app, None)
+    await actor.run()
+    return calls, reader.reads, reader.readuntils
+
+
+async def main():
+    # chunk = how many bytes the transport hands over per read.  65536 models
+    # a pipelined client whose batch lands in one segment; len(REQ) models a
+    # serialized keep-alive client, one request per delivery.
+    for chunk, shape in ((65536, 'pipelined (batch in one segment)'),
+                         (len(REQ), 'serialized keep-alive')):
+        print(f'--- {shape} ---')
+        for flag, label in (('0', 'streams (default)'), ('1', 'BB_H1_PROTOCOL=1')):
+            calls, reads, readuntils = await run_arm(flag, chunk)
+            total = reads + readuntils
+            print(f'  {label:22} requests={calls:3d}  read={reads:4d}  '
+                  f'readuntil={readuntils:4d}  total={total:4d}  '
+                  f'per-request={total / max(calls, 1):.2f}')
+
+
+asyncio.run(main())

--- a/blackbull/env.py
+++ b/blackbull/env.py
@@ -514,6 +514,15 @@ class Settings:
     #: Maximum concurrent HTTP/2 streams per connection (SETTINGS_MAX_CONCURRENT_STREAMS).
     h2_max_concurrent_streams: int = 100
 
+    #: Read HTTP/1.1 request heads through the buffer-owning front end: one
+    #: ``find(b'\r\n\r\n')`` scan over an accumulated buffer instead of one
+    #: ``readuntil(b'\r\n')`` per header line, with the surplus kept so a
+    #: keep-alive or pipelined peer's next head is usually already in hand
+    #: (zero suspensions between requests).  Off by default — this is a
+    #: measurement gate, not a permanent fork: it flips on, or is removed,
+    #: once the EC2 A/B has judged it.  Set ``BB_H1_PROTOCOL=1``.
+    h1_protocol: bool = False
+
     #: Advertise SETTINGS_ENABLE_CONNECT_PROTOCOL=1 (RFC 8441 §3) so peers may
     #: bootstrap WebSocket over HTTP/2 via Extended CONNECT.  Off by default —
     #: this path has fewer conformance tests than the HTTP/1.1 upgrade path,
@@ -649,6 +658,7 @@ def get_settings() -> Settings:
         h2_initial_window_size=_int_env('BB_H2_INITIAL_WINDOW_SIZE', 65535),
         h2_connection_window_size=_int_env('BB_H2_CONNECTION_WINDOW_SIZE', 65535),
         h2_max_concurrent_streams=_int_env('BB_H2_MAX_CONCURRENT_STREAMS', 100),
+        h1_protocol=_bool_env('BB_H1_PROTOCOL', False),
         h2_enable_websocket=_bool_env('BB_H2_ENABLE_WEBSOCKET', False),
         h2_ws_max_streams_per_connection=_int_env_nonneg(
             'BB_H2_WS_MAX_STREAMS_PER_CONNECTION', 5),

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -755,14 +755,15 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
     ``'conn'``, ``'body'``, ``'request'``, ``'dataclass'``, ``'depends'``
     (payload: the :class:`~blackbull.di.Depends` instance), or ``'query'``
     (payload: :class:`_QuerySpec`).  Precedence: path params first, then the
-    reserved names ``body``/``conn`` (``connection``/``scope`` alias), then a
-    ``Depends`` default, then
+    rejected name ``scope``, then the reserved names ``body``/``conn``
+    (``connection`` alias), then a ``Depends`` default, then
     ``Connection`` recognition, then a dataclass body annotation; anything left
     is a query param — the fallback category.
 
-    Raises ``TypeError`` (fail fast, at registration) for a ``Depends``
-    default on a reserved/path name, a second body-consuming parameter, or a
-    leftover parameter whose annotation is not a supported query scalar.
+    Raises ``TypeError`` (fail fast, at registration) for a parameter named
+    ``scope``, a ``Depends`` default on a reserved/path name, a second
+    body-consuming parameter, or a leftover parameter whose annotation is not a
+    supported query scalar.
     """
     from .connection import Connection as _Conn  # Sprint 79: Request is now a Connection alias
 
@@ -792,15 +793,33 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
                     f"is a path param of {sorted(path_param_names)!r} and "
                     f"cannot carry a Depends default.")
             categories[name] = ('path', None)
-        elif name in ('body', 'conn', 'connection', 'scope'):
+        elif name == 'scope':
+            # Rejected, not merely unsupported. ``scope`` was once an alias
+            # injecting the Connection, which is backwards: the word means a
+            # genuine ASGI scope dict everywhere else, so the alias handed back
+            # an object that answered to the wrong name and invited
+            # ``scope['headers']`` — a request-time AttributeError.
+            #
+            # This branch must precede the query-param fallback below. Deleting
+            # the alias without it would let an unannotated ``scope`` resolve as
+            # a *query parameter* named "scope", silently rebinding the argument
+            # instead of failing. A path param named ``scope`` is explicit, so
+            # the ``path`` branch above still wins.
+            raise TypeError(
+                f"Simplified handler {fn.__name__!r}: parameter 'scope' is not "
+                f"supported — BlackBull threads a Connection, not an ASGI scope "
+                f"dict, so the name misdescribes what would be injected. Rename "
+                f"it to 'conn' and use the typed attributes (conn.headers, "
+                f"conn.query_string, conn.cookies, conn.state, conn.extensions). "
+                f"Full-form handlers (conn, receive, send) are unaffected — "
+                f"their parameters are positional.")
+        elif name in ('body', 'conn', 'connection'):
             if is_dep:
                 raise TypeError(
                     f"Simplified handler {fn.__name__!r}: parameter {name!r} "
                     f"is reserved for the request {name} and cannot carry a "
                     f"Depends default — rename the parameter.")
-            # ``conn`` / ``connection`` inject the native Connection; ``scope`` is
-            # a deprecated alias for the same object (BlackBull threads a
-            # Connection, not an ASGI scope, on the native path).
+            # ``conn`` / ``connection`` inject the native Connection.
             categories[name] = ('body' if name == 'body' else 'conn', None)
         elif is_dep:
             categories[name] = ('depends', default)

--- a/blackbull/server/h1_buffer.py
+++ b/blackbull/server/h1_buffer.py
@@ -31,7 +31,7 @@ cost **zero suspensions**, against one loop turn per line today.
 """
 from __future__ import annotations
 
-from .recipient import IncompleteReadError
+from .recipient import AbstractReader, IncompleteReadError
 
 __all__ = ('BufferedH1Reader', 'LIMIT_EXCEEDED')
 
@@ -174,3 +174,14 @@ class BufferedH1Reader:
         # Anything else the underlying reader offers (feed_eof, transport
         # pokes in tests) passes through unchanged.
         return getattr(self._reader, name)
+
+
+# Registered rather than subclassed.  ``RecipientFactory`` wraps any reader
+# that fails this check in an ``AsyncioReader``, and it builds a recipient per
+# request — so without registration the front end whose whole purpose is to
+# remove per-request work would add an allocation to every request.  The class
+# already implements the full surface (including ``at_eof``), so inheritance
+# would contribute nothing but a ``__dict__``: ``AbstractReader`` declares no
+# ``__slots__``, and a base without them makes a subclass's ``__slots__`` a
+# silent no-op.
+AbstractReader.register(BufferedH1Reader)

--- a/blackbull/server/h1_buffer.py
+++ b/blackbull/server/h1_buffer.py
@@ -1,0 +1,176 @@
+"""Buffer-owning H/1.1 read front end (``BB_H1_PROTOCOL``).
+
+Phase 1a of the H/1.1 protocol-mode fast path.  The eventual front end is an
+:class:`asyncio.Protocol` whose ``data_received`` appends straight into a
+``bytearray``; this module implements the buffer half of that design *now*,
+layered over the existing reader, so the header scan, the pushback semantics,
+and the keep-alive residency can be built and proven before the transport is
+rewired.  The buffer logic here moves to the protocol unchanged.
+
+**Why the scan needs to own a buffer.** The obvious cheap version of this
+phase — keep ``StreamReader`` and swap the per-line ``readuntil(b'\\r\\n')``
+loop for one ``readuntil(b'\\r\\n\\r\\n')`` — does not work, twice over:
+
+1. ``readuntil`` on a *stream* cannot see bytes the protocol-detect stage
+   already moved into the actor's ``_request``.  A minimal
+   ``GET / HTTP/1.0\\r\\n\\r\\n`` leaves only the terminating ``\\r\\n`` on the
+   stream, and a search for the four-byte delimiter blocks until the peer
+   closes.  That deadlock is why the line-by-line loop exists at all.  Scanning
+   an *accumulated* buffer that starts with the already-consumed bytes has no
+   such blind spot.
+2. Any scan that reads in chunks will over-read — past the header block into
+   the body, or into the next pipelined request.  Line-by-line never
+   over-reads, which is precisely why it cannot be replaced without somewhere
+   to put the surplus.  The buffer is that somewhere: leftover stays put and
+   the next read is served from it.
+
+Point 2 is also where the performance comes from.  A keep-alive or pipelined
+peer usually has the next request head already in the buffer, and a coroutine
+that returns without awaiting does not yield to the loop — so those requests
+cost **zero suspensions**, against one loop turn per line today.
+"""
+from __future__ import annotations
+
+from .recipient import IncompleteReadError
+
+__all__ = ('BufferedH1Reader', 'LIMIT_EXCEEDED')
+
+#: ``fill_until`` result meaning "the byte budget ran out before the delimiter
+#: appeared".  Returned rather than raised so this module stays free of HTTP
+#: semantics — the caller owns the 431 that follows.
+LIMIT_EXCEEDED = -2
+
+# Read granularity.  Large enough that a typical head arrives in one call,
+# small enough not to hand a slow-loris peer a free 64 KiB allocation per
+# wakeup.  The protocol front end will not need this at all — the transport
+# decides chunk size there.
+_CHUNK = 65536
+
+
+class BufferedH1Reader:
+    """Reader that owns its unconsumed bytes.
+
+    Wraps any object exposing ``read`` / ``readuntil`` / ``readexactly`` and
+    presents the same three methods, so it is a drop-in for the
+    ``AbstractReader`` the H/1.1 actor and its recipient already take.  The
+    difference is the buffer: bytes read ahead of what a caller asked for are
+    kept, not discarded, and every method serves from the buffer before
+    touching the underlying reader.
+
+    Not thread-safe and not concurrency-safe — one connection, one reader, one
+    actor loop, per the actor model.
+    """
+
+    __slots__ = ('_reader', '_buf', '_eof')
+
+    def __init__(self, reader) -> None:
+        self._reader = reader
+        self._buf = bytearray()
+        self._eof = False
+
+    # -- buffer inspection (used by the single-scan header read) -----------
+
+    @property
+    def buffered(self) -> int:
+        """Bytes currently held, unconsumed."""
+        return len(self._buf)
+
+    def peek(self) -> bytes:
+        """The buffered bytes, without consuming them."""
+        return bytes(self._buf)
+
+    def unread(self, data: bytes) -> None:
+        """Push *data* back to the front of the buffer.
+
+        The seam that makes over-reading safe: the header scan hands back
+        whatever followed the header block, and the body reader or the next
+        keep-alive iteration picks it up transparently.
+        """
+        if data:
+            self._buf[:0] = data
+
+    async def _fill(self) -> int:
+        """Pull one chunk from the underlying reader.  Returns bytes added."""
+        if self._eof:
+            return 0
+        chunk = await self._reader.read(_CHUNK)
+        if not chunk:
+            self._eof = True
+            return 0
+        self._buf += chunk
+        return len(chunk)
+
+    async def fill_until(self, sep: bytes, start: int = 0, limit: int = 0) -> int:
+        """Read until *sep* appears at or after offset *start*.
+
+        Returns the index of *sep*, ``-1`` at EOF without a match, or
+        :data:`LIMIT_EXCEEDED` when *limit* (0 = unbounded) is passed without
+        one.  The limit is not optional in practice: without it a peer that
+        never sends the delimiter grows the buffer until the process dies,
+        which is the slow-loris shape the header budget exists to bound.
+
+        Rescans only from ``len(buf) - len(sep) + 1`` on each new chunk, so a
+        delimiter split across two reads is still found without re-scanning the
+        whole buffer — the quadratic trap in a naive "search it all again" loop.
+        """
+        idx = self._buf.find(sep, start)
+        while idx == -1:
+            if limit > 0 and len(self._buf) > limit:
+                return LIMIT_EXCEEDED
+            scan_from = max(start, len(self._buf) - len(sep) + 1)
+            if await self._fill() == 0:
+                return -1
+            idx = self._buf.find(sep, scan_from)
+        return idx
+
+    # -- AbstractReader surface --------------------------------------------
+
+    # Each method below delegates outright when the buffer is empty.  That is
+    # the common case once the head is consumed — a body read of any size, and
+    # every read on a connection with no surplus — and delegating keeps the
+    # underlying reader's exact semantics (its EOF timing, its error types, its
+    # own buffering) instead of re-deriving them here.  It also means a large
+    # body is never copied into this buffer just to be copied straight out.
+    # Interposition happens only while there is surplus to serve first, which
+    # is exactly the window that needs it.
+
+    async def read(self, n: int = -1) -> bytes:
+        if not self._buf:
+            return await self._reader.read(n)
+        if n < 0:
+            out, self._buf = bytes(self._buf), bytearray()
+            return out + await self._reader.read(-1)
+        out = bytes(self._buf[:n])
+        del self._buf[:n]
+        return out
+
+    async def readuntil(self, sep: bytes = b'\n') -> bytes:
+        if not self._buf:
+            return await self._reader.readuntil(sep)
+        idx = await self.fill_until(sep)
+        if idx < 0:
+            partial = bytes(self._buf)
+            self._buf = bytearray()
+            raise IncompleteReadError(partial)
+        end = idx + len(sep)
+        out = bytes(self._buf[:end])
+        del self._buf[:end]
+        return out
+
+    async def readexactly(self, n: int) -> bytes:
+        if not self._buf:
+            return await self._reader.readexactly(n)
+        if len(self._buf) >= n:
+            out = bytes(self._buf[:n])
+            del self._buf[:n]
+            return out
+        head, self._buf = bytes(self._buf), bytearray()
+        return head + await self._reader.readexactly(n - len(head))
+
+    def at_eof(self) -> bool:
+        return self._eof and not self._buf
+
+    def __getattr__(self, name):
+        # Anything else the underlying reader offers (feed_eof, transport
+        # pokes in tests) passes through unchanged.
+        return getattr(self._reader, name)

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -21,6 +21,7 @@ from ..connection import (
     Connection, bind_receive_channel, disconnected, mark_disconnected)
 from ..headers import Headers
 from .deadline import ConnectionDeadline
+from .h1_buffer import LIMIT_EXCEEDED, BufferedH1Reader
 from .recipient import AbstractReader, IncompleteReadError, RecipientFactory, _WS_EVENT_QUEUE_DEPTH
 from .sender import AbstractWriter, SenderFactory
 from .access_log import (AccessLogRecord as _AccessLogRecord,
@@ -353,6 +354,13 @@ class HTTP1Actor(Actor):
         connection_id: str = '',
     ) -> None:
         super().__init__()
+        # ``BB_H1_PROTOCOL`` swaps in the buffer-owning reader.  It is wrapped
+        # here rather than at the transport so the actor above is identical on
+        # both front ends — the flag must change how bytes arrive, never what
+        # the request means.
+        from ..env import get_settings as _get_settings  # noqa: PLC0415
+        if _get_settings().h1_protocol and not isinstance(reader, BufferedH1Reader):
+            reader = BufferedH1Reader(reader)
         self._reader = reader
         self._writer = writer
         self._app = app
@@ -1191,6 +1199,9 @@ class HTTP1Actor(Actor):
         exception class regardless of which side caught the overflow.
         """
         import asyncio  # noqa: PLC0415
+        if isinstance(self._reader, BufferedH1Reader):
+            await self._read_headers_scan(max_total)
+            return
         # Accumulate into a bytearray (amortised O(1) append) instead of the
         # O(n²) bytes ``+=`` growth, then publish back as bytes.  The loop
         # condition and size check are byte-for-byte equivalent to the prior
@@ -1211,6 +1222,54 @@ class HTTP1Actor(Actor):
                     f'header block {len(buf)} bytes > '
                     f'BB_HEADER_MAX_TOTAL={max_total}')
         self._request = bytes(buf)
+
+    async def _read_headers_scan(self, max_total: int) -> None:
+        """``BB_H1_PROTOCOL`` header read — one scan, surplus retained.
+
+        Same contract as :meth:`_read_headers`: on return ``self._request``
+        holds exactly the header block, ending in ``\\r\\n\\r\\n``, and raises
+        the same three exceptions so every 400/408/431 path in ``run()`` is
+        shared between the two front ends.
+
+        The scan starts from the bytes protocol detection already consumed
+        (``self._request``), which is what makes a single ``find`` safe here
+        where ``readuntil(b'\\r\\n\\r\\n')`` on the raw stream deadlocks — see
+        ``h1_buffer`` for the two failure modes this avoids.  Anything read
+        past the delimiter is pushed back, so the body reader and the next
+        pipelined request see it untouched.
+        """
+        reader = self._reader
+        prefix = self._request
+        if prefix:
+            # Bytes already consumed upstream sit in front of everything the
+            # reader holds, so the buffer's own offsets stay meaningful.
+            reader.unread(prefix)
+            self._request = b''
+
+        # A delimiter may straddle a chunk join; fill_until rescans the tail
+        # rather than the whole buffer, so this stays linear.  The limit is
+        # what stops a peer that never sends the terminator from growing the
+        # buffer without bound.
+        idx = await reader.fill_until(_REQ_END, limit=max_total)
+        if idx == LIMIT_EXCEEDED:
+            self._request = reader.peek()
+            raise HeaderTooLargeError(
+                f'header block {reader.buffered} bytes > '
+                f'BB_HEADER_MAX_TOTAL={max_total}')
+        if idx == -1:
+            # EOF with no complete head. ``run()`` distinguishes idle EOF from
+            # mid-header EOF by whether ``self._request`` is non-empty, so hand
+            # back what arrived before deciding.
+            self._request = await reader.read(-1)
+            raise IncompleteReadError(self._request)
+
+        end = idx + len(_REQ_END)
+        if max_total > 0 and end > max_total:
+            self._request = reader.peek()[:end]
+            raise HeaderTooLargeError(
+                f'header block {end} bytes > BB_HEADER_MAX_TOTAL={max_total}')
+
+        self._request = await reader.readexactly(end)
 
     def _should_keep_alive(self, conn) -> bool:
         """Return True if the connection should persist after this request.

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -22,7 +22,8 @@ from ..connection import (
 from ..headers import Headers
 from .deadline import ConnectionDeadline
 from .h1_buffer import LIMIT_EXCEEDED, BufferedH1Reader
-from .recipient import AbstractReader, IncompleteReadError, RecipientFactory, _WS_EVENT_QUEUE_DEPTH
+from .recipient import (AbstractReader, HTTP1Recipient, IncompleteReadError,
+                        RecipientFactory, _WS_EVENT_QUEUE_DEPTH)
 from .sender import AbstractWriter, SenderFactory
 from .access_log import (AccessLogRecord as _AccessLogRecord,
                          _make_disconnect_detecting_receive,
@@ -307,6 +308,23 @@ class RequestActor(Actor):
         self._app = app
         self._aggregator = aggregator
 
+    def bind(self, conn, receive, send) -> 'RequestActor':
+        """Point this actor at the next request on the same connection.
+
+        HTTP/1.1 dispatches one request at a time per connection, so the
+        instance is free between requests and rebinding it is indistinguishable
+        from building a new one — except for the allocation, which the keep-alive
+        loop would otherwise pay on every request.  ``app`` and ``aggregator``
+        are per-connection and stay put.
+
+        Deliberately **not** available to HTTP/2, whose streams are concurrent:
+        two live requests sharing one actor would interleave their fields.
+        """
+        self._conn = conn
+        self._receive = receive
+        self._send = send
+        return self
+
     async def run(self) -> None:  # override: single-shot, no inbox loop
         try:
             await self._app(self._conn, self._receive, self._send)
@@ -370,6 +388,9 @@ class HTTP1Actor(Actor):
         self._sockname = sockname
         self._ssl = ssl
         self._ws_queue_depth = ws_queue_depth
+        # Built on the first request, rebound on every later one — see
+        # ``RequestActor.bind``.
+        self._request_actor: RequestActor | None = None
         # Accept-time connection id (ConnectionActor's) — the one id for the
         # whole connection.  The WS upgrade path reuses it in the scope
         # instead of minting a second one; empty when the actor is
@@ -404,6 +425,8 @@ class HTTP1Actor(Actor):
         # below once the record exists.
         _loop_start_perf: float = 0.0
         _loop_start_cpu: float = 0.0
+        # Built on the first request that needs one, rebound thereafter.
+        inner_receive: HTTP1Recipient | None = None
         try:
             while True:
                 if _PHASE_TRACE:
@@ -596,11 +619,19 @@ class HTTP1Actor(Actor):
                     # ``method`` back from ``conn`` (now 'GET'), so no separate
                     # ``scope['method']`` write (which would force materialization).
                     conn.method = 'GET'
-                inner_receive = RecipientFactory.http1(
-                    self._reader, conn,
-                    body_timeout=cfg.body_timeout,
-                    deadline=dl,
-                )
+                # One recipient per connection, rebound per request — the same
+                # trade as ``send.reset_per_request_state()`` above, and for the
+                # same reason: the reader, body timeout, and deadline are
+                # connection properties, so rebuilding them per request bought
+                # nothing.  ``bind`` re-derives the framing from the new head.
+                if inner_receive is None:
+                    inner_receive = RecipientFactory.http1(
+                        self._reader, conn,
+                        body_timeout=cfg.body_timeout,
+                        deadline=dl,
+                    )
+                else:
+                    inner_receive.bind(conn)
 
                 if conn._asterisk_form:
                     # RFC 9112 §3.2.4 — ``OPTIONS *`` is a server-wide request
@@ -1140,10 +1171,14 @@ class HTTP1Actor(Actor):
                     inner_receive, conn, self._aggregator)
             else:
                 detecting_receive = inner_receive
-            request_actor = RequestActor(
-                conn, detecting_receive, capturing_send,
-                self._app, self._aggregator,
-            )
+            request_actor = self._request_actor
+            if request_actor is None:
+                request_actor = self._request_actor = RequestActor(
+                    conn, detecting_receive, capturing_send,
+                    self._app, self._aggregator,
+                )
+            else:
+                request_actor.bind(conn, detecting_receive, capturing_send)
             try:
                 await request_actor.run()
             except asyncio.CancelledError:

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -453,6 +453,43 @@ class HTTP1Recipient(BaseRecipient):
                  deadline: ConnectionDeadline | None = None,
                  chunk_size: int | None = None):
         super().__init__(reader)
+        # P4: deliver a Content-Length body in fixed-size chunks instead of one
+        # giant ``readexactly(content_length)`` allocation.  Falls back to the
+        # ``BB_BODY_CHUNK_SIZE`` setting when not injected (direct-instantiation
+        # tests pass it explicitly).
+        if chunk_size is None:
+            from ..env import get_settings as _get_settings  # noqa: PLC0415
+            chunk_size = _get_settings().body_chunk_size
+        self._chunk_size = chunk_size
+        # Sprint 17 Phase 3 — body-read deadline.  0 = disabled.  Applied
+        # per ``_read_with_timeout`` call (i.e. per chunk for chunked
+        # bodies, single window for Content-Length).  Mirrors nginx
+        # ``client_body_timeout`` semantics: each read has the same bound.
+        #
+        # Sprint 23 — the deadline is rescheduled on the shared
+        # :class:`ConnectionDeadline` rather than allocating a fresh
+        # ``asyncio.wait_for`` Timeout per chunk.  Per-chunk semantics
+        # preserved.
+        self._body_timeout = body_timeout
+        self._deadline = deadline
+        # Everything above belongs to the connection; everything ``bind`` sets
+        # belongs to the request.
+        self.bind(conn)
+
+    def bind(self, conn: dict | Connection) -> 'HTTP1Recipient':
+        """Point this recipient at *conn*, the next request on the connection.
+
+        The reader, chunk size, and deadline are properties of the connection
+        and survive; the framing state is re-derived from the new head.  One
+        recipient per connection instead of one per request is the same trade
+        the sender already makes — safe for HTTP/1.1 because a connection
+        dispatches one request at a time, and **not** safe for HTTP/2, whose
+        streams are concurrent.
+
+        The split is the whole contract: any per-request field left out of this
+        method would leak from request N into request N+1, so new state belongs
+        here, not in ``__init__``.
+        """
         # BlackBull's own actor passes the native :class:`Connection` directly
         # (Sprint 80 native-Connection entry); read its ``headers`` with no
         # conversion. A stashed Connection, or an external/hand-built ASGI scope
@@ -484,30 +521,12 @@ class HTTP1Recipient(BaseRecipient):
         self._chunked = (te == b'chunked')
         # Remaining Content-Length bytes; counts down as the body streams.
         self._content_length = int(cl) if cl else None
-        # P4: deliver a Content-Length body in fixed-size chunks instead of one
-        # giant ``readexactly(content_length)`` allocation.  Falls back to the
-        # ``BB_BODY_CHUNK_SIZE`` setting when not injected (direct-instantiation
-        # tests pass it explicitly).
-        if chunk_size is None:
-            from ..env import get_settings as _get_settings  # noqa: PLC0415
-            chunk_size = _get_settings().body_chunk_size
-        self._chunk_size = chunk_size
         self._done = False
-        # Sprint 17 Phase 3 — body-read deadline.  0 = disabled.  Applied
-        # per ``_read_with_timeout`` call (i.e. per chunk for chunked
-        # bodies, single window for Content-Length).  Mirrors nginx
-        # ``client_body_timeout`` semantics: each read has the same bound.
-        #
-        # Sprint 23 — the deadline is rescheduled on the shared
-        # :class:`ConnectionDeadline` rather than allocating a fresh
-        # ``asyncio.wait_for`` Timeout per chunk.  Per-chunk semantics
-        # preserved.
-        self._body_timeout = body_timeout
-        self._deadline = deadline
         # Set once a chunked-framing violation is detected: the byte stream is
         # now desynced, so the connection MUST close rather than keep-alive
         # (draining would parse smuggled bytes as the next request).
         self.framing_broken = False
+        return self
 
     def needs_drain(self) -> bool:
         """True if a declared request body may still be buffered unread.

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -43,7 +43,7 @@ ASGIServer                        (one per process; owns the listening socket)
 └── ConnectionActor               (one per accepted TCP connection)
       │
       ├── HTTP1Actor              (HTTP/1.1 driver)
-      │     └── RequestActor      (one per HTTP/1.1 request, short-lived)
+      │     └── RequestActor      (one per connection, rebound per request)
       │
       ├── HTTP2Actor              (HTTP/2 connection driver)
       │     └── StreamActor       (one per HTTP/2 stream)
@@ -109,8 +109,12 @@ server and under external ASGI hosts.
 ### `HTTP1Actor`
 
 - Drives the HTTP/1.1 request/response cycle.
-- For each request: spawns a `RequestActor`, awaits its
-  completion, then loops for keep-alive.
+- For each request: points its `RequestActor` at the request and
+  awaits completion, then loops for keep-alive.  The actor, the
+  sender, and the body recipient are built once per *connection*
+  and rebound per request — a connection dispatches one request at
+  a time, so rebinding is indistinguishable from rebuilding except
+  for the allocation.
 - On `Connection: Upgrade` (WebSocket): hands the reader /
   writer to a new `WebSocketActor` and exits.
 - Supervisor strategy: **isolate** — an error in one request
@@ -118,7 +122,10 @@ server and under external ASGI hosts.
 
 ### `RequestActor`
 
-- Owns one HTTP/1.1 request lifetime.
+- Owns one HTTP/1.1 request lifetime.  Under HTTP/1.1 one instance
+  serves the whole connection, rebound to each request in turn
+  (`bind`); HTTP/2 builds one per stream, because streams are
+  concurrent and would otherwise interleave their state.
 - Receives the parsed headers and body from `HTTP1Actor`.
 - Calls the ASGI app, collects the response, writes it back
   via the connection's writer.

--- a/docs/getting-started/first-app.md
+++ b/docs/getting-started/first-app.md
@@ -93,17 +93,34 @@ async def update_item(item_id: int, conn: Connection):
 See [Requests and responses](../guide/requests-and-responses.md)
 for the full surface.
 
-## The `scope` dict
+## The `conn` escape hatch
 
-Name a parameter `scope` to receive the full scope dict alongside
-other simplified parameters:
+Name a parameter `conn` to receive the full [`Connection`](../guide/requests-and-responses.md)
+alongside other simplified parameters:
 
 ```python
 @app.route(path='/items/{item_id:int}')
-async def get_item(item_id: int, scope):
-    lang = scope['headers'].get(b'accept-language', b'en').decode()
+async def get_item(item_id: int, conn):
+    lang = conn.headers.get(b'accept-language', b'en').decode()
     return {"id": item_id, "lang": lang}
 ```
+
+`connection` works as a synonym.  A `Connection` is an object with typed
+attributes — `conn.headers`, `conn.query_string`, `conn.cookies`,
+`conn.state`, `conn.extensions` — **not** a mapping, so `conn['headers']`
+and `conn.get(...)` do not work.
+
+!!! warning "`scope` is not a valid parameter name"
+
+    A simplified handler may not name a parameter `scope`; doing so raises
+    `TypeError` when the route is registered.  It was accepted until
+    v0.65.0, when it injected the `Connection` — the name promised an ASGI
+    scope dict and delivered something else, so `scope['headers']` compiled
+    fine and failed at request time.  Rename it to `conn`.
+
+    Full-form handlers are unaffected: `async def h(scope, receive, send)`
+    takes its arguments positionally, so the name is never inspected.  It
+    still receives a `Connection`, so `conn` reads better there too.
 
 ## Return value mapping
 

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -221,7 +221,7 @@ to know how the client delivered the cookies.
 ## Query parameters
 
 Declare them as handler parameters (since v0.56.0).  Any simplified-handler
-parameter that is not a path param, `body`, `scope`, `Connection`, a dataclass
+parameter that is not a path param, `body`, `conn`, `Connection`, a dataclass
 body, or [`Depends`](dependency-injection.md) resolves from the query
 string, coerced to its annotation:
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -61,6 +61,12 @@ first-hit-then-summary rate-limit model.
 | `BB_SOCKET_SNDBUF` | `0` (kernel default) | `SO_SNDBUF` (bytes) on each accepted socket.  `0` leaves the kernel default unchanged.  Linux doubles the requested value internally; larger values help throughput for responses ≥ 64 kB. |
 | `BB_SOCKET_RCVBUF` | `0` (kernel default) | `SO_RCVBUF` (bytes) on each accepted socket.  `0` leaves the kernel default unchanged.  Same doubling rule as `BB_SOCKET_SNDBUF`. |
 
+## HTTP/1.1 internals
+
+| Variable | Default | Controls |
+|---|---|---|
+| `BB_H1_PROTOCOL` | `0` | Read request heads through the buffer-owning front end: one `find(b'\r\n\r\n')` scan over an accumulated buffer instead of one `readuntil(b'\r\n')` per header line, keeping any surplus so a keep-alive or pipelined peer's next head is usually already in hand.  **Experimental measurement gate**, not a supported switch — it exists so the two read paths can be A/B'd on identical builds, and will either become the default or be removed once that measurement lands.  Both paths pass the same HTTP/1.1 conformance suite; enabling it changes how bytes arrive, never what a request means. |
+
 ## Logging
 
 | Variable | Default | Controls |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.64.0"
+version = "0.65.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/architecture/test_native_handler_contract.py
+++ b/tests/architecture/test_native_handler_contract.py
@@ -1,0 +1,208 @@
+"""Architecture guard: a registered handler receives a ``Connection``, not a scope.
+
+BlackBull's own server threads a typed ``Connection`` end-to-end; an ASGI scope
+dict exists only at the two external boundaries. A handler registered with
+``@app.route(...)`` / ``@app.websocket(...)``, or a middleware installed via
+``app.use(...)`` / ``middlewares=[...]``, is therefore handed a ``Connection``
+on the native path.
+
+Using that parameter as a mapping — ``conn['headers']``, ``conn.get(…)``,
+``conn.setdefault('state', {})`` — raises ``AttributeError`` at request time,
+not at import. Anywhere the test itself does not run, the breakage is
+invisible: that is how 33 integration/conformance tests sat red behind a
+default-skipped marker and an ungated CI tier. This scan turns that runtime
+failure into a collection-time one, repo-wide, with no allowlist.
+
+**What this guard does not catch.** Two known gaps, both deliberate:
+
+- *Indirect* mapping use — passing the ``Connection`` to a helper that
+  subscripts it (``parse_cookies(conn)`` was one of the 33) — needs call-graph
+  analysis this scan does not do.
+- Naming the parameter ``scope``. The word ``scope`` in this codebase means a
+  genuine ASGI scope dict, so the name misdescribes a ``Connection`` and is
+  what invites the mapping misuse. It is not asserted here only because ~200
+  handlers in the existing corpus carry the name while behaving correctly;
+  the rename is tracked as a follow-up, not a rule that has been waived.
+"""
+import ast
+import pathlib
+
+import pytest
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_CORPUS_DIRS = ('tests', 'examples')
+
+# Registration decorators: ``@app.route(...)``, ``@group.route(...)``,
+# ``@app.websocket(...)``. Matched on the attribute name alone — the receiver
+# is a local variable whose type the scan cannot know.
+_REGISTRATION_ATTRS = frozenset({'route', 'route_fn', 'websocket'})
+
+# Mapping operations a ``Connection`` does not answer. ``conn.state.get`` and
+# ``conn.headers.get`` are attribute chains, not calls on the parameter itself,
+# so they are not matched.
+_MAPPING_METHODS = frozenset({
+    'get', 'setdefault', 'keys', 'items', 'values', 'pop', 'update',
+})
+
+# Handlers that genuinely receive an ASGI scope dict, keyed by
+# ``<path-relative-to-repo>::<function name>``. A registered handler only ever
+# sees a scope dict on the ``BB_FORCE_ASGI_SCOPE`` compat lane; anything listed
+# here must be exercising that lane deliberately.
+_ASGI_LANE_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _iter_corpus_files():
+    for d in _CORPUS_DIRS:
+        root = _REPO_ROOT / d
+        if not root.is_dir():
+            continue
+        for path in root.rglob('*.py'):
+            if '__pycache__' in path.parts:
+                continue
+            yield path
+
+
+def _is_registration_decorator(node: ast.expr) -> bool:
+    """True for ``@x.route(...)`` / ``@x.websocket(...)`` and their bare forms."""
+    if isinstance(node, ast.Call):
+        node = node.func
+    return isinstance(node, ast.Attribute) and node.attr in _REGISTRATION_ATTRS
+
+
+def _registered_middleware_names(tree: ast.AST) -> set[str]:
+    """Names passed to ``app.use(mw)`` or ``middlewares=[mw, ...]`` in *tree*.
+
+    Only bare ``Name`` references are collected — a ``TrustedProxy([...])``
+    instance is a class, not a def this scan can inspect.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr == 'use':
+            names.update(a.id for a in node.args if isinstance(a, ast.Name))
+        for kw in node.keywords:
+            if kw.arg == 'middlewares' and isinstance(kw.value, (ast.List, ast.Tuple)):
+                names.update(e.id for e in kw.value.elts if isinstance(e, ast.Name))
+    return names
+
+
+def _handler_defs(tree: ast.AST):
+    """Yield every function in *tree* registered as a handler or middleware."""
+    middleware_names = _registered_middleware_names(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if (any(_is_registration_decorator(d) for d in node.decorator_list)
+                or node.name in middleware_names):
+            yield node
+
+
+def _param_names(fn) -> list[str]:
+    a = fn.args
+    return [p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)]
+
+
+def _mapping_uses(fn, param: str) -> bool:
+    """True if *param* is subscripted or has a mapping method called on it."""
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Subscript):
+            if isinstance(node.value, ast.Name) and node.value.id == param:
+                return True
+        elif isinstance(node, ast.Call):
+            f = node.func
+            if (isinstance(f, ast.Attribute) and f.attr in _MAPPING_METHODS
+                    and isinstance(f.value, ast.Name) and f.value.id == param):
+                return True
+    return False
+
+
+def _scan() -> list[str]:
+    """Return the labels of handlers using their Connection as a mapping."""
+    offenders: list[str] = []
+    for path in _iter_corpus_files():
+        try:
+            tree = ast.parse(path.read_text(encoding='utf-8'))
+        except SyntaxError:
+            continue  # deliberately-malformed fixture source
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        for fn in _handler_defs(tree):
+            label = f'{rel}::{fn.name}'
+            if label in _ASGI_LANE_ALLOWLIST:
+                continue
+            params = _param_names(fn)
+            if params and _mapping_uses(fn, params[0]):
+                offenders.append(label)
+    return offenders
+
+
+def test_no_registered_handler_treats_its_connection_as_a_mapping():
+    offenders = _scan()
+    assert not offenders, (
+        'A Connection is not a mapping — conn["headers"] / conn.get(...) / '
+        f'conn.setdefault(...) raise AttributeError at request time: {sorted(offenders)}. '
+        'Use the typed attributes instead (conn.headers, conn.query_string, '
+        'conn.cookies, conn.state, conn.extensions). If the handler genuinely '
+        'runs on the BB_FORCE_ASGI_SCOPE compat lane, add it to '
+        '_ASGI_LANE_ALLOWLIST with a note.')
+
+
+def test_allowlist_entries_exist():
+    """Guard against the allowlist rotting: every entry must name a real def."""
+    for label in _ASGI_LANE_ALLOWLIST:
+        rel, _, fn_name = label.partition('::')
+        path = _REPO_ROOT / rel
+        assert path.exists(), f'_ASGI_LANE_ALLOWLIST names a missing file: {rel}'
+        tree = ast.parse(path.read_text(encoding='utf-8'))
+        assert any(
+            isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == fn_name
+            for n in ast.walk(tree)
+        ), f'_ASGI_LANE_ALLOWLIST names a missing function: {label}'
+
+
+def test_scan_detects_the_offending_shape():
+    """The guard must fail on the shape it exists to forbid.
+
+    Without this, an accidental change to the AST walk (a renamed decorator, a
+    dropped branch) would silently turn the guard into a no-op that passes on
+    an empty offender list. The source below is the real pre-fix shape from
+    ``tests/integration/test_middleware_composition.py``.
+    """
+    source = '''
+async def mw(scope, receive, send, call_next):
+    scope.setdefault('state', {})['x'] = 1
+    await call_next(scope, receive, send)
+
+@app.route(path='/x', middlewares=[mw])
+async def handler(scope):
+    return {'q': scope.get('query_string', b'')}
+
+@app.websocket(path='/ws')
+async def ws(conn, receive, send):
+    return conn['subprotocols']
+'''
+    tree = ast.parse(source)
+    found = {fn.name for fn in _handler_defs(tree)}
+    assert found == {'mw', 'handler', 'ws'}, (
+        f'the scan no longer recognises registered handlers: found {found}')
+    for fn in _handler_defs(tree):
+        params = _param_names(fn)
+        assert _mapping_uses(fn, params[0]), f'{fn.name} should have been flagged'
+
+
+@pytest.mark.parametrize('source, why', [
+    ("@app.route(path='/x')\nasync def h(conn):\n    return conn.headers.get(b'a')",
+     'conn.headers.get is an attribute chain, not a call on conn'),
+    ("@app.route(path='/x')\nasync def h(conn):\n    conn.state['k'] = 1",
+     'subscripting conn.state is fine; only conn itself is forbidden'),
+    ("@app.route(path='/x')\nasync def h(conn):\n    return conn.cookies",
+     'plain attribute access is the sanctioned form'),
+    ("async def plain(scope, receive, send):\n    return scope['type']",
+     'an unregistered ASGI app is not a BlackBull handler'),
+])
+def test_scan_does_not_flag_legitimate_shapes(source, why):
+    tree = ast.parse(source)
+    handlers = list(_handler_defs(tree))
+    for fn in handlers:
+        assert not _mapping_uses(fn, _param_names(fn)[0]), why

--- a/tests/conformance/http1/test_http1_dispatch.py
+++ b/tests/conformance/http1/test_http1_dispatch.py
@@ -302,11 +302,15 @@ class TestHTTP11KeepAlive:
             call_count += 1
 
         reader = MagicMock(spec=AbstractReader)
+        # Both access patterns are scripted with the same bytes so the test is
+        # front-end agnostic: the streams path completes the header block via
+        # readuntil, the BB_H1_PROTOCOL scan via read.  Either way the peer
+        # sends one whole request and then EOFs, and the app must run once.
         reader.readuntil = AsyncMock(side_effect=[
             rest,
             IncompleteReadError(b'GET /two HTTP'),
         ])
-        reader.read = AsyncMock(return_value=b'')
+        reader.read = AsyncMock(side_effect=[rest, b'', b''])
 
         actor = HTTP1Actor(reader, _FakeWriter(), counting_app, None,
                            request=first_line + b'\r\n')

--- a/tests/conformance/http1/test_http1_request_timeout.py
+++ b/tests/conformance/http1/test_http1_request_timeout.py
@@ -111,10 +111,10 @@ def timeout_server():
     app = BlackBull()
 
     @app.route(path='/sleep')
-    async def sleep_handler(scope, receive, send):
+    async def sleep_handler(conn, receive, send):
         """Sleep for ``?s=N`` seconds (float), then reply.  Allows the test
         to control handler duration without restarting the server."""
-        qs = scope.get('query_string', b'').decode()
+        qs = conn.query_string.decode()
         duration = 0.0
         for param in qs.split('&'):
             if param.startswith('s='):
@@ -141,7 +141,7 @@ def timeout_server():
         return b'pong'
 
     @app.route(path='/buffered-stall')
-    async def buffered_stall_handler(scope, receive, send):
+    async def buffered_stall_handler(conn, receive, send):
         """Send ``http.response.start`` immediately, then stall for a
         duration controlled by ``?s=N`` before sending the body.
 
@@ -150,7 +150,7 @@ def timeout_server():
         set but ``_started`` is still False.  If the timeout fires in
         this window, the synthetic 408 must NOT emit the buffered
         status line (which would be 200, not 408)."""
-        qs = scope.get('query_string', b'').decode()
+        qs = conn.query_string.decode()
         duration = 0.0
         for param in qs.split('&'):
             if param.startswith('s='):
@@ -552,8 +552,8 @@ class TestRequestTimeoutCustomValue:
         app = BlackBull()
 
         @app.route(path='/nap')
-        async def nap_handler(scope, receive, send):
-            qs = scope.get('query_string', b'').decode()
+        async def nap_handler(conn, receive, send):
+            qs = conn.query_string.decode()
             duration = 0.0
             for param in qs.split('&'):
                 if param.startswith('s='):

--- a/tests/integration/test_cookies.py
+++ b/tests/integration/test_cookies.py
@@ -3,7 +3,6 @@ import pytest
 
 from blackbull import BlackBull, JSONResponse
 from blackbull.response import cookie_header
-from blackbull.request import parse_cookies
 from blackbull.testing import TestClient
 
 
@@ -11,22 +10,22 @@ def _make_app() -> BlackBull:
     app = BlackBull()
 
     @app.route(path='/set-cookie')
-    async def set_cookie_route(scope, receive, send):
+    async def set_cookie_route(conn, receive, send):
         await send(JSONResponse(
             {'ok': True},
             headers=[cookie_header('session', 'abc123')],
         ))
 
     @app.route(path='/set-cookie-no-httponly')
-    async def set_cookie_no_httponly(scope, receive, send):
+    async def set_cookie_no_httponly(conn, receive, send):
         await send(JSONResponse(
             {'ok': True},
             headers=[cookie_header('pref', 'dark', http_only=False)],
         ))
 
     @app.route(path='/read-cookies')
-    async def read_cookies(scope):
-        return parse_cookies(scope)
+    async def read_cookies(conn):
+        return conn.cookies
 
     return app
 

--- a/tests/integration/test_http2_advanced.py
+++ b/tests/integration/test_http2_advanced.py
@@ -36,9 +36,9 @@ def _make_push_app() -> BlackBull:
     app = BlackBull()
 
     @app.route(path='/page')
-    async def page(scope, receive, send):
+    async def page(conn, receive, send):
         # Push /style.css before sending the HTML response
-        if 'http.response.push' in scope.get('extensions', {}):
+        if 'http.response.push' in conn.extensions:
             await send({
                 'type':    'http.response.push',
                 'path':    '/style.css',
@@ -60,8 +60,8 @@ def _make_priority_app() -> BlackBull:
     app = BlackBull()
 
     @app.route(path='/priority')
-    async def priority_route(scope, receive, send):
-        hint = scope.get('http2_priority', {})
+    async def priority_route(conn, receive, send):
+        hint = conn.extensions.get('http.response.priority', {})
         await send({'type': 'http.response.start', 'status': 200,
                     'headers': [(b'content-type', b'application/json')]})
         import json
@@ -72,18 +72,20 @@ def _make_priority_app() -> BlackBull:
 
 
 def _make_stream_info_app() -> BlackBull:
-    """Sprint 32 — echoes both the new extensions surface and the
-    legacy ``http2_priority`` key so the integration test can verify
-    they agree."""
+    """Echoes the H/2 extensions surface a native handler sees.
+
+    The legacy top-level ``http2_priority`` key is deliberately not read
+    here: it is populated only on the ASGI-compat lane, so a native handler
+    has no such key to read.  Its shape contract is pinned in
+    ``tests/unit/test_http2_extensions.py::TestLegacyAliasContract``.
+    """
     app = BlackBull()
 
     @app.route(path='/stream-info')
-    async def stream_info_route(scope, receive, send):
+    async def stream_info_route(conn, receive, send):
         import json
-        ext = scope.get('extensions') or {}
-        legacy = scope.get('http2_priority', {})
+        ext = conn.extensions
         payload = {
-            'legacy_http2_priority': legacy,
             'priority_ext': ext.get('http.response.priority'),
             'http2_stream_ext': ext.get('http.response.http2_stream'),
             'extension_keys': sorted(ext.keys()),
@@ -130,16 +132,17 @@ async def test_server_push_route_reachable(push_app):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_server_push_scope_extension_present(push_app):
-    """http.response.push is advertised in scope['extensions'] for HTTP/2."""
+async def test_server_push_extension_present(push_app):
+    """http.response.push is advertised in conn.extensions for HTTP/2."""
     _extensions = {}
 
-    # Use a separate app to capture scope without triggering a push to httpx
+    # Use a separate app to capture the extensions without triggering a
+    # push to httpx.
     app2 = BlackBull()
 
     @app2.route(path='/ext')
-    async def ext(scope, receive, send):
-        _extensions.update(scope.get('extensions', {}))
+    async def ext(conn, receive, send):
+        _extensions.update(conn.extensions)
         await send({'type': 'http.response.start', 'status': 200, 'headers': []})
         await send({'type': 'http.response.body', 'body': b'ok', 'more_body': False})
 
@@ -157,7 +160,7 @@ async def test_server_push_scope_extension_present(push_app):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_priority_hint_in_scope(priority_app):
+async def test_priority_hint_present(priority_app):
     async with httpx.AsyncClient(
         http2=True, verify=_test_ssl_context(),
         base_url=f'https://127.0.0.1:{priority_app.port}',
@@ -174,7 +177,7 @@ async def test_priority_hint_in_scope(priority_app):
 
 
 # ---------------------------------------------------------------------------
-# Sprint 32 — http.response.priority + http.response.http2_stream extensions
+# http.response.priority + http.response.http2_stream extensions
 # ---------------------------------------------------------------------------
 
 @pytest.fixture(scope="module")
@@ -186,10 +189,9 @@ def stream_info_app(manage_cert_and_key):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_priority_extension_present_in_scope(stream_info_app):
-    """``scope['extensions']['http.response.priority']`` is populated for
-    every HTTP/2 request and carries the same RFC 9218 urgency/incremental
-    values the legacy ``scope['http2_priority']`` does."""
+async def test_priority_extension_present(stream_info_app):
+    """``conn.extensions['http.response.priority']`` is populated for every
+    HTTP/2 request and carries the RFC 9218 urgency/incremental values."""
     async with httpx.AsyncClient(
         http2=True, verify=_test_ssl_context(),
         base_url=f'https://127.0.0.1:{stream_info_app.port}',
@@ -201,15 +203,13 @@ async def test_priority_extension_present_in_scope(stream_info_app):
     assert body['priority_ext'] is not None
     assert body['priority_ext']['urgency'] == 2
     assert body['priority_ext']['incremental'] is True
-    # Deprecation alias must agree.
-    assert body['legacy_http2_priority'] == body['priority_ext']
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_http2_stream_extension_present_in_scope(stream_info_app):
-    """``scope['extensions']['http.response.http2_stream']`` carries
-    stream_id and the send-window snapshot."""
+async def test_http2_stream_extension_present(stream_info_app):
+    """``conn.extensions['http.response.http2_stream']`` carries stream_id
+    and the send-window snapshot."""
     async with httpx.AsyncClient(
         http2=True, verify=_test_ssl_context(),
         base_url=f'https://127.0.0.1:{stream_info_app.port}',
@@ -228,9 +228,8 @@ async def test_http2_stream_extension_present_in_scope(stream_info_app):
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_scope_advertises_three_extension_keys(stream_info_app):
-    """The HTTP/2 scope advertises push, priority, and http2_stream
-    keys.  Sprint 32 adds the latter two; the existing push key stays."""
+async def test_advertises_three_extension_keys(stream_info_app):
+    """An HTTP/2 request advertises push, priority, and http2_stream keys."""
     async with httpx.AsyncClient(
         http2=True, verify=_test_ssl_context(),
         base_url=f'https://127.0.0.1:{stream_info_app.port}',

--- a/tests/integration/test_middleware_composition.py
+++ b/tests/integration/test_middleware_composition.py
@@ -10,36 +10,36 @@ def _make_app() -> BlackBull:
 
     # --- per-route middleware ---
 
-    async def add_header_mw(scope, receive, send, call_next):
-        scope.setdefault('state', {})['mw_ran'] = True
-        await call_next(scope, receive, send)
+    async def add_header_mw(conn, receive, send, call_next):
+        conn.state['mw_ran'] = True
+        await call_next(conn, receive, send)
 
     @app.route(path='/with-mw', middlewares=[add_header_mw])
-    async def with_mw(scope):
-        return {'mw_ran': scope.get('state', {}).get('mw_ran', False)}
+    async def with_mw(conn):
+        return {'mw_ran': conn.state.get('mw_ran', False)}
 
     @app.route(path='/without-mw')
-    async def without_mw(scope):
-        return {'mw_ran': scope.get('state', {}).get('mw_ran', False)}
+    async def without_mw(conn):
+        return {'mw_ran': conn.state.get('mw_ran', False)}
 
     # --- middleware order: each appends a tag; handler returns the list ---
 
-    async def outer_mw(scope, receive, send, call_next):
-        scope.setdefault('state', {}).setdefault('order', []).append('outer')
-        await call_next(scope, receive, send)
+    async def outer_mw(conn, receive, send, call_next):
+        conn.state.setdefault('order', []).append('outer')
+        await call_next(conn, receive, send)
 
-    async def inner_mw(scope, receive, send, call_next):
-        scope.setdefault('state', {}).setdefault('order', []).append('inner')
-        await call_next(scope, receive, send)
+    async def inner_mw(conn, receive, send, call_next):
+        conn.state.setdefault('order', []).append('inner')
+        await call_next(conn, receive, send)
 
     @app.route(path='/order', middlewares=[outer_mw, inner_mw])
-    async def order_handler(scope):
-        scope['state']['order'].append('handler')
-        return scope['state']['order']
+    async def order_handler(conn):
+        conn.state['order'].append('handler')
+        return conn.state['order']
 
     # --- short-circuit: handler must not be called ---
 
-    async def blocking_mw(scope, receive, send, call_next):
+    async def blocking_mw(conn, receive, send, call_next):
         await send({'type': 'http.response.start', 'status': 403, 'headers': []})
         await send({'type': 'http.response.body', 'body': b'blocked', 'more_body': False})
         # deliberately does NOT call call_next
@@ -50,27 +50,27 @@ def _make_app() -> BlackBull:
 
     # --- route group ---
 
-    async def group_mw(scope, receive, send, call_next):
-        scope.setdefault('state', {})['group'] = True
-        await call_next(scope, receive, send)
+    async def group_mw(conn, receive, send, call_next):
+        conn.state['group'] = True
+        await call_next(conn, receive, send)
 
     group = app.group(middlewares=[group_mw])
 
     @group.route(path='/group/resource')
-    async def group_resource(scope):
-        return {'group': scope.get('state', {}).get('group', False)}
+    async def group_resource(conn):
+        return {'group': conn.state.get('group', False)}
 
     # --- global middleware ---
 
-    async def global_mw(scope, receive, send, call_next):
-        scope.setdefault('state', {})['global'] = True
-        await call_next(scope, receive, send)
+    async def global_mw(conn, receive, send, call_next):
+        conn.state['global'] = True
+        await call_next(conn, receive, send)
 
     app.use(global_mw)
 
     @app.route(path='/global')
-    async def global_route(scope):
-        return {'global': scope.get('state', {}).get('global', False)}
+    async def global_route(conn):
+        return {'global': conn.state.get('global', False)}
 
     return app
 

--- a/tests/integration/test_request_features.py
+++ b/tests/integration/test_request_features.py
@@ -2,7 +2,6 @@
 import pytest
 
 from blackbull import BlackBull
-from blackbull.request import parse_cookies
 from blackbull.testing import TestClient
 
 
@@ -10,22 +9,22 @@ def _make_app() -> BlackBull:
     app = BlackBull()
 
     @app.route(path='/header-echo')
-    async def header_echo(scope):
-        value = scope['headers'].get(b'x-custom-header')
+    async def header_echo(conn):
+        value = conn.headers.get(b'x-custom-header')
         return {'value': value.decode() if value else None}
 
     @app.route(path='/header-multivalue')
-    async def header_multivalue(scope):
-        pairs = scope['headers'].getlist(b'accept')
+    async def header_multivalue(conn):
+        pairs = conn.headers.getlist(b'accept')
         return {'values': [v.decode() for _, v in pairs]}
 
     @app.route(path='/cookies')
-    async def cookies(scope):
-        return parse_cookies(scope)
+    async def cookies(conn):
+        return conn.cookies
 
     @app.route(path='/query')
-    async def query(scope):
-        return {'query_string': scope.get('query_string', b'').decode()}
+    async def query(conn):
+        return {'query_string': conn.query_string.decode()}
 
     return app
 

--- a/tests/integration/test_trusted_proxy.py
+++ b/tests/integration/test_trusted_proxy.py
@@ -9,20 +9,20 @@ from blackbull.testing import TestClient
 def _make_app_trusted() -> BlackBull:
     """App that trusts 127.0.0.1 (the loopback default).
 
-    ``httpx.ASGITransport`` sets ``scope['client']`` to ``('127.0.0.1', 123)``
-    by default, so 127.0.0.1 in the trust list is what makes TestClient
+    ``httpx.ASGITransport`` sets the client to ``('127.0.0.1', 123)`` by
+    default, so 127.0.0.1 in the trust list is what makes TestClient
     requests appear to come from a trusted peer.
     """
     app = BlackBull()
     app.use(TrustedProxy(['127.0.0.1', '::1']))
 
     @app.route(path='/client-ip')
-    async def client_ip(scope):
-        return {'ip': (scope.get('client') or [''])[0]}
+    async def client_ip(conn):
+        return {'ip': (conn.client or [''])[0]}
 
     @app.route(path='/scheme')
-    async def scheme(scope):
-        return {'scheme': scope.get('scheme', '')}
+    async def scheme(conn):
+        return {'scheme': conn.scheme}
 
     return app
 
@@ -34,8 +34,8 @@ def _make_app_untrusted() -> BlackBull:
     app.use(TrustedProxy(['10.0.0.1']))
 
     @app.route(path='/client-ip')
-    async def client_ip(scope):
-        return {'ip': (scope.get('client') or [''])[0]}
+    async def client_ip(conn):
+        return {'ip': (conn.client or [''])[0]}
 
     return app
 
@@ -68,7 +68,7 @@ def test_x_forwarded_proto_rewritten(trusted):
 
 @pytest.mark.integration
 def test_untrusted_sender_header_ignored(untrusted):
-    """When the peer is not trusted, X-Forwarded-For must not rewrite scope['client']."""
+    """When the peer is not trusted, X-Forwarded-For must not rewrite conn.client."""
     r = untrusted.get('/client-ip', headers={'X-Forwarded-For': '203.0.113.99'})
     assert r.status_code == 200
     # The IP should be the actual peer (127.0.0.1), not the forwarded value.

--- a/tests/unit/test_adapt_zero_overhead.py
+++ b/tests/unit/test_adapt_zero_overhead.py
@@ -20,7 +20,7 @@ class _Item:
 
 async def _plain(): return 'x'
 async def _path_only(item_id: int): return item_id
-async def _full_legacy(item_id: int, body: bytes, scope, request: Request): pass
+async def _full_legacy(item_id: int, body: bytes, conn, request: Request): pass
 async def _dataclass_body(item: _Item): pass
 async def _with_query(q: str, page: int = 1): pass
 def _provider(): return 'db'

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -86,9 +86,9 @@ class _FakeAuthExtension:
         app.on_error(403)(self._on_403)
 
         @app.route(path='/whoami')
-        async def whoami(scope):
+        async def whoami(conn):
             self._whoami_called = True
-            user = scope.state.get('user', 'anonymous')
+            user = conn.state.get('user', 'anonymous')
             return {'user': user}
 
         # Keep a reference so the route callback is collected properly
@@ -136,8 +136,8 @@ class TestInitAppConvention:
 
         # Add a route that returns the injected user
         @app.route(path='/me')
-        async def me(scope):
-            return {'user': scope.state.get('user', '?')}
+        async def me(conn):
+            return {'user': conn.state.get('user', '?')}
 
         with TestClient(app) as client:
             resp = client.get('/me')
@@ -387,8 +387,8 @@ class TestASGIMiddlewareCompat:
         app.use(_x_request_id)
 
         @app.route(path='/mw-test')
-        async def mw_test(scope):
-            return {'request_id': scope.state.get('x-request-id', '?')}
+        async def mw_test(conn):
+            return {'request_id': conn.state.get('x-request-id', '?')}
 
         with TestClient(app) as client:
             resp = client.get('/mw-test')
@@ -486,8 +486,8 @@ class TestExtensionWithTestClient:
                 a.extensions['b'] = self
 
                 @a.route(path='/b')
-                async def b_route(scope):
-                    return {'ext_a': scope.state.get('x-ext-a', 'no')}
+                async def b_route(conn):
+                    return {'ext_a': conn.state.get('x-ext-a', 'no')}
 
                 self._handler = b_route
 

--- a/tests/unit/test_h1_buffer.py
+++ b/tests/unit/test_h1_buffer.py
@@ -1,0 +1,134 @@
+"""``BufferedH1Reader`` — the buffer half of the H/1.1 protocol-mode front end.
+
+The two properties worth pinning are the ones the streams front end gets for
+free and a scanning front end has to earn: **nothing is lost to over-reading**,
+and **nothing suspends when the answer is already buffered**.
+"""
+import pytest
+
+from blackbull.server.h1_buffer import LIMIT_EXCEEDED, BufferedH1Reader
+from blackbull.server.recipient import IncompleteReadError
+
+
+class _FakeReader:
+    """Hands out pre-scripted chunks, one per ``read`` call.
+
+    Chunk boundaries are the point: a reader that always returns the whole
+    request in one call cannot exercise a delimiter split across two reads.
+
+    Implements the whole ``AbstractReader`` surface, because
+    :class:`BufferedH1Reader` delegates to the underlying reader whenever its
+    own buffer is empty — a double that only answers ``read`` would silently
+    exercise just the interposing half.
+    """
+
+    def __init__(self, *chunks: bytes):
+        self._chunks = list(chunks)
+        self.read_calls = 0
+
+    async def read(self, n: int = -1) -> bytes:
+        self.read_calls += 1
+        if n < 0:
+            out = b''.join(self._chunks)
+            self._chunks = []
+            return out
+        return self._chunks.pop(0) if self._chunks else b''
+
+    async def readexactly(self, n: int) -> bytes:
+        buf = bytearray()
+        while len(buf) < n:
+            chunk = await self.read(65536)
+            if not chunk:
+                raise IncompleteReadError(bytes(buf))
+            buf += chunk
+        self._chunks.insert(0, bytes(buf[n:]))
+        return bytes(buf[:n])
+
+    async def readuntil(self, sep: bytes = b'\n') -> bytes:
+        buf = bytearray()
+        while sep not in buf:
+            chunk = await self.read(65536)
+            if not chunk:
+                raise IncompleteReadError(bytes(buf))
+            buf += chunk
+        end = buf.find(sep) + len(sep)
+        self._chunks.insert(0, bytes(buf[end:]))
+        return bytes(buf[:end])
+
+
+@pytest.mark.asyncio
+async def test_surplus_past_the_delimiter_is_retained():
+    """The over-read that makes a single scan possible must not lose bytes."""
+    r = BufferedH1Reader(_FakeReader(b'HEAD\r\n\r\nBODYBYTES'))
+    idx = await r.fill_until(b'\r\n\r\n')
+    head = await r.readexactly(idx + 4)
+    assert head == b'HEAD\r\n\r\n'
+    assert await r.read(-1) == b'BODYBYTES'
+
+
+@pytest.mark.asyncio
+async def test_delimiter_split_across_two_reads_is_found():
+    """TCP may split anywhere, including through the terminator itself."""
+    r = BufferedH1Reader(_FakeReader(b'GET / HTTP/1.1\r\n\r', b'\nrest'))
+    assert await r.fill_until(b'\r\n\r\n') == 14
+
+
+@pytest.mark.asyncio
+async def test_delimiter_split_one_byte_per_read():
+    """The pathological fragmentation the HttpArena validator probes."""
+    payload = b'GET / HTTP/1.1\r\nH: v\r\n\r\n'
+    r = BufferedH1Reader(_FakeReader(*[payload[i:i + 1] for i in range(len(payload))]))
+    assert await r.fill_until(b'\r\n\r\n') == len(payload) - 4
+
+
+@pytest.mark.asyncio
+async def test_buffered_answer_costs_no_read_call():
+    """Keep-alive residency: a second head already in hand must not re-read.
+
+    ``read_calls`` is the observable proxy for a loop suspension — an await
+    that resolves from the buffer never reaches the transport.
+    """
+    r = BufferedH1Reader(_FakeReader(b'A\r\n\r\nB\r\n\r\n'))
+    await r.readexactly(await r.fill_until(b'\r\n\r\n') + 4)
+    calls_after_first = r.read_calls
+    idx = await r.fill_until(b'\r\n\r\n')          # second head, same buffer
+    assert idx == 1
+    assert r.read_calls == calls_after_first, 'second head should not re-read'
+
+
+@pytest.mark.asyncio
+async def test_limit_stops_an_endless_head():
+    """Without the bound, a peer that never terminates the head grows the
+    buffer until the process dies — the slow-loris shape."""
+    r = BufferedH1Reader(_FakeReader(*[b'x' * 100] * 50))
+    assert await r.fill_until(b'\r\n\r\n', limit=200) == LIMIT_EXCEEDED
+
+
+@pytest.mark.asyncio
+async def test_eof_without_delimiter_reports_minus_one():
+    r = BufferedH1Reader(_FakeReader(b'GET / HTTP/1.1\r\n'))
+    assert await r.fill_until(b'\r\n\r\n') == -1
+
+
+@pytest.mark.asyncio
+async def test_unread_puts_bytes_back_in_front():
+    r = BufferedH1Reader(_FakeReader(b'DEF'))
+    await r.read(1)
+    r.unread(b'ABC')
+    assert await r.read(3) == b'ABC'
+
+
+@pytest.mark.asyncio
+async def test_readexactly_short_read_raises_runtime_agnostic_error():
+    """Must raise the AbstractReader error, not asyncio's — the actor catches
+    the former and would otherwise let a real EOF escape as an unknown type."""
+    r = BufferedH1Reader(_FakeReader(b'AB'))
+    with pytest.raises(IncompleteReadError):
+        await r.readexactly(10)
+
+
+@pytest.mark.asyncio
+async def test_read_all_drains_buffer_and_stream():
+    r = BufferedH1Reader(_FakeReader(b'AB', b'CD', b'EF'))
+    assert await r.read(-1) == b'ABCDEF'
+    assert await r.read(-1) == b''

--- a/tests/unit/test_h1_buffer.py
+++ b/tests/unit/test_h1_buffer.py
@@ -132,3 +132,29 @@ async def test_read_all_drains_buffer_and_stream():
     r = BufferedH1Reader(_FakeReader(b'AB', b'CD', b'EF'))
     assert await r.read(-1) == b'ABCDEF'
     assert await r.read(-1) == b''
+
+
+def test_counts_as_an_abstract_reader():
+    """``RecipientFactory.http1`` wraps anything that is not an
+    :class:`AbstractReader` in an :class:`AsyncioReader` — **per request**.
+
+    ``BufferedH1Reader`` already presents the whole surface, so failing that
+    check bought nothing but an allocation on every request of every keep-alive
+    connection, paid only on the front end that exists to remove per-request
+    work.  Registration is what keeps the recipient talking to the buffer
+    directly.
+    """
+    from blackbull.server.recipient import AbstractReader
+
+    assert isinstance(BufferedH1Reader(_FakeReader(b'')), AbstractReader)
+
+
+def test_recipient_factory_does_not_rewrap_it():
+    """The property the registration exists for, at the call site that pays."""
+    from blackbull.server.recipient import RecipientFactory
+
+    reader = BufferedH1Reader(_FakeReader(b''))
+    recipient = RecipientFactory.http1(
+        reader, {'headers': [], 'path': '/'})
+
+    assert recipient._reader is reader

--- a/tests/unit/test_recipient_reuse.py
+++ b/tests/unit/test_recipient_reuse.py
@@ -1,0 +1,164 @@
+"""``HTTP1Recipient`` rebinding across keep-alive requests.
+
+The actor builds one recipient per *connection* and points it at each request
+in turn, the way it already reuses the sender.  What matters is that a rebound
+recipient is indistinguishable from a fresh one: request N+1 must see its own
+framing and its own body, never a remnant of request N.  Every test here
+asserts that through the ASGI events the recipient emits, not through its
+attributes.
+"""
+import pytest
+
+from blackbull.connection import Connection
+from blackbull.headers import Headers
+from blackbull.server.recipient import AsyncioReader, HTTP1Recipient
+
+
+class _Source:
+    """Serves a byte stream; ``feed`` appends the next request's body."""
+
+    def __init__(self, data: bytes = b''):
+        self._d = bytearray(data)
+
+    def feed(self, data: bytes) -> None:
+        self._d += data
+
+    async def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            out, self._d = bytes(self._d), bytearray()
+            return out
+        out = bytes(self._d[:n])
+        del self._d[:n]
+        return out
+
+    async def readuntil(self, sep: bytes = b'\n') -> bytes:
+        idx = self._d.find(sep)
+        if idx == -1:
+            from blackbull.server.recipient import IncompleteReadError
+            out, self._d = bytes(self._d), bytearray()
+            raise IncompleteReadError(out)
+        end = idx + len(sep)
+        out = bytes(self._d[:end])
+        del self._d[:end]
+        return out
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._d) < n:
+            from blackbull.server.recipient import IncompleteReadError
+            out, self._d = bytes(self._d), bytearray()
+            raise IncompleteReadError(out)
+        out = bytes(self._d[:n])
+        del self._d[:n]
+        return out
+
+
+def _conn(headers: list[tuple[bytes, bytes]], path: str = '/p') -> Connection:
+    return Connection(
+        type='http', http_version='1.1', method='POST', path=path,
+        raw_path=path.encode(), query_string=b'', headers=Headers(headers),
+        scheme='http',
+    )
+
+
+@pytest.mark.asyncio
+async def test_rebound_recipient_reads_the_second_request_body():
+    """The reuse hazard in one test: a recipient that stayed ``_done`` would
+    answer request N+1 with ``http.disconnect`` and the handler would see an
+    empty body."""
+    src = _Source(b'first')
+    r = HTTP1Recipient(AsyncioReader(src), _conn([(b'content-length', b'5')]))
+
+    assert (await r())['body'] == b'first'
+
+    src.feed(b'second!')
+    r.bind(_conn([(b'content-length', b'7')]))
+
+    event = await r()
+    assert event['type'] == 'http.request'
+    assert event['body'] == b'second!'
+
+
+@pytest.mark.asyncio
+async def test_rebind_re_derives_framing_from_the_new_headers():
+    """Content-Length → chunked on the next request: the framing comes from
+    the new head, not the one the object was built with."""
+    src = _Source(b'abc')
+    r = HTTP1Recipient(AsyncioReader(src), _conn([(b'content-length', b'3')]))
+    assert (await r())['body'] == b'abc'
+
+    src.feed(b'4\r\nwxyz\r\n0\r\n\r\n')
+    r.bind(_conn([(b'transfer-encoding', b'chunked')]))
+
+    body = b''
+    while True:
+        event = await r()
+        if event['type'] != 'http.request':
+            break
+        body += event['body']
+        if not event.get('more_body'):
+            break
+    assert body == b'wxyz'
+
+
+@pytest.mark.asyncio
+async def test_rebind_clears_broken_framing():
+    """``framing_broken`` closes the connection; it must not be inherited by a
+    request that never broke anything."""
+    r = HTTP1Recipient(AsyncioReader(_Source()), _conn([]))
+    r.framing_broken = True
+
+    r.bind(_conn([(b'content-length', b'2')]))
+
+    assert r.framing_broken is False
+    assert r.needs_drain() is True
+
+
+@pytest.mark.asyncio
+async def test_rebind_rejects_unsupported_transfer_encoding():
+    """``__init__`` raises on an encoding we do not implement; rebinding is the
+    same entry point for request N+1 and must not become a way past it."""
+    r = HTTP1Recipient(AsyncioReader(_Source()), _conn([]))
+
+    with pytest.raises(NotImplementedError):
+        r.bind(_conn([(b'transfer-encoding', b'gzip')]))
+
+
+@pytest.mark.asyncio
+async def test_actor_builds_one_recipient_per_connection():
+    """The reason the rebinding exists, asserted where the cost is paid."""
+    from blackbull import BlackBull
+    from blackbull.event_aggregator import EventAggregator
+    from blackbull.server import recipient as recipient_mod
+    from blackbull.server.http1_actor import HTTP1Actor
+
+    app = BlackBull()
+
+    @app.route(path='/keepalive')
+    async def handler(conn):
+        return 'ok'
+
+    req = (b'GET /keepalive HTTP/1.1\r\nHost: x\r\n\r\n')
+    src = _Source(req * 3)
+
+    built = 0
+    original = recipient_mod.HTTP1Recipient.__init__
+
+    def counting_init(self, *a, **kw):
+        nonlocal built
+        built += 1
+        return original(self, *a, **kw)
+
+    from blackbull.server.sender import AbstractWriter
+
+    class _NullWriter(AbstractWriter):
+        async def write(self, data: bytes) -> None: pass
+
+    recipient_mod.HTTP1Recipient.__init__ = counting_init
+    try:
+        actor = HTTP1Actor(AsyncioReader(src), _NullWriter(), app,
+                           EventAggregator(app._dispatcher))
+        await actor.run()
+    finally:
+        recipient_mod.HTTP1Recipient.__init__ = original
+
+    assert built == 1

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -588,6 +588,90 @@ class TestSimplifiedHandlerFailFast:
             _adapt_handler(fn, '/items/{id}')
 
 
+class TestScopeParameterRejected:
+    """``scope`` is not a name a simplified handler may take.
+
+    It used to be a deprecated alias injecting the ``Connection``, which is
+    precisely backwards: ``scope`` means a genuine ASGI scope dict everywhere
+    else in the codebase, so the alias handed you an object that answered to
+    the wrong name and invited ``scope['headers']``.  Rejecting it at
+    registration is what makes the mistake unwritable rather than merely
+    discouraged.
+    """
+
+    def test_scope_param_raises_at_registration(self):
+        async def fn(scope): pass
+        with pytest.raises(TypeError, match="parameter 'scope' is not supported"):
+            _adapt_handler(fn, '/')
+
+    def test_error_names_the_replacement(self):
+        """A fail-fast error that does not say what to do instead is a puzzle."""
+        async def fn(scope): pass
+        with pytest.raises(TypeError, match="conn"):
+            _adapt_handler(fn, '/')
+
+    def test_scope_is_not_silently_demoted_to_a_query_param(self):
+        """The regression this guards against.
+
+        With the alias simply deleted, ``scope`` would fall through to the
+        query-param fallback (an unannotated param defaults to ``str``) and a
+        handler would start receiving the *query string value* named "scope" —
+        or ``None`` — instead of failing.  Silent rebinding is worse than the
+        alias was.
+        """
+        async def fn(scope): pass
+        with pytest.raises(TypeError):
+            _adapt_handler(fn, '/')
+
+    def test_path_param_named_scope_still_wins(self):
+        """``/x/{scope}`` names the parameter explicitly — no ambiguity, so
+        the path category keeps its precedence over the rejection."""
+        async def fn(scope): return Response(str(scope).encode())
+        wrapper = _adapt_handler(fn, '/x/{scope}')
+        assert wrapper is not None
+
+    @pytest.mark.asyncio
+    async def test_conn_and_connection_still_inject(self):
+        """Removing the alias must not disturb the names it aliased."""
+        captured = {}
+
+        async def by_conn(conn): captured['v'] = conn
+        async def by_connection(connection): captured['v'] = connection
+
+        for fn in (by_conn, by_connection):
+            captured.clear()
+            fake_scope = {'type': 'http', 'headers': []}
+            await _adapt_handler(fn, '/')(fake_scope, None, AsyncMock())
+            assert captured['v'] is fake_scope['_connection'], (
+                f'{fn.__name__} did not receive the request Connection')
+
+    def test_full_form_handler_may_still_be_named_scope(self):
+        """Full form is positional — the router never reads those names, so
+        the ~196 ``(scope, receive, send)`` handlers in the corpus and the docs
+        are untouched by this change.  Narrowing the blast radius to simplified
+        handlers is why the removal is affordable at all.
+
+        The gate is ``_is_simplified_handler``: a full-form handler never
+        reaches ``_adapt_handler``, which is where the rejection lives.
+        """
+        async def fn(scope, receive, send): pass
+        assert _is_simplified_handler(fn) is False
+
+    def test_full_form_registration_survives_on_a_real_app(self):
+        """The end-to-end version of the above — registration must not raise."""
+        from blackbull.testing import TestClient
+
+        app = BlackBull()
+
+        @app.route(path='/full')
+        async def full(scope, receive, send):
+            await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+            await send({'type': 'http.response.body', 'body': b'ok'})
+
+        with TestClient(app) as client:
+            assert client.get('/full').status_code == 200
+
+
 class TestSimplifiedHandlerPathParams:
     @pytest.mark.asyncio
     async def test_no_params(self):
@@ -631,15 +715,17 @@ class TestSimplifiedHandlerPathParams:
             await wrapper({'path_params': {'task_id': 'notanint'}}, None, AsyncMock())
 
     @pytest.mark.asyncio
-    async def test_scope_escape_hatch(self):
-        # Sprint 80: the ``scope`` param is an escape hatch to the raw request,
-        # which is now the native Connection (not an ASGI scope dict).
+    async def test_conn_escape_hatch(self):
+        # The escape hatch to the raw request is ``conn``: the native
+        # Connection, not an ASGI scope dict.  It was reachable as ``scope``
+        # until that alias was removed — the name promised a dict and
+        # delivered a Connection, which is the whole reason it is gone.
         captured = {}
-        async def fn(scope): captured['scope'] = scope
+        async def fn(conn): captured['conn'] = conn
         wrapper = _adapt_handler(fn, '/')
         fake_scope = {'type': 'http', 'method': 'GET', 'path': '/', 'headers': []}
         await wrapper(fake_scope, None, AsyncMock())
-        assert captured['scope'] is fake_scope['_connection']
+        assert captured['conn'] is fake_scope['_connection']
 
 
 class TestSimplifiedHandlerBodyInjection:
@@ -733,18 +819,18 @@ class TestSimplifiedHandlerRequestInjection:
         assert isinstance(captured['request'], Request)
 
     @pytest.mark.asyncio
-    async def test_request_with_scope(self):
+    async def test_request_with_conn(self):
         captured = {}
-        async def fn(scope, request: Request):
-            captured.update({'scope': scope, 'request': request})
+        async def fn(conn, request: Request):
+            captured.update({'conn': conn, 'request': request})
         wrapper = _adapt_handler(fn, '/')
         fake_scope = {'type': 'http', 'headers': []}
         await wrapper(fake_scope, None, AsyncMock())
-        # Both the ``scope`` and ``request`` params now resolve to the one
-        # native Connection for the request.
-        assert captured['scope'] is fake_scope['_connection']
+        # Both the ``conn`` and ``request`` params resolve to the one native
+        # Connection for the request.
+        assert captured['conn'] is fake_scope['_connection']
         assert captured['request'] is fake_scope['_connection']
-        assert captured['scope'] is captured['request']
+        assert captured['conn'] is captured['request']
 
     @pytest.mark.asyncio
     async def test_request_with_dataclass_body_single_drain(self):


### PR DESCRIPTION
Closes Sprint 84.  Single PR rather than the usual feature-PR-then-release-PR
pair: the six sprint commits were never merged to master, so splitting them
would cost two gated merges for one sprint's worth of content.  The release
commit itself is still edit-only (`pyproject.toml` + `CHANGELOG.md`).

**Version pick.** MINOR, not the PATCH originally scoped.  Workstream A's only
user-visible payload is a breaking removal (the `scope` handler-parameter
alias), and both `release.md` ("behaviour changes → MINOR") and the standing
rule from the v0.54.0 stop ("once master carries an unreleased breaking change,
the next release must be a MINOR") point the same way.  It rides Workstream B's
substantive payload rather than shipping alone.

## Summary

**Workstream A — the test gate.**  33 integration/conformance tests had rotted
against a single root cause: a handler written for an ASGI scope dict while
native dispatch hands it a `Connection`.  Three layers had to fail at once for
them to sit red unnoticed — the `integration` marker default-skips locally, the
only job passing `--run-integration` was gated on `schedule`, and on 3.14 they
errored at fixture setup.  All three are closed: integration now gates PRs
(3526 tests, ~98s), the fast tier runs 3.11/3.12/3.13/3.14, and a failing
scheduled Full tier files an issue.  `tests/architecture/test_native_handler_contract.py`
forbids the shape repo-wide.

**Workstream A′ — the `scope` alias, removed.**  Blast radius was 4 handlers,
not the ~200 first estimated: the alias only ever applied to *simplified*
handlers, where parameter names drive injection.  Rejecting the name at
registration (rather than merely dropping the alias) is deliberate — an
unannotated `scope` would otherwise fall through to the query-param fallback
and silently start receiving a query-string value instead of the request.

**Workstream B — H/1.1 fast path, phases 1a and 2.**  `BB_H1_PROTOCOL` adds a
buffer-owning read front end behind a default-off flag.  Phase 2 makes
keep-alive build one recipient and one `RequestActor` per *connection*:
17.46 → 16.25 µs/req (−6.9%).

## Test plan

- [x] 5445 tests, default tier (beartype-instrumented pre-commit gate)
- [x] 3526 integration + conformance under `BB_H1_PROTOCOL=0` **and** `=1`
- [x] Http11Probe 213 vectors: 0 failed, 0 errors — identical per-test verdict
      on both front ends and before/after the Phase 2 rebind.  That is the
      check that matters for a rebind: the framing state `bind` resets is
      exactly what request smuggling exploits when it leaks between requests.
- [x] `just typecheck` clean
- [x] `blackbull.__version__` → 0.65.0 after `uv pip install -e .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)