### PR TITLE
release: v0.66.0 — Sprints 85+86: parser C-level bulk ops + write timeout off the hot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,22 @@ bench/results/baselines/*
 !bench/results/baselines/pre_sprint9d/
 bench/results/baselines/pre_sprint9d/*
 !bench/results/baselines/pre_sprint9d/README.md
+
+# Bench output that landed at the repo root instead of under
+# bench/results/<run>/.  The harness itself anchors every artifact to its
+# result dir (`httparena_compare.sh` writes `$LOCAL_DEST/…`, `compare_table.py`
+# joins onto `result_dir`), so this only happens when one of those scripts is
+# invoked by hand with the repo root as its result dir — and then the rsync of
+# the remote HttpArena checkout drops ~480 files here, which is enough to bury
+# a real diff in `git status`.
+#
+# Anchored with a leading slash so it matches only the root: the legitimate
+# copies inside bench/results/ are already covered above, and a future
+# docs/COMPARISON.md or a nested provenance.md stays trackable.
+/httparena-tree/
+/COMPARISON.md
+/provenance.md
+/driver.log
 # bench/aws — runtime state and SSH private keys created by up.sh
 bench/aws/.state
 bench/aws/.known_hosts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ so the editable install's metadata catches up.
 
 ---
 
-## [Unreleased]
+## [0.66.0] — 2026-07-30
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,31 @@ so the editable install's metadata catches up.
 
 ### Changed
 
+- **The HTTP/1.1 parser validates octets with C-level bulk operations.**  The
+  request-target scan, the Host authority scan, and the field-name token check
+  were per-byte Python generator expressions or regexes; each is now a single
+  `bytes.translate` delete-table pass or a precompiled character class,
+  whichever the set size favours.  Field values are checked **once for the
+  whole header block** instead of once per header: deleting every permitted
+  octet leaves only CR, LF and forbidden CTLs, and a residue that tiles into
+  CRLF pairs proves no value can carry a forbidden octet.  A block that fails
+  the pre-scan falls back to the per-header regex, so every error message and
+  status code is unchanged — Http11Probe re-scores 159/159 with a
+  **per-test verdict diff that is empty across all 213 vectors**.  Measured on
+  a Zen 4 box: per-header cost **0.510 → 0.346 µs**, fixed cost **4.53 → 3.57
+  µs**, and a 32-header request **20.33 → 14.25 µs (−30 %)**.
+- **Header names are lowercased once instead of twice.**  `_parse` already
+  lowercases each name while validating it, then handed the list to
+  `Headers.__init__`, which lowercased every name again; `Headers.from_lowered`
+  is the alternate constructor for callers that can guarantee pre-lowered
+  input.  HTTP/2 qualifies by protocol — RFC 9113 §8.2.1 makes an uppercase
+  field name malformed and the frame is rejected before any pair reaches the
+  header list.  `Headers` lookups (`get`, `getlist`, `__contains__`,
+  `__getitem__`, and the Structured Fields accessors) now probe with the
+  caller's bytes before lowercasing.  The index is keyed lowercased, so the
+  probe can only hit on a key the old path would also have found — a
+  lowercase literal, which is what essentially every internal call site
+  passes, drops from 47 to 25 ns.
 - **`BB_WRITE_TIMEOUT` no longer arms a timer per response.**  It defaults to
   `30.0`, so every write took `asyncio.wait_for` — exactly one `loop.call_at`
   per response, which the loop-touch instrument read as `call_at=1.00`/req.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,32 @@ so the editable install's metadata catches up.
   now runs on every push/PR.  Current budgets: HTTP/1.1 2.20, HTTP/2 5.40,
   WebSocket 4.30 touches per request.
 
+### Docs
+
+- **Sprint numbers and private defect IDs removed from comments and
+  docstrings** across 249 files.  A docstring is read by users, who cannot
+  resolve `Sprint 79` or `bug 1.16` — and `git log`, this changelog and the
+  sprint logs already own the timeline.  Migration narration was rewritten as
+  present-tense fact ("Sprint 64 moved emission from the server layer" →
+  "Emission is consolidated into `_dispatch`").  Externally resolvable
+  references are kept: RFC and CVE citations, Http11Probe/Autobahn vector
+  names, and GitHub issue numbers.  Excluded deliberately: `bench/results/**`,
+  `bench/CHARACTERIZATION.md` and `docs/about/grpc-assessment.md`, which *are*
+  the record.
+- **`docs/about/internals.md` gains a §Parse-path invariant** documenting the
+  delete-the-allowed-table idiom, the whole-block value pre-scan, and a table
+  of three plausible optimisations that were measured and rejected, so they
+  are not retried blind.
+- **`KNOWN_LIMITATIONS.md` static-file section corrected.**  It claimed
+  `StaticFiles` emits no `ETag` and had to be paired with the `Cache`
+  middleware; `StaticFiles` has emitted a strong `ETag` + `Last-Modified` and
+  answered `If-None-Match` / `If-Modified-Since` by default since
+  `conditional=True` became the default.  The section now also states the
+  route-dispatch consequence for a miss under the prefix.
+- **`Headers` class docstring corrected** — it still said every accessor
+  lowercases the requested name, which stopped being true with the
+  probe-first lookup fast path.
+
 ## [0.65.0] — 2026-07-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,25 @@ so the editable install's metadata catches up.
   probe can only hit on a key the old path would also have found — a
   lowercase literal, which is what essentially every internal call site
   passes, drops from 47 to 25 ns.
+- **`app.static()` registers a route instead of global middleware.**  Static
+  serving no longer runs on every request: `<prefix>/{filepath:path}` (plus
+  `<prefix>` and `<prefix>/`, so `index=` can still answer the mount root)
+  resolves in the router, and a non-static request never enters `StaticFiles`
+  at all.  This is also what Starlette, Sanic, aiohttp, Flask and Django all
+  do.  The production gate is resolved once and memoised rather than calling
+  `get_settings()` per request.  **Behaviour change**: a miss under the prefix
+  is now answered 404 by the static route rather than falling through to
+  another route that also matches the prefix; the 404 takes the normal error
+  path, so `@app.on_error(HTTPStatus.NOT_FOUND)` still applies.  An explicit
+  route on the bare prefix always wins — `app.static()` never replaces a path
+  you registered yourself.
+- **`Compression` no longer parses body events on its no-codec path.**  When
+  the client accepts nothing the server can produce, the response is forwarded
+  verbatim through a wrapper that stamps `Vary: Accept-Encoding` on the
+  response start (bug 1.21f).  That wrapper ran `parse_response_event` on
+  every event, allocating a `ResponseBody` copy of each body chunk only for
+  the next line's `isinstance` to reject it.  It now discriminates on the raw
+  event type first, so a streamed body costs one dict lookup per chunk.
 - **`BB_WRITE_TIMEOUT` no longer arms a timer per response.**  It defaults to
   `30.0`, so every write took `asyncio.wait_for` — exactly one `loop.call_at`
   per response, which the loop-touch instrument read as `call_at=1.00`/req.

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -170,10 +170,18 @@ next request with no staleness window.  Default is `cache=False`;
 standalone deployments serving static traffic directly should opt
 in to keep prior performance.
 
-`StaticFiles` itself emits no `ETag`; pair it with the `Cache`
-middleware for ETag / `If-None-Match` revalidation (`blackbull serve`
-does this for you).  Byte-range-multipart responses are not
-implemented across any of the three paths.
+`StaticFiles` emits a strong `ETag` (over mtime + size) and
+`Last-Modified`, and answers `If-None-Match` / `If-Modified-Since`
+with a `304`, on by default via `conditional=True`.  Pass
+`conditional=False` to suppress the validators.  Byte-range-multipart
+responses are not implemented across any of the three paths.
+
+`app.static()` registers a route rather than global middleware, so a
+request that is not for a static path never enters `StaticFiles`.  The
+consequence to plan around: a miss *under* the prefix is answered `404`
+by the static route rather than falling through to another route that
+also matches the prefix.  Fully-static routes still resolve first, so
+only an overlapping *parametrised* route is affected.
 
 ### `Depends` is deliberately minimal; query params are scalars only
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Compose via `app.use(...)` or per-route `middlewares=[...]`:
 | Middleware       | What it does |
 |------------------|---|
 | `Compression`    | Negotiates `br` / `zstd` / `gzip` from `Accept-Encoding` |
-| `StaticFiles`    | Serves files from a directory under a URL prefix |
+| `StaticFiles`    | Serves files from a directory under a URL prefix — register with `app.static(prefix, root)`, which attaches it to a route |
 | `Cache`          | Per-worker LRU + ETag / `Cache-Control` honouring |
 | `CORS`           | Preflight + actual-request header injection |
 | `TrustedProxy`   | Rewrites `scope['client']` / `scope['scheme']` from proxy headers |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.66.x  | :white_check_mark: |
 | 0.65.x  | :white_check_mark: |
-| 0.64.x  | :white_check_mark: |
-| < 0.64  | :x:                |
+| < 0.65  | :x:                |
 
 This table updates with each minor release.
 

--- a/bench/app.py
+++ b/bench/app.py
@@ -41,7 +41,7 @@ from blackbull import BlackBull, Connection, Response
 from blackbull.utils import Scheme
 from bench.lag_monitor import LoopLagMonitor
 
-# Sprint 28 Task 2 — soak harness hook.  Set BB_TRACEMALLOC=1 to start
+# Soak harness hook.  Set BB_TRACEMALLOC=1 to start
 # tracemalloc at import (before any allocation we care about happens
 # in BlackBull's own setup) and expose a /tracemalloc endpoint that
 # returns the current top-N allocation snapshot as JSON.  Bench-only
@@ -210,7 +210,7 @@ def _parse_args():
     p.add_argument('--cert', default='cert.pem')
     p.add_argument('--key',  default='key.pem')
     p.add_argument('--no-tls', action='store_true',
-                   help='Listen on plain HTTP (no TLS).  Used by Sprint 27 profile '
+                   help='Listen on plain HTTP (no TLS).  Used by the profile '
                         'lanes to isolate framework cost from TLS-stack cost; mirrors '
                         'the common production topology where TLS is offloaded to '
                         'nginx.  See bench/aws/profile_lanes.sh BB_TLS=0.')
@@ -218,7 +218,7 @@ def _parse_args():
                    help='Enable the benchmark.BenchmarkService/GetSum unary gRPC '
                         'method (bench/httparena/grpc_bench.py) alongside the HTTP '
                         'routes.  Used by the coalescer G1 fan-out experiment '
-                        '(Sprint 77): a single connection carrying many concurrent '
+                        'a single connection carrying many concurrent '
                         'unary RPCs is the ConnCoalescer killer case.')
     p.add_argument('--workers', type=int, default=None,
                    help='Worker processes (default BB_WORKERS env or 1; 0 = cpu_count)')

--- a/bench/aws/config.sh
+++ b/bench/aws/config.sh
@@ -16,7 +16,7 @@
 : "${VOLUME_SIZE_GB:=20}"     # /dev/sda1 root volume — generous for venv + apt
 
 # --- Topology -------------------------------------------------------------
-# Sprint 20: TOPO=single keeps the historical one-host loopback bench
+# TOPO=single keeps the historical one-host loopback bench
 # unchanged (server and load generator share the c7i.xlarge); TOPO=split
 # launches a second LOADGEN instance in a cluster placement group and
 # drives the bench over VPC private networking.  Numbers from the two

--- a/bench/aws/down.sh
+++ b/bench/aws/down.sh
@@ -20,7 +20,7 @@ source "$(dirname "$0")/config.sh"
 _bench_aws_check_env || exit 1
 _bench_aws_load_state || exit 1
 
-# Backward-compat: pre-Sprint-20 state files only have INSTANCE_ID/PUBLIC_IP.
+# Backward-compat: legacy state files only have INSTANCE_ID/PUBLIC_IP.
 SERVER_INSTANCE_ID="${SERVER_INSTANCE_ID:-${INSTANCE_ID:-}}"
 LOADGEN_INSTANCE_ID="${LOADGEN_INSTANCE_ID:-}"
 TOPO="${TOPO:-single}"

--- a/bench/aws/httparena_compare.sh
+++ b/bench/aws/httparena_compare.sh
@@ -261,7 +261,7 @@ ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
 
 # ---------------------------------------------------------------------------
 # Step 2 — install Docker + HttpArena load-generator tooling (gcannon,
-# wrk, h2load, ghz).  Sprint 28 Task 4: the Task 3 first pass skipped these
+# wrk, h2load, ghz).  An earlier pass skipped these
 # and HttpArena's benchmark.sh reported 0 req/s for every run.
 #
 # liburing 2.9 + gcannon build from source (HttpArena's docs as of

--- a/bench/aws/httparena_compare.sh
+++ b/bench/aws/httparena_compare.sh
@@ -18,7 +18,8 @@
 #   PROFILES   space-separated HttpArena profile names
 #              (default: "baseline json json-tls static")
 #   FRAMEWORKS space-separated framework names to run
-#              (default: "blackbull fastapi")
+#              (default: "blackbull fastapi";
+#               supported: blackbull, blackbull-uvloop, fastapi, sanic)
 #   BLACKBULL_VERSION  PyPI version pin (default: pyproject.toml's version)
 #   SPRINT_TAG  prefix on the result directory (default: sprint29)
 #   SKIP_VALIDATE   set to 1 to skip the 49-point correctness check
@@ -87,12 +88,18 @@ export TOPO=single
 
 : "${PROFILES:?must be set explicitly, space-separated (e.g. 'baseline baseline-h2 echo-ws json json-comp json-tls limited-conn pipelined static static-h2 upload')}"
 FRAMEWORKS="${FRAMEWORKS:-blackbull fastapi}"
-# Supported frameworks: blackbull, fastapi, sanic
+# Supported frameworks: blackbull, blackbull-uvloop, fastapi, sanic
 KEEP_INSTANCE="${KEEP_INSTANCE:-0}"
 SKIP_VALIDATE="${SKIP_VALIDATE:-0}"
-# BB_UVLOOP: baked into the BlackBull image ENV. Default 0 (pure-Python event
-# loop) so the identity measurement is the default; pass BB_UVLOOP=1 to bench
-# the uvloop path.
+# BB_UVLOOP: baked into the `blackbull` image ENV. Default 0 (pure-Python event
+# loop) so the identity measurement is the default.
+#
+# To measure what uvloop is worth, do NOT flip this and compare against an
+# earlier run — put `blackbull blackbull-uvloop` in $FRAMEWORKS instead.  The
+# `blackbull-uvloop` variant is the same wheel and the same app with
+# BB_UVLOOP=1, so both loops are measured on one instance in one session
+# against the same peers, and the delta is not confounded by the machine, the
+# generator, or the day.
 BB_UVLOOP="${BB_UVLOOP:-0}"
 
 # --- Web server tuning defaults -------------------------------------------
@@ -379,12 +386,25 @@ scp "${SSH_OPTS[@]}" "$REPO_ROOT/bench/httparena/patch_cpuset.sh" \
 ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" 'bash ~/patch_cpuset.sh'
 
 # ---------------------------------------------------------------------------
-# Step 4 — vendor bench/httparena/ as the `blackbull` framework.  Rewrite
-# the Dockerfile to install from PyPI.  Flip meta.json enabled=true so
-# HttpArena's harness picks it up.
+# Step 4 — vendor bench/httparena/ as one framework dir per BlackBull variant.
+# Rewrite the Dockerfile to install from PyPI (or the local wheel).  Flip
+# meta.json enabled=true so HttpArena's harness picks it up.
+#
+# Two variants may be requested in the same run:
+#
+#   blackbull          BB_UVLOOP=$BB_UVLOOP   (default 0 — the shipped default)
+#   blackbull-uvloop   BB_UVLOOP=1
+#
+# Naming both in $FRAMEWORKS puts the two event loops on the *same instance in
+# the same session*, alongside the same peers.  That is the only way to read the
+# uvloop delta as a property of BlackBull rather than of the box: the two images
+# differ in exactly one ENV line — same wheel, same app.py, same launcher.py —
+# so nothing else can account for a gap between them.
+#
+# BB_UVLOOP is set in its own ENV layer at the very end of the Dockerfile.  It
+# is not needed at build time, and keeping it after the pip install lets the two
+# variants share every expensive layer: the second image builds in seconds.
 # ---------------------------------------------------------------------------
-echo ">>> staging blackbull framework dir on the instance ..."
-ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" 'mkdir -p HttpArena/frameworks/blackbull'
 
 # Upload framework files.  In LOCAL_BB_WHEEL=1 mode the wheel is also
 # uploaded so the Dockerfile can COPY+install it from the build context.
@@ -399,36 +419,45 @@ _BB_RSYNC_FILES=(
     "$REPO_ROOT/bench/httparena/db.py"
     "$REPO_ROOT/bench/httparena/grpc_bench.py"
 )
-rsync -e "ssh ${SSH_OPTS[*]}" -az --delete \
-    "${_BB_RSYNC_FILES[@]}" \
-    "$SERVER_REMOTE:HttpArena/frameworks/blackbull/"
-
-# The upstream HttpArena repo vendors a stale frameworks/blackbull/.dockerignore
-# that whitelists only requirements.txt/app.py/launcher.py and excludes
-# everything else (`**`), so db.py / grpc_bench.py never enter the Docker build
-# context and `COPY ... db.py` fails the build.  We don't rsync .dockerignore
-# (so --delete won't remove it), and our rsync already controls exactly which
-# files land in the dir — so just delete the stale ignore file.  Print the
-# resulting build context so the driver log records what the build will see.
-ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
-    'rm -f HttpArena/frameworks/blackbull/.dockerignore
-     echo "    build context:"; ls -1 HttpArena/frameworks/blackbull/'
-
-if [ "$LOCAL_BB_WHEEL" = "1" ]; then
-    echo "    uploading wheel $LOCAL_WHEEL_NAME ..."
-    rsync -e "ssh ${SSH_OPTS[*]}" -az \
-        "$LOCAL_WHEEL" \
-        "$SERVER_REMOTE:HttpArena/frameworks/blackbull/"
-fi
 
 # Access logging is now configured via env vars (BB_LOG_FILE from the shim +
 # BB_ACCESS_LOG), so no logging config file is COPYed into the image.
 _LOGGING_INI_COPY=''
 
-# Generate the Dockerfile on the remote instance.
-if [ "$LOCAL_BB_WHEEL" = "1" ]; then
-    # Dockerfile.dev style: COPY the local wheel, install from it.
-    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "cat > HttpArena/frameworks/blackbull/Dockerfile" <<EOF
+_stage_blackbull() {
+    local fw="$1" uvloop="$2"
+    local dir="HttpArena/frameworks/${fw}"
+
+    echo ">>> staging ${fw} framework dir on the instance (BB_UVLOOP=${uvloop}) ..."
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "mkdir -p ${dir}"
+
+    rsync -e "ssh ${SSH_OPTS[*]}" -az --delete \
+        "${_BB_RSYNC_FILES[@]}" \
+        "$SERVER_REMOTE:${dir}/"
+
+    # The upstream HttpArena repo vendors a stale
+    # frameworks/blackbull/.dockerignore that whitelists only
+    # requirements.txt/app.py/launcher.py and excludes everything else (`**`),
+    # so db.py / grpc_bench.py never enter the Docker build context and
+    # `COPY ... db.py` fails the build.  We don't rsync .dockerignore (so
+    # --delete won't remove it), and our rsync already controls exactly which
+    # files land in the dir — so just delete the stale ignore file.  Print the
+    # resulting build context so the driver log records what the build sees.
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "rm -f ${dir}/.dockerignore
+         echo '    build context:'; ls -1 ${dir}/"
+
+    if [ "$LOCAL_BB_WHEEL" = "1" ]; then
+        echo "    uploading wheel $LOCAL_WHEEL_NAME ..."
+        rsync -e "ssh ${SSH_OPTS[*]}" -az \
+            "$LOCAL_WHEEL" \
+            "$SERVER_REMOTE:${dir}/"
+    fi
+
+    # Generate the Dockerfile on the remote instance.
+    if [ "$LOCAL_BB_WHEEL" = "1" ]; then
+        # Dockerfile.dev style: COPY the local wheel, install from it.
+        ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "cat > ${dir}/Dockerfile" <<EOF
 # Auto-generated by bench/aws/httparena_compare.sh (LOCAL_BB_WHEEL=1).
 # Installs BlackBull from a locally-built wheel instead of PyPI.
 FROM python:3.13-slim
@@ -437,8 +466,7 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \\
     PYTHONUNBUFFERED=1 \\
     PIP_NO_CACHE_DIR=1 \\
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \\
-    BB_UVLOOP=${BB_UVLOOP}
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 COPY ${LOCAL_WHEEL_NAME} /tmp/
 # asyncpg + redis back the async-db / crud profiles (Postgres + Redis sidecars).
@@ -447,11 +475,14 @@ VOLUME /results
 
 COPY app.py launcher.py db.py grpc_bench.py /app/
 ${_LOGGING_INI_COPY}
+# Last layer, and the only one that differs between the blackbull variants —
+# everything above is shared cache.
+ENV BB_UVLOOP=${uvloop}
 EXPOSE 8080 8081 8443
 CMD ["python", "launcher.py"]
 EOF
-else
-    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "cat > HttpArena/frameworks/blackbull/Dockerfile" <<EOF
+    else
+        ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "cat > ${dir}/Dockerfile" <<EOF
 # Auto-generated by bench/aws/httparena_compare.sh.
 # Installs BlackBull from PyPI (no source tree on the instance).
 FROM python:3.13-slim
@@ -460,32 +491,45 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 \\
     PYTHONUNBUFFERED=1 \\
     PIP_NO_CACHE_DIR=1 \\
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \\
-    BB_UVLOOP=${BB_UVLOOP}
+    PIP_DISABLE_PIP_VERSION_CHECK=1
 
 RUN pip install --no-cache-dir 'blackbull[compression,speed]==${BLACKBULL_VERSION}' asyncpg redis
 VOLUME /results
 
 COPY app.py launcher.py db.py grpc_bench.py /app/
 ${_LOGGING_INI_COPY}
+# Last layer, and the only one that differs between the blackbull variants —
+# everything above is shared cache.
+ENV BB_UVLOOP=${uvloop}
 EXPOSE 8080 8081 8443
 CMD ["python", "launcher.py"]
 EOF
-fi
+    fi
 
-# Flip meta.json enabled=true on the remote copy.
-ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
-    'sed -i "s/\"enabled\": false/\"enabled\": true/" HttpArena/frameworks/blackbull/meta.json'
+    # Flip meta.json enabled=true, and name the variant after its own dir so
+    # HttpArena's report does not show two rows both called "blackbull".
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "sed -i 's/\"enabled\": false/\"enabled\": true/;
+                 s/\"display_name\": \"blackbull\"/\"display_name\": \"${fw}\"/' \
+             ${dir}/meta.json"
 
-# Place a build.sh alongside the Dockerfile so HttpArena's validate.sh
-# calls it instead of `docker build --no-cache`.  Our build.sh omits
-# --no-cache so Docker can reuse the pip layer from Step 5's pre-build.
-ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
-    'printf "#!/usr/bin/env bash\nset -euo pipefail\nSCRIPT_DIR=\"\$(cd \"\$(dirname \"\$0\")\" && pwd)\"\nFRAMEWORK=\"\$(basename \"\$SCRIPT_DIR\")\"\nIMAGE_NAME=\"httparena-\${FRAMEWORK}\"\ndocker build -t \"\$IMAGE_NAME\" \"\$SCRIPT_DIR\"\n" \
-        > HttpArena/frameworks/blackbull/build.sh \
-     && chmod +x HttpArena/frameworks/blackbull/build.sh'
+    # Place a build.sh alongside the Dockerfile so HttpArena's validate.sh
+    # calls it instead of `docker build --no-cache`.  Our build.sh omits
+    # --no-cache so Docker can reuse the pip layer from Step 5's pre-build.
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "printf '#!/usr/bin/env bash\nset -euo pipefail\nSCRIPT_DIR=\"\$(cd \"\$(dirname \"\$0\")\" && pwd)\"\nFRAMEWORK=\"\$(basename \"\$SCRIPT_DIR\")\"\nIMAGE_NAME=\"httparena-\${FRAMEWORK}\"\ndocker build -t \"\$IMAGE_NAME\" \"\$SCRIPT_DIR\"\n' \
+            > ${dir}/build.sh \
+         && chmod +x ${dir}/build.sh"
 
-echo "    staged."
+    echo "    ${fw} staged."
+}
+
+for fw in $FRAMEWORKS; do
+    case "$fw" in
+        blackbull)        _stage_blackbull blackbull "$BB_UVLOOP" ;;
+        blackbull-uvloop) _stage_blackbull blackbull-uvloop 1 ;;
+    esac
+done
 
 # ---------------------------------------------------------------------------
 # Step 4b — stage bench/httparena/sanic/ as the `sanic` framework.
@@ -549,6 +593,41 @@ for fw in $FRAMEWORKS; do
         fi
         echo \"    image \$IMAGE_NAME ready.\"
     " || echo "    (pre-build non-zero for $fw — kept going)"
+done
+
+# ---------------------------------------------------------------------------
+# Step 5b — prove which event loop each BlackBull image will actually run.
+#
+# The dangerous failure is silent: with BB_UVLOOP=1 but no uvloop in the image,
+# ``apply_event_loop_policy`` logs a warning and keeps the stock loop, and the
+# arm still produces a full set of plausible numbers — which then read as
+# "uvloop bought nothing".  So ask the image itself, through BlackBull's own
+# policy installer, and abort the run rather than measure a mislabelled arm.
+# ---------------------------------------------------------------------------
+_LOOP_PROBE='
+import asyncio, os
+from blackbull.env import apply_event_loop_policy, reset_settings_cache
+reset_settings_cache()
+apply_event_loop_policy()
+loop = asyncio.new_event_loop()
+print("BB_UVLOOP=" + str(os.environ.get("BB_UVLOOP"))
+      + " loop=" + type(loop).__module__ + "." + type(loop).__name__)
+loop.close()
+'
+for fw in $FRAMEWORKS; do
+    case "$fw" in blackbull|blackbull-uvloop) ;; *) continue ;; esac
+    _want=$([ "$fw" = "blackbull-uvloop" ] && echo 1 || echo "$BB_UVLOOP")
+    echo ">>> verifying event loop for $fw (expect BB_UVLOOP=${_want}) ..."
+    _probe=$(ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "sudo docker run --rm --entrypoint python httparena-${fw} -c '${_LOOP_PROBE}'" \
+        2>&1 | tail -1) || true
+    echo "    $_probe"
+    case "$_want:$_probe" in
+        1:*uvloop*)   echo "    OK — uvloop active." ;;
+        0:*asyncio*)  echo "    OK — stock asyncio loop." ;;
+        *) echo "FATAL: $fw did not get the intended event loop (wanted BB_UVLOOP=${_want}); probe said: ${_probe}" >&2
+           exit 1 ;;
+    esac
 done
 
 # ---------------------------------------------------------------------------

--- a/bench/aws/install.sh
+++ b/bench/aws/install.sh
@@ -12,7 +12,7 @@
 #   4. install tests/cert.pem into the system CA store
 #   5. smoke test: pytest -q tests/unit/
 #
-# TOPO=split (Sprint 20):
+# TOPO=split:
 #   1. same as above on the SERVER, **plus** regenerate tests/cert.pem
 #      with bench-server.internal + server private IP as SANs and reinstall
 #      in the server's CA store.
@@ -30,7 +30,7 @@ source "$(dirname "$0")/config.sh"
 _bench_aws_check_env
 _bench_aws_load_state
 
-# Backward-compat with pre-Sprint-20 state files.
+# Backward-compat with legacy state files.
 SERVER_INSTANCE_ID="${SERVER_INSTANCE_ID:-${INSTANCE_ID:-}}"
 SERVER_PUBLIC_IP="${SERVER_PUBLIC_IP:-${PUBLIC_IP:-}}"
 SERVER_PRIVATE_IP="${SERVER_PRIVATE_IP:-}"
@@ -172,7 +172,7 @@ sudo sysctl --quiet -p /etc/sysctl.d/99-blackbull-bench.conf
 echo "=== Smoke test ==="
 .venv/bin/python -m pytest -q tests/unit/ --timeout=30 -x 2>&1 | tail -5
 
-echo "=== Server CPU topology (Sprint 21 Phase B) ==="
+echo "=== Server CPU topology ==="
 mkdir -p bench/results
 {
     echo "# Server CPU topology — captured at bench install time."

--- a/bench/aws/loop_ab_nginx.sh
+++ b/bench/aws/loop_ab_nginx.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# bench/aws/loop_ab_nginx.sh — what uvloop is worth on CPython, behind nginx.
+#
+# Topology (the one you'd actually deploy):
+#
+#   wrk -c$CONNS -> nginx :8443 (TLS terminated, upstream keep-alive pool)
+#                -> BlackBull :8444 (cleartext HTTP/1.1)
+#
+# nginx is the constant: one binary, one config, started once, never
+# restarted between arms.  The only thing that changes is the upstream's
+# event loop.
+#
+#   arm A = BB_UVLOOP=1   (libuv)
+#   arm B = BB_UVLOOP=0   (stock asyncio)
+#
+# Both arms run on ONE instance in ONE session, and the arms are
+# INTERLEAVED across $CYCLES repetitions (A B A B A B), not run once each
+# back to back.  Two reasons, both learned the hard way:
+#
+#   - A single window per arm reports no spread, so a small delta cannot be
+#     told apart from one arm drawing a luckier window.
+#   - Running all of A then all of B aliases the arm against anything that
+#     drifts monotonically during the run (page cache, thermal, a noisy
+#     neighbour).  Interleaving decorrelates the arm from wall-clock.
+#
+# Never compare an arm here against a number from a different invocation:
+# the machine, the AMI, the kernel and the build all move between runs.
+# The delta this script prints is the only supported reading.
+#
+# Usage:
+#   INSTANCE_TYPE=m7a.2xlarge bash bench/aws/loop_ab_nginx.sh
+#
+# Env knobs:
+#   INSTANCE_TYPE  EC2 type for the single host        (default m7a.2xlarge)
+#   CYCLES         interleaved A/B repetitions         (default 3)
+#   PROFILES       routes to measure, space-separated  (default "ping json")
+#   WEB_WORKERS    BlackBull worker processes          (default 3)
+#   NGINX_WORKERS  nginx worker_processes              (default 2)
+#   CONNS/THREADS  wrk connections / threads           (default 256 / 4)
+#   WARMUP         per-arm-activation warmup seconds   (default 15)
+#   DURATION       per-measurement seconds             (default 30)
+#   TAG            result-directory prefix             (default loop-ab-nginx)
+#   SKIP_PROVISION reuse a running instance from .state
+set -euo pipefail
+
+: "${INSTANCE_TYPE:=m7a.2xlarge}"
+export INSTANCE_TYPE
+
+# shellcheck source=config.sh
+source "$(dirname "$0")/config.sh"
+_bench_aws_check_env
+
+export TOPO=single
+
+CYCLES="${CYCLES:-3}"
+PROFILES="${PROFILES:-ping json}"
+WEB_WORKERS="${WEB_WORKERS:-3}"
+NGINX_WORKERS="${NGINX_WORKERS:-2}"
+CONNS="${CONNS:-256}"
+THREADS="${THREADS:-4}"
+WARMUP="${WARMUP:-15}"
+DURATION="${DURATION:-30}"
+TAG="${TAG:-loop-ab-nginx}"
+KEEP_INSTANCE="${KEEP_INSTANCE:-0}"
+SKIP_PROVISION="${SKIP_PROVISION:-0}"
+
+UPSTREAM_PORT=8444
+LISTEN_PORT=8443
+
+TS="$(date -u +%Y%m%d-%H%M%SZ)"
+LOCAL_DEST="$REPO_ROOT/bench/results/loop-ab-nginx/${TAG}-${INSTANCE_TYPE}-${TS}"
+mkdir -p "$LOCAL_DEST"
+
+exec > >(tee -a "$LOCAL_DEST/driver.log") 2>&1
+
+echo "=== bench/aws/loop_ab_nginx.sh ==="
+echo "  destination:   $LOCAL_DEST"
+echo "  instance type: $INSTANCE_TYPE"
+echo "  profiles:      $PROFILES"
+echo "  cycles:        $CYCLES (arms interleaved A B A B ...)"
+echo "  workers:       BlackBull $WEB_WORKERS / nginx $NGINX_WORKERS"
+echo "  load:          wrk -t$THREADS -c$CONNS, ${WARMUP}s warmup + ${DURATION}s measure"
+echo "  local HEAD:    $(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo
+
+# ---------------------------------------------------------------------------
+# Step 1 — provision, with a teardown trap and an on-box backstop.
+# ---------------------------------------------------------------------------
+if [ "$SKIP_PROVISION" != "1" ]; then
+    echo ">>> bench/aws/up.sh ..."
+    bash "$(dirname "$0")/up.sh"
+fi
+
+_teardown() {
+    local rc=$?
+    if [ "$KEEP_INSTANCE" = "1" ]; then
+        echo "KEEP_INSTANCE=1 — leaving EC2 alive; run 'bash bench/aws/down.sh'"
+        return $rc
+    fi
+    echo ">>> bench/aws/down.sh (trap EXIT) ..."
+    bash "$(dirname "$0")/down.sh" || echo "WARNING: down.sh failed — check the console"
+    return $rc
+}
+trap _teardown EXIT
+
+_bench_aws_load_state
+SERVER_REMOTE="$SSH_USER@${SERVER_PUBLIC_IP:-${PUBLIC_IP:-}}"
+REMOTE_REPO="/home/$SSH_USER/BlackBull"
+
+# The EXIT trap dies with this shell.  Instances launch with
+# shutdown-behavior=terminate, so an on-box timer is the backstop that
+# survives a dropped SSH session or a killed driver.
+echo ">>> arming on-box self-terminate backstop (+90 min) ..."
+ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "sudo shutdown -h +90" || true
+
+# ---------------------------------------------------------------------------
+# Step 2 — deploy + toolchain (bench/install.sh brings nginx and wrk).
+# ---------------------------------------------------------------------------
+echo ">>> bench/aws/install.sh ..."
+bash "$(dirname "$0")/install.sh"
+
+# ---------------------------------------------------------------------------
+# Step 3 — run the interleaved A/B on the box.
+#
+# The whole measurement is one remote script so that arm switching, the
+# loop-identity check and the keep-alive check all happen inside a single
+# shell on the box — no per-step SSH round trips inside a timed window.
+# ---------------------------------------------------------------------------
+echo ">>> running $CYCLES interleaved A/B cycles ..."
+
+# shellcheck disable=SC2087  # the heredoc is deliberately expanded locally
+ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" "bash -s" <<REMOTE
+set -uo pipefail
+cd "$REMOTE_REPO"
+source .venv/bin/activate
+
+OUT=\$HOME/loop-ab-out
+rm -rf "\$OUT"; mkdir -p "\$OUT"
+
+echo "=== box ==="
+{ lscpu; echo; uname -a; echo; nginx -v 2>&1; wrk --version 2>&1 | head -1;
+  python -V; python -c 'import uvloop; print("uvloop", uvloop.__version__)'; } \
+  >"\$OUT/provenance.txt" 2>&1
+grep -E '^(Model name|Thread|Core|Socket|CPU\(s\))' "\$OUT/provenance.txt" || true
+
+command -v fuser >/dev/null || sudo apt-get install -y -qq psmisc >/dev/null 2>&1
+
+# --- nginx: the constant ---------------------------------------------------
+# nginx_proxy.conf carries "daemon off;" because run_peer.sh foregrounds it.
+# Here nginx must outlive the shell that starts it and stay identical across
+# arms, so it is daemonised in the config rather than with -g (nginx rejects
+# -g for a directive the config already sets).
+sed -e "s|__BB_CERT__|$REMOTE_REPO/tests/cert.pem|" \
+    -e "s|__BB_KEY__|$REMOTE_REPO/tests/key.pem|" \
+    -e "s|__BB_UPSTREAM_PORT__|$UPSTREAM_PORT|" \
+    -e "s|__BB_LISTEN_PORT__|$LISTEN_PORT|" \
+    -e "s|^worker_processes .*|worker_processes $NGINX_WORKERS;|" \
+    -e "s|^daemon off;|daemon on;|" \
+    bench/peers/nginx_proxy.conf >"\$OUT/nginx.conf"
+
+sudo fuser -k $LISTEN_PORT/tcp 2>/dev/null || true
+sleep 1
+sudo nginx -c "\$OUT/nginx.conf" 2>"\$OUT/nginx-start.err" || {
+    echo "FATAL: nginx failed to start"; cat "\$OUT/nginx-start.err"; exit 1; }
+echo "nginx up on :$LISTEN_PORT (worker_processes $NGINX_WORKERS)"
+
+UP_PGID=""
+
+stop_arm() {
+    # setsid makes the upstream a process-group leader, so one signal to
+    # -PGID takes the master and every forked worker.  Killing the master
+    # alone would orphan the workers and leave :$UPSTREAM_PORT bound.
+    [ -n "\$UP_PGID" ] && kill -TERM -"\$UP_PGID" 2>/dev/null
+    UP_PGID=""
+    for i in \$(seq 1 40); do
+        sudo fuser -s $UPSTREAM_PORT/tcp 2>/dev/null || return 0
+        sleep 0.25
+    done
+    sudo fuser -k $UPSTREAM_PORT/tcp 2>/dev/null || true
+    sleep 1
+}
+
+start_arm() {   # \$1 = arm letter, \$2 = BB_UVLOOP value
+    local arm="\$1" uv="\$2" i
+    stop_arm
+    # BB_WORKERS as well as --workers: the CLI flag reaches app.run(), but
+    # /config reports the *settings* value, so without the env var the
+    # provenance line would claim 1 worker while 3 were serving.
+    BB_UVLOOP="\$uv" BB_WORKERS=$WEB_WORKERS setsid nohup python bench/app.py \
+        --no-tls --port $UPSTREAM_PORT --workers $WEB_WORKERS \
+        >>"\$OUT/upstream-\$arm.log" 2>&1 &
+    UP_PGID=\$!
+    # -f is load-bearing: without it curl exits 0 on nginx's own 502, so a
+    # dead upstream reads as "ready" and the arm gets benchmarked against an
+    # error page.  Probe the upstream directly first so a failure names the
+    # layer that broke rather than just the proxy in front of it.
+    for i in \$(seq 1 60); do
+        curl -sf --max-time 1 "http://127.0.0.1:$UPSTREAM_PORT/ping" >/dev/null 2>&1 && break
+        sleep 0.5
+        if [ "\$i" = 60 ]; then
+            echo "FATAL: arm \$arm upstream never bound :$UPSTREAM_PORT"
+            tail -20 "\$OUT/upstream-\$arm.log"; return 1
+        fi
+    done
+    for i in \$(seq 1 20); do
+        curl -sfk --max-time 1 "https://127.0.0.1:$LISTEN_PORT/ping" >/dev/null 2>&1 && return 0
+        sleep 0.5
+    done
+    echo "FATAL: arm \$arm upstream is up but nginx will not proxy to it"
+    tail -20 /tmp/bench-nginx-proxy-error.log 2>/dev/null; return 1
+}
+
+# The failure this guards against is silent: when BB_UVLOOP=1 but uvloop
+# cannot be imported, the server logs a warning and keeps the stock loop.
+# The run then completes and produces a full, plausible set of numbers that
+# read as "uvloop bought nothing".  /config echoes what the process actually
+# installed, so ask it rather than trusting the env var we set.
+check_loop() {  # \$1 = arm letter, \$2 = expected true|false
+    local got
+    got=\$(curl -sfk --max-time 5 "https://127.0.0.1:$LISTEN_PORT/config") || {
+        echo "FATAL: arm \$1 — /config did not answer"; return 1; }
+    echo "  /config: \$got"
+    case "\$got" in
+        *'"uvloop": '\$2*) : ;;
+        *) echo "FATAL: arm \$1 wanted uvloop=\$2, /config disagrees"; return 1 ;;
+    esac
+    case "\$got" in
+        *'"workers": $WEB_WORKERS'*) : ;;
+        *) echo "FATAL: arm \$1 wanted $WEB_WORKERS workers, /config disagrees"; return 1 ;;
+    esac
+}
+
+# nginx must reuse pooled upstream connections; if it does not, every
+# request pays a TCP handshake and the run measures connection setup.
+# TcpActiveOpens counts outbound connects box-wide — on an otherwise idle
+# box that is nginx dialling the upstream.  Report it per request.
+active_opens() { nstat -asz TcpActiveOpens 2>/dev/null | awk '/TcpActiveOpens/{print \$2}'; }
+
+measure() {     # \$1 = arm, \$2 = cycle, \$3 = profile
+    local arm="\$1" cyc="\$2" prof="\$3"
+    local f="\$OUT/wrk-\$arm-\$prof-c\$cyc.txt"
+    local before after reqs
+    before=\$(active_opens)
+    wrk -t$THREADS -c$CONNS -d${DURATION}s --latency \
+        "https://127.0.0.1:$LISTEN_PORT/\$prof" >"\$f" 2>&1
+    after=\$(active_opens)
+    reqs=\$(awk '/requests in/{print \$1}' "\$f")
+    echo "reconnects=\$((after - before)) requests=\${reqs:-0}" >>"\$f"
+    printf '  %s/%s cycle %s: %s req/s (reconnects/req %s)\n' \
+        "\$arm" "\$prof" "\$cyc" \
+        "\$(awk '/Requests\/sec/{print \$2}' "\$f")" \
+        "\$(awk -v a=\$((after - before)) -v r="\${reqs:-1}" 'BEGIN{printf "%.4f", a/r}')"
+}
+
+for cyc in \$(seq 1 $CYCLES); do
+    for spec in "A 1 true" "B 0 false"; do
+        set -- \$spec
+        arm=\$1; uv=\$2; want=\$3
+        echo "--- cycle \$cyc / arm \$arm (BB_UVLOOP=\$uv) ---"
+        start_arm "\$arm" "\$uv" || exit 1
+        check_loop "\$arm" "\$want" || exit 1
+        wrk -t$THREADS -c$CONNS -d${WARMUP}s \
+            "https://127.0.0.1:$LISTEN_PORT/ping" >/dev/null 2>&1
+        for prof in $PROFILES; do
+            measure "\$arm" "\$cyc" "\$prof"
+        done
+    done
+done
+
+stop_arm
+sudo nginx -c "\$OUT/nginx.conf" -s quit 2>/dev/null || sudo fuser -k $LISTEN_PORT/tcp 2>/dev/null || true
+echo "AB_DONE"
+REMOTE
+rc=$?
+echo "remote A/B exit=$rc"
+[ "$rc" -eq 0 ] || exit "$rc"
+
+# ---------------------------------------------------------------------------
+# Step 4 — pull the raw wrk output back and summarise.
+# ---------------------------------------------------------------------------
+echo ">>> fetching results ..."
+rsync -e "ssh ${SSH_OPTS[*]}" -az "$SERVER_REMOTE:loop-ab-out/" "$LOCAL_DEST/raw/"
+
+python3 "$REPO_ROOT/bench/aws/loop_ab_summary.py" "$LOCAL_DEST" \
+    --instance "$INSTANCE_TYPE" --workers "$WEB_WORKERS" --conns "$CONNS"
+
+echo "done; teardown via trap"

--- a/bench/aws/loop_ab_summary.py
+++ b/bench/aws/loop_ab_summary.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Summarise a ``loop_ab_nginx.sh`` run into a decision-quality table.
+
+Reads the raw wrk output ``loop_ab_nginx.sh`` pulled back to
+``<result_dir>/raw/wrk-<arm>-<profile>-c<cycle>.txt`` and writes
+``RESULT.md`` into the result dir, echoing it to stdout.
+
+Usage:
+    python3 loop_ab_summary.py <result_dir> [--instance TYPE] [--workers N]
+                                            [--conns N]
+
+Stdlib only — it runs on the bench driver host at the end of a run.
+
+Every arm is measured $CYCLES times, interleaved with the other arm, so
+each row carries a spread alongside its mean.  The uvloop delta is a
+finding only when it is large next to that spread; a delta inside the
+spread is reported as such rather than quoted as a number.
+"""
+import argparse
+import glob
+import os
+import re
+import statistics
+import sys
+
+# "Requests/sec:  40723.94" — wrk's throughput line.
+_RPS_RE = re.compile(r'^Requests/sec:\s*([0-9.]+)', re.M)
+# "  99%   12.34ms" from wrk --latency's distribution block.
+_P99_RE = re.compile(r'^\s*99%\s+([0-9.]+)(us|ms|s)\s*$', re.M)
+# The footer loop_ab_nginx.sh appends: "reconnects=41 requests=1222899".
+_CONN_RE = re.compile(r'^reconnects=(-?\d+)\s+requests=(\d+)', re.M)
+# wrk-A-ping-c1.txt
+_NAME_RE = re.compile(r'^wrk-(\w+)-([\w.-]+)-c(\d+)\.txt$')
+
+_UNIT_MS = {'us': 1e-3, 'ms': 1.0, 's': 1e3}
+
+# Arm A is uvloop, arm B is stock asyncio — set by loop_ab_nginx.sh.
+UVLOOP_ARM, STOCK_ARM = 'A', 'B'
+_ARM_LABEL = {UVLOOP_ARM: 'A: CPython+uvloop', STOCK_ARM: 'B: CPython+asyncio'}
+
+
+def collect(result_dir):
+    """Return {profile: {arm: [{'rps', 'p99_ms', 'reconnects_per_req'}, ...]}}."""
+    runs = {}
+    for path in sorted(glob.glob(os.path.join(result_dir, "raw", "wrk-*.txt"))):
+        name = _NAME_RE.match(os.path.basename(path))
+        if not name:
+            continue
+        arm, profile, cycle = name.group(1), name.group(2), int(name.group(3))
+        with open(path, errors="replace") as fh:
+            text = fh.read()
+        rps = _RPS_RE.search(text)
+        if not rps:
+            print(f"loop_ab_summary: no Requests/sec in {path} — skipped",
+                  file=sys.stderr)
+            continue
+        p99 = _P99_RE.search(text)
+        conn = _CONN_RE.search(text)
+        runs.setdefault(profile, {}).setdefault(arm, []).append({
+            'cycle': cycle,
+            'rps': float(rps.group(1)),
+            'p99_ms': float(p99.group(1)) * _UNIT_MS[p99.group(2)] if p99 else None,
+            'reconnects_per_req': (int(conn.group(1)) / int(conn.group(2))
+                                   if conn and int(conn.group(2)) else None),
+        })
+    return runs
+
+
+def _spread(values):
+    mean = statistics.fmean(values)
+    return (max(values) - min(values)) / mean if mean else 0.0
+
+
+def render(runs, meta):
+    lines = [
+        "# What uvloop is worth on CPython, behind nginx",
+        "",
+        f"**Instance**: {meta.instance} (single host: wrk + nginx + BlackBull)  ",
+        f"**Topology**: `wrk -c{meta.conns} -> nginx :8443 (TLS) -> "
+        f"BlackBull :8444 (cleartext H1, keep-alive pooled)`  ",
+        f"**Per arm**: {meta.workers} workers; arms interleaved across cycles.",
+        "",
+        "Arm A is `BB_UVLOOP=1`, arm B is `BB_UVLOOP=0`; same wheel, same app,",
+        "same nginx.  Every figure below comes from this one instance in this",
+        "one session — nothing here is comparable to a number from another run.",
+        "",
+        "## Per-arm throughput",
+        "",
+        "| profile | arm | runs | mean req/s | min | max | spread | p99 (ms) |",
+        "|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for profile in sorted(runs):
+        for arm in (UVLOOP_ARM, STOCK_ARM):
+            entries = runs[profile].get(arm)
+            if not entries:
+                continue
+            rps = [e['rps'] for e in entries]
+            p99 = [e['p99_ms'] for e in entries if e['p99_ms'] is not None]
+            lines.append(
+                f"| /{profile} | {_ARM_LABEL[arm]} | {len(rps)} | "
+                f"{statistics.fmean(rps):,.0f} | {min(rps):,.0f} | "
+                f"{max(rps):,.0f} | {_spread(rps) * 100:.1f}% | "
+                f"{statistics.fmean(p99):.2f} |" if p99 else
+                f"| /{profile} | {_ARM_LABEL[arm]} | {len(rps)} | "
+                f"{statistics.fmean(rps):,.0f} | {min(rps):,.0f} | "
+                f"{max(rps):,.0f} | {_spread(rps) * 100:.1f}% | — |"
+            )
+
+    lines += [
+        "",
+        "## A -> B: what uvloop is worth",
+        "",
+        "| profile | uvloop mean | asyncio mean | uvloop's worth | max spread | verdict |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for profile in sorted(runs):
+        uv = [e['rps'] for e in runs[profile].get(UVLOOP_ARM, [])]
+        st = [e['rps'] for e in runs[profile].get(STOCK_ARM, [])]
+        if not uv or not st:
+            continue
+        u_mean, s_mean = statistics.fmean(uv), statistics.fmean(st)
+        delta = (u_mean - s_mean) / s_mean
+        spread = max(_spread(uv), _spread(st))
+        verdict = "inside noise" if abs(delta) <= spread else "outside noise"
+        lines.append(
+            f"| /{profile} | {u_mean:,.0f} | {s_mean:,.0f} | "
+            f"{delta * 100:+.1f}% | {spread * 100:.1f}% | {verdict} |"
+        )
+
+    # A run where nginx failed to pool upstream connections measures TCP
+    # handshakes, not request handling, so surface the ratio rather than
+    # leaving it in the raw files for nobody to read.
+    ratios = [e['reconnects_per_req']
+              for prof in runs.values() for arm in prof.values()
+              for e in arm if e['reconnects_per_req'] is not None]
+    if ratios:
+        worst = max(ratios)
+        lines += [
+            "",
+            f"**Upstream keep-alive**: worst reconnects/request = {worst:.4f} "
+            + ("— pooling held, the numbers measure request handling."
+               if worst < 0.01 else
+               "— **pooling did not hold; this run measures connection setup**."),
+        ]
+
+    lines += ["", "## Per-cycle detail", "",
+              "| profile | arm | cycle | req/s |", "|---|---|---:|---:|"]
+    for profile in sorted(runs):
+        for arm in (UVLOOP_ARM, STOCK_ARM):
+            for e in sorted(runs[profile].get(arm, []), key=lambda x: x['cycle']):
+                lines.append(f"| /{profile} | {arm} | {e['cycle']} | {e['rps']:,.0f} |")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("result_dir")
+    ap.add_argument("--instance", default="unknown")
+    ap.add_argument("--workers", default="?")
+    ap.add_argument("--conns", default="?")
+    meta = ap.parse_args(argv[1:])
+
+    runs = collect(meta.result_dir)
+    if not runs:
+        print(f"loop_ab_summary: no wrk output under {meta.result_dir}/raw",
+              file=sys.stderr)
+        return 1
+    table = render(runs, meta)
+    out = os.path.join(meta.result_dir, "RESULT.md")
+    with open(out, "w") as fh:
+        fh.write(table)
+    print(table)
+    print(f"[loop_ab_summary] wrote {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/bench/aws/profile.sh
+++ b/bench/aws/profile.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# bench/aws/profile.sh — Sprint 15: capture two py-spy flame graphs on EC2,
+# bench/aws/profile.sh — capture two py-spy flame graphs on EC2,
 # one at low concurrency (B1-like, K6_VUS=200) and one at high concurrency
 # (C2, K6_VUS=500).  The goal is to find what shifts in the profile under
 # 500 VU — the suspected cause of the BlackBull→uvicorn gap widening from
-# 1.8× (B1 c=256) to 2.4× (C2 500 VU) observed in Sprint 13/14.
+# 1.8× (B1 c=256) to 2.4× (C2 500 VU) observed on the peer matrix.
 #
 # Expects bench/aws/.state from up.sh + a remote box prepared by install.sh
 # (which now installs the .[profiling] extra → py-spy).  Re-runnable.

--- a/bench/aws/profile_lanes.sh
+++ b/bench/aws/profile_lanes.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bench/aws/profile_lanes.sh — Sprint 27 Phase 1: wrk-driven per-lane
+# bench/aws/profile_lanes.sh — wrk-driven per-lane
 # py-spy capture on EC2 split topology.
 #
 # For each lane in $LANES (default "B1 B2 B3"), starts BlackBull on the
@@ -7,9 +7,9 @@
 # loadgen host, then pulls the speedscope JSON + wrk output back.
 #
 # Methodology pin: re-profile on the SAME EC2 instance type used for
-# the sprint cumulative measurement (c7i.xlarge server, c7i.2xlarge
+# the cumulative measurement (c7i.xlarge server, c7i.2xlarge
 # loadgen) — WSL2 profile shape diverges materially at high
-# concurrency.  Sprint 21 Phase B finding.
+# concurrency.
 #
 # Prereqs:
 #   - bench/aws/.state populated by up.sh (TOPO=split)
@@ -114,7 +114,7 @@ _run_one_lane() {
     echo ">>> $lane: profile_secs=${profile_secs}s, wrk_cmd=$wrk_cmd"
 
     # 1. Kill any lingering BlackBull on the server.  Use the bracket
-    #    trick so pkill -f doesn't self-match (Sprint 25 close-out
+    #    trick so pkill -f doesn't self-match (a close-out
     #    lesson).
     ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
         "pkill -f '[b]ench/app.py' 2>/dev/null || true
@@ -127,7 +127,7 @@ _run_one_lane() {
     #    process to init BEFORE the outer SSH bash exits.  Without the
     #    explicit subshell (e.g. plain `cmd & ` form), the backgrounded
     #    process remains a child of the SSH bash and dies via SIGHUP
-    #    when SSH disconnects (Sprint 27 Phase 1 finding — cleartext-v1
+    #    when SSH disconnects (measured — cleartext-v1
     #    attempt without the subshell broke server startup on B1).
     #
     #    B2 (c=1024 + pipeline=16) wants `ulimit -n` raised, but applying
@@ -171,7 +171,7 @@ _run_one_lane() {
     # 4. Warmup — discarded.  Settles wrk loadgen state + accept queue
     #    BEFORE the measured wrk pass, so the first lane in a run
     #    doesn't pay the cold-cache + connection-storm tax that lane-N
-    #    runs don't see (Sprint 27 Phase 1 finding: B3-first throughput
+    #    runs don't see (measured: B3-first throughput
     #    was ~21 % lower than B3-last on the same code).
     echo "  warmup (${WARMUP}s) ..."
     ssh "${SSH_OPTS[@]}" "$LOADGEN_REMOTE" \

--- a/bench/aws/run.sh
+++ b/bench/aws/run.sh
@@ -11,7 +11,7 @@
 #   LANES="A B-wrk" bash bench/aws/run.sh
 #
 # Knobs consumed by bench/peers/compare_servers.sh:
-#   RUNS      h2load median-of-N (default 3 — Sprint 13 plan defaults to 5)
+#   RUNS      h2load median-of-N (default 3 — the plan defaults to 5)
 #   LANES     subset of {A, B-wrk, B-oha, C, D}
 #   STACKS    subset of {blackbull, uvicorn, hypercorn, granian, daphne, nginx}
 #   DURATION  per-scenario seconds for wrk/oha (default 30)
@@ -29,7 +29,7 @@ source "$(dirname "$0")/config.sh"
 _bench_aws_check_env
 _bench_aws_load_state
 
-# Backward-compat shims for state files written before Sprint 20.
+# Backward-compat shims for legacy state files.
 SERVER_PUBLIC_IP="${SERVER_PUBLIC_IP:-${PUBLIC_IP:-}}"
 SERVER_PRIVATE_IP="${SERVER_PRIVATE_IP:-}"
 LOADGEN_PUBLIC_IP="${LOADGEN_PUBLIC_IP:-}"
@@ -54,7 +54,7 @@ echo "  LANES=$LANES"
 echo "  STACKS=$STACKS"
 echo
 
-# Sprint 21 Phase B: BB_BENCH_TASKSET is optional and threaded through to the
+# BB_BENCH_TASKSET is optional and threaded through to the
 # server's launch path.  Empty means no pinning.
 BB_BENCH_TASKSET="${BB_BENCH_TASKSET:-}"
 

--- a/bench/aws/up.sh
+++ b/bench/aws/up.sh
@@ -2,10 +2,10 @@
 # bench/aws/up.sh — provision EC2 instance(s) for an AWS bench pass.
 #
 # TOPO=single (default): one $INSTANCE_TYPE host runs both the server
-#   under test and the load tools (legacy Sprint-13–16 topology).
+#   under test and the load tools (legacy single-host topology).
 # TOPO=split:            two hosts in a cluster placement group — a
 #   $INSTANCE_TYPE server and a $LOADGEN_INSTANCE_TYPE load generator
-#   talking over VPC private networking (Sprint 20).
+#   talking over VPC private networking.
 #
 # Idempotent: existing key pair / security group / placement group are
 # reused if their names already match.  The only blocking failure is

--- a/bench/benchmarker_target.py
+++ b/bench/benchmarker_target.py
@@ -1,0 +1,43 @@
+"""Minimal BlackBull app matching The Benchmarker's Starlette reference:
+https://github.com/the-benchmarker/web-frameworks/blob/develop/python/starlette/server.py
+
+Routes:
+  GET  /                → empty response
+  GET  /user/{user_id}  → returns user_id as text
+  POST /user            → empty response
+"""
+import os
+import sys
+
+# Allow running as `python bench/benchmarker_target.py` from the repo root
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from http import HTTPMethod
+
+from blackbull import BlackBull
+
+app = BlackBull()
+
+
+@app.route(path="/")
+async def homepage():
+    return b""
+
+
+@app.route(path="/user/{user_id}")
+async def user(user_id: str):
+    return user_id
+
+
+@app.route(path="/user", methods=[HTTPMethod.POST])
+async def userinfo():
+    return b""
+
+
+if __name__ == "__main__":
+    import argparse
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--port", type=int, default=8000)
+    args = p.parse_args()
+    app.run(port=args.port)

--- a/bench/benchmarker_target_fastapi.py
+++ b/bench/benchmarker_target_fastapi.py
@@ -1,0 +1,20 @@
+"""Minimal FastAPI app matching The Benchmarker's reference."""
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+app = FastAPI()
+
+
+@app.get("/")
+async def homepage():
+    return PlainTextResponse("")
+
+
+@app.get("/user/{user_id}")
+async def user(user_id: str):
+    return PlainTextResponse(user_id)
+
+
+@app.post("/user")
+async def userinfo():
+    return PlainTextResponse("")

--- a/bench/benchmarker_target_sanic.py
+++ b/bench/benchmarker_target_sanic.py
@@ -1,0 +1,22 @@
+"""Minimal Sanic app matching The Benchmarker's reference.
+https://github.com/the-benchmarker/web-frameworks/blob/develop/python/sanic/server.py
+"""
+from sanic import Sanic
+from sanic.response import text
+
+app = Sanic("benchmark")
+
+
+@app.route("/")
+async def index(request):
+    return text("")
+
+
+@app.route("/user/<id:int>", methods=["GET"])
+async def user_info(request, id):
+    return text(str(id))
+
+
+@app.route("/user", methods=["POST"])
+async def user(request):
+    return text("")

--- a/bench/conformance/autobahn_run.sh
+++ b/bench/conformance/autobahn_run.sh
@@ -15,7 +15,7 @@
 # CASES is a comma-separated list of Autobahn case patterns (default '*').
 # The static autobahn_fuzzingclient.json is a template: a per-run copy with
 # "cases" substituted is rendered into the results dir and mounted instead
-# (P.2, Sprint 72 — previously CASES was documented but ignored and subset
+# (P.2 — CASES was once documented but ignored, and subset
 # runs silently ran all 517 cases).
 #
 # Reports land in bench/conformance/results/autobahn_<timestamp>/.

--- a/bench/h1_frontend_ab.py
+++ b/bench/h1_frontend_ab.py
@@ -8,7 +8,7 @@ Each underlying ``read``/``readuntil`` is one trip, i.e. at minimum one chance
 for the loop to suspend, and fewer of them is the whole claim behind
 ``BB_H1_PROTOCOL``.
 
-What it established (Sprint 84): the per-line header loop runs only for the
+What it established: the per-line header loop runs only for the
 *first* request on a connection — ``run()`` already reads each subsequent head
 with a single ``readuntil(b'\r\n\r\n')`` — so the buffered front end wins on
 pipelined arrival (~1.1 → ~0.04 trips/req) and not on serialized keep-alive

--- a/bench/hostile_repro/attacks/idle_park.py
+++ b/bench/hostile_repro/attacks/idle_park.py
@@ -5,7 +5,7 @@ This is the *benign* variant of the same shape as the HttpArena
 burst-close cliff: lots of suspended-on-readuntil tasks parked in
 the event loop, each holding a slot.
 
-Defence: shorter ``BB_KEEP_ALIVE_TIMEOUT`` (Sprint 30 lowers
+Defence: shorter ``BB_KEEP_ALIVE_TIMEOUT`` (BlackBull lowers
 default from 60 s to 5 s) and ``BB_MAX_CONNECTIONS`` cap.
 
 Note: unlike the other attack scripts, this one DELIBERATELY does

--- a/bench/hostile_repro/attacks/slow_read.py
+++ b/bench/hostile_repro/attacks/slow_read.py
@@ -1,6 +1,6 @@
 """Slow-read attack: complete request, then read response 1 byte/sec.
 
-Hits the slow-read defence gap noted in Sprint 30's peer audit —
+Hits the slow-read defence gap noted in the peer audit —
 BlackBull does NOT have a `BB_WRITE_TIMEOUT` today (planned in
 Tier 1.1).  Without it, a slow-reading client holds the server's
 write coroutine in `drain()` indefinitely as the kernel send buffer

--- a/bench/hostile_repro/characterize_slowloris.py
+++ b/bench/hostile_repro/characterize_slowloris.py
@@ -1,4 +1,4 @@
-"""Slowloris quantitative characterisation (Sprint 77).
+"""Slowloris quantitative characterisation.
 
 Turns the qualitative "the three deadline timeouts work" claim in
 `KNOWN_LIMITATIONS.md` into a defendable curve:

--- a/bench/hostile_repro/probe.sh
+++ b/bench/hostile_repro/probe.sh
@@ -2,7 +2,7 @@
 # Drive one hostile attack against a fresh BlackBull server, capturing
 # event-loop health metrics.
 #
-# Sprint 30 Tier 1 verification harness.
+# Tier 1 verification harness.
 #
 # Usage:
 #   bash bench/hostile_repro/probe.sh slowloris_headers

--- a/bench/hotpath/folded.py
+++ b/bench/hotpath/folded.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Summarise a py-spy raw (folded) profile: self time and inclusive time.
+
+A folded line is `<frame>;<frame>;...;<leaf> <count>`, one per distinct
+stack.  Self time is the leaf's share; inclusive time is every stack the
+frame appears anywhere in.  Import-time stacks are dropped — they are
+startup, not the request hot path.
+"""
+import collections
+import re
+import sys
+
+DROP = ('_find_and_load', 'exec_module')
+
+
+def load(path):
+    self_t = collections.Counter()
+    incl = collections.Counter()
+    total = 0
+    for line in open(path):
+        line = line.rstrip('\n')
+        if not line:
+            continue
+        stack, _, cnt = line.rpartition(' ')
+        try:
+            n = int(cnt)
+        except ValueError:
+            continue
+        stack = re.sub(r'^process \d+:"[^"]*";', '', stack)
+        frames = [f for f in stack.split(';') if f]
+        if not frames or any(d in f for f in frames for d in DROP):
+            continue
+        total += n
+        self_t[frames[-1]] += n
+        for f in set(frames):
+            incl[f] += n
+    return total, self_t, incl
+
+
+def show(path, top=30):
+    total, self_t, incl = load(path)
+    print(f'== {path}  ({total} request-path samples) ==')
+    print(f'{"self%":>7} {"incl%":>7}  frame')
+    for f, n in self_t.most_common(top):
+        print(f'{100*n/total:7.2f} {100*incl[f]/total:7.2f}  {f}')
+    return total, self_t, incl
+
+
+if __name__ == '__main__':
+    for p in sys.argv[1:]:
+        show(p)
+        print()

--- a/bench/hotpath/hotpath_ab.sh
+++ b/bench/hotpath/hotpath_ab.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# hotpath_ab.sh — BlackBull(+uvloop) vs FastAPI(uvicorn+uvloop+httptools).
+#
+# Question: HttpArena's `baseline` profile puts FastAPI ~6 % ahead of
+# BlackBull+uvloop.  Is that a per-request hot-path cost, or does it come
+# from something the leaderboard entry mounts on top of the framework, or
+# from the scale it is run at?  Three phases, one box, one session:
+#
+#   1  cost per request   1 worker pinned to ONE core, 64 conns.  The core
+#                         saturates, so throughput is the direct inverse of
+#                         CPU-seconds per request.  Bare app and the
+#                         HttpArena middleware stack (PEER_MW=httparena)
+#                         are both measured, for both frameworks.
+#   2  attribution        py-spy over the same single-worker load.
+#   3  scale              3 workers on 3 physical cores, 512 conns — the
+#                         shape the leaderboard actually runs.
+#
+# Arms are interleaved rather than run as one block each, so a monotonic
+# drift (thermal, page cache) cannot alias onto the arm.  SMT siblings are
+# (2n, 2n+1) here, so a generator on core 3 would share silicon with a
+# server on core 2.
+#
+# Companions in this directory, run against the output dir this prints:
+#   hotpath_summary.py <dir>   per-phase tables + inside/outside-noise verdicts
+#   folded.py <dir>/raw/X.folded   self/inclusive rollup of a py-spy profile
+#   parser_micro.py            `_parse` vs httptools on byte-identical requests
+#
+# Findings: ../../.claude/planning/research/blackbull-vs-fastapi-hotpath.md
+set -u
+
+REPO=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$REPO" || exit 1
+
+PORT="${PORT:-8501}"
+GEN_CPUS="${GEN_CPUS:-6,8,10}"
+WARMUP="${WARMUP:-5}"
+DURATION="${DURATION:-15}"
+CYCLES="${CYCLES:-3}"
+SAMPLE_HZ="${SAMPLE_HZ:-200}"
+PROFILE_SECS="${PROFILE_SECS:-60}"
+BASELINE_Q='/baseline11?a=1&b=2&c=3'
+PHASES="${PHASES:-1 3 2 4 5}"
+
+has_phase() { case " $PHASES " in *" $1 "*) return 0 ;; *) return 1 ;; esac; }
+
+TS=$(date -u +%Y%m%d-%H%M%SZ)
+OUT="${OUT:-$REPO/bench/results/hotpath-ab/$TS}"
+mkdir -p "$OUT/raw"
+cp "$0" "$OUT/hotpath_ab.sh"
+
+ulimit -n 65536 2>/dev/null || true
+TICKS=$(getconf CLK_TCK)
+SRV_PGID=""
+WRAP_PID=""
+MY_PGID=$(ps -o pgid= -p $$ | tr -d ' ')
+
+log() { echo "[$(date -u +%H:%M:%S)] $*" | tee -a "$OUT/run.log"; }
+
+# --- process bookkeeping ---------------------------------------------------
+
+pgid_pids() { pgrep -g "$1" 2>/dev/null; }
+port_pid()  { fuser "$PORT/tcp" 2>/dev/null | awk '{print $1}'; }
+
+# utime+stime in clock ticks, summed over the arm's whole process group.
+# 10 ms resolution over a 15 s window is 0.07 % — `ps -o cputimes` reports
+# whole seconds only and could not support a verdict on a few percent.
+pgid_cpu_ticks() {
+    local pid total=0 one
+    for pid in $(pgid_pids "$1"); do
+        # comm can contain spaces and parens, so split on the LAST ') '.
+        one=$(awk '{n=split($0,a,") "); m=split(a[n],b," "); print b[12]+b[13]}' \
+              "/proc/$pid/stat" 2>/dev/null) || continue
+        total=$(( total + ${one:-0} ))
+    done
+    echo "$total"
+}
+
+stop_arm() {
+    # Signal the group only when the arm really has its own group.  The
+    # profiled launch skips setsid, so the server sits in THIS script's
+    # group — a group-wide TERM there would kill the run itself.
+    if [ -n "$SRV_PGID" ] && [ "$SRV_PGID" != "$MY_PGID" ]; then
+        kill -TERM -"$SRV_PGID" 2>/dev/null
+    fi
+    [ -n "$WRAP_PID" ] && kill -TERM "$WRAP_PID" 2>/dev/null
+    SRV_PGID=""; WRAP_PID=""
+    fuser -k "$PORT/tcp" 2>/dev/null
+    for _ in $(seq 1 60); do
+        fuser -s "$PORT/tcp" 2>/dev/null || return 0
+        sleep 0.25
+    done
+    return 0
+}
+trap 'stop_arm' EXIT
+
+wait_ready() {
+    local i
+    for i in $(seq 1 200); do
+        # -f matters: without it curl exits 0 on an error page, so a dead
+        # server reads as ready and gets benchmarked against the error.
+        curl -sf --max-time 1 "http://127.0.0.1:$PORT/ping" >/dev/null 2>&1 && return 0
+        sleep 0.25
+    done
+    echo "FATAL: $1 never answered on :$PORT" | tee -a "$OUT/run.log"
+    tail -25 "$OUT/raw/$1.server.log" 2>/dev/null
+    return 1
+}
+
+# The silent-fallback failure mode: a server that quietly fell back to the
+# stock selector loop, or to the pure-Python parser, still produces a full
+# and plausible set of numbers.  Prove the accelerated libraries are mapped.
+assert_libs() {
+    local arm="$1"; shift
+    local pid want hit found=""
+    for want in "$@"; do
+        hit=""
+        for pid in $(pgid_pids "$SRV_PGID"); do
+            grep -qi "$want" "/proc/$pid/maps" 2>/dev/null && { hit=$pid; break; }
+        done
+        [ -z "$hit" ] && { echo "FATAL: $arm — $want is not mapped into any server process" \
+            | tee -a "$OUT/run.log"; return 1; }
+        found="$found $want"
+    done
+    log "  $arm: $(pgid_pids "$SRV_PGID" | wc -l) procs, libs$found"
+}
+
+# start_arm <arm> <workers> <srv_cpus> [wrapper argv...]
+start_arm() {
+    local arm="$1" workers="$2" cpus="$3"; shift 3
+    local mw="" a="$arm"
+    case "$arm" in *-mw) mw=httparena; a="${arm%-mw}" ;; esac
+    local -a cmd
+    case "$a" in
+        blackbull)
+            cmd=(env BB_UVLOOP=1 "BB_WORKERS=$workers" BB_ACCESS_LOG=0 "PEER_MW=$mw"
+                 taskset -c "$cpus"
+                 "$REPO/.venv/bin/blackbull" bench.peers.native_app:app
+                 --bind "127.0.0.1:$PORT")
+            ;;
+        fastapi)
+            # --loop / --http named rather than `auto`: provenance must not
+            # depend on what happens to be installed.
+            cmd=(env "PEER_MW=$mw"
+                 taskset -c "$cpus"
+                 "$REPO/.venv/bin/uvicorn" bench.peers.fastapi_app:app
+                 --host 127.0.0.1 --port "$PORT"
+                 --loop uvloop --http httptools --workers "$workers"
+                 --log-level warning --no-access-log)
+            ;;
+        *) echo "unknown arm $arm"; return 1 ;;
+    esac
+    stop_arm
+    if [ "$#" -gt 0 ]; then
+        # Profiled launch.  Deliberately NOT setsid: job control is on in
+        # this shell, so setsid forks and $! would name a process that exits
+        # at once — phase 2 must be able to wait for the profiler itself.
+        "$@" "${cmd[@]}" >"$OUT/raw/$arm.server.log" 2>&1 &
+        WRAP_PID=$!
+    else
+        setsid nohup "${cmd[@]}" >"$OUT/raw/$arm.server.log" 2>&1 &
+        WRAP_PID=""
+    fi
+    wait_ready "$arm" || return 1
+    # Derive the group from whoever owns the port, not from $! — the
+    # wrapper may or may not be the group leader.
+    SRV_PGID=$(ps -o pgid= -p "$(port_pid)" 2>/dev/null | tr -d ' ')
+    [ -n "$SRV_PGID" ] || { echo "FATAL: $arm — cannot find the server pgid"; return 1; }
+    case "$a" in
+        blackbull) assert_libs "$arm" uvloop || return 1 ;;
+        fastapi)   assert_libs "$arm" uvloop httptools || return 1 ;;
+    esac
+}
+
+# measure <arm> <phase> <cycle> <path> <conns> <threads> [wrk -H args...]
+measure() {
+    local arm="$1" phase="$2" cyc="$3" p="$4" conns="$5" thr="$6" f t0 t1 secs reqs rps
+    shift 6
+    f="$OUT/raw/wrk-$phase-$arm-${p//[^a-zA-Z0-9]/_}-c$cyc.txt"
+    taskset -c "$GEN_CPUS" wrk -t"$thr" -c"$conns" -d"${WARMUP}s" "$@" \
+        "http://127.0.0.1:$PORT$p" >/dev/null 2>&1
+    t0=$(pgid_cpu_ticks "$SRV_PGID")
+    taskset -c "$GEN_CPUS" wrk -t"$thr" -c"$conns" -d"${DURATION}s" --latency "$@" \
+        "http://127.0.0.1:$PORT$p" >"$f" 2>&1
+    t1=$(pgid_cpu_ticks "$SRV_PGID")
+    secs=$(awk -v a="$t0" -v b="$t1" -v k="$TICKS" 'BEGIN{printf "%.3f",(b-a)/k}')
+    reqs=$(awk '/requests in/{print $1}' "$f")
+    rps=$(awk '/Requests\/sec/{print $2}' "$f")
+    printf 'cpu_seconds=%s requests=%s arm=%s phase=%s path=%s conns=%s\n' \
+        "$secs" "$reqs" "$arm" "$phase" "$p" "$conns" >>"$f"
+    log "  $arm $p c$cyc: $rps req/s | ${secs}s CPU / ${DURATION}s wall | $reqs reqs"
+}
+
+# --- phase 1: cost per request --------------------------------------------
+
+if has_phase 1; then
+log "phase 1 — one worker on one core (cpu 2), 64 conns"
+for cyc in $(seq 1 "$CYCLES"); do
+    for arm in blackbull fastapi blackbull-mw fastapi-mw; do
+        start_arm "$arm" 1 2 || exit 1
+        for p in /ping "$BASELINE_Q"; do
+            measure "$arm" p1 "$cyc" "$p" 64 3
+        done
+        stop_arm
+    done
+done
+fi
+
+# --- phase 5: what the router costs as the table grows --------------------
+# /ping is the first route in both apps, /pingz the last and byte-identical.
+# BlackBull probes a dict; starlette runs a regex per candidate in order.
+
+if has_phase 5; then
+log "phase 5 — route position: /ping (first) vs /pingz (last)"
+for cyc in $(seq 1 "$CYCLES"); do
+    for arm in blackbull fastapi; do
+        start_arm "$arm" 1 2 || exit 1
+        for p in /ping /pingz "$BASELINE_Q"; do
+            measure "$arm" p5 "$cyc" "$p" 64 3
+        done
+        stop_arm
+    done
+done
+fi
+
+# --- phase 4: what a header costs -----------------------------------------
+# The one structural difference between the stacks is the parser: BlackBull
+# validates every field line in Python (an architectural rule), uvicorn
+# hands the bytes to httptools in C.  wrk sends one header by default, which
+# is the friendliest possible case for the Python parser; real clients send
+# more.  Same endpoint, same body — only the request head grows.
+
+if has_phase 4; then
+log "phase 4 — request header count sensitivity on /ping"
+H3=(-H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    -H 'Accept-Language: en-US,en;q=0.9')
+H7=("${H3[@]}"
+    -H 'Cookie: session=8f14e45fceea167a5a36dedd4bea2543'
+    -H 'Referer: http://127.0.0.1:8501/index.html'
+    -H 'X-Request-Id: 3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+    -H 'X-Forwarded-For: 203.0.113.7')
+for cyc in $(seq 1 "$CYCLES"); do
+    for arm in blackbull fastapi; do
+        start_arm "$arm" 1 2 || exit 1
+        measure "$arm" p4h1 "$cyc" /ping 64 3
+        measure "$arm" p4h4 "$cyc" /ping 64 3 "${H3[@]}"
+        measure "$arm" p4h8 "$cyc" /ping 64 3 "${H7[@]}"
+        stop_arm
+    done
+done
+fi
+
+# --- phase 3: the shape the leaderboard runs ------------------------------
+# Run before the profiles so a profiler crash cannot cost the scale data.
+
+if has_phase 3; then
+log "phase 3 — 3 workers on cpus 0,2,4, 512 conns"
+for cyc in $(seq 1 "$CYCLES"); do
+    for arm in blackbull fastapi; do
+        start_arm "$arm" 3 0,2,4 || exit 1
+        measure "$arm" p3 "$cyc" "$BASELINE_Q" 512 3
+        stop_arm
+    done
+done
+fi
+
+# --- phase 2: where the cycles go -----------------------------------------
+#
+# Sampled in its own run: py-spy pauses the process on every sample, so the
+# cost-per-request numbers above must come from unsampled runs.  Spawn form
+# is mandatory — ptrace_scope=1 refuses `-p` attach to a sibling process,
+# but any process may ptrace its own descendants.  Blocking sampling, not
+# --nonblocking: on a saturated core nonblocking dropped ~45 % of samples,
+# and a dropped sample is not random — reads tear precisely when frames
+# churn fastest.  py-spy is left unpinned so it does not eat the server's
+# core.
+
+if has_phase 2; then
+log "phase 2 — py-spy attribution (${SAMPLE_HZ} Hz, ${PROFILE_SECS}s, $BASELINE_Q)"
+for arm in blackbull fastapi; do
+    # --nonblocking is mandatory here, not a tuning preference.  Blocking
+    # mode ptrace-stops the process for every sample; on this box that took
+    # the server from ~28 000 req/s down to 14 req/s, and a profile taken at
+    # 14 req/s describes connection setup, not the hot path.  Nonblocking
+    # discards samples it cannot read cleanly (counted as Errors) but leaves
+    # the server running.  The wrk result is recorded next to the profile
+    # precisely so the profile can be thrown out if the rate collapsed.
+    start_arm "$arm" 1 2 \
+        "$REPO/.venv/bin/py-spy" record -f raw -r "$SAMPLE_HZ" --nonblocking \
+            -d "$PROFILE_SECS" -o "$OUT/raw/$arm.folded" -- \
+        || exit 1
+    taskset -c "$GEN_CPUS" wrk -t3 -c64 -d"$((PROFILE_SECS - 5))s" \
+        "http://127.0.0.1:$PORT$BASELINE_Q" >"$OUT/raw/pyspy-load-$arm.txt" 2>&1
+    wait "$WRAP_PID"
+    log "  $arm: $(rg -N -o 'Samples: [0-9]+ Errors: [0-9]+' "$OUT/raw/$arm.server.log" | tail -1) | under load: $(awk '/Requests\/sec/{print $2}' "$OUT/raw/pyspy-load-$arm.txt") req/s"
+    stop_arm
+done
+fi
+
+# --- provenance ------------------------------------------------------------
+
+{
+    echo "# hotpath A/B provenance"
+    echo
+    echo "- when: $TS"
+    echo "- host: $(uname -srm)"
+    echo "- cpu: $(rg -m1 'model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ //') ($(nproc) threads, SMT siblings 2n/2n+1)"
+    echo "- generator cores: $GEN_CPUS (wrk)"
+    echo "- phase 1/2: 1 worker on cpu 2, wrk -t3 -c64"
+    echo "- phase 3: 3 workers on cpus 0,2,4, wrk -t3 -c512"
+    echo "- window: ${WARMUP}s warmup + ${DURATION}s measure, $CYCLES interleaved cycles"
+    echo "- endpoints: /ping (4-byte pre-encoded body) and $BASELINE_Q (HttpArena's baseline handler)"
+    echo "- '-mw' arms: PEER_MW=httparena — BlackBull adds Compression()+static(); FastAPI adds GZipMiddleware(1000)+/static mount"
+    echo "- blackbull: $("$REPO/.venv/bin/python" -c 'import blackbull;print(blackbull.__version__)') @ $(git -C "$REPO" rev-parse --short HEAD)"
+    echo "- peers: $("$REPO/.venv/bin/python" -c 'import uvicorn,starlette,fastapi,httptools,uvloop;print(f"uvicorn {uvicorn.__version__}, starlette {starlette.__version__}, fastapi {fastapi.__version__}, httptools {httptools.__version__}, uvloop {uvloop.__version__}")')"
+    echo "- python: $("$REPO/.venv/bin/python" -V)"
+    echo "- wrk: $(wrk --version 2>&1 | head -1)"
+} > "$OUT/provenance.md"
+
+log "done -> $OUT"
+echo "$OUT"

--- a/bench/hotpath/hotpath_summary.py
+++ b/bench/hotpath/hotpath_summary.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Summarise a hotpath_ab.sh run into RESULT.md.
+
+Reports CPU microseconds per request as the primary figure.  Throughput
+alone cannot be compared across phases (different core counts); CPU cost
+per request can, and it is what "hot path" actually means.
+"""
+import collections
+import pathlib
+import re
+import statistics
+import sys
+
+RPS = re.compile(r'^Requests/sec:\s*([0-9.]+)', re.M)
+P99 = re.compile(r'^\s*99%\s+([0-9.]+)(us|ms|s)\b', re.M)
+META = re.compile(
+    r'^cpu_seconds=([0-9.]+) requests=(\d+) arm=(\S+) phase=(\S+) '
+    r'path=(\S+) conns=(\d+)', re.M)
+UNIT = {'us': 1e-3, 'ms': 1.0, 's': 1000.0}
+
+LABEL = {
+    'blackbull': 'BlackBull + uvloop',
+    'fastapi': 'FastAPI / uvicorn + uvloop + httptools',
+    'blackbull-mw': 'BlackBull + uvloop + HttpArena middleware',
+    'fastapi-mw': 'FastAPI + HttpArena middleware',
+}
+
+
+def collect(raw: pathlib.Path):
+    rows = collections.defaultdict(list)
+    for f in sorted(raw.glob('wrk-*.txt')):
+        text = f.read_text()
+        m = META.search(text)
+        r = RPS.search(text)
+        if not m or not r:
+            continue
+        cpu_s, reqs, arm, phase, path, conns = m.groups()
+        reqs, cpu_s = int(reqs), float(cpu_s)
+        p = P99.search(text)
+        rows[(phase, path, conns, arm)].append({
+            'rps': float(r.group(1)),
+            # CPU microseconds per request: the cost of the hot path itself,
+            # independent of how many cores were thrown at it.
+            'us_cpu': 1e6 * cpu_s / reqs if reqs else float('nan'),
+            'p99_ms': float(p.group(1)) * UNIT[p.group(2)] if p else float('nan'),
+        })
+    return rows
+
+
+def agg(vals):
+    mean = statistics.fmean(vals)
+    spread = (max(vals) - min(vals)) / mean * 100 if mean else 0.0
+    return mean, spread
+
+
+def table(rows, phase, title, note):
+    keys = sorted(k for k in rows if k[0] == phase)
+    if not keys:
+        return ''
+    out = [f'## {title}', '', note, '',
+           '| endpoint | arm | runs | req/s | CPU µs/req | spread | p99 ms |',
+           '|---|---|---:|---:|---:|---:|---:|']
+    for phase_, path, conns, arm in keys:
+        rs = rows[(phase_, path, conns, arm)]
+        rps, rps_spread = agg([r['rps'] for r in rs])
+        us, _ = agg([r['us_cpu'] for r in rs])
+        p99, _ = agg([r['p99_ms'] for r in rs])
+        out.append(f'| `{path}` | {LABEL.get(arm, arm)} | {len(rs)} | '
+                   f'{rps:,.0f} | {us:.2f} | {rps_spread:.1f}% | {p99:.2f} |')
+    out.append('')
+    return '\n'.join(out)
+
+
+def deltas(rows, phase, pairs):
+    """A vs B, in CPU cost per request, with the noise floor beside it."""
+    out = ['| endpoint | comparison | A µs/req | B µs/req | B is | worst spread | verdict |',
+           '|---|---|---:|---:|---:|---:|---|']
+    paths = sorted({(k[1], k[2]) for k in rows if k[0] == phase})
+    for path, conns in paths:
+        for a, b in pairs:
+            ka, kb = (phase, path, conns, a), (phase, path, conns, b)
+            if ka not in rows or kb not in rows:
+                continue
+            ua, sa = agg([r['us_cpu'] for r in rows[ka]])
+            ub, sb = agg([r['us_cpu'] for r in rows[kb]])
+            worst = max(sa, sb)
+            pct = (ub - ua) / ua * 100
+            verdict = 'outside noise' if abs(pct) > worst else 'inside noise'
+            out.append(f'| `{path}` | {a} → {b} | {ua:.2f} | {ub:.2f} | '
+                       f'{pct:+.1f}% | {worst:.1f}% | {verdict} |')
+    return '\n'.join(out) + '\n'
+
+
+TITLES = {
+    'p1': ('Phase 1 — one worker on one core, 64 connections',
+           'The core saturates, so `CPU µs/req` is the hot-path cost outright.'),
+    'p3': ('Phase 3 — 3 workers on 3 physical cores, 512 connections',
+           'The shape the leaderboard runs, scaled to this box.'),
+    'p5': ('Phase 5 — route position (`/ping` first vs `/pingz` last)',
+           'Byte-identical handlers; only their place in the route table differs.'),
+    'p4h1': ('Phase 4a — 1 request header (wrk default)', ''),
+    'p4h4': ('Phase 4b — 4 request headers', ''),
+    'p4h8': ('Phase 4c — 8 request headers (browser-shaped)', ''),
+}
+PAIRS = [('blackbull', 'fastapi'), ('blackbull', 'blackbull-mw'),
+         ('fastapi', 'fastapi-mw'), ('blackbull-mw', 'fastapi-mw')]
+
+
+def main(d):
+    d = pathlib.Path(d)
+    rows = collect(d / 'raw')
+    parts = ['# BlackBull vs FastAPI — where does a request cost its CPU?', '',
+             (d / 'provenance.md').read_text() if (d / 'provenance.md').exists() else '',
+             '']
+    for phase in sorted({k[0] for k in rows}):
+        title, note = TITLES.get(phase, (f'Phase `{phase}`', ''))
+        parts.append(table(rows, phase, title, note))
+        parts.append(deltas(rows, phase, PAIRS))
+    (d / 'RESULT.md').write_text('\n'.join(parts))
+    print((d / 'RESULT.md').read_text())
+
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/bench/hotpath/parser_micro.py
+++ b/bench/hotpath/parser_micro.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Head-to-head on the one thing the two stacks do not share: the parser.
+
+BlackBull owns every byte of HTTP/1.1 in Python (an architectural rule, not
+an oversight); uvicorn delegates to httptools, a C wrapper around the
+Node.js parser.  Everything else in a request — routing, the handler, the
+response write — is Python on both sides, so if the frameworks differ in
+per-request cost this is the first place to look, and it is the one place
+where the difference is structural rather than incidental.
+
+Both are fed byte-identical requests.  The comparison is deliberately
+per-header, because that is the axis a real client moves along: wrk sends
+one header, a browser sends eight.
+"""
+import statistics
+import sys
+import time
+
+sys.path.insert(0, '/home/toshio/work/BlackBull')
+
+import httptools  # noqa: E402
+from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
+
+TARGET = b'/baseline11?a=1&b=2&c=3'
+EXTRA = [
+    b'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    b'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    b'Accept-Encoding: gzip, deflate, br',
+    b'Accept-Language: en-US,en;q=0.9',
+    b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543',
+    b'Referer: http://127.0.0.1:8501/index.html',
+    b'X-Request-Id: 3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+]
+
+
+def request_bytes(n_extra: int) -> bytes:
+    lines = [b'GET ' + TARGET + b' HTTP/1.1', b'Host: 127.0.0.1:8501']
+    lines += EXTRA[:n_extra]
+    return b'\r\n'.join(lines) + b'\r\n\r\n'
+
+
+class _Sink:
+    """httptools needs a callback target; keep it as cheap as uvicorn's."""
+
+    def __init__(self):
+        self.headers = []
+
+    def on_message_begin(self):
+        # uvicorn resets per message on a reused parser; without this the
+        # list grows across iterations and the benchmark measures realloc.
+        self.headers = []
+
+    def on_url(self, url):
+        self.url = url
+
+    def on_header(self, name, value):
+        self.headers.append((name.lower(), value))
+
+    def on_headers_complete(self):
+        pass
+
+    def on_body(self, body):
+        pass
+
+    def on_message_complete(self):
+        pass
+
+
+def bench(fn, data, iters):
+    fn(data)  # warm the branch predictors and any lazily-built state
+    best = []
+    for _ in range(7):
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            fn(data)
+        best.append((time.perf_counter_ns() - t0) / iters / 1000)  # µs
+    return min(best), statistics.median(best)
+
+
+def main():
+    actor = HTTP1Actor.__new__(HTTP1Actor)
+    actor._ssl = False
+
+    def blackbull(data):
+        return actor._parse(data)
+
+    # One parser for the whole run, as uvicorn keeps one per connection —
+    # constructing a parser per request would be a cost uvicorn never pays.
+    sink = _Sink()
+    parser = httptools.HttpRequestParser(sink)
+
+    def httptools_parse(data):
+        parser.feed_data(data)
+
+    print(f'{"headers":>8} {"BlackBull µs":>14} {"httptools µs":>14} {"ratio":>7}')
+    for n in (1, 2, 4, 8):
+        data = request_bytes(n - 1)
+        bb, _ = bench(blackbull, data, 20000)
+        ht, _ = bench(httptools_parse, data, 20000)
+        print(f'{n:>8} {bb:>14.2f} {ht:>14.2f} {bb / ht:>6.1f}x')
+
+    # Per-header slope: the term that grows with what the client sends.
+    d1, d8 = request_bytes(0), request_bytes(7)
+    bb1, _ = bench(blackbull, d1, 20000)
+    bb8, _ = bench(blackbull, d8, 20000)
+    ht1, _ = bench(httptools_parse, d1, 20000)
+    ht8, _ = bench(httptools_parse, d8, 20000)
+    print(f'\nper-header slope: BlackBull {(bb8 - bb1) / 7:.3f} µs, '
+          f'httptools {(ht8 - ht1) / 7:.3f} µs')
+    print(f'fixed cost (1 header): BlackBull {bb1:.2f} µs, httptools {ht1:.2f} µs')
+
+
+if __name__ == '__main__':
+    main()

--- a/bench/hotpath/parser_micro.py
+++ b/bench/hotpath/parser_micro.py
@@ -10,33 +10,84 @@ where the difference is structural rather than incidental.
 
 Both are fed byte-identical requests.  The comparison is deliberately
 per-header, because that is the axis a real client moves along: wrk sends
-one header, a browser sends eight.
+one header, a browser sends eight, and a logged-in page behind a CDN can
+send twenty.
+
+``EXTRA`` is a real Chrome request in real send order, not synthetic
+filler.  That matters for anything that special-cases well-known names:
+filler like ``X-Filler-07`` would miss every such fast path and report a
+slope no real client would see.  Past 32 the list would have to be
+invented, which is why the sweep stops there.
 """
+import argparse
+import json
+import pathlib
 import statistics
 import sys
 import time
 
-sys.path.insert(0, '/home/toshio/work/BlackBull')
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
 
 import httptools  # noqa: E402
 from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
 
 TARGET = b'/baseline11?a=1&b=2&c=3'
 EXTRA = [
+    b'Connection: keep-alive',
+    b'Cache-Control: max-age=0',
+    b'sec-ch-ua: "Chromium";v="130", "Not?A_Brand";v="99"',
+    b'sec-ch-ua-mobile: ?0',
+    b'sec-ch-ua-platform: "Linux"',
+    b'Upgrade-Insecure-Requests: 1',
     b'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
     b'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    b'Sec-Fetch-Site: same-origin',
+    b'Sec-Fetch-Mode: navigate',
+    b'Sec-Fetch-User: ?1',
+    b'Sec-Fetch-Dest: document',
     b'Accept-Encoding: gzip, deflate, br',
     b'Accept-Language: en-US,en;q=0.9',
     b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543',
     b'Referer: http://127.0.0.1:8501/index.html',
+    b'Origin: http://127.0.0.1:8501',
+    b'DNT: 1',
+    b'Pragma: no-cache',
+    b'If-None-Match: W/"3f2504e0-4f89"',
+    b'If-Modified-Since: Wed, 29 Jul 2026 10:00:00 GMT',
+    b'TE: trailers',
+    b'X-Requested-With: XMLHttpRequest',
+    b'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+    b'X-Forwarded-For: 203.0.113.7',
+    b'X-Forwarded-Proto: http',
+    b'X-Forwarded-Host: example.test',
+    b'X-Real-Ip: 203.0.113.7',
     b'X-Request-Id: 3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+    b'X-Correlation-Id: 9b2c1f0e-77aa-4c31-b5c6-0d1e2f3a4b5c',
+    b'Priority: u=0, i',
 ]
+COUNTS = (1, 2, 4, 8, 16, 32)
 
 
 def request_bytes(n_extra: int) -> bytes:
+    if n_extra > len(EXTRA):
+        raise ValueError(f'only {len(EXTRA)} real headers available')
     lines = [b'GET ' + TARGET + b' HTTP/1.1', b'Host: 127.0.0.1:8501']
     lines += EXTRA[:n_extra]
     return b'\r\n'.join(lines) + b'\r\n\r\n'
+
+
+def slope(points: dict[int, float]) -> float:
+    """Least-squares µs-per-header over every measured count.
+
+    A 1→8 endpoint difference is one subtraction of two noisy numbers; the
+    regression uses all six and is what the sweep is for.
+    """
+    xs = sorted(points)
+    mx = statistics.fmean(xs)
+    my = statistics.fmean(points[x] for x in xs)
+    num = sum((x - mx) * (points[x] - my) for x in xs)
+    den = sum((x - mx) ** 2 for x in xs)
+    return num / den
 
 
 class _Sink:
@@ -78,6 +129,13 @@ def bench(fn, data, iters):
 
 
 def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--iters', type=int, default=20000)
+    ap.add_argument('--json', type=pathlib.Path,
+                    help='also write the raw points here, for before/after diffing')
+    ap.add_argument('--label', default='', help='tag recorded in the JSON')
+    args = ap.parse_args()
+
     actor = HTTP1Actor.__new__(HTTP1Actor)
     actor._ssl = False
 
@@ -92,22 +150,41 @@ def main():
     def httptools_parse(data):
         parser.feed_data(data)
 
+    bb_pts: dict[int, float] = {}
+    ht_pts: dict[int, float] = {}
     print(f'{"headers":>8} {"BlackBull µs":>14} {"httptools µs":>14} {"ratio":>7}')
-    for n in (1, 2, 4, 8):
+    for n in COUNTS:
         data = request_bytes(n - 1)
-        bb, _ = bench(blackbull, data, 20000)
-        ht, _ = bench(httptools_parse, data, 20000)
-        print(f'{n:>8} {bb:>14.2f} {ht:>14.2f} {bb / ht:>6.1f}x')
+        bb_pts[n], _ = bench(blackbull, data, args.iters)
+        ht_pts[n], _ = bench(httptools_parse, data, args.iters)
+        print(f'{n:>8} {bb_pts[n]:>14.2f} {ht_pts[n]:>14.2f} '
+              f'{bb_pts[n] / ht_pts[n]:>6.1f}x')
 
-    # Per-header slope: the term that grows with what the client sends.
-    d1, d8 = request_bytes(0), request_bytes(7)
-    bb1, _ = bench(blackbull, d1, 20000)
-    bb8, _ = bench(blackbull, d8, 20000)
-    ht1, _ = bench(httptools_parse, d1, 20000)
-    ht8, _ = bench(httptools_parse, d8, 20000)
-    print(f'\nper-header slope: BlackBull {(bb8 - bb1) / 7:.3f} µs, '
-          f'httptools {(ht8 - ht1) / 7:.3f} µs')
-    print(f'fixed cost (1 header): BlackBull {bb1:.2f} µs, httptools {ht1:.2f} µs')
+    # Two slopes.  The regression is the honest one; the 1→8 endpoint pair is
+    # kept because every number recorded before this sweep existed was 1→8,
+    # and a target quoted against that basis has to be checked against it.
+    bb_slope, ht_slope = slope(bb_pts), slope(ht_pts)
+    bb_18, ht_18 = (bb_pts[8] - bb_pts[1]) / 7, (ht_pts[8] - ht_pts[1]) / 7
+    print(f'\nper-header slope (least squares, 1..32): '
+          f'BlackBull {bb_slope:.3f} µs, httptools {ht_slope:.3f} µs')
+    print(f'per-header slope (1→8 endpoints):        '
+          f'BlackBull {bb_18:.3f} µs, httptools {ht_18:.3f} µs')
+    print(f'fixed cost (1 header): BlackBull {bb_pts[1]:.2f} µs, '
+          f'httptools {ht_pts[1]:.2f} µs')
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps({
+            'label': args.label,
+            'python': sys.version.split()[0],
+            'iters': args.iters,
+            'blackbull_us': bb_pts,
+            'httptools_us': ht_pts,
+            'blackbull_slope_lsq': bb_slope,
+            'blackbull_slope_1_8': bb_18,
+            'httptools_slope_lsq': ht_slope,
+        }, indent=2, sort_keys=True) + '\n')
+        print(f'\nwrote {args.json}')
 
 
 if __name__ == '__main__':

--- a/bench/http11probe/probe_scan.py
+++ b/bench/http11probe/probe_scan.py
@@ -1,7 +1,6 @@
 """Local substitute for the .NET Http11Probe — fires the exact Cluster A/B/C
 vectors from the baseline proposal at a live BlackBull server and reports the
-actual status / behaviour, so we can see the post-Sprint-61 delta and what
-Sprint 63 still needs to fix.  Not a pytest file; run directly."""
+actual status / behaviour, so the remaining gaps are visible.  Not a pytest file; run directly."""
 import asyncio
 import socket
 from http import HTTPMethod

--- a/bench/httparena/app.py
+++ b/bench/httparena/app.py
@@ -124,7 +124,7 @@ async def _baseline_handler(conn: Connection):
     the semantics are identical: sum integer query params, add posted
     body if integer, return as text/plain.
 
-    Sprint 79: uses ``Connection`` instead of the raw ASGI triplet.
+    Uses ``Connection`` instead of the raw ASGI triplet.
     """
     total = 0
     for vals in _qs(conn).values():
@@ -193,7 +193,7 @@ async def json_comp_endpoint(count: int, conn: Connection):
 
 @app.route(path='/upload', methods=[HTTPMethod.POST])
 async def upload_endpoint(conn: Connection):
-    # Sprint 80: stream the body with ``Connection.stream()`` — the profile only
+    # Stream the body with ``Connection.stream()`` — the profile only
     # needs the byte count, so we never materialize the (up to 20 MB) payload.
     # ``conn.body()`` would ``b''.join`` the whole upload (~4-12x the CPU and a
     # multiple of the throughput under load); streaming keeps a one-chunk working
@@ -249,7 +249,7 @@ def _int_qs(conn: Connection, name, default):
 
 @app.route(path='/async-db', methods=[HTTPMethod.GET])
 async def async_db_endpoint(req: Connection, db_conn=Depends(db.get_db_conn)):
-    # Sprint 79: ``req`` is the BlackBull Connection; ``conn`` is the db handle.
+    # ``req`` is the BlackBull Connection; ``conn`` is the db handle.
     min_price = _int_qs(req, 'min', 10)
     max_price = _int_qs(req, 'max', 50)
     limit = max(1, min(_int_qs(req, 'limit', 50), 50))
@@ -263,7 +263,7 @@ async def async_db_endpoint(req: Connection, db_conn=Depends(db.get_db_conn)):
 
 @app.route(path='/crud/items', methods=[HTTPMethod.GET])
 async def crud_items_list(req: Connection, db_conn=Depends(db.get_db_conn)):
-    # Sprint 79: ``req`` is the BlackBull Connection; ``conn`` is the db handle.
+    # ``req`` is the BlackBull Connection; ``conn`` is the db handle.
     qs = _qs(req)
     category = qs.get('category', [None])[0]
     page = _int_qs(req, 'page', 1)

--- a/bench/httparena/app_v0600.py
+++ b/bench/httparena/app_v0600.py
@@ -124,7 +124,7 @@ async def _baseline_handler(conn: Connection):
     the semantics are identical: sum integer query params, add posted
     body if integer, return as text/plain.
 
-    Sprint 79: uses ``Connection`` instead of the raw ASGI triplet.
+    Uses ``Connection`` instead of the raw ASGI triplet.
     """
     total = 0
     for vals in _qs(conn).values():
@@ -193,7 +193,7 @@ async def json_comp_endpoint(count: int, conn: Connection):
 
 @app.route(path='/upload', methods=[HTTPMethod.POST])
 async def upload_endpoint(conn: Connection):
-    # Sprint 80: stream the body with ``Connection.stream()`` — the profile only
+    # Stream the body with ``Connection.stream()`` — the profile only
     # needs the byte count, so we never materialize the (up to 20 MB) payload.
     # ``conn.body()`` would ``b''.join`` the whole upload (~4-12x the CPU and a
     # multiple of the throughput under load); streaming keeps a one-chunk working
@@ -249,7 +249,7 @@ def _int_qs(conn: Connection, name, default):
 
 @app.route(path='/async-db', methods=[HTTPMethod.GET])
 async def async_db_endpoint(req: Connection, db_conn=Depends(db.get_db_conn)):
-    # Sprint 79: ``req`` is the BlackBull Connection; ``conn`` is the db handle.
+    # ``req`` is the BlackBull Connection; ``conn`` is the db handle.
     min_price = _int_qs(req, 'min', 10)
     max_price = _int_qs(req, 'max', 50)
     limit = max(1, min(_int_qs(req, 'limit', 50), 50))
@@ -263,7 +263,7 @@ async def async_db_endpoint(req: Connection, db_conn=Depends(db.get_db_conn)):
 
 @app.route(path='/crud/items', methods=[HTTPMethod.GET])
 async def crud_items_list(req: Connection, db_conn=Depends(db.get_db_conn)):
-    # Sprint 79: ``req`` is the BlackBull Connection; ``conn`` is the db handle.
+    # ``req`` is the BlackBull Connection; ``conn`` is the db handle.
     qs = _qs(req)
     category = qs.get('category', [None])[0]
     page = _int_qs(req, 'page', 1)

--- a/bench/httparena/compare_table.py
+++ b/bench/httparena/compare_table.py
@@ -13,10 +13,18 @@ Stdlib only, no third-party deps — it runs on the bench driver host at the end
 of a successful benchmark.  When ``blackbull`` and exactly one peer framework
 are present, a ``BB/peer`` throughput ratio column is added; otherwise it just
 lists each framework's req/s side by side.
+
+The JSON's ``rps`` is HttpArena's **best of three** runs.  Best-of-N is a fine
+headline but a poor basis for judging a small gap: it reports no spread, so a
+3 % difference between two arms is indistinguishable from one arm getting a
+luckier run.  So a second table re-reads every individual run out of
+``logs/benchmark-<framework>-<profile>.log`` and prints mean ± spread beside
+the best.  Read a gap as real only when it is large against the spread column.
 """
 import glob
 import json
 import os
+import re
 import sys
 
 # Canonical profile order (matches the suite's default PROFILES); anything not
@@ -62,6 +70,110 @@ def collect(result_dir: str) -> tuple[dict, list]:
     return rows, frameworks
 
 
+# "=== blackbull / baseline / 512c (tool=gcannon) ===" — the section header
+# benchmark.sh prints before each (framework, profile, conns) group of runs.
+_HEAD_RE = re.compile(r'^===\s*(\S+)\s*/\s*(\S+)\s*/\s*(\d+)c\b')
+# "  Throughput: 179.61K req/s" — one per run within the group.
+_RUN_RE = re.compile(r'Throughput:\s*([0-9.]+)\s*([KM]?)\s*req/s')
+
+_SUFFIX = {'': 1.0, 'K': 1e3, 'M': 1e6}
+
+
+def collect_runs(result_dir: str) -> dict:
+    """Return {(profile, conns): {fw: [rps, ...]}} from the benchmark logs.
+
+    The per-run throughputs never reach the JSON — only their maximum does —
+    so the logs are the only place the spread survives.  benchmark.sh prints
+    them rounded to ~4 significant figures ("179.61K req/s"), which quantises
+    these figures by ~0.05 % — two orders below the spread they are read for.
+    """
+    runs: dict = {}
+    pattern = os.path.join(result_dir, "logs", "benchmark-*.log")
+    for path in glob.glob(pattern):
+        key = None
+        with open(path, errors="replace") as fh:
+            for line in fh:
+                head = _HEAD_RE.match(line.strip())
+                if head:
+                    fw, profile, conns = head.group(1), head.group(2), int(head.group(3))
+                    key = (profile, conns, fw)
+                    continue
+                run = _RUN_RE.search(line)
+                if run and key is not None:
+                    value = float(run.group(1)) * _SUFFIX[run.group(2)]
+                    profile, conns, fw = key
+                    runs.setdefault((profile, conns), {}).setdefault(fw, []).append(value)
+    return runs
+
+
+def render_runs(runs: dict, frameworks: list) -> str:
+    """Mean ± spread beside the best, so a small gap can be judged."""
+    if not runs:
+        return ""
+    lines = [
+        "",
+        "## Per-run throughput (mean of all runs, spread = (max-min)/mean)",
+        "",
+        "Best-of-3 is what the JSON records; this is every run.  A gap between "
+        "two arms is a finding only when it is large next to the spread.",
+        "",
+        "| profile/conns | framework | runs | mean req/s | best req/s | spread |",
+        "|---|---|---|---:|---:|---:|",
+    ]
+    for key in sorted(runs, key=lambda k: _profile_key(*k)):
+        profile, conns = key
+        for fw in frameworks:
+            values = runs[key].get(fw)
+            if not values:
+                continue
+            mean = sum(values) / len(values)
+            spread = (max(values) - min(values)) / mean if mean else 0.0
+            lines.append(
+                f"| {profile}/{conns} | {fw} | {len(values)} | "
+                f"{mean:,.0f} | {max(values):,.0f} | {spread * 100:.1f}% |"
+            )
+    return "\n".join(lines) + "\n"
+
+
+def render_uvloop_delta(runs: dict) -> str:
+    """What uvloop is worth, when both loop arms ran in this session.
+
+    This is the only honest form of the question.  Comparing a uvloop number
+    from one run against a stock number from another confounds the loop with
+    the machine, the generator, the peer set, and the build; here the two arms
+    are the same wheel and the same app on one instance, differing in one ENV.
+
+    The verdict column compares the delta against the larger of the two arms'
+    own run-to-run spreads: a delta inside the noise is not a measurement.
+    """
+    stock_key, uv_key = "blackbull", "blackbull-uvloop"
+    present = {fw for cell in runs.values() for fw in cell}
+    if not {stock_key, uv_key} <= present:
+        return ""
+
+    lines = [
+        "",
+        "## uvloop delta (same instance, same session, same wheel)",
+        "",
+        "| profile/conns | stock mean | uvloop mean | Δ | max spread | verdict |",
+        "|---|---:|---:|---:|---:|---|",
+    ]
+    for key in sorted(runs, key=lambda k: _profile_key(*k)):
+        stock, uvloop = runs[key].get(stock_key), runs[key].get(uv_key)
+        if not stock or not uvloop:
+            continue
+        s_mean, u_mean = sum(stock) / len(stock), sum(uvloop) / len(uvloop)
+        delta = (u_mean - s_mean) / s_mean
+        spread = max((max(v) - min(v)) / (sum(v) / len(v)) for v in (stock, uvloop))
+        verdict = "inside noise" if abs(delta) <= spread else "outside noise"
+        profile, conns = key
+        lines.append(
+            f"| {profile}/{conns} | {s_mean:,.0f} | {u_mean:,.0f} | "
+            f"{delta * 100:+.1f}% | {spread * 100:.1f}% | {verdict} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
 def render(rows: dict, frameworks: list) -> str:
     ratio_peer = None
     if "blackbull" in frameworks and len(frameworks) == 2:
@@ -97,7 +209,10 @@ def main(argv: list) -> int:
     if not rows:
         print(f"compare_table.py: no result JSONs under {result_dir}", file=sys.stderr)
         return 1
-    table = render(rows, frameworks)
+    runs = collect_runs(result_dir)
+    table = (render(rows, frameworks)
+             + render_runs(runs, frameworks)
+             + render_uvloop_delta(runs))
     out = os.path.join(result_dir, "COMPARISON.md")
     with open(out, "w") as fh:
         fh.write(table)

--- a/bench/httparena/patch_httparena.py
+++ b/bench/httparena/patch_httparena.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Patch HttpArena to honour Sprint-34 env knobs.
+"""Patch HttpArena to honour BlackBull env knobs.
 
 Run on the EC2 instance after the HttpArena clone, before
 `docker build` / `validate.sh` / `benchmark.sh`.  Reads the HttpArena

--- a/bench/httparena/runner.sh
+++ b/bench/httparena/runner.sh
@@ -8,10 +8,10 @@ WEB_NOFILE="${4:-65536}"
 LOADGEN_CPUS="${5:-}"
 LOADGEN_NOFILE="${6:-65536}"
 
-# Sprint 34: native-mode wrk inherits the parent shell's RLIMIT_NOFILE
+# Native-mode wrk inherits the parent shell's RLIMIT_NOFILE
 # (HttpArena defaults LOADGEN_DOCKER=false so wrk runs via
 # `taskset -c $GCANNON_CPUS wrk ...` directly).  Set the shell limit to
-# LOADGEN_NOFILE so the wrk-FD-cap hypothesis (Sprint 33) is directly
+# LOADGEN_NOFILE so the wrk-FD-cap hypothesis is directly
 # controllable from the harness.  Framework container's ulimit is set
 # separately via the HARD_NOFILE override below.
 ulimit -n "${LOADGEN_NOFILE}"
@@ -25,7 +25,7 @@ ulimit -n "${LOADGEN_NOFILE}"
 # (added to args[] in the matching framework.sh sed-patch).
 export HARD_NOFILE="${WEB_NOFILE}"
 export WEB_WORKERS WEB_NOFILE LOADGEN_NOFILE
-# Sprint 34 Cell B: forwarded to launcher.py via -e in framework.sh
+# Forwarded to launcher.py via -e in framework.sh
 # (patched by patch_httparena.py).  Comma-list of listeners to spawn;
 # default = all three (back-compat).  For static-profile sweeps we
 # pass only "http" so :8081/:8443 don't fork idle worker pools.

--- a/bench/mqtt/tap_throughput.py
+++ b/bench/mqtt/tap_throughput.py
@@ -9,11 +9,11 @@ the real ``BrokerActor`` + ``serve_connection`` over in-memory pipes:
 Two dispatch modes, selected with ``--tap-mode`` (the **only** variable between
 runs — same load generator, same machine, same build):
 
-* ``inline``  — the tap runs inline on the publisher's connection (Sprint 53
+* ``inline``  — the tap runs inline on the publisher's connection (the
   contract), so a slow tap serialises that connection's reads.  Throughput
   falls and p99 rises as ``tap_delay`` grows, while coverage stays 100 %.
 * ``actor``   — the publish is *offered* to a decoupled bounded ``TapActor``
-  (Sprint 54, drop-newest overflow).  A slow tap no longer back-pressures
+  (decoupled, drop-newest overflow).  A slow tap does not back-pressure
   delivery; throughput/p99 stay ~flat, the cost surfacing as coverage < 100 %
   and a non-zero drop count.
 
@@ -22,7 +22,6 @@ Run both back-to-back in one session for the controlled side-by-side:
   python bench/mqtt/tap_throughput.py --tap-mode inline [--messages N]
   python bench/mqtt/tap_throughput.py --tap-mode actor [--messages N]
 
-(see bench/sprint-logs/sprint-54.md).
 """
 from __future__ import annotations
 
@@ -227,8 +226,8 @@ if __name__ == '__main__':
                     help='messages per tap_delay (default 500; '
                          'kept modest because inline taps serialise at 1/tap_delay)')
     ap.add_argument('--tap-mode', choices=('inline', 'actor'), default='actor',
-                    help="tap dispatch: 'inline' (Sprint 53) or 'actor' "
-                         "(Sprint 54, decoupled + drop-newest; default)")
+                    help="tap dispatch: 'inline' or 'actor' "
+                         "(decoupled + drop-newest; default)")
     ap.add_argument('--tap-queue', type=int, default=256,
                     help='actor-mode TapActor inbox bound (default 256; '
                          'overflow drops newest)')

--- a/bench/parse_microbench.py
+++ b/bench/parse_microbench.py
@@ -1,4 +1,4 @@
-"""HTTP/1.1 `_parse` microbenchmark — Sprint 77 (zero-copy P3 go/no-go).
+"""HTTP/1.1 `_parse` microbenchmark — the zero-copy go/no-go.
 
 `zero-copy-native-interface.md` phase 2 gates the single-normalized-buffer
 parser on a **+10 % RPS** EC2 result, and notes the prototype "is expected
@@ -68,7 +68,7 @@ def main() -> None:
 
     h = _make_handler()
     # Sanity: each request parses without raising.
-    # Sprint 79: ``_parse`` now returns a ``Connection`` dataclass, not a dict.
+    # ``_parse`` now returns a ``Connection`` dataclass, not a dict.
     for name, data in REQUESTS.items():
         conn = h._parse(data)
         assert conn.type == 'http', name

--- a/bench/peers/compare_servers.sh
+++ b/bench/peers/compare_servers.sh
@@ -17,31 +17,31 @@
 #   STACKS    space-separated subset (default: all five)
 #   LANES     space-separated subset of {A, B-wrk, B-oha, C, D} (default: all)
 #   PORT      bind port (default 8443)
-#   DURATION  per-scenario seconds for wrk/oha (default 60 from Sprint 24;
-#             was 30 in Sprints 13–23 — set DURATION=30 to reproduce older
+#   DURATION  per-scenario seconds for wrk/oha (default 60;
+#             older rows used 30 — set DURATION=30 to reproduce
 #             numbers)
 #   WARMUP    server warmup seconds before any measured run (default 15);
 #             one wrk pass at /plaintext c=64, output discarded.  Set to 0
-#             to skip — older Sprint 13–23 numbers were captured without
+#             to skip — the oldest numbers were captured without
 #             this pass.
 #   RUNS      h2load runs per scenario (median picked; default 3)
 
 set -e
 
 BASE_PORT="${PORT:-8443}"
-# Sprint 20: $BENCH_TARGET_HOST replaces the hard-coded `localhost` in every
+# $BENCH_TARGET_HOST replaces the hard-coded `localhost` in every
 # $BASE URL the load tools see.  Default keeps loopback semantics for the
 # single-instance harness; split-topology sets BENCH_TARGET_HOST to a name
 # that resolves to the server instance's VPC private IP (with cert SAN +
 # /etc/hosts entry in place so TLS verification keeps working).
 BENCH_TARGET_HOST="${BENCH_TARGET_HOST:-localhost}"
 # BASE is now per-stack — set inside bench_stack() via compute_base() so
-# the Sprint 14 *-cleartext stacks target http:// and *-nginx / *-h11 stacks
+# the *-cleartext stacks target http:// and *-nginx / *-h11 stacks
 # stay on https://.  Initial value is the standalone-TLS default so the
 # pre-loop health check / report header still work.
 BASE="https://${BENCH_TARGET_HOST}:${BASE_PORT}"
 
-# Sprint 20: when BENCH_REMOTE_LIFECYCLE=1 the launcher / kill / readiness
+# When BENCH_REMOTE_LIFECYCLE=1 the launcher / kill / readiness
 # checks dispatch over SSH to a second instance instead of running locally.
 # BENCH_REMOTE_SSH is the ssh prefix (e.g. `ssh -i ~/.ssh/server.pem ... ubuntu@10.0.0.5`).
 # BENCH_REMOTE_REPO is the absolute path of the BlackBull checkout on the
@@ -59,41 +59,41 @@ fi
 CERT="tests/cert.pem"
 KEY="tests/key.pem"
 RUNS="${RUNS:-3}"
-# Sprint 24: default duration raised from 30 s to 60 s for the
+# Default duration raised from 30 s to 60 s for the
 # wrk/oha lanes.  30 s left allocator-state,
 # kernel-pacing, and TLS-session-cache transients in the measured
 # window.  Older numbers in CHARACTERIZATION.md were captured at 30 s;
-# Sprint 24+ rows are 60 s.  Override via env to reproduce.
+# Recent rows are 60 s.  Override via env to reproduce.
 DURATION="${DURATION:-60}"
-# Sprint 24: explicit server warmup pass before any lane runs.  One
+# Explicit server warmup pass before any lane runs.  One
 # 15 s wrk burst against /plaintext c=64 — discards output, just nudges
 # Python allocator + kernel TCP autotune + TLS session-cache to
 # steady-state before the measured runs start.
 WARMUP="${WARMUP:-15}"
 
 STACKS_ALL="blackbull uvicorn hypercorn granian daphne nginx sanic"
-# Sprint 24 added Lane E (connection churn).  Defaulting it off in the
+# Lane E is connection churn.  Defaulting it off in the
 # all-lanes set so existing AWS runs (and the cost envelope they assume)
 # don't grow without intent — opt in with LANES="A B-wrk B-oha C D E-wrk".
 LANES_ALL="A B-wrk B-oha C D"
 STACKS="${STACKS:-$STACKS_ALL}"
 LANES="${LANES:-$LANES_ALL}"
 
-# Servers that support HTTP/2 (lane A applies).  Sprint 14 variants
+# Servers that support HTTP/2 (lane A applies).  The variants
 # (*-cleartext, *-nginx, *-h11) are intentionally NOT listed — Lane A
 # would either not negotiate (cleartext) or measure nginx-frontend H2
 # (which isn't apples-to-apples with the standalone H2 numbers).
-# Sprint 16 *-w<N> variants are checked against the base name via
+# The *-w<N> variants are checked against the base name via
 # strip_worker_suffix() below, so multi-worker stacks inherit capabilities.
 SUPPORTS_H2="blackbull hypercorn granian nginx"
 # Servers that DO NOT support /echo POST or /ws — those scenarios are skipped
 # automatically by the orchestrator's health check (server returns 405 / no WS).
 NO_POST_NO_WS="nginx"
 
-# Sprint 16: strip the -w<N> worker-count suffix so blackbull-w2 etc. match
+# Strip the -w<N> worker-count suffix so blackbull-w2 etc. match
 # the SUPPORTS_H2 / NO_POST_NO_WS lists exactly like plain "blackbull".
 # Other suffixes (-cleartext, -nginx, -h11) are intentionally NOT stripped —
-# those variants have different capability semantics by design (Sprint 14).
+# those variants have different capability semantics by design.
 strip_worker_suffix() {
     case "$1" in
         *-w[0-9]|*-w[0-9][0-9]) echo "${1%-w*}" ;;
@@ -101,8 +101,8 @@ strip_worker_suffix() {
     esac
 }
 
-# Per-stack BASE URL.  Sprint 14 introduces three suffix conventions;
-# Sprint 16 adds a fourth (multi-worker):
+# Per-stack BASE URL.  Three suffix conventions, plus
+# a fourth (multi-worker):
 #   *-cleartext     → http  on $BASE_PORT (no TLS on the server)
 #   *-nginx         → https on $BASE_PORT (TLS terminated by nginx, HTTP upstream)
 #   *-h11           → https on $BASE_PORT (uvicorn with --http h11)
@@ -186,7 +186,7 @@ kill_existing() {
 # In remote-lifecycle mode the local orchestrator cannot see the server's
 # process tree, so we drop the PID-descendant check and trust that the
 # preceding kill_existing left the port clean.  The HTTP probe is the only
-# remaining readiness signal — same shape as Sprint 16's between-lane
+# remaining readiness signal — same shape as the between-lane
 # health_check, just used at startup instead of between lanes.
 wait_ready() {
     local expected_pid="$1"
@@ -327,7 +327,7 @@ run_lane_c_k6() {
     local json_c2="$SCRATCH/k6_${label}_c2.json"
 
     # C1 — 200 VU.  BASE is exported so the k6 script picks up the
-    # actual benchmark target (Sprint 20 split topology points BASE at
+    # actual benchmark target (the split topology points BASE at
     # bench-server.internal rather than localhost).
     K6_VUS=200 K6_DURATION=60s BASE="$BASE" \
         k6 run --quiet --summary-export="$json_c1" \
@@ -427,7 +427,7 @@ PYEOF
 bench_stack() {
     local stack="$1"
 
-    # Sprint 14: per-stack BASE.  *-cleartext stacks target http://, the
+    # Per-stack BASE.  *-cleartext stacks target http://, the
     # rest stay on https://.  All downstream helpers (health_check, the
     # lane runners) read $BASE from the outer scope.
     BASE="$(compute_base "$stack")"
@@ -454,7 +454,7 @@ bench_stack() {
         # remote log on failure so the orchestrator output is useful.
         local granian_log_env_remote=""
         [ "$stack" = "granian" ] && granian_log_env_remote="GRANIAN_LOG_TARGET=$BENCH_REMOTE_REPO/$SCRATCH/server_granian.log"
-        # Sprint 21 Phase B: propagate BB_BENCH_TASKSET so per-stack runs
+        # Propagate BB_BENCH_TASKSET so per-stack runs
         # can pin workers to specific CPUs.  Empty (the default) means no
         # pinning on the server side.
         local taskset_env_remote=""
@@ -477,7 +477,7 @@ bench_stack() {
         # buffering question altogether); other stacks use the shell pipe.
         local granian_log_env=""
         [ "$stack" = "granian" ] && granian_log_env="GRANIAN_LOG_TARGET=$(pwd)/$SCRATCH/server_granian.log"
-        # Sprint 21 Phase B: optional CPU pinning, same env var as remote mode.
+        # Optional CPU pinning, same env var as remote mode.
         local taskset_prefix=()
         [ -n "${BB_BENCH_TASKSET:-}" ] && taskset_prefix=(taskset -c "$BB_BENCH_TASKSET")
         env $granian_log_env \
@@ -505,11 +505,11 @@ bench_stack() {
     fi
     echo "$stack ready (spawn pid=$server_pid)."
 
-    # Sprint 24: short warmup burst to settle Python allocator, kernel
+    # Short warmup burst to settle Python allocator, kernel
     # TCP autotune, and TLS session-cache before any measured run.
     # Output is discarded — this exists to remove transients, not to
     # produce a number.  WARMUP=0 disables (back-compat with the
-    # Sprint 13–23 protocol).
+    # the older protocol).
     if [ "${WARMUP:-15}" -gt 0 ]; then
         echo "  warmup ${WARMUP}s ..."
         wrk -t2 -c64 -d"${WARMUP}s" "$BASE/plaintext" >/dev/null 2>&1 || true
@@ -529,7 +529,7 @@ bench_stack() {
 
     # Capability checks against SUPPORTS_H2 / NO_POST_NO_WS use the
     # worker-suffix-stripped base name so blackbull-w<N> inherits from
-    # blackbull.  Sprint 14 suffixes (-cleartext / -nginx / -h11) are NOT
+    # blackbull.  The suffixes (-cleartext / -nginx / -h11) are NOT
     # stripped — their capability semantics differ from the base by design.
     local stack_base
     stack_base="$(strip_worker_suffix "$stack")"
@@ -583,7 +583,7 @@ bench_stack() {
     echo "Methodology: bench/CHARACTERIZATION.md"
     echo "App:         bench/peers/asgi_app.py (shared minimal ASGI)"
     echo "             — BlackBull uses bench/app.py for parity at the wire level"
-    echo "Target:      $BASE  (default; Sprint 14 *-cleartext stacks use http:// instead)"
+    echo "Target:      $BASE  (default; *-cleartext stacks use http:// instead)"
     echo ""
     echo "Hardware:    $(uname -a | cut -d' ' -f1-3)"
     echo "CPU:         $(grep -m1 'model name' /proc/cpuinfo | sed 's/.*: //')"

--- a/bench/peers/fastapi_app.py
+++ b/bench/peers/fastapi_app.py
@@ -1,17 +1,127 @@
-"""FastAPI benchmark app — minimal /ping route to match BlackBull's bench shape.
+"""FastAPI benchmark app — wire-compatible with bench/peers/asgi_app.py.
+
+Same endpoints, same response bodies, same content-types.
 
 Run with:
-    hypercorn --bind 0.0.0.0:8443 \\
-        --certfile tests/cert.pem --keyfile tests/key.pem \\
-        --workers 1 --worker-class asyncio \\
-        bench.peers.fastapi_app:app
+    uvicorn bench.peers.fastapi_app:app --host 127.0.0.1 --port 8443 \\
+        --ssl-certfile tests/cert.pem --ssl-keyfile tests/key.pem \\
+        --loop auto --http auto --workers 1 --log-level warning --no-access-log
 """
-from fastapi import FastAPI
-from fastapi.responses import Response
+import os
+
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi.responses import PlainTextResponse, Response
 
 app = FastAPI()
 
+# PEER_MW=httparena reproduces what HttpArena's own fastapi entry mounts
+# (post-PR-#1054: gzip at minimum_size=1000, no BaseHTTPMiddleware) so the
+# two frameworks can be compared carrying the same accessories.
+if os.environ.get("PEER_MW") == "httparena":
+    from fastapi.middleware.gzip import GZipMiddleware
+    app.add_middleware(GZipMiddleware, minimum_size=1000, compresslevel=5)
 
-@app.get('/ping')
+# -- pre-encoded bodies (same as asgi_app.py) -------------------------------
+_PLAINTEXT = b"Hello, World!"
+_JSON = b'{"message":"Hello, World!"}'
+_PONG = b"pong"
+_1KB = os.urandom(1024)
+_16KB = os.urandom(16000)
+_64KB = os.urandom(65536)
+_1MB = os.urandom(1024 * 1024)
+
+_PLAIN_CT = "text/plain; charset=utf-8"
+_HTML_CT = "text/html; charset=utf-8"
+_JSON_CT = "application/json"
+_OCTET_CT = "application/octet-stream"
+
+
+@app.get("/ping")
 async def ping():
-    return Response(b'pong')
+    return Response(_PONG, media_type=_HTML_CT)
+
+
+@app.get("/plaintext")
+async def plaintext():
+    return Response(_PLAINTEXT, media_type=_PLAIN_CT)
+
+
+@app.get("/json")
+async def json_endpoint():
+    return Response(_JSON, media_type=_JSON_CT)
+
+
+@app.get("/1kb")
+async def _1kb_endpoint():
+    return Response(_1KB, media_type=_HTML_CT)
+
+
+@app.get("/16kb")
+async def _16kb_endpoint():
+    return Response(_16KB, media_type=_HTML_CT)
+
+
+@app.get("/64kb")
+async def _64kb_endpoint():
+    return Response(_64KB, media_type=_HTML_CT)
+
+
+@app.get("/1mb")
+async def _1mb_endpoint():
+    return Response(_1MB, media_type=_HTML_CT)
+
+
+@app.post("/echo")
+async def echo(request: Request):
+    body = await request.body()
+    return Response(body, media_type=_OCTET_CT)
+
+
+# HttpArena's `baseline` profile endpoint, copied from that harness's own
+# fastapi entry so a local A/B exercises the same handler as the leaderboard
+# run.  /ping measures the framework floor; this measures the floor plus
+# query parsing and a dynamically built body.
+@app.api_route("/baseline11", methods=["GET", "POST"])
+async def baseline11(request: Request):
+    total = 0
+    for val in request.query_params.values():
+        try:
+            total += int(val)
+        except ValueError:
+            pass
+    if request.method == "POST":
+        body = await request.body()
+        if body:
+            try:
+                total += int(body.strip())
+            except ValueError:
+                pass
+    return PlainTextResponse(str(total))
+
+
+# Mounted LAST, as HttpArena's entry does: starlette matches routes in
+# registration order, so a mount registered ahead of the benchmark routes
+# would tax every request with a prefix check it does not need.
+if os.environ.get("PEER_MW") == "httparena":
+    from fastapi.staticfiles import StaticFiles
+    app.mount("/static", StaticFiles(
+        directory=os.path.dirname(os.path.abspath(__file__))), name="static")
+
+
+@app.websocket("/ws")
+async def ws_echo(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            await websocket.send_text(data)
+    except WebSocketDisconnect:
+        pass
+
+
+# Registered LAST on purpose — see the note on native_app.pingz.  Starlette
+# matches routes in registration order with a regex per candidate, so the
+# /ping vs /pingz delta is the cost of the scan.
+@app.get("/pingz")
+async def pingz():
+    return Response(_PONG, media_type=_HTML_CT)

--- a/bench/peers/native_app.py
+++ b/bench/peers/native_app.py
@@ -8,10 +8,20 @@ Loaded by BlackBull's own server:
 """
 import os
 from http import HTTPMethod
+from urllib.parse import parse_qs
 
-from blackbull import BlackBull, Response
+from blackbull import BlackBull, Connection, Response
 
 app = BlackBull()
+
+# PEER_MW=httparena reproduces the middleware stack bench/httparena/app.py
+# registers, so a local A/B can ask whether the leaderboard gap lives in the
+# framework or in what the leaderboard entry mounts on top of it.  Off by
+# default: the bare app is the framework floor.
+if os.environ.get("PEER_MW") == "httparena":
+    from blackbull.middleware.compression import Compression
+    app.use(Compression())
+    app.static("/static", os.path.dirname(os.path.abspath(__file__)))
 
 # -- pre-encoded bodies (same as asgi_app.py) -------------------------------
 _PLAINTEXT = b"Hello, World!"
@@ -68,6 +78,30 @@ async def echo(body: bytes):
     return Response(body, content_type=_OCTET_CT)
 
 
+# HttpArena's `baseline` profile endpoint, copied from bench/httparena/app.py
+# so a local A/B exercises the same handler as the leaderboard run.  /ping
+# measures the framework floor; this measures the floor plus query parsing
+# and a dynamically built body, which is where the leaderboard gap shows up.
+@app.route(path="/baseline11", methods=[HTTPMethod.GET, HTTPMethod.POST])
+async def baseline11(conn: Connection):
+    total = 0
+    raw = conn.query_string or b""
+    for vals in parse_qs(raw.decode("latin-1"), keep_blank_values=True).values():
+        for v in vals:
+            try:
+                total += int(v)
+            except ValueError:
+                pass
+    if conn.method == "POST":
+        body = await conn.body()
+        if body:
+            try:
+                total += int(body.strip())
+            except ValueError:
+                pass
+    return Response(str(total).encode(), content_type=_PLAIN_CT)
+
+
 @app.route(path="/ws", methods=[HTTPMethod.GET])
 async def ws_echo(conn, receive, send):
     """WebSocket echo — full-form handler (conn, receive, send)."""
@@ -88,3 +122,11 @@ async def ws_echo(conn, receive, send):
         else:
             await send({"type": "websocket.send",
                         "bytes": event.get("bytes") or b""})
+
+
+# Registered LAST on purpose.  Paired with /ping — the first route — this
+# measures what the router costs as the table grows: BlackBull resolves a
+# static path with one dict probe, so the pair should cost the same.
+@app.route(path="/pingz", methods=[HTTPMethod.GET])
+async def pingz():
+    return Response(_PONG, content_type=_HTML_CT)

--- a/bench/peers/nginx_proxy.conf
+++ b/bench/peers/nginx_proxy.conf
@@ -1,4 +1,4 @@
-# Sprint 14 — nginx HTTPS frontend + cleartext HTTP upstream.
+# Nginx HTTPS frontend + cleartext HTTP upstream.
 #
 # Used by bench/peers/run_peer.sh for the *-nginx topology variants
 # (blackbull-nginx, uvicorn-nginx, granian-nginx).  The base server

--- a/bench/peers/run_comparison.py
+++ b/bench/peers/run_comparison.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Comprehensive peer benchmark: BlackBull (no uvloop) vs FastAPI vs Sanic.
+
+Uses bench/peers/run_peer.sh to launch each stack, then runs wrk + oha
+against all endpoints at multiple concurrency levels.  Cleartext HTTP/1.1
+only (no TLS) — fast and apples-to-apples.
+
+Usage:
+    BB_UVLOOP=0 python bench/peers/run_comparison.py
+"""
+import subprocess
+import sys
+import time
+import json
+import os
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+RUN_PEER = REPO / "bench" / "peers" / "run_peer.sh"
+PORT = 8444  # Avoid conflict with default 8443
+
+STACKS = ["blackbull", "fastapi", "sanic"]
+ENDPOINTS = {
+    "/ping":      ("GET",  "text/html"),
+    "/plaintext": ("GET",  "text/plain"),
+    "/json":      ("GET",  "application/json"),
+    "/echo":      ("POST", "application/octet-stream"),
+    "/1kb":       ("GET",  "text/html"),
+    "/16kb":      ("GET",  "text/html"),
+}
+CONCURRENCIES = [64, 256, 512, 1024]
+DURATION = 15
+WARMUP = 5
+WRK_THREADS = 8
+
+
+def run(cmd, **kwargs):
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=REPO, **kwargs)
+
+
+def launch(stack, cleartext=True):
+    """Launch a stack via run_peer.sh. Returns the Popen process."""
+    variant = "cleartext" if cleartext else "tls"
+    stack_name = f"{stack}-{variant}" if cleartext else stack
+    env = os.environ.copy()
+    if stack == "blackbull":
+        env["BB_UVLOOP"] = "0"
+    proc = subprocess.Popen(
+        ["bash", str(RUN_PEER), stack_name, str(PORT)],
+        env=env, cwd=REPO,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    return proc
+
+
+def wait_ready(url, timeout=30):
+    """Wait until the server responds 200."""
+    import urllib.request
+    import urllib.error
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            req = urllib.request.Request(url, method="GET")
+            resp = urllib.request.urlopen(req, timeout=2)
+            if resp.status == 200:
+                return True
+        except (urllib.error.URLError, OSError, ConnectionRefusedError):
+            pass
+        time.sleep(0.5)
+    return False
+
+
+def run_wrk(url, concurrency, duration=DURATION):
+    """Run wrk and return (req_s, avg_lat_ms, max_lat_ms)."""
+    cmd = [
+        "wrk", f"-t{WRK_THREADS}", f"-c{concurrency}",
+        f"-d{duration}s", "--timeout", "8", url
+    ]
+    result = run(cmd, timeout=duration + 30)
+    out = result.stdout
+    req_s = avg_lat = max_lat = None
+    for line in out.splitlines():
+        if "Requests/sec:" in line:
+            try:
+                req_s = float(line.strip().split()[1])
+            except (ValueError, IndexError):
+                pass
+        if "Latency" in line and "Avg" not in line:
+            parts = line.strip().split()
+            try:
+                avg_idx = parts.index("Avg") if "Avg" in parts else None
+                if avg_idx is None:
+                    # Format: Latency  avg  stdev  max  +/-stdev
+                    avg_lat = float(parts[1]) if len(parts) > 1 else None
+                    # Find max
+                    for i, p in enumerate(parts):
+                        if p == "Max" or (p.replace('.', '').isdigit() and i > 1):
+                            continue
+                    # Simpler: just parse known format
+                    if len(parts) >= 4:
+                        avg_lat = float(parts[1])
+                        # max is parts[3] but might have unit
+                        max_lat = float(parts[3].rstrip('usms'))
+            except (ValueError, IndexError):
+                pass
+    return req_s, avg_lat, max_lat
+
+
+def run_oha(url, concurrency, duration=DURATION):
+    """Run oha with --disable-keepalive (matching The Benchmarker)."""
+    cmd = [
+        "oha", "--no-tui", "--disable-keepalive", "--latency-correction",
+        "-c", str(concurrency), "-z", f"{duration}s", url
+    ]
+    result = run(cmd, timeout=duration + 30)
+    out = result.stdout
+    req_s = None
+    for line in out.splitlines():
+        if "Requests/sec:" in line:
+            try:
+                req_s = float(line.strip().split()[1])
+            except (ValueError, IndexError):
+                pass
+    return req_s
+
+
+def bench_stack(stack_name):
+    """Benchmark one stack across all endpoints and concurrencies."""
+    print(f"\n{'='*60}")
+    print(f"  {stack_name}")
+    print(f"{'='*60}")
+
+    # Launch
+    proc = launch(stack_name, cleartext=True)
+    base_url = f"http://127.0.0.1:{PORT}"
+
+    if not wait_ready(f"{base_url}/ping"):
+        print(f"  ERROR: {stack_name} failed to start")
+        proc.kill()
+        proc.wait()
+        return None
+
+    print(f"  Server ready")
+
+    # Warmup
+    run(["wrk", f"-t{WRK_THREADS}", "-c64", f"-d{WARMUP}s", "--timeout", "8",
+         f"{base_url}/plaintext"], timeout=WARMUP + 10)
+
+    results = {}
+    for endpoint, (method, _ct) in ENDPOINTS.items():
+        url = f"{base_url}{endpoint}"
+        results[endpoint] = {"wrk": {}, "oha": {}}
+
+        for c in CONCURRENCIES:
+            rps, avg_lat, max_lat = run_wrk(url, c)
+            results[endpoint]["wrk"][c] = {
+                "rps": rps,
+                "avg_lat_ms": avg_lat,
+                "max_lat_ms": max_lat,
+            }
+
+        # oha at one concurrency (64) for The Benchmarker comparison
+        oha_rps = run_oha(url, 64)
+        results[endpoint]["oha"] = {"c64_rps": oha_rps}
+
+    # Stop
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    time.sleep(1)
+
+    return results
+
+
+def print_summary(all_results):
+    """Print side-by-side comparison tables."""
+    print("\n\n" + "=" * 80)
+    print("  SUMMARY — wrk throughput (req/s)")
+    print("=" * 80)
+
+    for endpoint in ENDPOINTS:
+        print(f"\n--- {endpoint} ---")
+        header = f"{'Stack':>12s}"
+        for c in CONCURRENCIES:
+            header += f" {'c=' + str(c):>10s}"
+        print(header)
+        print("-" * len(header))
+
+        for stack in STACKS:
+            if stack not in all_results or all_results[stack] is None:
+                continue
+            row = f"{stack:>12s}"
+            for c in CONCURRENCIES:
+                rps = all_results[stack].get(endpoint, {}).get("wrk", {}).get(c, {}).get("rps")
+                if rps:
+                    row += f" {rps:>10,.0f}"
+                else:
+                    row += f" {'—':>10s}"
+            print(row)
+
+        # Ratios vs BlackBull
+        if "blackbull" in all_results and all_results["blackbull"] is not None:
+            print()
+            for stack in ["fastapi", "sanic"]:
+                if stack not in all_results or all_results[stack] is None:
+                    continue
+                row = f"{'  ' + stack + '/BB':>12s}"
+                for c in CONCURRENCIES:
+                    bb_rps = all_results["blackbull"].get(endpoint, {}).get("wrk", {}).get(c, {}).get("rps")
+                    fa_rps = all_results[stack].get(endpoint, {}).get("wrk", {}).get(c, {}).get("rps")
+                    if bb_rps and fa_rps:
+                        row += f" {fa_rps/bb_rps:>10.2f}x"
+                    else:
+                        row += f" {'—':>10s}"
+                print(row)
+
+    # oha comparison (matching The Benchmarker methodology)
+    print(f"\n\n--- oha --disable-keepalive c=64 (The Benchmarker method) ---")
+    print(f"{'Stack':>12s} {'/ping':>10s} {'/plaintext':>12s} {'/json':>10s} {'/echo':>10s}")
+    for stack in STACKS:
+        if stack not in all_results or all_results[stack] is None:
+            continue
+        row = f"{stack:>12s}"
+        for ep in ["/ping", "/plaintext", "/json", "/echo"]:
+            rps = all_results[stack].get(ep, {}).get("oha", {}).get("c64_rps")
+            if rps:
+                row += f" {rps:>10,.0f}"
+            else:
+                row += f" {'—':>10s}"
+        print(row)
+
+
+if __name__ == "__main__":
+    all_results = {}
+    for stack in STACKS:
+        all_results[stack] = bench_stack(stack)
+
+    print_summary(all_results)

--- a/bench/peers/run_full_comparison.sh
+++ b/bench/peers/run_full_comparison.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Comprehensive peer benchmark — BlackBull(no-uvloop) vs FastAPI vs Sanic
+# Uses bench/peers/run_peer.sh for server lifecycle
+set -e
+
+REPO="/home/toshio/work/BlackBull"
+PORT=8444
+DUR=15
+WARMUP=5
+THREADS=8
+STACKS=("blackbull" "fastapi" "sanic")
+ENDPOINTS=("/plaintext" "/json" "/ping" "/echo")
+CONCURRENCIES=(64 256 512 1024)
+RESULTS="$REPO/bench/results/peer_cmp_$(date +%Y%m%d-%H%M%S).txt"
+
+cd "$REPO"
+
+echo "# Peer Benchmark: BlackBull(no-uvloop) vs FastAPI vs Sanic" | tee "$RESULTS"
+echo "# $(date)" | tee -a "$RESULTS"
+echo "# wrk -t$THREADS -c{N} -d${DUR}s --timeout 8" | tee -a "$RESULTS"
+echo "" | tee -a "$RESULTS"
+
+for stack in "${STACKS[@]}"; do
+    echo "" | tee -a "$RESULTS"
+    echo "## $stack" | tee -a "$RESULTS"
+    
+    # Launch server
+    pkill -9 -f "run_peer\|benchmarker\|uvicorn.*8444\|sanic.*8444\|blackbull.*8444" 2>/dev/null || true
+    sleep 1
+    
+    if [ "$stack" = "blackbull" ]; then
+        BB_UVLOOP=0 bash bench/peers/run_peer.sh blackbull-cleartext $PORT &
+    else
+        bash bench/peers/run_peer.sh ${stack}-cleartext $PORT &
+    fi
+    PID=$!
+    
+    # Wait for ready
+    for i in $(seq 1 30); do
+        if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/ping 2>/dev/null | grep -q 200; then
+            break
+        fi
+        sleep 0.5
+    done
+    echo "  ready (PID=$PID)" | tee -a "$RESULTS"
+    
+    # Warmup
+    wrk -t$THREADS -c64 -d${WARMUP}s --timeout 8 http://127.0.0.1:$PORT/plaintext >/dev/null 2>&1 || true
+    
+    for ep in "${ENDPOINTS[@]}"; do
+        url="http://127.0.0.1:$PORT$ep"
+        echo "  $ep" | tee -a "$RESULTS"
+        
+        for c in "${CONCURRENCIES[@]}"; do
+            out=$(wrk -t$THREADS -c$c -d${DUR}s --timeout 8 "$url" 2>&1)
+            rps=$(echo "$out" | grep "Requests/sec:" | awk '{print $2}')
+            lat=$(echo "$out" | grep -E "^\s+Latency" | awk '{printf "%s/%s/%s", $2, $3, $4}')
+            printf "    c=%-5s  rps=%-10s  lat=%s\n" "$c" "$rps" "$lat" | tee -a "$RESULTS"
+        done
+        
+        # oha --disable-keepalive (The Benchmarker method) at c=64
+        oha_out=$(oha --no-tui --disable-keepalive --latency-correction -c 64 -z ${DUR}s "$url" 2>&1)
+        oha_rps=$(echo "$oha_out" | grep "Requests/sec:" | awk '{print $2}')
+        printf "    oha-c=64 rps=%-10s\n" "$oha_rps" | tee -a "$RESULTS"
+    done
+    
+    # Stop
+    kill $PID 2>/dev/null || true
+    wait $PID 2>/dev/null || true
+    sleep 1
+done
+
+echo "" | tee -a "$RESULTS"
+echo "## Done — results saved to $RESULTS" | tee -a "$RESULTS"

--- a/bench/peers/run_peer.sh
+++ b/bench/peers/run_peer.sh
@@ -151,8 +151,11 @@ case "$base" in
         # *same* shared peer app (bench.peers.asgi_app:app) that uvicorn /
         # hypercorn / granian / daphne load — no BlackBull-only bench/app.py
         # path any more.
+        # Honour BB_UVLOOP env if already set; default to 1 for apples-to-
+        # apples with uvicorn/ hypercorn/ granian (all uvloop by default).
+        bb_uvloop="${BB_UVLOOP:-1}"
         LAUNCH_CMD=(
-            env BB_UVLOOP=1 "BB_WORKERS=$workers"
+            env BB_UVLOOP="$bb_uvloop" "BB_WORKERS=$workers"
                 BB_H2_INITIAL_WINDOW_SIZE=65535
                 BB_H2_CONNECTION_WINDOW_SIZE=65535
                 BB_H2_MAX_CONCURRENT_STREAMS=100
@@ -176,6 +179,23 @@ case "$base" in
         fi
         LAUNCH_CMD=(
             uvicorn bench.peers.asgi_app:app
+                --host "$BIND_HOST" --port "$upstream_port"
+                "${uv_tls_args[@]}"
+                --loop auto --http "$uv_http" --workers 1
+                --log-level warning --no-access-log
+        )
+        finalize
+        ;;
+    fastapi)
+        # FastAPI on uvicorn — same engine as the uvicorn stack but serving
+        # bench.peers.fastapi_app:app (FastAPI routing layer on top).
+        if [ "$variant" = "h11" ]; then
+            uv_http=h11
+        else
+            uv_http=auto
+        fi
+        LAUNCH_CMD=(
+            uvicorn bench.peers.fastapi_app:app
                 --host "$BIND_HOST" --port "$upstream_port"
                 "${uv_tls_args[@]}"
                 --loop auto --http "$uv_http" --workers 1

--- a/bench/peers/run_peer.sh
+++ b/bench/peers/run_peer.sh
@@ -12,13 +12,13 @@
 #   daphne      daphne    (HTTP/1.1 + WS)             — no HTTP/2
 #   nginx       reference floor (static GETs, HTTP/2, no upstream)
 #
-# Sprint 14 — topology / parser variants (blackbull, uvicorn, granian only):
+# Topology / parser variants (blackbull, uvicorn, granian only):
 #   <base>-cleartext   plain HTTP on $port (no TLS); isolates TLS cost
 #   <base>-nginx       nginx HTTPS on $port + base on $((port+1)) cleartext
 #                      via nginx_proxy.conf; isolates TLS+accept-loop offload
 #   uvicorn-h11        TLS as default but force the pure-Python h11 parser
 #
-# Sprint 16 — multi-worker variants (blackbull only):
+# Multi-worker variants (blackbull only):
 #   blackbull-w<N>     N worker processes (BB_WORKERS=N), SO_REUSEPORT
 #                      single TLS port.  e.g. blackbull-w2, blackbull-w4.
 #
@@ -35,7 +35,7 @@ cert="${3:-tests/cert.pem}"
 key="${4:-tests/key.pem}"
 
 # Bind interface for every peer's listen socket.  Defaults to 127.0.0.1 so
-# the legacy single-host benchmark path is byte-identical.  Sprint 20 split
+# the legacy single-host benchmark path is byte-identical.  The split
 # topology sets BIND_HOST=0.0.0.0 so the load generator on a second
 # instance can reach the server over the VPC private network.
 BIND_HOST="${BIND_HOST:-127.0.0.1}"
@@ -43,8 +43,8 @@ BIND_HOST="${BIND_HOST:-127.0.0.1}"
 if [ -z "$stack" ]; then
     echo "Usage: $0 <stack> [port] [cert] [key]" >&2
     echo "Bases: blackbull, uvicorn, hypercorn, granian, daphne, nginx, sanic" >&2
-    echo "Variants (Sprint 14): <base>-cleartext, <base>-nginx, uvicorn-h11" >&2
-    echo "Variants (Sprint 16): blackbull-w<N> (N workers, e.g. blackbull-w4)" >&2
+    echo "Variants: <base>-cleartext, <base>-nginx, uvicorn-h11" >&2
+    echo "Variants: blackbull-w<N> (N workers, e.g. blackbull-w4)" >&2
     exit 1
 fi
 
@@ -147,7 +147,7 @@ case "$base" in
         # Production defaults (BB_ACCESS_LOG=1, BB_ASYNC_LOGGING=1)
         # remain unchanged in env.py — only this harness overrides.
         #
-        # Sprint 11: the BlackBull console-script CLI lets us point at the
+        # The BlackBull console-script CLI lets us point at the
         # *same* shared peer app (bench.peers.asgi_app:app) that uvicorn /
         # hypercorn / granian / daphne load — no BlackBull-only bench/app.py
         # path any more.
@@ -170,7 +170,7 @@ case "$base" in
         # --http auto picks httptools if installed, else h11.
         # --loop auto picks uvloop if installed, else asyncio.
         # For best numbers install uvicorn[standard] (httptools + uvloop).
-        # Sprint 14: uvicorn-h11 forces the pure-Python h11 parser to
+        # Uvicorn-h11 forces the pure-Python h11 parser to
         # isolate the C-parser advantage.
         if [ "$variant" = "h11" ]; then
             uv_http=h11
@@ -206,8 +206,8 @@ case "$base" in
     hypercorn)
         # bench/peers/hypercorn.toml carries the tuning; --bind on the CLI
         # overrides the toml's bind so we share $port with the other peers.
-        # Sprint 14: hypercorn intentionally has no cleartext/nginx variants
-        # (Sprint 13 ranked it well behind the matrix; the layer-attribution
+        # Hypercorn intentionally has no cleartext/nginx variants
+        # (it ranked well behind the matrix; the layer-attribution
         # A/B would not be informative).
         LAUNCH_CMD=(
             hypercorn --config bench/peers/hypercorn.toml
@@ -267,7 +267,7 @@ json.dump(cfg, open(sys.argv[2], 'w'))
         ;;
     daphne)
         # daphne endpoint spec: ssl:<port>:privateKey=<key>:certKey=<cert>
-        # Sprint 14: daphne intentionally has no cleartext/nginx variants
+        # Daphne intentionally has no cleartext/nginx variants
         # (same rationale as hypercorn).
         LAUNCH_CMD=(
             daphne --bind "$BIND_HOST"
@@ -279,7 +279,7 @@ json.dump(cfg, open(sys.argv[2], 'w'))
         ;;
     nginx)
         # Reference floor — pure C, static content only.  This is the
-        # standalone-nginx peer (Sprint 13).  Sprint 14's nginx-fronted
+        # standalone-nginx peer.  The nginx-fronted
         # variants use the same nginx binary but a different config
         # (nginx_proxy.conf) via the *-nginx suffix on other base stacks.
         if [ "$port" != "8443" ]; then

--- a/bench/peers/server_lifecycle_remote.sh
+++ b/bench/peers/server_lifecycle_remote.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bench/peers/server_lifecycle_remote.sh — Sprint 20.
+# bench/peers/server_lifecycle_remote.sh
 #
 # Server-side launch / kill helper invoked over SSH by compare_servers.sh
 # when BENCH_REMOTE_LIFECYCLE=1.  Runs on the server instance.  The peer
@@ -57,7 +57,7 @@ case "$cmd" in
             source .venv/bin/activate
         fi
 
-        # Optional CPU pinning for Sprint 21 Phase B (w=2→w=4 scaling
+        # Optional CPU pinning (w=2→w=4 scaling
         # diagnosis).  When BB_BENCH_TASKSET is set, prefix the launch
         # with `taskset -c $BB_BENCH_TASKSET` so the worker pool inherits
         # the CPU mask.  Defaults to no pinning, matching prior behaviour.
@@ -68,7 +68,7 @@ case "$cmd" in
 
         # Detach so the SSH session can return immediately; orchestrator's
         # wait_ready does the actual readiness probe.  Redirect stdin from
-        # /dev/null per Sprint 10/11 caution: pipe stdin to a non-reader
+        # /dev/null per a known caution: pipe stdin to a non-reader
         # is a known deadlock shape.
         nohup env $granian_env BIND_HOST="$bind_host" PATH="$PATH" \
             "${taskset_prefix[@]}" \

--- a/bench/profile_under_load.sh
+++ b/bench/profile_under_load.sh
@@ -18,8 +18,8 @@ RESULT_DIR="bench/results"
 mkdir -p "$RESULT_DIR"
 TS="$(date +%Y%m%d-%H%M%S)"
 
-# Default to 500 VU / 60 s — these match the C2 lane in Sprint 13's matrix.
-# Sprint 15 calls this script twice with K6_VUS=200 (B1-like) and K6_VUS=500
+# Default to 500 VU / 60 s — these match the C2 lane in the peer matrix.
+# Callers run this script twice with K6_VUS=200 (B1-like) and K6_VUS=500
 # (C2) to capture the high-vs-low concurrency comparison.
 K6_VUS="${K6_VUS:-500}"
 K6_DURATION="${K6_DURATION:-60s}"

--- a/bench/router_microbench.py
+++ b/bench/router_microbench.py
@@ -1,4 +1,4 @@
-"""Router `_resolve` microbenchmark — Sprint 77 (router-cache Phase 2/3).
+"""Router `_resolve` microbenchmark — the router-cache go/no-go.
 
 Measures the per-call cost of ``Router._resolve`` (cache bypassed) and
 ``Router.__getitem__`` (cache path) across the regimes the proposal names:
@@ -29,7 +29,7 @@ async def _h(scope, receive, send):
 
 
 def build_router(n_fixed: int = 30, n_param: int = 10) -> Router:
-    """A route table shaped like a realistic small API (like Sprint 68 W2)."""
+    """A route table shaped like a realistic small API."""
     r = Router()
     for i in range(n_fixed):
         r[(f'/api/resource{i}/list', HTTPMethod.GET)] = _h

--- a/bench/run_benchmarker_cmp.sh
+++ b/bench/run_benchmarker_cmp.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Run wrk against BlackBull, FastAPI+uvicorn, Sanic with same params as The Benchmarker
+# wrk -t8 -c{64,256,512} -d15s --timeout 8
+set -e
+
+VENV=/home/toshio/work/BlackBull/.venv/bin/python
+PORT=8001
+
+bench_one() {
+    local name=$1
+    local server_cmd=$2
+    echo ""
+    echo "============================================"
+    echo "  $name"
+    echo "============================================"
+
+    # Start server
+    $server_cmd &
+    local pid=$!
+    sleep 3
+
+    # Quick health check
+    if ! curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:$PORT/ | grep -q 200; then
+        echo "ERROR: $name failed to start"
+        kill $pid 2>/dev/null
+        return 1
+    fi
+    echo "  Server OK (PID=$pid)"
+
+    # Bench at 3 concurrency levels
+    for c in 64 256 512; do
+        echo "  --- Concurrency $c ---"
+        wrk -t8 -c$c -d15s --timeout 8 http://127.0.0.1:$PORT/ 2>&1 | grep -E '(Requests/sec|Latency|Transfer/sec)'
+    done
+
+    kill $pid 2>/dev/null
+    wait $pid 2>/dev/null
+    sleep 1
+}
+
+# 1. BlackBull
+bench_one "BlackBull (built-in server)" \
+    "$VENV /home/toshio/work/BlackBull/bench/benchmarker_target.py --port $PORT"
+
+# 2. FastAPI + uvicorn
+bench_one "FastAPI + uvicorn" \
+    "$VENV -m uvicorn bench.benchmarker_target_fastapi:app --host 127.0.0.1 --port $PORT --log-level error"
+
+# 3. Sanic (built-in server)
+bench_one "Sanic (built-in, 1 worker)" \
+    "$VENV -c \"from bench.benchmarker_target_sanic import app; app.run(host='127.0.0.1', port=$PORT, debug=False, access_log=False, workers=1)\""

--- a/bench/soak/sample.py
+++ b/bench/soak/sample.py
@@ -1,4 +1,4 @@
-"""bench/soak/sample.py — Sprint 28 Task 2 soak-harness sampler.
+"""bench/soak/sample.py — soak-harness sampler.
 
 Polls server-process metrics every INTERVAL seconds and appends one
 row per sample to sample.csv:

--- a/bench/soak/soak.sh
+++ b/bench/soak/soak.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bench/soak/soak.sh — Sprint 28 Task 2 soak orchestrator.
+# bench/soak/soak.sh
 #
 # Starts bench/app.py with BB_TRACEMALLOC=1, kicks off bench/soak/
 # sample.py to capture RSS / FD / connection / tracemalloc snapshots

--- a/bench/static_repro/access_log_server.py
+++ b/bench/static_repro/access_log_server.py
@@ -1,6 +1,6 @@
 """Server wrapper that enables the access log and writes it to a file.
 
-Sprint 30 Tier 2 probe — measures **per-request server-side
+Measures **per-request server-side
 duration** directly from the access log, so we can compare
 latencies (not throughput) with and without watermarks.
 
@@ -64,7 +64,7 @@ def _setup_access_log(path: str) -> None:
 def _patch_access_log_format() -> None:
     """Monkeypatch ``AccessLogRecord.format`` to print sub-ms precision.
 
-    Sprint 30 Tier 2 probe — the production format
+    The production format
     ``f'{self.duration_ms():.0f}ms'`` integer-rounds, which wipes the
     signal on static-file workloads where each request takes <1 ms.
     Local-probe-only override; production format stays integer-ms.

--- a/bench/static_repro/drain_time.sh
+++ b/bench/static_repro/drain_time.sh
@@ -2,7 +2,7 @@
 # Drain-time probe — measures how long the server holds FDs after a
 # burst of wrk connections all FIN simultaneously.
 #
-# Sprint 30 Tier 1.5 Step 5 — answers the question:
+# Answers the question:
 # "Does the custom protocol actually shorten connection-close time?"
 #
 # Methodology:

--- a/bench/static_repro/latency_probe.sh
+++ b/bench/static_repro/latency_probe.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Sprint 30 Tier 2 — DIRECT LATENCY PROBE.
+# DIRECT LATENCY PROBE.
 #
 # Methodology (per the user's correction):
 #   - r/s is an indirect metric; Tier 2 was designed to shorten

--- a/bench/static_repro/parse_access_log.py
+++ b/bench/static_repro/parse_access_log.py
@@ -1,7 +1,7 @@
 """Parse a BlackBull access log and compute latency percentiles for
 a measurement window (skipping warmup).
 
-Sprint 30 Tier 2 probe.  The access log format is:
+Access-log probe.  The format is:
 
     YYYY-MM-DDTHH:MM:SS.mmm {ip} "{method} {path} HTTP/{ver}" {status} {bytes} {ms}ms
 

--- a/bench/static_repro/run.sh
+++ b/bench/static_repro/run.sh
@@ -2,7 +2,7 @@
 # Reproduces the HttpArena static-profile run-2/3 degradation shape
 # locally on a single-process BlackBull, with per-run instrumentation.
 #
-# Sprint 30 Task 1 — local reproduction harness.
+# Local reproduction harness.
 #
 # Usage:
 #   bash bench/static_repro/run.sh

--- a/bench/wrk/_stats.py
+++ b/bench/wrk/_stats.py
@@ -1,6 +1,6 @@
 """Aggregate per-run numbers from a wrk multi-run.
 
-Sprint 24 : the wrk/oha lanes now run
+The wrk/oha lanes now run
 RUNS times per scenario and report a robust set of stats:
 
     median  median-absolute-deviation  min  max  noise_pct

--- a/bench/wrk/lane_e.sh
+++ b/bench/wrk/lane_e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# bench/wrk/lane_e.sh — Sprint 24 Lane E: connection-churn / short-lived
+# bench/wrk/lane_e.sh — Lane E: connection-churn / short-lived
 # connections.  Mirrors bench/wrk/run.sh's contract (same env, same row
 # format including the trailing "noise (MAD)" column) but only runs E1
 # and E2 with the no_keepalive.lua script forcing `Connection: close`.

--- a/bench/wrk/no_keepalive.lua
+++ b/bench/wrk/no_keepalive.lua
@@ -1,4 +1,4 @@
--- bench/wrk/no_keepalive.lua — short-lived connections, Sprint 24 Lane E.
+-- bench/wrk/no_keepalive.lua — short-lived connections, Lane E.
 --
 -- wrk holds connections open across requests by default; with this
 -- script every request adds `Connection: close` so the server is

--- a/bench/wrk/run.sh
+++ b/bench/wrk/run.sh
@@ -24,9 +24,9 @@ OUTDIR="${OUTDIR:-bench/results}"
 LABEL="${LABEL:-}"
 LABEL_PREFIX="${LABEL_PREFIX:-}"   # filename prefix so per-stack runs don't overwrite
 D="${DURATION:-30}"
-# Sprint 24 : RUNS_WRK > 1 enables multi-run aggregation —
+# RUNS_WRK > 1 enables multi-run aggregation —
 # median req/s with MAD / min / max / noise% columns.  RUNS_WRK=1 keeps
-# Sprint 13–23 single-run behaviour (the report just emits the wrk numbers
+# the older single-run behaviour (the report just emits the wrk numbers
 # directly and the noise columns read `—`).
 RUNS_WRK="${RUNS_WRK:-3}"
 
@@ -46,7 +46,7 @@ run_one() {
         cmd="$cmd -- $pipe_args"
     fi
 
-    # Sprint 24: loop RUNS_WRK times, capture each run's req/s + the
+    # Loop RUNS_WRK times, capture each run's req/s + the
     # latency stats from the LAST run (the latency distribution is
     # already a per-run percentile; aggregating it across runs would
     # be misleading, while aggregating throughput is straightforward).
@@ -119,7 +119,7 @@ run_one() {
     fi
 }
 
-# Header — Sprint 24 added the trailing "noise (MAD)" column.  Rows
+# Header — the trailing "noise (MAD)" column is optional.  Rows
 # where MAD/median > 10 % carry a 🌫 marker; older RUNS_WRK=1 reports
 # leave the column blank.
 echo "| Scenario | req/s | mean lat | p50 | p99 | max | socket errors | noise (MAD) |"

--- a/blackbull/__init__.py
+++ b/blackbull/__init__.py
@@ -13,8 +13,8 @@ Public API exports:
 - `QUERY`: the HTTP QUERY method (RFC 10008) as a plain string — ``http.HTTPMethod`` lacks the member until Python ≥3.16.
 - `UnprocessableQuery`: raise from a QUERY handler for ``422`` when the (accepted) request media type carries a semantically unprocessable query (RFC 10008).
 - `Headers`: case-insensitive, ordered, multi-valued HTTP header store.
-- `Connection`: the typed internal request representation (Sprint 79); the handler context object exposing ``method``/``path``/``headers``/``cookies``/``body()``/``json()``/``text()``. The ASGI ``scope`` is a derived view (``Connection.as_scope()``).
-- `Request`: **deprecated** alias of ``Connection`` (Sprint 79 Phase 5). Accessing ``blackbull.Request`` emits a ``DeprecationWarning``; replace ``request: Request`` handler params with ``conn: Connection`` (identical API). Removal no earlier than 2027-08-01.
+- `Connection`: the typed internal request representation; the handler context object exposing ``method``/``path``/``headers``/``cookies``/``body()``/``json()``/``text()``. The ASGI ``scope`` is a derived view (``Connection.as_scope()``).
+- `Request`: **deprecated** alias of ``Connection``. Accessing ``blackbull.Request`` emits a ``DeprecationWarning``; replace ``request: Request`` handler params with ``conn: Connection`` (identical API). Removal no earlier than 2027-08-01.
 - `WebSocket`: the high-level WebSocket handler object — ``await ws.accept()``, ``async for message in ws``, ``ws.send_text()``/``send_bytes()``/``send_json()``, ``await ws.close()``. Declare ``async def handler(ws: WebSocket)`` on a ``Scheme.websocket`` route to receive it; the raw ``(conn, receive, send)`` form keeps working unchanged.
 - `WebSocketDisconnect`: raised by ``ws.receive()`` when the peer closes; carries ``code`` and ``reason``. ``async for`` ends the loop instead of raising.
 - `Depends`: per-request provider injection for simplified handlers (async-generator providers get teardown after the response is sent).
@@ -75,8 +75,8 @@ from .middleware.proxy import TrustedProxy
 def __getattr__(name):
     """Lazy, deprecated attribute access — ``blackbull.Request``.
 
-    ``Request`` was the opt-in HTTP context object; Sprint 79 Phase 5 merged
-    it into :class:`Connection` and demoted the name to an alias. Resolving it
+    ``Request`` was the opt-in HTTP context object; it has been merged
+    into :class:`Connection` and the name demoted to an alias. Resolving it
     through the module ``__getattr__`` (PEP 562) means the ``DeprecationWarning``
     fires only if code actually touches ``Request`` — importing the package
     stays warning-free — and the alias still evaluates to ``Connection`` so

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -51,7 +51,7 @@ def _wrap_send(raw_send: ASGISendCallable):
     inside :meth:`_dispatch` — never at :meth:`__call__` around the whole
     middleware chain.  Wrapping outward leaks ``Response`` objects into
     middleware ``send`` wrappers, which reasonably assume ASGI dicts and
-    crash on ``msg['type']`` (the 0.43.2 regression; locked by
+    crash on ``msg['type']`` (locked by
     ``tests/unit/test_middleware_decorator.py``).  Keep it innermost so
     everything above the route handler observes plain ASGI dicts.
 
@@ -561,7 +561,7 @@ class BlackBull:
                     # A raising @app.on_startup / @app.intercept('app_startup')
                     # hook must fail startup, not kill the lifespan task before
                     # it acks — otherwise LifespanManager.__aenter__ blocks
-                    # forever and the server never starts (bug 1.3).  Sending
+                    # forever and the server never starts.  Sending
                     # lifespan.startup.failed is also the ASGI-correct signal
                     # under external servers (uvicorn/hypercorn).
                     self._logger.error('app_startup hook failed:\n%s',
@@ -578,7 +578,7 @@ class BlackBull:
                     # ASGI lifespan spec — a raising @app.on_shutdown /
                     # @app.intercept('app_shutdown') hook must answer with
                     # lifespan.shutdown.failed, not unwind the lifespan task
-                    # silently (bug 1.18); external servers (uvicorn,
+                    # silently; external servers (uvicorn,
                     # hypercorn) log the failure and exit non-zero.
                     self._logger.error('app_shutdown hook failed:\n%s',
                                        traceback.format_exc())

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -277,7 +277,7 @@ class BlackBull:
         # docs/guide/extensions.md.
         self.extensions: dict[str, object] = {}
 
-        # Non-ASGI protocol registry (Sprint 50) — lazily built on the first
+        # Non-ASGI protocol registry — lazily built on the first
         # raw_handler / register_protocol_handler so importing BlackBull does
         # not drag in the server package.  None means "HTTP-only" (the bridge
         # is fully dormant).
@@ -594,7 +594,7 @@ class BlackBull:
 
         Single emission point for the in-request Level B lifecycle events
         (``request_received`` / ``before_handler`` / ``after_handler``) —
-        Sprint 64 consolidated them here, the one choke point every
+        this is the one choke point every
         transport passes (BlackBull's own HTTP/1.1 and HTTP/2 actors,
         uvicorn/hypercorn, TestClient), so each fires exactly once per
         request regardless of how the app is served.  ``request_completed``
@@ -612,7 +612,7 @@ class BlackBull:
         """
         self._logger.debug((conn, receive, send))
 
-        # WebSocket is native too (Sprint 80): ``conn`` is a Connection here as
+        # WebSocket is native too: ``conn`` is a Connection here as
         # well. Route it by its ``path`` to the registered WS handler, which
         # receives ``(conn, receive, send)``. WS has its own lifecycle events
         # (websocket_connected/message/disconnected), so it skips the HTTP
@@ -650,7 +650,7 @@ class BlackBull:
                              send: ASGISendCallable, scheme):
         """Route and run one HTTP request (the non-WebSocket half of _dispatch).
 
-        Sprint 80: BlackBull is a native-Connection framework — the dispatch
+        BlackBull is a native-Connection framework — the dispatch
         pipeline threads the typed :class:`Connection` end to end (routing,
         handler, error handlers, gRPC, and events all read ``conn.*``). The ASGI
         ``scope`` dict exists only at the external/``BB_FORCE_ASGI_SCOPE`` boundary,
@@ -835,7 +835,7 @@ class BlackBull:
             return
         elif conn.get('type') == 'websocket':
             # External ASGI host (uvicorn) delivered a websocket scope dict.
-            # WebSocket is native too (Sprint 80): convert it to a Connection at
+            # WebSocket is native too: convert it to a Connection at
             # the boundary — the WS extras are derived (``conn.subprotocols``
             # reads the request header) or actor-set (``conn._ws``), so no scope
             # dict is threaded past here. BlackBull's own server already hands us
@@ -1200,7 +1200,7 @@ class BlackBull:
         port: int | None = None,
         tls: bool = False,
     ) -> None:
-        """Register a handler for a non-ASGI (raw) protocol (Sprint 50).
+        """Register a handler for a non-ASGI (raw) protocol.
 
         The handler is an async callable ``(reader, writer, ctx) -> None`` that
         owns the connection for its whole lifetime.  When *port* is set, the
@@ -1210,12 +1210,12 @@ class BlackBull:
         Args:
             name: Protocol name (e.g. ``'echo'``, ``'mqtt'``); must be unique.
             handler: Async ``(reader, writer, ctx)`` coroutine.
-            detector: Reserved for first-byte sniffing on shared ports
-                (Sprint 51); unused today.
+            detector: Reserved for first-byte sniffing on shared ports;
+                unused today.
             port: Dedicated listening port for this protocol.
             tls: Serve this port through the server's TLS machinery (e.g.
                 ``mqtts://``).  Requires the server to be configured with a
-                certificate; startup fails fast otherwise (Sprint 75).
+                certificate; startup fails fast otherwise.
         """
         if self._protocol_registry is None:
             from .server.protocol_registry import ProtocolRegistry  # noqa: PLC0415

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -1004,10 +1004,41 @@ class BlackBull:
         self._global_middlewares.append(mw)
         self._chain = None  # invalidate cached chain
 
+    def _is_route_free(self, path: str, methods) -> bool:
+        """True when *path* has no route registered for any of *methods*.
+
+        Used by :meth:`static` before it claims the bare mount prefix, since
+        registering an already-registered path replaces it silently.
+        """
+        for method in methods:
+            try:
+                self._router[(path, method, Scheme.http)]
+            except (PathNotRegistered, MethodNotApplicable):
+                continue
+            return False
+        return True
+
+    def _static_miss(self):
+        """Terminal handler for a static route whose target is not a file.
+
+        Routes the miss through the app's own 404 path so a static miss is
+        answered exactly as any unmatched path is, including a user's
+        ``@app.on_error(HTTPStatus.NOT_FOUND)`` override.  A static route
+        must end in a real handler: ``_register_chain`` binds the last
+        function's ``call_next`` to ``do_nothing``, which sends no response
+        at all.
+        """
+        async def _static_not_found(conn, receive, send):
+            conn.state['error_status'] = HTTPStatus.NOT_FOUND
+            handler = self._error_router[HTTPStatus.NOT_FOUND]
+            if handler is not None:
+                await handler(conn, receive, send)
+        return _static_not_found
+
     def static(self, url_prefix: str, root_dir: str | Path, *,
                cache: bool = False, index: str | None = None,
                conditional: bool = True) -> None:
-        """Serve static files from *root_dir* under *url_prefix* via global middleware.
+        """Serve static files from *root_dir* under *url_prefix* as a route.
 
         ``cache`` (default ``False``): when ``True``, file bodies are
         held in-memory for fast cache-hit serving.  Useful for
@@ -1024,14 +1055,37 @@ class BlackBull:
         ``conditional`` (default ``True``): emit ``ETag`` / ``Last-Modified``
         validators and answer ``If-None-Match`` / ``If-Modified-Since`` with
         a 304.  Set ``False`` to disable conditional responses.
+
+        Registered as a **route**, not global middleware, so a request that
+        is not for a static path never enters this code: it resolves in the
+        router's exact-match dict and never reaches the parametrised scan.
+        This is also what every peer framework does — Starlette, Sanic,
+        aiohttp, Flask and Django all mount static as a route.
         """
         from blackbull.middleware.static import StaticFiles
         root = Path(root_dir).resolve()
         self._static_roots.append((url_prefix, root))
-        self._global_middlewares.append(
-            StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache,
-                        index=index, conditional=conditional))
-        self._chain = None  # invalidate cached chain
+        mw = StaticFiles(url_prefix=url_prefix, root_dir=root, cache=cache,
+                         index=index, conditional=conditional)
+        prefix = url_prefix.rstrip('/')
+        methods = [HTTPMethod.GET, HTTPMethod.HEAD]
+        chain = [mw, self._static_miss()]
+        self._router.route(methods=methods,
+                           path=f'{prefix}/{{filepath:path}}',
+                           functions=list(chain))
+        # The ``path`` converter is ``r'.+'`` — it needs at least one
+        # character, so neither ``/assets`` nor ``/assets/`` matches the
+        # route above.  Both must resolve for ``index=`` to serve the mount
+        # root (and ``blackbull serve``, which mounts at ``/``, depends on
+        # it), so each gets its own exact-match entry.
+        #
+        # Registering the same path twice silently replaces the first entry,
+        # so an explicit route always wins: a mount at ``/`` must not quietly
+        # eat the app's own root handler.
+        for bare in ((prefix, f'{prefix}/') if prefix else ('/',)):
+            if self._is_route_free(bare, methods):
+                self._router.route(methods=methods, path=bare,
+                                   functions=list(chain))
 
     def on_error(self, key):
         """Register a custom error handler for an HTTPStatus or exception class.

--- a/blackbull/cli.py
+++ b/blackbull/cli.py
@@ -31,7 +31,7 @@ from .app import serve as _serve
 
 
 # ---------------------------------------------------------------------------
-# TOML config loading — Sprint 12c
+# TOML config loading
 # ---------------------------------------------------------------------------
 
 # Mapping: (section, key) → BB_* environment variable name.
@@ -302,7 +302,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 # ---------------------------------------------------------------------------
-# ``blackbull serve`` — zero-code static file server (Sprint 49, B4)
+# ``blackbull serve`` — zero-code static file server
 # ---------------------------------------------------------------------------
 
 def _build_serve_parser() -> argparse.ArgumentParser:
@@ -368,7 +368,7 @@ def _build_static_app(directory: str, *, etag: bool, cache: bool,
 
     app = BlackBull()
     # StaticFiles emits ETag / Last-Modified and honours If-None-Match /
-    # If-Modified-Since natively (Sprint 69, bug 1.21d); ``--no-etag``
+    # If-Modified-Since natively; ``--no-etag``
     # (``etag=False``) turns that off.
     app.static('/', directory, cache=cache, index=index or None,
                conditional=etag)

--- a/blackbull/client/__init__.py
+++ b/blackbull/client/__init__.py
@@ -2,7 +2,7 @@ from .client import Client
 from .http1 import HTTP1Client, HTTP1RequestSender, HTTP1ResponseRecipient
 from .http2 import ClientResponse, HTTP2Client
 from .response import ResponderFactory
-# Sprint 46 moved the scenario primitives to blackbull.fault_injection.
+# The scenario primitives live in blackbull.fault_injection.
 # The names stay reachable from blackbull.client without a deprecation
 # warning so existing top-level callers keep working; the deep-import
 # path (blackbull.client.scenario) is the one that emits the warning.

--- a/blackbull/client/http1.py
+++ b/blackbull/client/http1.py
@@ -41,7 +41,7 @@ RequestBody = Union[bytes, bytearray, memoryview, AsyncIterable[bytes]]
 # CRLF as used throughout RFC 7230.
 _CRLF = b'\r\n'
 
-# Sprint 17 Phase 3 — methods for which an empty body still warrants an
+# Methods for which an empty body still warrants an
 # explicit ``Content-Length: 0`` on the wire.  RFC 9110 §8.6 makes the
 # header optional in this case, but always emitting it removes ambiguity
 # for upstreams (notably reverse proxies that treat absent CL on POST as
@@ -86,7 +86,7 @@ class HTTP1RequestSender:
                                   body: bytes) -> None:
         """Emit / validate the ``Content-Length`` header for the request.
 
-        Sprint 17 Phase 3 — replaces the previous "add CL only if body is
+        Replaces the previous "add CL only if body is
         truthy and no CL already present" rule, which let an empty POST go
         out without any framing header at all (RFC-legal but confuses
         reverse proxies) and silently sent inconsistent framing if the
@@ -141,8 +141,8 @@ class HTTP1RequestSender:
         if method_upper in _BODY_LESS_METHODS:
             # GET/HEAD/etc. with no body — skip the header by design.
             return
-        # Unknown method: forwards-compatible fallback identical to the
-        # pre-Sprint-17 behaviour (omit CL on empty body).
+        # Unknown method: forwards-compatible fallback — omit CL on an
+        # empty body.
         return
 
     async def _send_chunked(self, method: str, path: str, headers: Headers,
@@ -274,15 +274,15 @@ class HTTP1Client:
         self._reader: AbstractReader | None = None
         self._writer: AbstractWriter | None = None
         self._raw_writer: asyncio.StreamWriter | None = None
-        # Sprint 17 Phase 2 — opt-in wire-bytes capture for the low-level
+        # Opt-in wire-bytes capture for the low-level
         # primitives (send_raw, send_request_line, send_header_line, ...).
         # When True, every byte sent through those methods is also appended
         # to ``self._wire_buffer`` for later inspection by failing tests.
-        # request() does NOT populate this buffer in Sprint 17; capture
-        # there is a Phase 8 concern.
+        # request() does NOT populate this buffer; only the low-level
+        # primitives record.
         self._record_wire_bytes = record_wire_bytes
         self._wire_buffer: bytearray = bytearray()
-        # Sprint 17 Phase 5 — bound the connect() so a hung accept can't
+        # Bound the connect() so a hung accept can't
         # stall the scenario executor before any step runs.  atheris in
         # particular cannot afford an unbounded wait per TestOneInput.
         # None = no timeout (preserves pre-Phase-5 behaviour).
@@ -367,7 +367,7 @@ class HTTP1Client:
             h.append(b'host', f'{self._host}:{self._port}'.encode())
         return h
 
-    # ---- Sprint 17 Phase 2 — low-level test-instrument primitives ----
+    # ---- Low-level test-instrument primitives ----------------------------
     #
     # These methods bypass HTTP1RequestSender's safety net (no Host
     # injection, no Content-Length, no validation).  They exist so tests
@@ -479,11 +479,11 @@ class HTTP1Client:
             return await coro
         return await asyncio.wait_for(coro, timeout=timeout)
 
-    # ---- Sprint 17 Phase 5 — scenario executor ----------------------------
+    # ---- Scenario executor -----------------------------------------------
     #
     # A :class:`Scenario` is a tagged sequence of steps (SendBytes / Sleep /
     # ReadResponse / Abort) shared by the differential test and the atheris
-    # fuzz harness.  The executor below is glue over the Phase 2 primitives:
+    # fuzz harness.  The executor below is glue over the low-level primitives:
     # it walks the steps, dispatches each to the appropriate primitive, and
     # folds the outcome into a :class:`ScenarioResult` without raising.
 

--- a/blackbull/client/http2.py
+++ b/blackbull/client/http2.py
@@ -296,7 +296,7 @@ class HTTP2Client:
     def _make_sender(self, stream_id: int) -> HTTP2Sender:
         if stream_id not in self._senders:
             assert self._writer is not None
-            # Bug 1.20a — seed the per-stream send window from the server's
+            # Seed the per-stream send window from the server's
             # announced SETTINGS_INITIAL_WINDOW_SIZE: a sender created after
             # the SETTINGS exchange must not start at the RFC default
             # (``_on_initial_window_size`` only delta-adjusts *existing*

--- a/blackbull/client/scenario.py
+++ b/blackbull/client/scenario.py
@@ -1,6 +1,6 @@
 """Deprecation shim — moved to :mod:`blackbull.fault_injection`.
 
-Sprint 46 grouped the HTTP/1.1 client-side scenario model and the new
+Groups the HTTP/1.1 client-side scenario model and the
 HTTP/2 server-side fault-injection surface under
 :mod:`blackbull.fault_injection`.  Import from there going forward::
 

--- a/blackbull/client/scenario_oracle.py
+++ b/blackbull/client/scenario_oracle.py
@@ -1,6 +1,6 @@
 """Deprecation shim — moved to :mod:`blackbull.fault_injection`.
 
-Sprint 46 grouped the HTTP/1.1 differential oracle alongside the
+Groups the HTTP/1.1 differential oracle alongside the
 scenario model under :mod:`blackbull.fault_injection`.  Import from
 there going forward::
 

--- a/blackbull/client/websocket.py
+++ b/blackbull/client/websocket.py
@@ -109,7 +109,7 @@ class WebSocketSession:
         """Send a CLOSE frame, await the peer's echoed CLOSE (bounded by
         *drain_timeout*), and stop the background reader task.
 
-        Sprint 72 (audit 1.20c) — RFC 6455 §7.1.2: the closing handshake
+        RFC 6455 §7.1.2 — the closing handshake
         is complete once both endpoints have sent and received a Close
         frame.  A silent peer cannot hang ``close()``: after
         *drain_timeout* the reader is shut down regardless.  Data frames

--- a/blackbull/client/websocket_h2.py
+++ b/blackbull/client/websocket_h2.py
@@ -69,7 +69,7 @@ _WINDOW_UPDATE_THRESHOLD = 32768
 class _H2QueueReader(AbstractReader):
     """``AbstractReader`` over a raw-stream DATA-frame queue.
 
-    Sprint 72 (audit 1.20b / F.2) — lets the H2 client session reuse the
+    Lets the H2 client session reuse the
     shared ``ws_codec`` + ``WebSocketRecipient`` stack (whose read path
     calls only ``readexactly``) instead of a third, private WS frame
     parser.  DATA payloads are buffered as a byte stream; flow-control
@@ -123,8 +123,8 @@ class WebSocketH2Session:
 
     Outgoing frames are masked (RFC 6455 §5.1) and wrapped in H2 DATA
     frames.  Incoming DATA payloads feed the shared
-    ``WebSocketRecipient`` stack through :class:`_H2QueueReader`
-    (Sprint 72, audit 1.20b) — fragmentation reassembly, FIN/RSV/mask
+    ``WebSocketRecipient`` stack through :class:`_H2QueueReader` —
+    fragmentation reassembly, FIN/RSV/mask
     validation, UTF-8 checks, and auto-PONG all come from the same
     codec the server and the H1 client use.
     """
@@ -199,7 +199,7 @@ class WebSocketH2Session:
         frame), await the peer's echoed CLOSE bounded by *drain_timeout*,
         and stop the recipient's reader task.  Idempotent.
 
-        Sprint 72 (audit 1.20c) — same close discipline as the H1
+        Same close discipline as the H1
         client's :meth:`WebSocketSession.close`.
         """
         if self._closed:

--- a/blackbull/connection.py
+++ b/blackbull/connection.py
@@ -1,5 +1,5 @@
 """The native `Connection` interface — BlackBull's single internal request
-representation (Sprint 79, proposal `native-connection-interface.md`).
+representation.
 
 BlackBull is a multi-protocol server that owns both sides of the wire on its
 self-hosted path; the ASGI ``scope`` dict is therefore an *internal
@@ -48,7 +48,7 @@ def mark_disconnected(target) -> None:
 
 #: Envelope key under which a protocol actor stashes the typed :class:`Connection`
 #: it parsed, so the self-hosted dispatch path (dispatcher, router, handlers, and
-#: ``TrustedProxy``) reads it back with **zero** re-conversion (Sprint 79 Phase 5).
+#: ``TrustedProxy``) reads it back with **zero** re-conversion.
 #: A single named constant instead of a bare ``'_connection'`` literal repeated
 #: across the actors, app, router, and proxy: one typo on a write-side would
 #: otherwise silently miss the stash and force a redundant ``from_scope`` on the
@@ -56,7 +56,7 @@ def mark_disconnected(target) -> None:
 CONNECTION_STASH_KEY = '_connection'
 
 #: Shared, never-mutated ASGI info sub-dict for the native dispatch scope
-#: (Sprint 80 Tier-1b). ``as_scope()`` still emits a fresh copy for the external
+#: ``as_scope()`` still emits a fresh copy for the external
 #: compat boundary; only the self-hosted ``to_asgi_scope`` fast path reuses
 #: this constant to save one dict allocation per request. ASGI consumers read
 #: ``scope['asgi']['version']`` but never mutate the sub-dict.
@@ -133,7 +133,7 @@ _CONNECTION_FIELDS: list[_FieldSpec] = [
 #: The scope-mapped registry entries, computed **once** at module load — the
 #: ASGI round-trip subset of ``_CONNECTION_FIELDS``. Rebuilding this filtered
 #: list on every ``as_scope()``/``from_scope()`` call was a measurable per-request
-#: cost on the self-hosted hot path (Sprint 80 Tier-1), so it is a constant.
+#: cost on the self-hosted hot path, so it is a constant.
 _SCOPE_FIELDS: list[_FieldSpec] = [s for s in _CONNECTION_FIELDS if s.scope_key is not None]
 
 
@@ -150,7 +150,7 @@ def stashed_connection(target, receive) -> tuple['Connection', bool]:
     native path, or an ASGI scope dict on the external/compat lane.
 
     The one *ASGI-scope → Connection* accessor shared by the dispatcher
-    (``app._connection_of``) and the router (``router._conn_of``), Sprint 79.
+    (``app._connection_of``) and the router (``router._conn_of``).
     BlackBull's own protocol actors stash the ``Connection`` they parsed on the
     scope envelope under :data:`CONNECTION_STASH_KEY`, so the self-hosted path
     reads it back with **no** re-conversion. Under an external ASGI server
@@ -164,7 +164,7 @@ def stashed_connection(target, receive) -> tuple['Connection', bool]:
     router seeds ``path_params`` from an input scope key — because those needs
     differ by call site.
     """
-    # Native path (Sprint 80): the actor/app hands the typed Connection straight
+    # Native path: the actor/app hands the typed Connection straight
     # through, so ``target`` *is* the Connection — return it, nothing to build.
     if isinstance(target, Connection):
         return target, False
@@ -236,7 +236,7 @@ class Connection:
     # -- mutable per-request state ----------------------------------------
     state: dict[str, Any] = field(default_factory=dict)
     # Lazy: no dict is allocated until the router actually matches path params
-    # (Sprint 80 Tier-1b). No-param routes — the framework-bound hot profiles
+    # No-param routes — the framework-bound hot profiles
     # (baseline/pipelined/limited-conn) — never touch it, saving one dict per
     # request. Exposed via the ``path_params`` property below; excluded from
     # equality (a transient routing detail, never an identity input).
@@ -345,7 +345,7 @@ class Connection:
         typed :class:`Connection` stashed on it for zero-reconversion reads.
 
         The single canonical *Connection → dispatch-ready scope* bridge shared
-        by the H/1.1 ``run()`` and H/2 ``_conn_to_scope`` seams (Sprint 79) —
+        by the H/1.1 ``run()`` and H/2 ``_conn_to_scope`` seams —
         they used to hand-roll the same five steps:
 
         1. derive the ASGI scope via :meth:`as_scope` (the one native→ASGI point);
@@ -364,7 +364,7 @@ class Connection:
         is layered on by the caller *after* this returns — it is not a
         :class:`Connection` field (proposal §2.1).
 
-        Sprint 80 Tier-1: the default (``force_asgi=False``) native path builds
+        The default (``force_asgi=False``) native path builds
         the scope by **direct attribute access**, placing the rich ``Headers``
         object straight in (no ``list(headers)`` that the old code computed via
         the registry and then immediately discarded), and skips the per-field

--- a/blackbull/di.py
+++ b/blackbull/di.py
@@ -14,7 +14,7 @@ framework* rather than by the request::
     async def get_item(id: int, db=Depends(get_db)):
         return await db.fetch_item(id)
 
-Design (Sprint 74): everything is resolved at **registration time** on the
+Design: everything is resolved at **registration time** on the
 ``_adapt_handler`` seam — a handler that declares no ``Depends`` parameter
 compiles to exactly the wrapper it compiled to before this module existed
 (no per-request stack, no empty dependency loop).  Contrast FastAPI, which

--- a/blackbull/env.py
+++ b/blackbull/env.py
@@ -342,8 +342,8 @@ class Settings:
     #: correctly).  ``0`` disables the cap entirely — relies on the OS
     #: file-descriptor limit instead.
     #:
-    #: Default raised from 0 (disabled) to 1024 in Sprint 30 (event-loop
-    #: integrity).  Unbounded per-worker concurrency lets a single
+    #: Capped rather than unbounded, for event-loop integrity:
+    #: unbounded per-worker concurrency lets a single
     #: client (or burst, or slowloris-class workload) park thousands of
     #: suspended-readuntil tasks on the event loop, amplifying drain
     #: time on burst-close and inflating worst-case latency.  Set
@@ -423,8 +423,8 @@ class Settings:
     #: ``TCP_USER_TIMEOUT`` on the listening socket (inherits to accepted)
     #: which handles the *active-but-stuck* case.  0 disables the timer.
     #:
-    #: Default lowered from 60 s to 5 s in Sprint 30 (event-loop
-    #: integrity).  60 s parks ghost / idle connections in the loop's
+    #: Kept short for event-loop integrity: a conventional 60 s
+    #: parks ghost / idle connections in the loop's
     #: ``readuntil`` for far longer than necessary, inflating the
     #: suspended-task count and amplifying burst-close drain time.
     #: 5 s is a common short-idle value for request-pipeline keep-alive.
@@ -483,7 +483,7 @@ class Settings:
     #: typical reverse-proxy defaults.
     header_max_total: int = 65536
 
-    #: Dual-path conformance lane (Sprint 79 §4.3).  When true, every request
+    #: Dual-path conformance lane.  When true, every request
     #: round-trips the native :class:`~blackbull.connection.Connection` through
     #: ``as_scope()`` + ``from_scope()`` before dispatch, so the ASGI compat
     #: conversion is exercised on the self-hosted path and cannot silently

--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -18,7 +18,7 @@ def _request_fields(conn):
 
 def _ws_fields(conn):
     """Read ``(client, connection_id, path)`` for a WebSocket event detail from
-    a native :class:`~blackbull.connection.Connection` (Sprint 80) or, on a
+    a native :class:`~blackbull.connection.Connection` or, on a
     direct test drive, an ASGI scope dict."""
     from blackbull.connection import Connection  # noqa: PLC0415 — avoid import cycle
     if isinstance(conn, Connection):
@@ -67,7 +67,7 @@ class EventAggregator:
     # ------------------------------------------------------------------
     # The request-lifecycle events are emitted by the application layer —
     # request_received / before_handler / after_handler by BlackBull._dispatch
-    # (Sprint 64), request_completed by BlackBull.__call__ after the global
+    # emits it; request_completed is emitted by BlackBull.__call__ after the global
     # middleware chain returns (issue #145) — so they fire under external
     # ASGI hosts (uvicorn, TestClient) too, exactly once per request.  Only
     # wire-level events remain here.

--- a/blackbull/extension.py
+++ b/blackbull/extension.py
@@ -1,4 +1,4 @@
-"""Extension mechanism — the single, generic plugin contract (Sprint 53).
+"""Extension mechanism — the single, generic plugin contract.
 
 An :class:`Extension` wires itself into a :class:`~blackbull.app.BlackBull`
 application through the public ``app.*`` API: routes, middleware, event

--- a/blackbull/fault_injection/_tls.py
+++ b/blackbull/fault_injection/_tls.py
@@ -43,8 +43,7 @@ def make_self_signed_h2_context() -> ssl.SSLContext:
     # (including the *unencrypted* private key) are written to a tempdir.  A
     # weakref.finalize on the returned context removes that tempdir when the
     # context is garbage-collected — or, failing that, at interpreter exit —
-    # so the key material doesn't accumulate in /tmp (bug 1.22b: the old code
-    # promised this cleanup but never registered it).
+    # so the key material doesn't accumulate in /tmp.
     tmp = Path(tempfile.mkdtemp(prefix='blackbull-fault-tls-'))
     cert_path = tmp / 'cert.pem'
     key_path = tmp / 'key.pem'

--- a/blackbull/fault_injection/h2_server.py
+++ b/blackbull/fault_injection/h2_server.py
@@ -87,7 +87,7 @@ def _refuse_in_production() -> None:
     ``BLACKBULL_ENV=production`` (surfaced as ``Settings.env``); the previous
     check keyed on ``BB_PRODUCTION`` alone — a var read nowhere else in the
     codebase — so a standard production process did **not** trip the guard
-    (bug 1.22a).  ``BB_PRODUCTION`` is still honoured as an explicit override
+    ``BB_PRODUCTION`` is still honoured as an explicit override
     so the guard also trips outside the Settings machinery.
     """
     override = os.environ.get('BB_PRODUCTION', '').strip().lower() in (

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -366,7 +366,7 @@ async def _read_unary_request(receive, encoding: bytes) -> bytes:
     except ClientDisconnected as exc:
         # RST_STREAM / client disconnect before the request finished — the
         # canonical gRPC mapping is CANCELLED, not a fabricated INTERNAL over
-        # a truncated body (bug 1.11).
+        # a truncated body.
         raise GrpcError(
             GrpcStatus.CANCELLED,
             'client disconnected before sending the request') from exc

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -564,7 +564,7 @@ async def _serve_server_streaming(handler, request, context, send, content_type,
     # on input — the loop runs this task and everything already yielded goes
     # out.  Without it, a partial batch was withheld until the *next* message
     # completed, which for an indefinitely-parked producer meant never
-    # (Sprint 66: grpc.health Watch clients never received their initial
+    # (grpc.health Watch clients otherwise never receive their initial
     # status).
     flush_wanted = asyncio.Event()
     finished = False

--- a/blackbull/headers.py
+++ b/blackbull/headers.py
@@ -25,8 +25,8 @@ class Headers:
     - Header names and values are always ``bytes`` (per ASGI spec).
     - Lookups are case-insensitive: the internal index is keyed on
       ``name.lower()`` (RFC 7230 §3.2 — header field names are case-insensitive).
-      ``__contains__``, ``__getitem__``, ``getlist``, and ``get`` all lowercase
-      the requested name; iteration preserves the original casing of the input.
+      ``__contains__``, ``__getitem__``, ``getlist``, and ``get`` accept any
+      casing; iteration preserves the original casing of the input.
     - Insertion order of duplicate names is preserved (RFC 7230 §3.2.2).
 
     Examples::
@@ -93,7 +93,7 @@ class Headers:
 
         Two ``Headers`` are equal when they carry the same fields in the same
         order (RFC 7230 §3.2.2 — order is significant for repeated fields).
-        Enables ``Connection`` round-trip equality (Sprint 79)."""
+        Enables ``Connection`` round-trip equality."""
         if isinstance(other, Headers):
             return self._list == other._list
         return NotImplemented

--- a/blackbull/headers.py
+++ b/blackbull/headers.py
@@ -52,6 +52,34 @@ class Headers:
         for pair in self._list:
             self._index.setdefault(pair[0].lower(), []).append(pair)
 
+    @classmethod
+    def from_lowered(cls, pairs: list[tuple[bytes, bytes]]) -> 'Headers':
+        """Build from pairs whose names are **already lowercase**.
+
+        The caller must guarantee that; nothing here checks it, and a name
+        containing uppercase would be indexed unreachably (every accessor
+        lowercases before its fallback probe, so the field would be
+        invisible to lookup while still appearing in iteration).
+
+        Two callers can guarantee it.  ``http1_actor._parse`` lowercases
+        each name while validating it, so re-lowercasing in ``__init__``
+        recomputes a known answer.  HTTP/2 field names are lowercase by
+        protocol — RFC 9113 §8.2.1 makes an uppercase name malformed, and
+        ``HeadersFrame.parse_payload`` rejects the frame before any pair
+        reaches the header list.
+
+        Takes ownership of *pairs* rather than copying it; the parser
+        builds a throwaway list per request, and the copy is the point of
+        the shortcut.  Do not pass a list you intend to keep mutating.
+        """
+        self = cls.__new__(cls)
+        self._list = pairs
+        index: dict[bytes, list[tuple[bytes, bytes]]] = {}
+        for pair in pairs:
+            index.setdefault(pair[0], []).append(pair)
+        self._index = index
+        return self
+
     # ---- ASGI-compliant iterable ----------------------------------------
 
     def __iter__(self):
@@ -76,16 +104,30 @@ class Headers:
 
     # ---- dict-like lookup (returns list of pairs) -----------------------
 
+    # Every accessor probes with the caller's bytes before lowercasing.
+    # `_index` is keyed lowercased, so a probe can only hit on a key the
+    # `.lower()` path would also have found — the fast path is exactly
+    # semantics-preserving, not a heuristic.  It pays off because callers
+    # overwhelmingly pass a lowercase literal (`headers.get(b'content-type')`),
+    # for which `bytes.lower()` costs more than the dict lookup it precedes.
+    # A mixed-case caller pays one extra failed probe.
+
     def __contains__(self, name: bytes) -> bool:
-        return name.lower() in self._index
+        return name in self._index or name.lower() in self._index
 
     def __getitem__(self, name: bytes) -> list[tuple[bytes, bytes]]:
         """Return all pairs for *name*.  Raises ``KeyError`` if absent."""
-        return self._index[name.lower()]
+        pairs = self._index.get(name)
+        if pairs is None:
+            return self._index[name.lower()]
+        return pairs
 
     def getlist(self, name: bytes) -> list[tuple[bytes, bytes]]:
         """Return all pairs for *name*, or ``[]`` if the header is absent."""
-        return self._index.get(name.lower(), [])
+        pairs = self._index.get(name)
+        if pairs is None:
+            pairs = self._index.get(name.lower())
+        return pairs if pairs is not None else []
 
     def get(self, name: bytes, default: bytes = b'') -> bytes:
         """Return the first value for *name*, or *default* if absent.
@@ -93,7 +135,9 @@ class Headers:
         Mirrors ``dict.get(key, default)``: single value, optional default.
         For headers that may repeat use ``getlist(name)``.
         """
-        pairs = self._index.get(name.lower())
+        pairs = self._index.get(name)
+        if pairs is None:
+            pairs = self._index.get(name.lower())
         return pairs[0][1] if pairs else default
 
     def append(self, name_or_pairs, value: bytes | None = None) -> None:
@@ -124,7 +168,9 @@ class Headers:
         Multiple field lines are joined with ``b', '`` before parsing, as
         the RFC requires for List- and Dictionary-typed fields.
         """
-        pairs = self._index.get(name.lower())
+        pairs = self._index.get(name)
+        if pairs is None:
+            pairs = self._index.get(name.lower())
         if not pairs:
             return None
         if len(pairs) == 1:

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -95,7 +95,7 @@ def _merge_vary(headers: list[tuple[bytes, bytes]],
 
     A compressed response's body depends on the request ``Accept-Encoding``;
     without ``Vary: Accept-Encoding`` a shared cache may replay the encoded
-    body to a client that sent ``identity``/no ``Accept-Encoding`` (bug 1.21a).
+    body to a client that sent ``identity``/no ``Accept-Encoding``.
     Folds *field* into an existing ``Vary`` (no duplicate token; a pre-existing
     ``Vary: *`` already covers everything and is left untouched); otherwise
     appends ``Vary: Accept-Encoding``.  Mutates *headers* in place.
@@ -205,7 +205,7 @@ class Compression:
         """Wrap *send* so a compressible, not-yet-encoded ``ResponseStart`` gains
         ``Vary: Accept-Encoding`` — used on the no-matching-codec path where the
         body is forwarded verbatim but must still be cache-keyed on the encoding
-        (bug 1.21f, Branch 1).  Same predicate as the compress path's decision
+        Same predicate as the compress path's decision
         point: compressible Content-Type AND no pre-existing Content-Encoding.
         """
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
@@ -241,7 +241,7 @@ class Compression:
             # We won't compress, but the response may still be *compressible*,
             # so a downstream shared cache needs Vary: Accept-Encoding — else it
             # stores this identity variant under the bare key and replays it to a
-            # later client that does accept an encoding (bug 1.21f, Branch 1).
+            # later client that does accept an encoding.
             await call_next(conn, receive, self._vary_ensuring_send(send))
             return
 
@@ -282,7 +282,7 @@ class Compression:
                         # varies by Accept-Encoding on *every* exit path
                         # (compressed, too-small, executor-at-cap), so stamp
                         # Vary now — at the decision point — instead of only
-                        # after a successful compress (bug 1.21f).  Later paths
+                        # after a successful compress.  Later paths
                         # inherit it via start_event; the compress path's own
                         # _merge_vary then no-ops.
                         hdrs = list(start_event.get('headers', []))

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -36,7 +36,7 @@ _SERVER_PREFERENCE = ['br', 'zstd', 'gzip']  # server-side priority order
 # re-compressing them is the worst case (high-entropy input; under the
 # brotli library's bare-call default of quality 11 — BlackBull's own
 # default is q=4 via ``BB_BROTLI_QUALITY``) and contributes a measurable
-# per-request CPU tail in Sprint 35's HttpArena static-rotate probe.
+# per-request CPU tail on a static-asset workload.
 _SKIP_CONTENT_TYPES = (
     'image/',
     'audio/',
@@ -143,7 +143,7 @@ class Compression:
         # Concurrency cap on executor offloads.  When at cap, fall back to
         # uncompressed rather than queueing — keeps the asyncio default
         # thread pool from growing an unbounded backlog under burst load
-        # (the HttpArena `static` profile collapse mode, Sprint 29).
+        # (the collapse mode a static-asset workload triggers).
         self._executor_max_inflight = executor_max_inflight
         self._executor_inflight: int = 0
         self._brotli_quality = brotli_quality
@@ -152,7 +152,7 @@ class Compression:
         # has very few distinct Accept-Encoding values (browsers send a
         # constant string; benchmark generators send one); parsing the
         # q-values + iterating the server-preference list on every request
-        # showed up in the Sprint 33 py-spy profile.  Bounded so a hostile
+        # showed up in py-spy profiles.  Bounded so a hostile
         # peer can't grow it unboundedly.
         self._codec_cache: dict[bytes, tuple[str, Callable[[bytes], bytes]] | None] = {}
 
@@ -260,7 +260,7 @@ class Compression:
             # pass-through decision (already-encoded response, non-
             # compressible Content-Type, or streaming chunks), subsequent
             # events are forwarded verbatim — no parse, no re-wrap, no
-            # match.  Sprint 33 py-spy showed this overhead at ~35 % of
+            # match.  py-spy put this overhead at ~35 % of
             # the static-path CPU on responses StaticFiles already
             # encoded via a precompressed sibling.
             if start_forwarded and (skip_compression or streaming):
@@ -327,7 +327,7 @@ class Compression:
         # as the end of the first response — causing the connection to
         # be closed after every successful response.  Detected via the
         # 1:1 success/read-error ratio under wrk keep-alive load
-        # (Sprint 29).
+        # workload.
         if start_forwarded:
             return
 
@@ -344,7 +344,7 @@ class Compression:
             # compressions running, skip this one and serve uncompressed
             # rather than queueing.  Prevents the unbounded executor backlog
             # that caused the HttpArena `static` profile to collapse to 0 r/s
-            # on run 2 under c=1024 (Sprint 29).  Counter increment / decrement
+            # on run 2 under c=1024.  Counter increment / decrement
             # is safe without a lock — asyncio is single-threaded.
             if (self._executor_max_inflight > 0
                     and self._executor_inflight >= self._executor_max_inflight):

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -211,13 +211,18 @@ class Compression:
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
         # app.py).  ``event`` is an ASGISendEvent.
         async def vary_send(event):
-            parsed = parse_response_event(event)
-            if isinstance(parsed, ResponseStart) and \
-                    _is_compressible_content_type(parsed.headers) and \
-                    not parsed.headers.get(b'content-encoding'):
-                hdrs = list(event.get('headers', []))
-                _merge_vary(hdrs)
-                event = {**event, 'headers': hdrs}
+            # Discriminate on the raw type before building anything.  Going
+            # through `parse_response_event` allocated a `ResponseBody` copy
+            # of every body event just to have the next line's `isinstance`
+            # reject it — a per-chunk cost on a streamed response, for a
+            # wrapper that only ever cares about the start event.
+            if event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
+                headers = Headers(event.get('headers', []))
+                if _is_compressible_content_type(headers) and \
+                        not headers.get(b'content-encoding'):
+                    hdrs = list(event.get('headers', []))
+                    _merge_vary(hdrs)
+                    event = {**event, 'headers': hdrs}
             await send(event)
         return vary_send
 

--- a/blackbull/middleware/proxy.py
+++ b/blackbull/middleware/proxy.py
@@ -16,7 +16,7 @@ def _parse_forwarded(value: str) -> dict[str, str]:
     client) and return its parameters, e.g.
     ``{'for': '203.0.113.1', 'proto': 'https'}``.
 
-    Splitting on ``;`` alone (the pre-Sprint-69 behaviour) folded the
+    Splitting on ``;`` alone folds the
     second element's ``for=`` into the first value, poisoning
     ``conn['client']``.
     """

--- a/blackbull/middleware/proxy.py
+++ b/blackbull/middleware/proxy.py
@@ -120,7 +120,7 @@ class TrustedProxy:
 
         # X-Forwarded-Prefix — the reverse-proxy mount prefix, honoured only
         # here (behind the trusted-peer gate).  The parser layer deliberately
-        # ignores it off the wire (bug 1.16); a spoofed prefix from an
+        # ignores it off the wire; a spoofed prefix from an
         # untrusted client would otherwise poison URL generation / routing.
         xf_prefix = headers.get(b'x-forwarded-prefix', b'').decode()
         if xf_prefix:

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -187,6 +187,8 @@ class StaticFiles:
         # ``<root>/...`` exactly, reject ``<root>x/...``.
         self._root_sep: str = self._root_str + os.sep
         self._url_prefix = url_prefix.rstrip('/')
+        # None until the first request resolves it; see `__call__`.
+        self._enabled: bool | None = None
         self._cache_enabled: bool = cache
         self._index: str | None = index
         self._conditional: bool = conditional
@@ -225,6 +227,10 @@ class StaticFiles:
         # BlackBull threads a native Connection for HTTP and WebSocket alike;
         # the guard is defensive against a raw ASGI scope dict (only reachable
         # if this middleware runs outside BlackBull's own dispatch).
+        #
+        # Registered as a route middleware, the route table has already
+        # decided scheme and method before this runs; the checks stay because
+        # `StaticFiles` is also usable stand-alone as a plain ASGI app.
         if (not isinstance(conn, Connection) or conn.type != 'http'
                 or conn.method not in ('GET', 'HEAD')):
             if call_next:
@@ -233,7 +239,13 @@ class StaticFiles:
                 await self._respond(send, HTTPStatus.NOT_FOUND)
             return
 
-        if get_settings().env == Environment.PRODUCTION:
+        # Resolved once, not per request.  Hoisting it into `__init__` would
+        # be wrong — settings may be loaded after the app is constructed —
+        # so it is memoised on first use instead, which keeps late-loaded
+        # settings working while charging one attribute test thereafter.
+        if self._enabled is None:
+            self._enabled = get_settings().env != Environment.PRODUCTION
+        if not self._enabled:
             if call_next:
                 await call_next(conn, receive, send)
             else:

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -19,8 +19,7 @@ from blackbull.asgi import ASGIEvent
 # ``mimetypes.guess_type('foo.woff2')`` return ``None``; StaticFiles
 # falls back to ``application/octet-stream``; downstream Compression
 # middleware then runs brotli on already-compressed font/image bytes —
-# Sprint 35 phase-trace traced this to a 30-60 ms per-request CPU tail
-# on HttpArena's ``regular.woff2`` and ``bold.woff2`` files.
+# a 30-60 ms per-request CPU tail on ``.woff2`` files.
 #
 # ``mimetypes.add_type`` is idempotent, runs once at module import, and
 # integrates with the standard machinery so ``mimetypes.guess_type``
@@ -47,7 +46,7 @@ def _parse_byte_range(range_hdr: str, size: int) -> tuple[int, int] | None:
     ``multipart/byteranges``), or a syntactically malformed range.  Per
     RFC 9110 §14.2 an unparseable/ignored Range is served as a normal 200,
     so the caller treats ``None`` as "serve the whole file".  Never raises:
-    the pre-Sprint-69 code ran bare ``int()`` here and 500'd on
+    a bare ``int()`` here 500s on
     ``Range: bytes=abc-def`` (bug 1.21c).  *Satisfiability* against ``size``
     is still checked by the caller (so an out-of-range spec stays a 416).
     """
@@ -132,7 +131,7 @@ class StaticFiles:
     # edit-on-disk visibility under a second while removing the per-
     # request stat from the cache-hit hot path.  Override via
     # ``BB_STATIC_STAT_TTL_S`` (env var, float seconds); set to ``0`` to
-    # restore the pre-Sprint-33 every-request behaviour.
+    # stat on every request.
     _STAT_TTL_S = float(os.environ.get('BB_STATIC_STAT_TTL_S', '1.0'))
 
     # Server preference order for precompressed variant selection.
@@ -180,8 +179,8 @@ class StaticFiles:
         # Internal hot path uses ``str`` + ``os.path`` rather than
         # ``pathlib.Path``: each request previously allocated several
         # PurePath / Path objects for the same traversal-safety check
-        # and showed up under ``mw_static_in → static_pre_send`` in the
-        # Sprint 33 phase trace.  ``os.path`` is a thin C wrapper.
+        # showed up under ``mw_static_in → static_pre_send`` in profiles.
+        # ``os.path`` is a thin C wrapper.
         self._root_str: str = os.path.realpath(os.fspath(resolved))
         # Pre-computed prefix for the traversal check — accept
         # ``<root>/...`` exactly, reject ``<root>x/...``.
@@ -218,7 +217,7 @@ class StaticFiles:
 
     @property
     def _root(self) -> Path:
-        """Backwards-compat: pre-Sprint-33 callers and tests may inspect
+        """Backwards-compat: callers and tests may inspect
         ``staticfiles._root`` as a :class:`Path`.  Built on demand so
         the hot path keeps its plain-string representation."""
         return Path(self._root_str)

--- a/blackbull/middleware/static.py
+++ b/blackbull/middleware/static.py
@@ -47,7 +47,7 @@ def _parse_byte_range(range_hdr: str, size: int) -> tuple[int, int] | None:
     RFC 9110 §14.2 an unparseable/ignored Range is served as a normal 200,
     so the caller treats ``None`` as "serve the whole file".  Never raises:
     a bare ``int()`` here 500s on
-    ``Range: bytes=abc-def`` (bug 1.21c).  *Satisfiability* against ``size``
+    ``Range: bytes=abc-def``.  *Satisfiability* against ``size``
     is still checked by the caller (so an out-of-range spec stays a 416).
     """
     if not range_hdr.startswith('bytes='):
@@ -447,7 +447,7 @@ class StaticFiles:
         if self._conditional:
             # Validators: a strong ETag over (mtime, size) plus Last-Modified,
             # so ``If-None-Match`` / ``If-Modified-Since`` can produce a 304
-            # instead of a full re-transfer (bug 1.21d).  Cheap; emitted on
+            # instead of a full re-transfer.  Cheap; emitted on
             # every response, including the streaming path.
             etag = f'"{mtime_ns:x}-{size:x}"'.encode()
             last_modified = formatdate(mtime_ns / 1_000_000_000, usegmt=True).encode()

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -24,8 +24,8 @@ def _normalize_send(inner_send: ASGISendCallable | None):
 
     ASGI ``send`` is always called with a single positional event — no
     ``*args/**kwargs`` form needs to be preserved here, and dropping it
-    shaves a per-event call-frame setup that showed in the Sprint 33
-    py-spy profile on the static path.
+    shaves a per-event call-frame setup that shows in py-spy profiles of
+    the static path.
 
     The Response→ASGI expansion is delegated to :meth:`Response.__call__` so
     there is a single source of truth for the start/body event shape (shared

--- a/blackbull/mqtt/broker.py
+++ b/blackbull/mqtt/broker.py
@@ -151,7 +151,7 @@ class BrokerActor(Actor):
 
     Connection actors ``send`` it client events; it ``send``s ``Send``/``Close``
     back to them.  Serial inbox processing means no locks and no shared mutable
-    state — the design goal of the Sprint 53 refactor.
+    state — the design goal of the actor split.
     """
 
     def __init__(self) -> None:

--- a/blackbull/mqtt/connection.py
+++ b/blackbull/mqtt/connection.py
@@ -52,7 +52,7 @@ class PacketFramer:
     * a **hard decode error** (reserved flag bits, unknown type — the junk a
       desynchronised stream produces) drops one byte and resyncs.
 
-    This replaces Sprint 53's ``stalled_len`` bookkeeping.  The ``bytes(...)``
+    This replaces explicit ``stalled_len`` bookkeeping.  The ``bytes(...)``
     snapshot at the decode boundary stays because the codec's input contract is
     deliberately ``bytes``; a zero-copy framer would mean widening that contract
     to the buffer protocol (deferred).
@@ -83,7 +83,7 @@ class MQTT5Actor(Actor):
 
     Tap dispatch is selected at construction: pass a running :class:`TapActor`
     as *tap* for decoupled (actor-mode) dispatch, or *app_handlers* for inline
-    dispatch on this connection (the Sprint 53 contract).
+    dispatch on this connection.
     """
 
     def __init__(self, writer: AbstractWriter, broker: BrokerActor,
@@ -213,7 +213,7 @@ class MQTT5Actor(Actor):
         In actor mode the :class:`Message` is *offered* to the shared
         :class:`TapActor` and we return at once (a slow tap never back-pressures
         this connection or the broker).  In inline mode the matching callbacks
-        run here, sequentially, with isolated exceptions (the Sprint 53 contract).
+        run here, sequentially, with isolated exceptions.
         """
         if self._tap is None and not self._inline_taps:
             return

--- a/blackbull/mqtt/extension.py
+++ b/blackbull/mqtt/extension.py
@@ -69,7 +69,7 @@ class MQTTExtension(Extension):
 
     ``tap_mode`` selects how taps are dispatched: ``'actor'`` (default) runs
     them on the decoupled :class:`TapActor` so a slow tap never back-pressures
-    delivery; ``'inline'`` reproduces the Sprint 53 connection-actor dispatch
+    delivery; ``'inline'`` uses the connection-actor dispatch directly
     and exists mainly so ``bench/mqtt/tap_throughput.py`` can compare the two on
     one build.  ``tap_queue_size`` bounds the actor-mode inbox (drop-newest on
     overflow).
@@ -82,7 +82,7 @@ class MQTTExtension(Extension):
         if tap_mode not in ('actor', 'inline'):
             raise ValueError(f"tap_mode must be 'actor' or 'inline', got {tap_mode!r}")
         self.port = port
-        # Sprint 75 — serve the broker port over TLS (mqtts://, conventionally
+        # Serve the broker port over TLS (mqtts://, conventionally
         # port 8883).  Requires the server to have a certificate configured.
         self.tls = tls
         self.tap_mode = tap_mode

--- a/blackbull/mqtt/messages.py
+++ b/blackbull/mqtt/messages.py
@@ -1,4 +1,4 @@
-"""MQTT 5.0 control-packet codec — Sprint 52.
+"""MQTT 5.0 control-packet codec.
 
 Level-A (pure-data) layer for the ``blackbull-mqtt`` broker sidecar: the 15
 MQTT 5.0 control packets as frozen dataclasses, a wire encoder/decoder, the

--- a/blackbull/mqtt/messages.py
+++ b/blackbull/mqtt/messages.py
@@ -867,7 +867,7 @@ def _decode_connect(body: bytes, flags: int) -> MQTTConnect:
     # Remaining Length stops short of them must be rejected as a Malformed
     # Packet (§1.5.5, §4.13) — a raw ``body[pos]`` here would raise IndexError,
     # which the framer's ``except`` does not catch, unwinding ``read_loop``
-    # and dropping the connection instead of resyncing (audit 1.19g).
+    # and dropping the connection instead of resyncing.
     if pos + 4 > len(body):
         raise MQTTDecodeError('CONNECT truncated before the fixed header fields')
     proto_level = body[pos]

--- a/blackbull/mqtt/tap.py
+++ b/blackbull/mqtt/tap.py
@@ -14,7 +14,7 @@ Two dispatch engines share one code path (:func:`run_taps`):
   *newest* message is dropped and a running dropped-count is logged (taps are
   best-effort, but silent loss is unacceptable).
 * **inline** — the connection actor awaits the callbacks itself.  This is the
-  Sprint 53 contract, retained as an internal option so the perf comparison
+  original contract, retained as an internal option so the perf comparison
   (``bench/mqtt/tap_throughput.py``) stays reproducible.
 
 A topic filter may carry ``{name}`` capture segments

--- a/blackbull/openapi.py
+++ b/blackbull/openapi.py
@@ -106,7 +106,7 @@ def _path_parameters(param_specs: dict[str, str]) -> list[dict]:
 def _query_parameters(handler, param_specs: dict[str, str]) -> list[dict]:
     """Build ``in: query`` parameter entries for a simplified handler.
 
-    Minimal tier (Sprint 74): name, schema from the annotation's scalar type,
+    Minimal tier: name, schema from the annotation's scalar type,
     ``required`` from default-presence.  Reuses the router's registration-time
     classifier so this walk can never disagree with what the wrapper actually
     resolves; ``Depends`` params are not request inputs and carry no entry.

--- a/blackbull/protocol/frame.py
+++ b/blackbull/protocol/frame.py
@@ -45,7 +45,7 @@ class FrameFactory:
     def create(self, type_: FrameTypes, flags: FrameFlags | int, stream_id: int, *, data: bytes = b'', **kwds):
         # NB: no per-create trace here — create() runs on every outbound frame
         # and every inbound load(), so an eager f-string here is pure overhead
-        # on the hottest H2 loop (frame-assembly-fast-path Tier 1).  The frame's
+        # on the hottest H2 loop.  The frame's
         # fields are available via its __repr__ when a caller needs them.
         frame = FrameBase._registry[type_](
             len(data),

--- a/blackbull/protocol/frame_types.py
+++ b/blackbull/protocol/frame_types.py
@@ -421,7 +421,7 @@ class Headers(FrameBase):
     def save(self):
         encoder = self.encoder if self.encoder is not None else Encoder()
         # Pseudo-headers MUST come before regular headers (RFC 7540 §8.1.2.1)
-        # Sprint 21 Phase C — fast-path :status when its value is one of the
+        # Fast-path :status when its value is one of the
         # static-table entries (RFC 7541 App A indices 8-14).  The encoder
         # would emit the same single byte, but at the cost of dict lookups
         # and a generator iteration we can sidestep.  Static-indexed fields
@@ -489,11 +489,10 @@ class PushPromise(FrameBase):
 
     def save(self) -> bytes:
         encoder = self.encoder if self.encoder is not None else Encoder()
-        # Sprint 24: extend the HPACK static fastpath to the request-side
+        # Extend the HPACK static fastpath to the request-side
         # pseudo-headers that PUSH_PROMISE emits (``:method``, ``:scheme``,
         # ``:path``).  Same wire-equivalence + dynamic-table-neutrality
-        # invariants as the Sprint 21 Phase C ``:status`` fast-path on
-        # ``Headers.save``.
+        # invariants as the ``:status`` fast-path on ``Headers.save``.
         fast_bytes = b''
         remaining_pseudo = []
         for k, v in self.pseudo_headers.items():

--- a/blackbull/protocol/frame_types.py
+++ b/blackbull/protocol/frame_types.py
@@ -100,7 +100,7 @@ class FrameBase:
         self.flags = flags
         self.stream_id = stream_id
         # Guarded: __init__ runs on every frame in both directions, so the
-        # f-string must not be built when DEBUG is off (Tier 1).
+        # f-string must not be built when DEBUG is off.
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug('type=%s, flag=%s, stream_id=%s and payload size=%s',
                          self.type_, self.flags, self.stream_id, self.length)
@@ -443,7 +443,7 @@ class Headers(FrameBase):
 
         base = super().save()
         # Guarded: fires on every HEADERS write; the unguarded form also
-        # allocated `base + payload` purely to log it (Tier 1).
+        # allocated `base + payload` purely to log it.
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug('Headers.save: %r', base + payload)
         return base + payload
@@ -590,7 +590,7 @@ class Data(FrameBase):
             self.payload = payload.read(data_length)
         else:
             # Non-padded is the common case: the payload IS the frame data, so
-            # skip the BytesIO wrap + read copy (copy-reduction-http2 P2).
+            # skip the BytesIO wrap + read copy.
             # FrameFactory.load already sliced data to exactly ``length``; the
             # conditional preserves BytesIO.read(length) semantics for the rare
             # over-long input without copying when it already fits.

--- a/blackbull/protocol/hpack_fastpath.py
+++ b/blackbull/protocol/hpack_fastpath.py
@@ -25,8 +25,8 @@ defined (the only entries eligible for single-byte encoding):
 
 All other static-table entries are name-only (e.g. ``content-type`` at
 index 31 has no static value), so they cannot use the single-byte
-indexed encoding.  Sprint 24 confirmed the table is exhausted at this
-encoding tier — any further fastpath work would need to handle the
+indexed encoding.  The table is exhausted at this encoding tier — any
+further fastpath work would need to handle the
 literal-with-indexed-name encoding (RFC 7541 §6.2), which involves
 encoder choices (Huffman vs raw, incremental indexing vs not) that we
 cannot pre-decide without coupling to encoder configuration.
@@ -70,8 +70,7 @@ def status_fast_bytes(status_value) -> bytes | None:
     value matches a static-table entry, else ``None``.
 
     Accepts ``str`` (the ASGI shape, e.g. ``'200'``) or ``bytes``.
-    Kept as a separate function for backwards compatibility with the
-    Sprint 21 Phase C ``Headers.save()`` call site.
+    Kept as a separate function for the ``Headers.save()`` call site.
     """
     return _STATIC_INDEXED.get((b':status', _coerce_bytes(status_value)))
 

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -11,7 +11,7 @@ Provides:
   callers that hold a scope dict.
 
 The opt-in HTTP context object formerly named ``Request`` moved to
-:class:`blackbull.connection.Connection` (Sprint 79 Phase 5); ``Request`` is now
+:class:`blackbull.connection.Connection`; ``Request`` is now
 a deprecated alias of ``Connection`` (see ``blackbull.__getattr__``). This
 module holds only the transport-agnostic free functions, which
 :class:`Connection` builds on.

--- a/blackbull/request.py
+++ b/blackbull/request.py
@@ -43,7 +43,7 @@ async def read_body(receive: ASGIReceiveCallable) -> bytes:
 
     Collects chunks in a list and joins once, rather than the O(n²) ``+=``
     growth.  A single-chunk body (the common case) is returned directly with
-    no intermediate copy at all (copy-reduction-http1 P1).
+    no intermediate copy at all.
 
     Raises :class:`ClientDisconnected` if an ``http.disconnect`` arrives
     before the body is complete, so a truncated upload is never silently

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -424,7 +424,7 @@ has_inner = has_middleware_param  # backward-compat alias
 
 #: A full-form handler is identified by carrying **both** transport channels
 #: (``receive`` and ``send``); its first positional param is the request context
-#: — the native ``conn``/``connection`` (Sprint 80), the deprecated ``scope``
+#: — the native ``conn``/``connection``, the deprecated ``scope``
 #: alias, or a WS handler's ``websocket``. The context name is not part of the
 #: test: a simplified handler never takes ``receive``/``send`` (those are the
 #: framework's channels, not request data), so their presence alone is decisive.
@@ -691,7 +691,7 @@ async def _finish_result(result, conn, receive, send, converters, fn_name: str) 
 
 
 # ---------------------------------------------------------------------------
-# Simplified-handler parameter classification (Sprint 74)
+# Simplified-handler parameter classification
 # ---------------------------------------------------------------------------
 
 # RFC-agnostic textual boolean forms accepted for ``param: bool`` query params.
@@ -765,7 +765,7 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
     body-consuming parameter, or a leftover parameter whose annotation is not a
     supported query scalar.
     """
-    from .connection import Connection as _Conn  # Sprint 79: Request is now a Connection alias
+    from .connection import Connection as _Conn  # ``Request`` is an alias of it
 
     params = inspect.signature(fn).parameters
     annotations = {n: p.annotation for n, p in params.items()}
@@ -874,7 +874,7 @@ def _conn_of(target, receive):
     inbound ASGI scope via :meth:`Connection.from_scope` before dispatch), or a
     hand-built ASGI scope dict on a direct unit-test drive of a wrapper.
 
-    Sprint 79 Phase 5 (consumer switch): the protocol actor builds the
+    The protocol actor builds the
     ``Connection`` in its parser and stashes it on the ASGI scope envelope
     under :data:`~blackbull.connection.CONNECTION_STASH_KEY`, so the self-hosted
     path reuses that object with
@@ -911,11 +911,11 @@ def _conn_of(target, receive):
 def _set_path_params(target, receive, params: dict) -> None:
     """Record matched URL path params on the request's :class:`Connection`.
 
-    Sprint 79 Phase 5: replaces the old ``scope.setdefault('path_params', {})``
+    Replaces the old ``scope.setdefault('path_params', {})``
     closure. The handler reads them back via ``conn.path_params`` (see
     :func:`_conn_of`).
 
-    Sprint 80 Tier-1b: no-op fast-return when there are no matched params, so a
+    No-op fast-return when there are no matched params, so a
     no-param route never touches ``conn.path_params`` and its lazy backing dict
     is never allocated.
     """
@@ -1037,7 +1037,7 @@ def _websocket_param_plan(fn, path_param_names: set = frozenset()) -> tuple[tupl
             # are rare and the reserved-name space makes bare names genuinely
             # ambiguous — `async def chat(socket)` means the socket, not a query
             # param named "socket".  Requiring the annotation costs one word and
-            # keeps the Sprint 82 property that a typo fails at registration
+            # keeps the property that a typo fails at registration
             # instead of rejecting every connection at runtime.
             target = None if bare else _unwrap_optional(ann)
             coercer = _QUERY_COERCERS.get(target) if isinstance(target, type) else None
@@ -1089,7 +1089,7 @@ def _adapt_websocket_handler(fn, path: str = ''):
     plan = _websocket_param_plan(fn, _path_param_names(path))
 
     # The overwhelmingly common shape — a lone ``ws`` — gets a wrapper with no
-    # per-connection argument assembly at all.  Unchanged since Sprint 82.
+    # per-connection argument assembly at all.
     if len(plan) == 1 and plan[0][1] == 'ws':
         @wraps(fn)
         async def _ws_wrapper(conn, receive, send):
@@ -1211,7 +1211,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
       TypeError at registration time (fail fast).
 
     Handlers using neither query params nor ``Depends`` compile to the same
-    basic wrapper as before Sprint 74 — the zero-overhead pin.
+    basic wrapper as a handler that uses neither — the zero-overhead pin.
 
     Return values: Response → send(result); bytes → send(Response(result));
     str → send(Response(result.encode())); dict → send(JSONResponse(result));
@@ -1298,7 +1298,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
 
     if not has_query and not depends_plan:
         # Zero-overhead pin: neither new parameter category is in play, so
-        # this handler gets the exact wrapper it got before Sprint 74.
+        # this handler gets the plain wrapper.
         return _wrapper
 
     # Extended wrapper — query params and/or Depends.  The plan below was
@@ -1727,8 +1727,8 @@ class Router:
         """Core route lookup — trie first, regex fallback.  Raises on miss.
 
         No logging on the hit path: even a disabled ``logger.debug`` costs
-        ~100 ns/call, a measurable slice of the <1000 ns ``_resolve`` budget
-        (Sprint 77).  Miss-path logging is retained below.
+        ~100 ns/call, a measurable slice of the <1000 ns ``_resolve`` budget.
+        Miss-path logging is retained below.
         """
         key_path, key_method, key_scheme = key
 

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -127,7 +127,7 @@ class _RouteTrie:
                     # {name:path} consumes all remaining segments, so it must be
                     # the final segment.  A route like ``/a/{p:path}/b`` used to
                     # silently register as ``/a/{p:path}`` — dropping ``/b`` — so
-                    # reject it at registration (bug 1.13).
+                    # reject it at registration.
                     if i != len(segments) - 1:
                         raise ConfigurationError(
                             f"path converter {seg!r} must be the last segment of "
@@ -561,7 +561,7 @@ def _instantiate_dataclass(cls: Any, data: dict) -> Any:
 
 def _decode_json_body(cls: Any, raw: bytes, handler_name: str) -> Any:
     """Parse *raw* JSON and instantiate the dataclass *cls*, mapping any
-    client-input error to a 400 (bug 1.12).
+    client-input error to a 400.
 
     Malformed JSON, a wrong top-level shape, unknown/missing fields, or a
     field that fails type coercion are all *client* errors — they must surface

--- a/blackbull/server/access_log.py
+++ b/blackbull/server/access_log.py
@@ -17,7 +17,7 @@ from ..logger import enqueue_access_log  # O4 fast path (no import cycle: logger
 
 _access_logger = logging.getLogger('blackbull.access')
 
-# Sprint 33 investigation knob: capture per-request phase wall + CPU
+# Capture per-request phase wall + CPU
 # checkpoints into AccessLogRecord.phases.  Off by default — the
 # extra time.perf_counter() + time.process_time() calls would otherwise
 # show up in benchmark numbers.  Set ``BB_PHASE_TRACE=1`` to turn on
@@ -112,7 +112,7 @@ class AccessLogRecord:
     status:         int | str = '-'
     response_bytes: int       = 0
     close_code:     int | None = None
-    # Sprint 35 phase-trace diagnostic — request/response headers we want
+    # Request/response headers we want
     # to correlate against per-phase timing.  Empty bytes are interpreted
     # as "header absent" in ``format()``.  Populated only when
     # ``PHASE_TRACE=1`` so production responses don't pay the bytes
@@ -161,7 +161,7 @@ class AccessLogRecord:
     @classmethod
     def from_conn(cls, conn) -> 'AccessLogRecord':
         """Build directly from a :class:`~blackbull.connection.Connection`
-        (Sprint 80 Tier-2) so the self-hosted actor never materializes the ASGI
+        so the self-hosted actor never materializes the ASGI
         scope just to record the access line."""
         client = conn.client or ('-',)
         ae = b''

--- a/blackbull/server/cap_log.py
+++ b/blackbull/server/cap_log.py
@@ -5,7 +5,7 @@ timeouts, connection cap, WS frame cap, WS queue depth, H/2 stream
 caps, compression in-flight) is silent by default when it rejects
 traffic.  Operators see the consequence — a 503, a CLOSE 1009, a
 dropped event — but no record naming the cap.  Regressions like the
-1 MiB WS frame default that shipped in v0.35.0 (caught by the Sprint
+1 MiB WS frame default that shipped in v0.35.0 (caught by the
 43 conformance lane in v0.39.0) can hide across releases.
 
 This module emits one ``WARNING``-level record per cap rejection on

--- a/blackbull/server/connection_actor.py
+++ b/blackbull/server/connection_actor.py
@@ -1,4 +1,4 @@
-"""Connection Actor — Phase 6 Step 5."""
+"""Connection Actor — owns one transport and spawns its protocol actor."""
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
@@ -188,7 +188,7 @@ class ConnectionActor(Actor):
         # both halves.
         deadline = cfg.header_timeout if cfg.header_timeout > 0 else None
 
-        # Sprint 23: one rescheduled TimerHandle per connection replaces
+        # One rescheduled TimerHandle per connection replaces
         # the per-phase ``async with asyncio.timeout(d):`` allocations.
         # The deadline binds to *this* task — the per-connection dispatch
         # task — and gets passed down into HTTP1Actor / HTTP1Recipient so
@@ -196,7 +196,7 @@ class ConnectionActor(Actor):
         # re-arms the same handle.
         dl = ConnectionDeadline()
 
-        # Port-bound non-ASGI protocol (Sprint 50): the listening socket already
+        # Port-bound non-ASGI protocol: the listening socket already
         # identifies the protocol, so skip detection and the deadline machinery
         # entirely — the handler owns the connection lifetime and the raw reader.
         if self._bound_binding is not None:

--- a/blackbull/server/deadline.py
+++ b/blackbull/server/deadline.py
@@ -1,14 +1,13 @@
-"""Per-connection rescheduled deadline (Sprint 26 Phase B — scanner form).
+"""Per-connection rescheduled deadline.
 
 Replaces ``async with asyncio.timeout(...)`` on the per-request hot
-path.  Sprint 23 used one ``loop.call_later`` ``TimerHandle`` per
-connection, cancelled and rescheduled at every phase transition.
-Sprint 26 Phase B replaces the per-arm ``call_later`` with a
-per-process tick scanner: one singleton ``TimerHandle`` re-arms itself
+path, and the per-connection ``loop.call_later`` ``TimerHandle`` that
+had to be cancelled and rescheduled at every phase transition.
+Instead, a per-process tick scanner: one singleton ``TimerHandle``
+re-arms itself
 every :data:`_TICK_S` and walks the registry of armed
 :class:`ConnectionDeadline` instances for expirations.  Per-arm cost
-drops from ~1.7 µs to ~0.34 µs (WSL2 microbench, Sprint 26 Phase B
-spike).
+is ~0.34 µs rather than ~1.7 µs.
 
 Trade-off: a fired deadline lands within ``[now, now + _TICK_S]``
 rather than at the exact requested instant.  At the default
@@ -93,8 +92,7 @@ class ConnectionDeadline:
     saturation the per-arm path costs ~1.7 µs (TimerHandle + heap
     push + cancel).  The scanner replaces that with one
     ``loop.time()`` call + one comparison + one set membership check
-    on the registry (~0.34 µs).  Sprint 26 Phase B microbench: 80 %
-    per-call reduction; cascade-multiplied estimate ~15–25 % B1.
+    on the registry (~0.34 µs) — an ~80 % per-call reduction.
     """
 
     __slots__ = ('_loop', '_task', '_deadline_at', '_fired',

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -82,6 +82,43 @@ _HTTP_VERSION_RE = re.compile(rb'^HTTP/\d\.\d$')
 _FIELD_NAME_INVALID_RE = re.compile(rb"[^!#$%&'*+\-.^_`|~0-9A-Za-z]")
 _FIELD_VALUE_INVALID_RE = re.compile(rb"[\x00-\x08\x0a-\x1f\x7f]")
 
+# RFC 9110 §5.6.2 tchar, spelled out.  Deleting every allowed octet leaves
+# the empty string for a valid token, so a non-empty result is the rejection
+# — the same trick as `_TARGET_ALLOWED_OCTETS`, and measurably cheaper than
+# `_FIELD_NAME_INVALID_RE` (which stays as the source of truth this table is
+# tested against, octet for octet).
+_TCHAR_OCTETS = (b"!#$%&'*+-.^_`|~"
+                 b'0123456789'
+                 b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+                 b'abcdefghijklmnopqrstuvwxyz')
+
+# Everything a header *block* may contain, so that deleting it leaves only
+# CR, LF, and the CTLs a field value may not carry (`_FIELD_VALUE_INVALID_RE`).
+# A clean block therefore reduces to a run of CRLFs — which is what
+# `_block_values_are_clean` checks, in one C-level pass for the whole request
+# instead of one regex per header.
+_BLOCK_ALLOWED_OCTETS = bytes(
+    c for c in range(256)
+    if not (c < 0x09 or 0x0B <= c <= 0x0C or 0x0E <= c <= 0x1F or c == 0x7F)
+    and c not in (0x0A, 0x0D)
+)
+
+
+def _block_values_are_clean(data: bytes) -> bool:
+    """True when no field value in *data* can contain a forbidden octet.
+
+    Deleting every permitted octet leaves only CR, LF and forbidden CTLs.
+    If what remains tiles exactly into CRLF pairs, then every CR and LF in
+    the block is a line terminator and no forbidden CTL appears anywhere —
+    so the per-header field-value check cannot fire, and is skipped.
+
+    A ``False`` result proves nothing about *which* line is at fault (it can
+    even be the request line, which has its own checks), so it only turns the
+    per-header regex back on.  The caller's error messages are unchanged.
+    """
+    residue = data.translate(None, _BLOCK_ALLOWED_OCTETS)
+    return residue.count(b'\r\n') * 2 == len(residue)
+
 # RFC 9110 §8.6 — strict Content-Length: at most one canonical leading SP
 # (the byte after the colon), then ``0`` or a no-leading-zero decimal.
 # Matched against the *raw* post-colon bytes, before the generic OWS strip
@@ -216,6 +253,18 @@ def _validate_message_framing(headers: 'Headers') -> None:
 # included (Sprint 63, COMP-HOST-WITH-USERINFO): the deprecated userinfo
 # component has no place in a Host header and enables credential-spoofing.
 _HOST_FORBIDDEN_BYTES = frozenset(b'/?# \t@')
+# Derived from the set above so the two cannot drift.  A small forbidden
+# class scans faster as a regex than as a `translate` delete table (the
+# opposite of the request-target case below, where the allowed set is large).
+_HOST_FORBIDDEN_RE = re.compile(
+    b'[' + re.escape(bytes(sorted(_HOST_FORBIDDEN_BYTES))) + b']')
+
+# RFC 9112 §2.1 / RFC 3986 — a request-target may carry only visible ASCII.
+# Deleting every allowed octet leaves the empty string for a valid target, so
+# a non-empty result *is* the rejection: one C-level pass instead of a Python
+# generator over each byte, and no allocation in the accept case (CPython
+# returns the shared empty bytes).
+_TARGET_ALLOWED_OCTETS = bytes(range(0x21, 0x7F))
 
 
 def _parse_host_header(value: bytes, default_port: int) -> tuple[str, int]:
@@ -271,7 +320,7 @@ def _validate_host(headers: 'Headers') -> None:
     value = hosts[0][1].strip(b' \t')
     if not value:
         raise BadRequestError('empty Host header value')
-    if any(b in _HOST_FORBIDDEN_BYTES for b in value):
+    if _HOST_FORBIDDEN_RE.search(value):
         raise BadRequestError(
             f'invalid Host authority {value!r}: contains '
             f'delimiter / whitespace forbidden by RFC 3986 §3.2')
@@ -782,7 +831,10 @@ class HTTP1Actor(Actor):
         from ..env import get_settings as _get_settings  # noqa: PLC0415
         max_line = _get_settings().header_max_line
         lines = data.split(b'\r\n')
-        if max_line > 0:
+        # No line can be longer than the block that contains it, so the
+        # per-line walk is only reachable for a block that is itself over the
+        # limit — one comparison retires it for every request under 8 KiB.
+        if max_line > 0 and len(data) > max_line:
             for ln in lines:
                 if len(ln) > max_line:
                     raise HeaderTooLargeError(
@@ -805,7 +857,7 @@ class HTTP1Actor(Actor):
         method, path, version = parts
 
         # Method (§4 / RFC 9110 §9.1) — case-sensitive token of 1+ tchar.
-        if not method or _FIELD_NAME_INVALID_RE.search(method):
+        if not method or method.translate(None, _TCHAR_OCTETS):
             raise BadRequestError(f'invalid method {method!r}')
 
         # HTTP-version (§2.5) — exactly ``HTTP/d.d``.
@@ -860,7 +912,7 @@ class HTTP1Actor(Actor):
         # smuggling vector, MAL-NON-ASCII-URL).  Skipped for asterisk-form
         # (the literal ``*`` is validated above).
         if not asterisk_form and (
-                not path or any(b < 0x21 or b == 0x7F or b >= 0x80 for b in path)):
+                not path or path.translate(None, _TARGET_ALLOWED_OCTETS)):
             raise BadRequestError(f'invalid request-target {path!r}')
 
         if asterisk_form:
@@ -888,6 +940,12 @@ class HTTP1Actor(Actor):
         else:
             _decoded_path = _raw_path_b.decode('utf-8')
 
+        # One C-level pass decides whether any field value *could* hold a
+        # forbidden octet.  When it says no, the per-header regex below is
+        # dead weight and is skipped; when it says yes, that regex still runs
+        # and still raises, so the diagnostic never changes.
+        values_need_checking = not _block_values_are_clean(data)
+
         raw: list[tuple[bytes, bytes]] = []
         for line in lines[idx + 1:]:
             if not line:
@@ -895,8 +953,10 @@ class HTTP1Actor(Actor):
                 # split off upstream because we read until CRLFCRLF).
                 continue
             # RFC 9112 §5.2 — obs-fold (leading SP/HTAB on a header line)
-            # MUST be rejected in requests.
-            if line[:1] in (b' ', b'\t'):
+            # MUST be rejected in requests.  Indexing yields an int and skips
+            # the one-byte slice a `line[:1]` comparison would allocate; the
+            # empty-line case is retired by the `continue` above.
+            if line[0] in (0x20, 0x09):
                 raise BadRequestError(
                     f'obsolete line folding rejected: {line!r}')
             colon = line.find(b':')
@@ -904,12 +964,16 @@ class HTTP1Actor(Actor):
                 raise BadRequestError(f'malformed header line: {line!r}')
             key = line[:colon]
             value = line[colon + 1:]
-            # §5.1 — no whitespace between field-name and ':'.
-            if key[-1:] in (b' ', b'\t'):
-                raise BadRequestError(
-                    f'whitespace before colon (smuggling vector): {line!r}')
             # field-name must be a valid token (§5.1 / RFC 9110 §5.6.2).
-            if _FIELD_NAME_INVALID_RE.search(key):
+            # SP and HTAB are not tchar, so this one test also decides §5.1
+            # (no whitespace between field-name and ':') — a well-formed name
+            # answers both questions at once, and only a rejected name pays
+            # for telling the two apart.  `colon < 1` above guarantees a
+            # non-empty key, so indexing is safe.
+            if key.translate(None, _TCHAR_OCTETS):
+                if key[-1] in (0x20, 0x09):
+                    raise BadRequestError(
+                        f'whitespace before colon (smuggling vector): {line!r}')
                 raise BadRequestError(f'invalid header name {key!r}')
             lkey = key.lower()
             if lkey in _UNDERSCORE_FRAMING_NAMES:
@@ -925,7 +989,7 @@ class HTTP1Actor(Actor):
             # Strip the OWS surrounding the value (§5).
             value = value.strip(b' \t')
             # field-value MUST NOT contain CTLs except HTAB.
-            if _FIELD_VALUE_INVALID_RE.search(value):
+            if values_need_checking and _FIELD_VALUE_INVALID_RE.search(value):
                 raise BadRequestError(
                     f'CTL in header value (smuggling / log-injection): '
                     f'{key!r}: {value!r}')
@@ -938,7 +1002,9 @@ class HTTP1Actor(Actor):
         if authority_override is not None:
             raw = [(k, v) for k, v in raw if k != b'host']
             raw.append((b'host', authority_override))
-        headers = Headers(raw)
+        # Names were lowercased in the loop above while being validated;
+        # `Headers.__init__` would lowercase them a second time.
+        headers = Headers.from_lowered(raw)
 
         # RFC 9110 §8.3 — Content-Type is a singleton; multiple values are
         # ambiguous and a request-smuggling surface (COMP-DUPLICATE-CT).

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -44,7 +44,7 @@ _HTTP_PORT  = 80
 _HTTPS_PORT = 443
 
 # Upper bound on request-body bytes drained to recover keep-alive framing
-# when a handler leaves the body unread (bug 1.6).  A larger unread body
+# when a handler leaves the body unread.  A larger unread body
 # closes the connection rather than spending bandwidth draining it — nginx's
 # lingering-close does the same.
 _MAX_KEEPALIVE_DRAIN = 64 * 1024
@@ -1306,7 +1306,7 @@ class HTTP1Actor(Actor):
         # Accumulate into a bytearray (amortised O(1) append) instead of the
         # O(n²) bytes ``+=`` growth, then publish back as bytes.  The loop
         # condition and size check are byte-for-byte equivalent to the prior
-        # form (copy-reduction-http1 P2).
+        # form.
         buf = bytearray(self._request)
         while not buf.endswith(_REQ_END):
             try:

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -1,4 +1,4 @@
-"""HTTP/1.1 Actor classes for the BlackBull Actor model (Phase 6 Step 3).
+"""HTTP/1.1 Actor classes for the BlackBull actor model.
 
 HTTP1Actor drives the keep-alive loop for one TCP connection.
 RequestActor owns the lifetime of a single HTTP request.
@@ -70,7 +70,7 @@ _TOKEN_CHARS = (
 _TOKEN_SET = frozenset(_TOKEN_CHARS)
 _HTTP_VERSION_RE = re.compile(rb'^HTTP/\d\.\d$')
 
-# Sprint 25 Phase B — compiled-regex validators replace per-byte
+# Compiled-regex validators replace per-byte
 # `any(c not in _TOKEN_SET for c in …)` and `any((b < 0x20 or
 # b == 0x7F) and b != 0x09 for b in …)` scans in `_parse`.  The
 # character classes below are the exact negation of the RFC 9110
@@ -187,7 +187,7 @@ def _validate_message_framing(headers: 'Headers') -> None:
       ``identity, chunked`` multi-coding form, etc.) raises
       :class:`NotImplementedFramingError`.  Without this check the
       recipient layer raised ``NotImplementedError`` later and the
-      connection dropped silently (Sprint 17 Finding C).
+      connection dropped silently.
     """
     cls = headers.getlist(b'content-length')
     tes = headers.getlist(b'transfer-encoding')
@@ -211,7 +211,7 @@ def _validate_message_framing(headers: 'Headers') -> None:
             raise BadRequestError(
                 f'conflicting Content-Length values: {sorted(values)!r}')
 
-    # Sprint 18 Phase 2 / Sprint 63 — Transfer-Encoding validation.
+    # Transfer-Encoding validation.
     #
     # RFC 9112 §6.1 distinguishes two failure modes:
     #   * ``chunked`` present but NOT the final coding (``chunked, gzip``,
@@ -249,8 +249,8 @@ def _validate_message_framing(headers: 'Headers') -> None:
 # RFC 3986 §3.2 — authority = [userinfo "@"] host [":" port].  None of
 # these delimiter octets belong in a Host header value; their presence
 # (or an empty value) is a smuggling / SSRF vector that nginx rejects
-# with 400 and BlackBull, pre-Sprint-18, accepted silently.  ``@`` is
-# included (Sprint 63, COMP-HOST-WITH-USERINFO): the deprecated userinfo
+# with 400 and a lenient parser accepts silently.  ``@`` is
+# included: the deprecated userinfo
 # component has no place in a Host header and enables credential-spoofing.
 _HOST_FORBIDDEN_BYTES = frozenset(b'/?# \t@')
 # Derived from the set above so the two cannot drift.  A small forbidden
@@ -297,9 +297,9 @@ def _parse_host_header(value: bytes, default_port: int) -> tuple[str, int]:
 
 def _validate_host(headers: 'Headers') -> None:
     """RFC 9112 §3.2 / §7.2 — Host MUST be present and contain a valid
-    URI-authority component.  Sprint 17 Finding B captured several
-    inputs (``host: 0/0``, empty host) where BlackBull answered 200 and
-    nginx answered 400.  This check brings BlackBull into RFC alignment.
+    URI-authority component.  Inputs such as ``host: 0/0`` and an empty
+    host are accepted by a lenient parser and rejected with 400 by nginx;
+    this check keeps BlackBull on the RFC side of that split.
 
     Rules enforced:
       * at most one Host header (§7.2; multiple is a smuggling vector);
@@ -336,7 +336,7 @@ class RequestActor(Actor):
     Spawned by HTTP1Actor, awaited to completion.  Calls the ASGI app.
 
     The request-lifecycle Level B events are emitted by the application
-    layer (``BlackBull._dispatch`` / ``__call__``, Sprint 64 + issue #145) —
+    layer (``BlackBull._dispatch`` / ``__call__``) —
     the cross-transport emission points — not here.  The
     actor layer emits only the Level B ``error`` event, for exceptions that
     escape the app call (e.g. a raising global middleware).
@@ -459,7 +459,7 @@ class HTTP1Actor(Actor):
         from ..env import get_settings as _get_settings  # noqa: PLC0415
         from .access_log import PHASE_TRACE as _PHASE_TRACE  # noqa: PLC0415
         cfg = _get_settings()
-        # Sprint 23: one rescheduled TimerHandle per connection drives
+        # One rescheduled TimerHandle per connection drives
         # all phase deadlines (headers / body / keep-alive).  Created
         # lazily so tests that instantiate HTTP1Actor without a wrapping
         # ConnectionActor still work — same task either way.
@@ -467,7 +467,7 @@ class HTTP1Actor(Actor):
             self._deadline = ConnectionDeadline()
         dl = self._deadline
         send = SenderFactory.http1(self._writer)
-        # Sprint 33 investigation: capture loop_start at the very top
+        # Capture loop_start at the very top
         # of each iteration so we can quantify the between-request gap
         # (dispatch_done(N) → loop_start(N+1)) on a keep-alive
         # connection.  Plain locals — assigned to log_record.phases
@@ -494,7 +494,7 @@ class HTTP1Actor(Actor):
                     else:
                         await self._read_headers(cfg.header_max_total)
                 except IncompleteReadError:
-                    # Sprint 17 Phase 3 — distinguish idle EOF from
+                    # Distinguish idle EOF from
                     # mid-headers EOF.  ``self._request`` is empty in
                     # the idle case (just-after keep-alive reset or
                     # fresh connection with no preamble); peer closed
@@ -562,8 +562,8 @@ class HTTP1Actor(Actor):
                         send, b'400 Bad Request', HTTPStatus.BAD_REQUEST)
                     return
                 except NotImplementedFramingError as exc:
-                    # Sprint 18 Phase 2 — RFC 9112 §6.1: server received a
-                    # Transfer-Encoding it does not implement.  Pre-Sprint-18
+                    # RFC 9112 §6.1: server received a
+                    # Transfer-Encoding it does not implement.  A lenient
                     # this raised inside HTTP1Recipient and the connection
                     # dropped silently (Finding C in user-corpus).  Match
                     # nginx and answer with 501 then close.
@@ -582,7 +582,7 @@ class HTTP1Actor(Actor):
                     return
                 self._fill_connection_info(conn)
 
-                # Sprint 80 Tier-2 / native-Connection entry: BlackBull's own
+                # Native-Connection entry: BlackBull's own
                 # server dispatches the typed ``Connection`` directly — the app
                 # is ``app(conn, receive, send)``, no ASGI scope object at all.
                 # Only ``BB_FORCE_ASGI_SCOPE=1`` takes the compat lane: the server
@@ -597,7 +597,7 @@ class HTTP1Actor(Actor):
                     app_arg = conn                                     # native Connection
 
                 if conn.type == 'websocket':
-                    # WebSocket is native too (Sprint 80): the upgrade path
+                    # WebSocket is native too: the upgrade path
                     # threads the typed Connection — the WS-only extras
                     # (subprotocols, the deferred 101 responder, deflate params)
                     # live on it (``conn.subprotocols`` / ``conn._ws``), so there
@@ -617,8 +617,8 @@ class HTTP1Actor(Actor):
                 # (access log / phase trace / request_completed listener). On the
                 # baseline hot path — no logging, no listeners — skipping it drops
                 # a per-request allocation and the ``conn.state`` dict it forces
-                # (Sprint 80 alloc-reduction; the Connection graph's per-request
-                # objects are what the cyclic GC scans under concurrency). The
+                # (the Connection graph's per-request objects are what the
+                # cyclic GC scans under concurrency). The
                 # legacy (no-aggregator) branch of ``_dispatch_request`` reads the
                 # record unconditionally, so keep building it when there is no
                 # aggregator. Consumers below are all None-tolerant (the sender
@@ -635,7 +635,7 @@ class HTTP1Actor(Actor):
                     conn.state['access_log'] = log_record
                 else:
                     log_record = None
-                # Sprint 38 Task B — reset per-request sender state.  The
+                # Reset per-request sender state.  The
                 # HTTP1Sender instance is shared across keep-alive
                 # requests on this connection; without this reset
                 # ``_started`` stays True after the first response and
@@ -706,7 +706,7 @@ class HTTP1Actor(Actor):
                     self._request = next_chunk
                     continue
 
-                # Sprint 38 Task B — BB_REQUEST_TIMEOUT parity with the
+                # BB_REQUEST_TIMEOUT parity with the
                 # HTTP/2 path.  ``HTTP2Actor._spawn_stream_task`` wraps each
                 # stream coroutine with ``asyncio.wait_for``; the HTTP/1.1
                 # path mirrors that here.  On expiry: synthesise 408 if
@@ -808,9 +808,9 @@ class HTTP1Actor(Actor):
     def _parse(self, data: bytes) -> Connection:
         """Parse raw HTTP/1.1 request bytes into a native :class:`Connection`.
 
-        (Sprint 79 Phase 3 — the parser now produces the typed native model;
-        the ASGI scope is a derived view obtained via ``conn.as_scope()`` at
-        the dispatch boundary.)
+        The parser produces the typed native model; the ASGI scope is a
+        derived view obtained via ``conn.as_scope()`` at the dispatch
+        boundary.
 
         Raises :class:`BadRequestError` on any RFC 9112 framing violation
         the caller should answer with 400.  Validation rules:
@@ -918,9 +918,9 @@ class HTTP1Actor(Actor):
         if asterisk_form:
             _raw_path_b, _query_string = b'*', b''
         else:
-            # Sprint 25 Phase A — split the bytes request-target with C-level
+            # Split the bytes request-target with C-level
             # partition calls (~12× faster than urlparse): strip #fragment,
-            # then split ?query.  Sprint 68 — ';' is NOT split off: RFC 3986
+            # then split ?query.  ';' is NOT split off: RFC 3986
             # treats it as an ordinary path sub-delimiter (the ;params grammar
             # is obsolete RFC 2396), so it stays in the path component.  The
             # path component (raw_path) and its decoded form (path) are now
@@ -928,7 +928,7 @@ class HTTP1Actor(Actor):
             _no_frag, _, _ = path.partition(b'#')
             _raw_path_b, _, _query_string = _no_frag.partition(b'?')
 
-        # Sprint 68 W1 — ASGI: scope['path'] is the percent-decoded (UTF-8)
+        # ASGI: scope['path'] is the percent-decoded (UTF-8)
         # path component.  The b'%' guard keeps the no-escape common case on
         # the plain-decode fast path; the target was already rejected above
         # if it contains bytes >= 0x80, so .decode('ascii') cannot fail.
@@ -1013,7 +1013,7 @@ class HTTP1Actor(Actor):
 
         # RFC 9112 §6 — message framing validation.  Done here so a bad
         # framing header is rejected before any body bytes are read.
-        # Sprint 18 — also validates Host (§3.2 / §7.2) and the
+        # Also validates Host (§3.2 / §7.2) and the
         # transfer-coding registry (§6.1 → 501 on unknown coding).
         _validate_message_framing(headers)
         _validate_host(headers)
@@ -1083,7 +1083,7 @@ class HTTP1Actor(Actor):
             conn.scheme = 'wss' if conn.type == 'websocket' else 'https'
 
     async def _handle_upgrade(self, conn: Connection) -> None:
-        """Handle WebSocket upgrade (native Connection, Sprint 80)."""
+        """Handle WebSocket upgrade, threading the native Connection."""
         from .conn_id import new_connection_id  # noqa: PLC0415
         from .websocket_actor import WebSocketActor  # noqa: PLC0415
         aggregator = self._aggregator
@@ -1248,7 +1248,7 @@ class HTTP1Actor(Actor):
             try:
                 await request_actor.run()
             except asyncio.CancelledError:
-                # Sprint 38 Task B — let BB_REQUEST_TIMEOUT's wait_for see
+                # Let BB_REQUEST_TIMEOUT's wait_for see
                 # the cancellation; swallowing it here would convert a
                 # timeout into a normal close without the 408 synthesis.
                 raise
@@ -1280,8 +1280,8 @@ class HTTP1Actor(Actor):
         raises :class:`HeaderTooLargeError` when the buffer overshoots.
 
         Read **one CRLF-terminated line per iteration** rather than scanning
-        for the contiguous ``\\r\\n\\r\\n`` delimiter.  Sprint 19 — the
-        ``readuntil(b'\\r\\n\\r\\n')`` shape deadlocked when
+        for the contiguous ``\\r\\n\\r\\n`` delimiter.  A
+        ``readuntil(b'\\r\\n\\r\\n')`` shape deadlocks when
         :class:`ConnectionActor` had already consumed the first line's
         ``\\r\\n`` via its protocol-detect ``readuntil(b'\\r\\n')`` and the
         remaining buffer contained only the terminating empty line's
@@ -1375,7 +1375,7 @@ class HTTP1Actor(Actor):
     def _should_keep_alive(self, conn) -> bool:
         """Return True if the connection should persist after this request.
 
-        Reads the :class:`Connection` directly (Sprint 80 Tier-2) so the
+        Reads the :class:`Connection` directly so the
         per-request keep-alive decision never materializes the lazy scope."""
         http_version = conn.http_version
         connection = conn.headers.get(b'connection', b'').lower()

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -104,7 +104,7 @@ def _make_log_record(conn: Connection):
 
 _DEFAULT_PRIORITY: dict[str, int | bool] = {'urgency': 3, 'incremental': False}
 
-# Upper bound on the per-connection closed-stream record (bug 1.9).  Streams
+# Upper bound on the per-connection closed-stream record.  Streams
 # closed beyond this many back fall off the exact cache and are recognised as
 # CLOSED via the high-water mark instead, defaulting to the lenient
 # (non-RST-close) §5.1 treatment.
@@ -363,7 +363,7 @@ class HTTP2Actor(Actor):
         # Flow-control state — updated by SettingsResponder / WindowUpdateResponder
         # so that new stream senders start with the current peer-granted windows.
         self._peer_initial_window_size: int = DEFAULT_INITIAL_WINDOW_SIZE
-        # Shared connection-level send window (bug 1.2).  Every stream sender
+        # Shared connection-level send window.  Every stream sender
         # created by ``make_sender`` references this one object, so N concurrent
         # streams debit a single stream-0 budget instead of N private copies.
         self._conn_window = ConnectionWindow(DEFAULT_INITIAL_WINDOW_SIZE)
@@ -443,14 +443,14 @@ class HTTP2Actor(Actor):
         # already-closed identifiers and choosing the right error code.
         # Bounded record of recently-closed stream ids → closed-via-RST bool,
         # for §5.1 late-frame validation.  Capped so a long-lived connection
-        # cycling millions of streams (gRPC) does not grow it without bound
-        # (bug 1.9).  Ids below _closed_high_water that have fallen off the cap
+        # cycling millions of streams (gRPC) does not grow it without bound.
+        # Ids below _closed_high_water that have fallen off the cap
         # are still recognised as CLOSED via the watermark.
         self._closed_streams: dict[int, bool] = {}
         self._closed_high_water: int = 0
         # Set by receive() when a frame declares a payload larger than the
         # SETTINGS_MAX_FRAME_SIZE we advertise; the frame loop raises a
-        # FRAME_SIZE_ERROR without the payload ever being buffered (bug 1.14).
+        # FRAME_SIZE_ERROR without the payload ever being buffered.
         self._oversize_frame_len: int = 0
 
     # ------------------------------------------------------------------
@@ -472,7 +472,7 @@ class HTTP2Actor(Actor):
             sender = SenderFactory.http2(
                 self._writer, self.factory, stream_id,
                 push_callback=self._handle_push,
-                conn_window=self._conn_window,  # shared stream-0 budget (bug 1.2)
+                conn_window=self._conn_window,  # shared stream-0 budget
                 # Seed the per-stream window from what the peer has currently
                 # granted us, rather than the RFC default, which may already
                 # have been changed by SETTINGS frames received before this
@@ -687,7 +687,7 @@ class HTTP2Actor(Actor):
     def _mark_closed(self, stream_id: int, via_rst: bool) -> None:
         """Record *stream_id* as closed for §5.1 late-frame validation.
 
-        Bounded (bug 1.9): only the most recent ``_CLOSED_STREAMS_CAP`` streams
+        Bounded: only the most recent ``_CLOSED_STREAMS_CAP`` streams
         keep their exact closed-via-RST bool; older ids are evicted (oldest
         first) but stay recognisable as CLOSED through ``_closed_high_water``.
         """
@@ -707,7 +707,7 @@ class HTTP2Actor(Actor):
             return b''
         size = int.from_bytes(data[:3], 'big', signed=False)
         if size > DEFAULT_MAX_FRAME_SIZE:
-            # RFC 9113 §4.2 (bug 1.14) — a frame larger than the
+            # RFC 9113 §4.2 — a frame larger than the
             # SETTINGS_MAX_FRAME_SIZE we advertise is a FRAME_SIZE_ERROR.
             # Refuse to buffer its (attacker-declared, up to 16 MiB) payload:
             # hand back the 9-byte header and let the frame loop raise the
@@ -771,7 +771,7 @@ class HTTP2Actor(Actor):
         while data := await self.receive():
             if self._goaway_sent:
                 # A previous frame triggered a connection error and the GOAWAY
-                # has been flushed.  Signal recipients before exiting (bug 1.8):
+                # has been flushed.  Signal recipients before exiting:
                 # stream tasks blocked in receive() awaiting body would
                 # otherwise never get http.disconnect, so the enclosing
                 # TaskGroup waits on them forever and the connection wedges.
@@ -780,7 +780,7 @@ class HTTP2Actor(Actor):
                 return
             if self._oversize_frame_len:
                 # receive() refused to buffer an over-sized frame's payload
-                # (bug 1.14).  Raise the FRAME_SIZE_ERROR and close without
+                # Raise the FRAME_SIZE_ERROR and close without
                 # ever loading the frame — the un-read payload bytes stay in
                 # the socket buffer and are discarded on close.
                 n = self._oversize_frame_len
@@ -896,7 +896,7 @@ class HTTP2Actor(Actor):
                 is_closed = closed_via_rst is not None
                 if not is_closed and 0 < frame.stream_id <= self._closed_high_water:
                     # Recorded as closed but evicted from the bounded cache
-                    # (bug 1.9) — still CLOSED, not IDLE.  Default to the lenient
+                    # — still CLOSED, not IDLE.  Default to the lenient
                     # (non-RST) treatment so a late WINDOW_UPDATE/RST_STREAM is
                     # ignored rather than answered.
                     is_closed = True
@@ -978,7 +978,7 @@ class HTTP2Actor(Actor):
                         # already-open request stream is *trailers*, not a new
                         # request.  Previously _validate_stream_state permitted
                         # HEADERS in OPEN and this respawned a second request
-                        # over the live recipient/task (bug 1.14).  We don't
+                        # over the live recipient/task.  We don't
                         # surface request trailers to the ASGI app, so we mark a
                         # clean end-of-stream instead.  Trailers MUST carry
                         # END_STREAM; without it the request is malformed.
@@ -1134,7 +1134,7 @@ class HTTP2Actor(Actor):
         """Handle a HEADERS frame; return True if stream task spawned, False if awaiting CONTINUATION."""
         if self._active_stream_count >= self.max_concurrent_streams:
             if not frame.end_headers:
-                # Bug 1.14 #2 — the header block legally continues in
+                # The header block legally continues in
                 # CONTINUATION frames (RFC 9113 §6.10); refusing here would
                 # leave run() not expecting them and escalate the peer's
                 # legal CONTINUATION into a bogus connection error.  Keep
@@ -1209,7 +1209,7 @@ class HTTP2Actor(Actor):
         # Build the access-log record (and wrap send to capture status/bytes)
         # only when something consumes it: access log, phase trace, or a
         # request_completed listener. The legacy (aggregator=None) path always
-        # builds it — _run_with_log emits unconditionally. See P3 (HTTP/1.1).
+        # builds it — _run_with_log emits unconditionally.
         if self._aggregator is None or _request_record_needed(self._aggregator):
             log_record = _make_log_record(conn)
             dispatch_send = _make_capturing_send(send, log_record)
@@ -1238,7 +1238,7 @@ class HTTP2Actor(Actor):
                 'unexpected CONTINUATION without preceding HEADERS')
             return True
 
-        # copy-reduction-http2 P3 — accumulate into a bytearray so each
+        # Accumulate into a bytearray so each
         # CONTINUATION is an amortised-O(1) in-place extend rather than the
         # O(n²) ``bytes += bytes`` that reallocates the whole block per frame.
         # parse_payload() wraps raw_block in BytesIO, which accepts bytearray.
@@ -1307,7 +1307,7 @@ class HTTP2Actor(Actor):
         stream.conn = target
         stream_recipient = self._make_stream_recipient(stream.stream_id)
         self._recipients[stream.stream_id] = stream_recipient
-        # Same consumer-gate as the HEADERS path (P3): skip the record + capturing
+        # Same consumer-gate as the HEADERS path: skip the record + capturing
         # send wrapper when nothing reads them.
         if self._aggregator is None or _request_record_needed(self._aggregator):
             log_record = _make_log_record(conn)

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -1,4 +1,4 @@
-"""HTTP/2 Actor classes for the BlackBull Actor model (Phase 6 Step 4).
+"""HTTP/2 Actor classes for the BlackBull actor model.
 
 HTTP2Actor drives the HTTP/2 connection state machine for one TCP connection.
 StreamActor owns the lifetime of a single HTTP/2 stream.
@@ -92,8 +92,8 @@ def _signal_recipients(recipients: dict[int, _StreamRecipient]) -> None:
 def _make_log_record(conn: Connection):
     # Publish the record for the app layer: BlackBull._dispatch sources the
     # request_completed detail's wire fields (status / response_bytes /
-    # duration_ms) from the request's ``conn.state['access_log']`` (Sprint 64
-    # event consolidation) — same contract as the HTTP/1.1 actor. The actor
+    # duration_ms) from the request's ``conn.state['access_log']`` — same
+    # contract as the HTTP/1.1 actor. The actor
     # always has the parsed Connection, even on the BB_FORCE_ASGI_SCOPE lane
     # (where the emitted scope shares ``conn.state`` by identity, so the app's
     # rebuilt Connection sees the same record) — so the log record is always
@@ -119,7 +119,7 @@ def _build_h2_extensions(
 ) -> dict:
     """Return a freshly-built ``scope['extensions']`` dict for one HTTP/2 request.
 
-    The shape Sprint 32 introduces:
+    The shape:
 
     - ``http.response.push`` — empty marker; signals the application can
       send ``http.response.push`` events on this scope (existing behaviour).
@@ -485,8 +485,7 @@ class HTTP2Actor(Actor):
     def _make_stream_recipient(self, stream_id: int) -> HTTP2Recipient:
         """Recipient with consume-time WINDOW_UPDATE crediting.
 
-        Consume-based inbound flow control (the Sprint 62 deferral,
-        ``proposals/consume-based-inbound-flow-control.md``): credit is
+        Consume-based inbound flow control: credit is
         replayed when the app pops the event off the queue, not when the
         DATA frame is enqueued, so a stalled handler closes the window and
         back-pressures the peer instead of overflowing the recipient queue
@@ -567,7 +566,7 @@ class HTTP2Actor(Actor):
         """Materialize an ASGI scope dict for the **compat lanes only**.
 
         The native HTTP/2 dispatch path never calls this — it threads the
-        :class:`Connection` itself (WebSocket included, Sprint 80). The one
+        :class:`Connection` itself, WebSocket included. The one
         boundary that still needs an ASGI scope is **``BB_FORCE_ASGI_SCOPE``**
         (§4.3): a pure ASGI scope round-tripped back through ``from_scope`` at
         the app boundary. Also used to synthesize the pushed-request scope for
@@ -1173,7 +1172,7 @@ class HTTP2Actor(Actor):
 
         if conn.type == 'websocket':
             # RFC 8441 — Extended CONNECT bootstrapping WebSocket over HTTP/2.
-            # WebSocket is native too (Sprint 80): thread the Connection — its
+            # WebSocket is native too: thread the Connection — its
             # WS extras (subprotocols / the deferred 200 responder) live on it,
             # so there is no scope dict even under BB_FORCE_ASGI_SCOPE (the
             # force-asgi lane only round-trips the HTTP app boundary).

--- a/blackbull/server/parser.py
+++ b/blackbull/server/parser.py
@@ -236,7 +236,7 @@ def parse_headers(frame) -> Connection | None:
         raw_headers = _request_headers_with_host(frame, require_present=False)
         if raw_headers is None:
             return None  # frame already marked malformed by the helper
-        # Bug 1.16 — root_path is NOT taken from the client-controlled
+        # ``root_path`` is NOT taken from the client-controlled
         # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the
         # peer.  Left at the field default ('') — the RFC-safe empty mount.
         # ``subprotocols`` is derived from the request headers by the actor
@@ -281,7 +281,7 @@ def parse_headers(frame) -> Connection | None:
     # change, not a cleanup.
     effective_method = method or 'HEAD'
 
-    # Bug 1.16 — root_path is NOT taken from the client-controlled
+    # ``root_path`` is NOT taken from the client-controlled
     # X-Forwarded-Prefix; only TrustedProxy sets it after verifying the peer.
     # Left at the field default ('').
     return _build_h2_connection(effective_method, path, raw_path,

--- a/blackbull/server/parser.py
+++ b/blackbull/server/parser.py
@@ -8,17 +8,17 @@ from .http1_actor import _HOST_FORBIDDEN_RE
 
 logger = logging.getLogger(__name__)
 
-# Sprint 80 alloc hygiene (`proposals/connection-alloc-hygiene.md` Phase 2,
-# 2026-07-24) — a shared empty extensions dict for the plain-HTTP/2 dispatch
-# path. ``HTTP2Actor._apply_priority_and_extensions`` unconditionally replaces
-# ``conn.extensions`` with a fresh per-stream dict *before* the app or any
-# middleware sees the Connection (``_on_headers_frame`` / ``_on_continuation_
-# frame``, both call it ahead of ``_spawn_stream_task``), so this sentinel is
-# never read or mutated by user code — same convention as
-# ``http1_actor._H1_PATHSEND_EXTENSIONS``. The RFC 8441 WebSocket branch of
-# ``parse_headers`` does NOT go through ``_apply_priority_and_extensions``, so
-# it must NOT use this sentinel — it keeps a fresh ``{}`` (the dataclass
-# default) for the connection's lifetime.
+# Shared empty extensions dict for the plain-HTTP/2 dispatch path — safe to
+# share because ``HTTP2Actor._apply_priority_and_extensions`` unconditionally
+# replaces ``conn.extensions`` with a fresh per-stream dict *before* the app or
+# any middleware sees the Connection (``_on_headers_frame`` /
+# ``_on_continuation_frame`` both call it ahead of ``_spawn_stream_task``), so
+# this sentinel is never read or mutated by user code.  Same convention as
+# ``http1_actor._H1_PATHSEND_EXTENSIONS``.
+#
+# The RFC 8441 WebSocket branch of ``parse_headers`` does NOT go through
+# ``_apply_priority_and_extensions``, so it must NOT use this sentinel — it
+# keeps a fresh ``{}`` for the connection's lifetime.
 _EMPTY_H2_EXTENSIONS: dict = {}
 
 
@@ -27,13 +27,11 @@ def _build_h2_connection(method: str, path: str, raw_path: bytes,
                          scheme: str) -> Connection:
     """Lean constructor for the plain-HTTP/2 :func:`parse_headers` return.
 
-    Sprint 80 alloc hygiene Phase 2: bypasses the dataclass-generated
-    ``Connection.__init__`` (type-call + default-binding machinery, ~200 ns/req
-    measured in `bench/results/h2-alloc-cpu-ab/20260723-161201Z-conn-decomp/`)
-    via ``object.__new__`` + explicit slot stores. Behaviourally identical to
-    ``Connection(method=method, path=path, raw_path=raw_path,
-    query_string=query_string, headers=headers, http_version='2',
-    scheme=scheme)`` — pinned field-for-field by
+    Bypasses the dataclass-generated ``Connection.__init__`` (type-call +
+    default-binding machinery, ~200 ns/req) via ``object.__new__`` + explicit
+    slot stores.  Behaviourally identical to ``Connection(method=method,
+    path=path, raw_path=raw_path, query_string=query_string, headers=headers,
+    http_version='2', scheme=scheme)`` — pinned field-for-field by
     ``tests/architecture/test_h2_connection_builder.py``, which must be kept
     in sync with any change to :class:`Connection`'s field set.
 
@@ -80,13 +78,12 @@ def _split_h2_path(raw: str):
     ``str`` when the HEADERS frame is parsed (``frame_types`` decodes them),
     and the server-push caller passes the ASGI event's ``str`` path.
 
-    Sprint 68 — ``urlsplit`` (not ``urlparse``) so an RFC 3986 ``;`` path
-    sub-delimiter is kept in the path component rather than split off as
-    obsolete RFC 2396 ``;params`` (``urlparse`` would strip it from both
-    ``path`` and ``raw_path``).  The ``'%' in path`` guard keeps escape-free
-    targets on the plain fast path; unquote semantics match uvicorn ('+'
-    stays literal, malformed escapes pass through, ``errors='replace'`` can
-    never raise).
+    ``urlsplit`` (not ``urlparse``) so an RFC 3986 ``;`` path sub-delimiter is
+    kept in the path component rather than split off as obsolete RFC 2396
+    ``;params`` (``urlparse`` would strip it from both ``path`` and
+    ``raw_path``).  The ``'%' in path`` guard keeps escape-free targets on the
+    plain fast path; unquote semantics match uvicorn ('+' stays literal,
+    malformed escapes pass through, ``errors='replace'`` can never raise).
     """
     parsed = urlsplit(raw)
     path = parsed.path
@@ -157,30 +154,22 @@ def parse_headers(frame) -> Connection | None:
     callers avoid the dict-lookup + parser allocation that ``ParserFactory``
     requires.
 
-    Sprint 79 Phase 4: yields a :class:`Connection` rather than an ASGI scope
-    dict (the H/2 analogue of :meth:`HTTP1Actor._parse`).  The actor derives
-    the compat scope via :meth:`Connection.as_scope` at the dispatch boundary
-    until Phase 5 switches the consumers onto ``conn`` directly; the
-    websocket-only ``subprotocols`` scope key is likewise attached there (it is
-    not a :class:`Connection` field — see the proposal §2.1 field set), the
-    same way :meth:`HTTP1Actor._handle_upgrade` augments the derived scope.
+    Yields a :class:`Connection`, not an ASGI scope dict — the H/2 analogue of
+    :meth:`HTTP1Actor._parse`.  The actor derives the compat scope via
+    :meth:`Connection.as_scope` at the dispatch boundary; the websocket-only
+    ``subprotocols`` scope key is attached there too, since it is not a
+    :class:`Connection` field, the same way
+    :meth:`HTTP1Actor._handle_upgrade` augments the derived scope.
 
-    Sprint 80 alloc hygiene (`proposals/connection-alloc-hygiene.md`,
-    2026-07-24): builds the :class:`Connection` **once**, at the very end, from
-    locals accumulated while walking the pseudo-headers — the same
-    single-construction idiom :meth:`HTTP1Actor._parse` already uses (Phase 1).
-    The previous version built a placeholder via a removed
-    ``_default_connection`` helper (with a throwaway ``Headers([])``, discarded
-    ~154 ns/req) and mutated it field by field. Every early-out below now
-    returns ``None`` instead of a half-built ``Connection`` — including the
-    (previously reachable but never-observed) host-validation-failure path,
-    since ``_request_headers_with_host`` already marks ``frame.malformed``
-    before returning ``None``, and every caller checks ``frame.malformed``
-    before reading this function's result. The contract is now uniformly
-    ``result is None ⟺ frame.malformed``. The plain-HTTP branch's final
-    construction goes through ``_build_h2_connection`` (Phase 2 — an
-    ``object.__new__`` lean builder), not the dataclass constructor; see that
-    function's docstring.
+    The :class:`Connection` is built **once**, at the very end, from locals
+    accumulated while walking the pseudo-headers — the same
+    single-construction idiom :meth:`HTTP1Actor._parse` uses.  Every early-out
+    returns ``None`` rather than a half-built ``Connection``, so the contract
+    is uniformly ``result is None ⟺ frame.malformed``: callers check
+    ``frame.malformed`` before reading the result, and
+    ``_request_headers_with_host`` marks it before returning ``None``.  The
+    plain-HTTP branch constructs through ``_build_h2_connection`` rather than
+    the dataclass constructor; see that function's docstring.
 
     Also performs request-level pseudo-header presence checks (RFC 9113
     §8.3.1).  Field-level checks already happened in ``parse_payload``.  On any
@@ -263,9 +252,9 @@ def parse_headers(frame) -> Connection | None:
     if p := frame.pseudo_headers.get(PseudoHeaders.PATH):
         path, raw_path, query_string = _split_h2_path(p)
 
-    # The previous version's ``if scheme := …: conn.scheme = scheme`` left the
-    # ``_default_connection`` placeholder ('https') in place when ``:scheme``
-    # was absent or empty; ``or 'https'`` reproduces that exactly.
+    # An absent or empty ``:scheme`` falls back to 'https'.  Absence is
+    # already rejected above for non-CONNECT requests, so this only covers
+    # CONNECT and the empty-value case.
     scheme = frame.pseudo_headers.get(PseudoHeaders.SCHEME) or 'https'
 
     # RFC 9113 §8.3.1 — validate the host authority and surface
@@ -286,13 +275,10 @@ def parse_headers(frame) -> Connection | None:
             return None  # frame already marked malformed by the helper
         headers = Headers.from_lowered(raw_headers)
 
-    # The previous version's ``if method: conn.method = method`` silently kept
-    # the 'HEAD' placeholder for a (spec-illegal, never observed in practice)
-    # empty ``:method`` value; ``or 'HEAD'`` reproduces that pre-existing
-    # quirk exactly rather than silently changing it as a refactor side
-    # effect. Fixing this latent gap (empty ``:method`` isn't rejected the
-    # way empty ``:path`` is, above) is a conformance question, out of scope
-    # here.
+    # A spec-illegal empty ``:method`` falls back to 'HEAD' instead of being
+    # rejected the way an empty ``:path`` is.  That asymmetry is a known
+    # conformance gap, deliberately left alone — closing it is a behaviour
+    # change, not a cleanup.
     effective_method = method or 'HEAD'
 
     # Bug 1.16 — root_path is NOT taken from the client-controlled

--- a/blackbull/server/parser.py
+++ b/blackbull/server/parser.py
@@ -4,7 +4,7 @@ from ..protocol.frame_types import PseudoHeaders
 import logging
 from ..connection import Connection
 from ..headers import Headers
-from .http1_actor import _HOST_FORBIDDEN_BYTES
+from .http1_actor import _HOST_FORBIDDEN_RE
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def _request_headers_with_host(frame, *, require_present: bool) -> list | None:
         if not value:
             frame._mark_malformed('empty :authority')
             return None
-        if any(b in _HOST_FORBIDDEN_BYTES for b in value):
+        if _HOST_FORBIDDEN_RE.search(value):
             frame._mark_malformed(
                 f'invalid :authority {authority!r}: contains userinfo, '
                 f'delimiter, or whitespace forbidden by RFC 3986 §3.2')
@@ -141,7 +141,7 @@ def _request_headers_with_host(frame, *, require_present: bool) -> list | None:
     if not value:
         frame._mark_malformed('empty Host header value')
         return None
-    if any(b in _HOST_FORBIDDEN_BYTES for b in value):
+    if _HOST_FORBIDDEN_RE.search(value):
         frame._mark_malformed(
             f'invalid Host authority {value!r}: contains delimiter / '
             f'whitespace forbidden by RFC 3986 §3.2')
@@ -256,7 +256,7 @@ def parse_headers(frame) -> Connection | None:
             type='websocket', method=method,
             scheme='wss' if scheme_pseudo == 'https' else 'ws',
             path=path, raw_path=raw_path, query_string=query_string,
-            headers=Headers(raw_headers), http_version='2',
+            headers=Headers.from_lowered(raw_headers), http_version='2',
         )
 
     path, raw_path, query_string = '', b'', b''
@@ -272,14 +272,19 @@ def parse_headers(frame) -> Connection | None:
     # ``:authority`` as the ``host`` header (ASGI).  Plain CONNECT is
     # excluded: §8.5 gives its ``:authority`` tunnel semantics, and the
     # presence rule only binds http/https requests.
+    #
+    # ``from_lowered`` is safe on every H/2 path: §8.2.1 makes an uppercase
+    # field name malformed and ``HeadersFrame.parse_payload`` rejects the
+    # frame before the pair reaches ``frame.headers``, so the list is
+    # lowercase by protocol.  The injected ``host`` is a lowercase literal.
     if method == 'CONNECT':
-        headers = Headers(frame.headers)
+        headers = Headers.from_lowered(frame.headers)
     else:
         raw_headers = _request_headers_with_host(
             frame, require_present=scheme in ('http', 'https'))
         if raw_headers is None:
             return None  # frame already marked malformed by the helper
-        headers = Headers(raw_headers)
+        headers = Headers.from_lowered(raw_headers)
 
     # The previous version's ``if method: conn.method = method`` silently kept
     # the 'HEAD' placeholder for a (spec-illegal, never observed in practice)

--- a/blackbull/server/protocol_registry.py
+++ b/blackbull/server/protocol_registry.py
@@ -1,4 +1,4 @@
-"""Unified protocol registry — Sprint 50.
+"""Unified protocol registry.
 
 BlackBull dispatches every accepted connection through a single
 :class:`ProtocolRegistry`.  ``http1`` and ``http2`` are built-in *bindings*;
@@ -97,7 +97,7 @@ class ConnectionView:
 
 
 # ---------------------------------------------------------------------------
-# Detection (Sprint 51 — wired into ConnectionActor._dispatch())
+# Detection — wired into ConnectionActor._dispatch()
 # ---------------------------------------------------------------------------
 
 class ProtocolDetector(ABC):
@@ -280,7 +280,7 @@ class RawBinding(ProtocolBinding):
         self.handler = handler
         self.detector = detector
         self.port = port
-        # Sprint 75 — serve this binding's port through the server's TLS
+        # Serve this binding's port through the server's TLS
         # machinery (mqtts:// and friends).  Cleartext remains the default.
         self.tls = tls
 
@@ -352,7 +352,7 @@ class ProtocolRegistry:
         :class:`ProtocolDetector`).  When several registered detectors could
         match the same first bytes, dispatch picks the **first registered**
         one — ``raw_bindings`` preserves insertion order.  ``tls=True`` serves
-        the binding's own port through the server's TLS machinery (Sprint 75).
+        the binding's own port through the server's TLS machinery.
         """
         if name in self._ports or name in {b.name for b in self._cleartext}:
             raise ValueError(f'Protocol {name!r} already registered')

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -101,7 +101,7 @@ def _validate_chunk_ext(ext: bytes) -> None:
                 raise _bad_request(f'invalid chunk-ext-val {val!r}')
 
 
-# Bug 1.24 (MAL-CHUNK-EXT-64K, CVE-2023-39326 class) — hard bound on any
+# MAL-CHUNK-EXT-64K (CVE-2023-39326 class) — hard bound on any
 # single chunk-framing line (chunk-size + chunk-ext, or one trailer field
 # line).  Mirrors the BB_HEADER_MAX_LINE default: extensions and trailers
 # are ignored on receipt, so nothing legitimate needs more.  Without the
@@ -453,7 +453,7 @@ class HTTP1Recipient(BaseRecipient):
                  deadline: ConnectionDeadline | None = None,
                  chunk_size: int | None = None):
         super().__init__(reader)
-        # P4: deliver a Content-Length body in fixed-size chunks instead of one
+        # Deliver a Content-Length body in fixed-size chunks instead of one
         # giant ``readexactly(content_length)`` allocation.  Falls back to the
         # ``BB_BODY_CHUNK_SIZE`` setting when not injected (direct-instantiation
         # tests pass it explicitly).
@@ -580,7 +580,7 @@ class HTTP1Recipient(BaseRecipient):
         rejections, before this).  Length violations — whether detected by
         our own bound or pre-empted by ``asyncio.StreamReader``'s buffer
         limit (``LimitOverrunError``) — surface as 400 with the stream
-        marked unframeable (bug 1.24, MAL-CHUNK-EXT-64K).
+        marked unframeable (MAL-CHUNK-EXT-64K).
         """
         try:
             line = await self._read_with_timeout(self._reader.readuntil(b'\n'))
@@ -663,7 +663,7 @@ class HTTP1Recipient(BaseRecipient):
                         f'chunk-data not CRLF-terminated: {term!r}')
                 return {'type': ASGIEvent.HTTP_REQUEST, 'body': data, 'more_body': True}
             else:
-                # P4: stream the Content-Length body in ``chunk_size`` slices so
+                # Stream the Content-Length body in ``chunk_size`` slices so
                 # a large upload is delivered as several ``http.request`` events
                 # (``more_body: True`` until exhausted) rather than one giant
                 # allocation.  ``readexactly`` keeps the exact-bytes contract —

--- a/blackbull/server/recipient.py
+++ b/blackbull/server/recipient.py
@@ -22,7 +22,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Per-stream and per-connection event queue depth limits.
-# These cap memory growth under overload; see Phase 0 in bench/README.md.
+# These cap memory growth under overload; see bench/README.md.
 _HTTP2_STREAM_QUEUE_DEPTH = 64
 _WS_EVENT_QUEUE_DEPTH = 256
 
@@ -461,12 +461,12 @@ class HTTP1Recipient(BaseRecipient):
             from ..env import get_settings as _get_settings  # noqa: PLC0415
             chunk_size = _get_settings().body_chunk_size
         self._chunk_size = chunk_size
-        # Sprint 17 Phase 3 — body-read deadline.  0 = disabled.  Applied
+        # Body-read deadline.  0 = disabled.  Applied
         # per ``_read_with_timeout`` call (i.e. per chunk for chunked
         # bodies, single window for Content-Length).  Mirrors nginx
         # ``client_body_timeout`` semantics: each read has the same bound.
         #
-        # Sprint 23 — the deadline is rescheduled on the shared
+        # The deadline is rescheduled on the shared
         # :class:`ConnectionDeadline` rather than allocating a fresh
         # ``asyncio.wait_for`` Timeout per chunk.  Per-chunk semantics
         # preserved.
@@ -491,7 +491,7 @@ class HTTP1Recipient(BaseRecipient):
         here, not in ``__init__``.
         """
         # BlackBull's own actor passes the native :class:`Connection` directly
-        # (Sprint 80 native-Connection entry); read its ``headers`` with no
+        # on the native-Connection entry; read its ``headers`` with no
         # conversion. A stashed Connection, or an external/hand-built ASGI scope
         # dict, are the other two shapes.
         #
@@ -695,7 +695,7 @@ class HTTP1Recipient(BaseRecipient):
         except IncompleteReadError:
             # EOF mid-body — not a cap hit (peer disappeared).  Surface
             # disconnect so the handler can clean up; server closes on
-            # return (no synthetic 408, see Sprint 17 plan note).
+            # return; no synthetic 408.
             self._done = True
             return {'type': ASGIEvent.HTTP_DISCONNECT}
 
@@ -712,8 +712,7 @@ class HTTP2Recipient(BaseRecipient):
     ``http.request`` event.  The Queue is then never allocated — the empty event
     is synthesized lazily in :meth:`__call__` only if the handler reads it.
 
-    **Consume-based inbound flow control** (the Sprint 62 deferral,
-    ``proposals/consume-based-inbound-flow-control.md``): when constructed with
+    **Consume-based inbound flow control**: when constructed with
     a ``credit_callback``, WINDOW_UPDATE credit for a DATA frame is replayed
     through the callback when the app *pops* the event — not when the frame is
     enqueued.  A stalled handler then stops crediting, the peer's window
@@ -927,10 +926,8 @@ class WebSocketRecipient(BaseRecipient):
     #
     # Default: 64 MiB — large enough to pass the Autobahn|Testsuite
     # 9.x large-message cases (up to 9.1.6 = 64 MiB text) while still
-    # bounding per-connection memory.  Sprint 39 (v0.35.0) introduced
-    # this cap at 1 MiB; Sprint 43 raised the default to 64 MiB and
-    # exposed it via ``BB_WS_MAX_FRAME_PAYLOAD`` after the conformance
-    # CI lane discovered the 1 MiB cap was regressing Autobahn 9.x.
+    # bounding per-connection memory.  A 1 MiB cap regresses the
+    # Autobahn 9.x cases, which is why the default is this high.
     # Override per-deployment via ``BB_WS_MAX_FRAME_PAYLOAD`` for
     # stricter (or looser) exposure than the default.
     _MAX_FRAME_PAYLOAD: int = 64 * 1024 * 1024
@@ -1211,8 +1208,8 @@ class WebSocketRecipient(BaseRecipient):
     async def shutdown(self) -> None:
         """Cancel and await the background read-loop task.
 
-        Sprint 72 (audit 1.20c) — client sessions call this from
-        ``close()`` so no reader task outlives the session (a leaked task
+        Client sessions call this from ``close()`` so no reader task
+        outlives the session (a leaked task
         warns at event-loop shutdown and keeps reading a dead transport).
         Idempotent, and safe to call before the first ``__call__`` ever
         started the loop.

--- a/blackbull/server/response.py
+++ b/blackbull/server/response.py
@@ -240,7 +240,7 @@ class PriorityResponder(Responder):
             # stream is treated as a dependency on stream 0.  Previously
             # find_child returned None and .add_child() raised AttributeError,
             # unwinding the frame loop and killing every stream on the
-            # connection without a GOAWAY (bug 1.10).
+            # connection without a GOAWAY.
             parent = handler.root_stream.find_child(self.frame.dependent_stream)
             if parent is None:
                 parent = handler.root_stream

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -510,7 +510,7 @@ class HTTP1Sender(BaseSender):
                 self._expect_trailers = bool(body.get('trailers', False))
                 if self._log_record is not None:
                     self._log_record.status = body.get('status', '-')
-                    # Sprint 35 phase-trace: capture response headers
+                    # Capture response headers
                     # inline (same pattern as response_bytes capture) so
                     # we can correlate per-phase µs against negotiated
                     # Content-Type / Content-Encoding without re-walking
@@ -532,7 +532,7 @@ class HTTP1Sender(BaseSender):
                 more_body = body.get('more_body', False)
                 if self._log_record is not None and content:
                     self._log_record.response_bytes += len(content)
-                # Sprint 35 phase trace: bracket the actual transport
+                # Bracket the actual transport
                 # write for the last body event so we can see whether the
                 # 30-60 ms woff2 tail lives in middleware/handler work
                 # before the write (``start_arm_out → body_arm_in``) or
@@ -593,10 +593,10 @@ class HTTP1Sender(BaseSender):
                 raise TypeError(f'HTTP1Sender expected bytes or dict, got {type(body)!r}')
 
     def reset_per_request_state(self) -> None:
-        # Sprint 38 lesson — HTTP1Sender is shared across keep-alive requests;
+        # HTTP1Sender is shared across keep-alive requests;
         # forgetting a reset silently breaks the next request's framing
         # (`_started` skipped 408 emission on the second request).  See
-        # `.claude/patterns/cautions.md` — Sprint 38 section.
+        # `.claude/patterns/cautions.md`.
         self._buffered_status = None
         self._buffered_headers = None
         self._chunked = False

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -68,7 +68,7 @@ def _has_header(items, name: bytes) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Response-HEADERS fast-path builders (frame-assembly-fast-path Tier 2)
+# Response-HEADERS fast-path builders
 # ---------------------------------------------------------------------------
 #
 # These encode a HEADERS frame straight to wire bytes, skipping
@@ -448,7 +448,7 @@ class HTTP1Sender(BaseSender):
         # Set True once a complete response has been written for this request
         # (a full ``bytes`` response, a body event with ``more_body=False``,
         # trailers, or a pathsend).  Further response events are then dropped
-        # (bug 1.4) so a handler that raises *after* completing its response
+        # so a handler that raises *after* completing its response
         # can't write a second one onto the same keep-alive connection —
         # mirrors the H2 sender's post-END_STREAM drop.
         self._completed: bool = False
@@ -486,7 +486,7 @@ class HTTP1Sender(BaseSender):
         bodies raise ``TypeError``.
         """
         if self._completed:
-            # bug 1.4 — a complete response has already gone out for this
+            # A complete response has already gone out for this
             # request; drop any further response events so a handler that
             # raises after completing (→ the error handler emits a second
             # response) can't splice two responses onto one connection.
@@ -730,7 +730,7 @@ class ConnectionWindow:
     One instance per connection, referenced by every stream's
     :class:`HTTP2Sender`, so all senders debit and await a single budget.
 
-    Without sharing (bug 1.2) each sender held a *private copy* of the
+    Without sharing each sender held a *private copy* of the
     connection window and debited only that copy, while the actor-level total
     was only ever incremented — so N concurrent streams could each spend a
     full 65535-byte window and the server could emit N×65535 bytes with zero
@@ -782,10 +782,10 @@ class HTTP2Sender(BaseSender):
         self._factory = factory
         self._stream_id = stream_id
         self._push_callback = push_callback
-        # Shared connection-level send window (bug 1.2).  The server passes one
+        # Shared connection-level send window.  The server passes one
         # ``ConnectionWindow`` instance to every stream sender so they debit a
         # single budget; when omitted (the experimental client, whose per-sender
-        # windowing is bug 1.20a and deferred) each sender gets a private one,
+        # windowing is deferred) each sender gets a private one,
         # preserving today's behaviour there.
         self._conn_window = conn_window if conn_window is not None else ConnectionWindow()
         # Per-stream send window.  Refactor 2.5 — a plain int (this was a
@@ -816,7 +816,7 @@ class HTTP2Sender(BaseSender):
 
     @property
     def connection_window_size(self) -> int:
-        """The shared connection-level send window (bug 1.2).
+        """The shared connection-level send window.
 
         Proxies :attr:`ConnectionWindow.size` so existing call sites — the
         experimental client's per-sender crediting and flow-control tests —

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -69,7 +69,7 @@ class LifespanManager:
         # app that dies before acking — e.g. a startup hook that raises and
         # takes the task down with it — would otherwise strand __aenter__ on
         # an empty send queue forever and the server would neither start nor
-        # error (bug 1.3).  Mirrors the FIRST_COMPLETED race in __aexit__.
+        # error.  Mirrors the FIRST_COMPLETED race in __aexit__.
         getter = asyncio.ensure_future(self._send_q.get())
         try:
             await asyncio.wait(
@@ -87,8 +87,8 @@ class LifespanManager:
             exc = self._task.exception()
             if exc is not None:
                 # The lifespan app raised before acking — a real startup
-                # failure (bug 1.3: previously this stranded __aenter__ on an
-                # empty send queue and the server never started).
+                # failure.  Without this raise, __aenter__ strands on an
+                # empty send queue and the server never starts.
                 raise RuntimeError(f'Lifespan startup failed: {exc!r}') from exc
             # The app returned without implementing the lifespan protocol — a
             # bare ASGI app that ignores the lifespan scope.  ASGI treats this

--- a/blackbull/server/server.py
+++ b/blackbull/server/server.py
@@ -29,7 +29,7 @@ async def _run_with_log(coro, record: AccessLogRecord) -> None:
     cancel sibling streams through the TaskGroup.
 
     Request-lifecycle Level B events are emitted by ``BlackBull._dispatch``
-    (Sprint 64 consolidation), not here.
+    not here.
     """
     try:
         await coro
@@ -133,7 +133,7 @@ async def SocketManager(socket_cb_pairs, ssl_context):
 
     *socket_cb_pairs* is an iterable of ``(sock, callback)`` — each socket is
     served by its own accept callback.  The shared HTTP listener uses
-    :meth:`Server.client_connected_cb`; port-bound non-ASGI protocols (Sprint 50)
+    :meth:`Server.client_connected_cb`; port-bound non-ASGI protocols
     use a per-binding raw callback.
 
     On enter: wraps each socket in asyncio.start_server (TCP) or
@@ -143,8 +143,8 @@ async def SocketManager(socket_cb_pairs, ssl_context):
     Dispatches by ``sock.family``: AF_INET / AF_INET6 take the TCP
     server, AF_UNIX takes the unix server.  Both honour the configured
     ``socket_backlog`` (asyncio's default of 100 is silently re-applied
-    via ``sock.listen(backlog)`` otherwise — caused wrk c=1024 connect
-    errors in Sprint 9c).
+    via ``sock.listen(backlog)`` otherwise, which produces wrk c=1024
+    connect errors).
     """
     import socket as _socket  # noqa: PLC0415
     from ..env import get_settings as _get_settings  # noqa: PLC0415
@@ -180,7 +180,7 @@ class Server:
 
     The shared HTTP listener detects HTTP/1.1 vs HTTP/2 (and upgrades to
     WebSocket); port-bound non-ASGI protocols registered via
-    :meth:`BlackBull.raw_handler` get their own listening socket (Sprint 50).
+    :meth:`BlackBull.raw_handler` get their own listening socket.
     When ssl_context or certfile is set, the HTTP listener runs as HTTPS.
 
     Formerly ``ASGIServer`` — that name remains as a backward-compat alias.
@@ -294,7 +294,7 @@ class Server:
         return _cb
 
     def _raw_tls_context(self):
-        """TLS context for ``tls=True`` raw bindings (Sprint 75).
+        """TLS context for ``tls=True`` raw bindings.
 
         When cert/key paths are available a dedicated context is built without
         the HTTP listener's ``h2``/``http/1.1`` ALPN list — a raw-protocol
@@ -315,7 +315,7 @@ class Server:
     async def _serve_connection(self, reader, writer, *, bound_binding=None):
         """Wrap the transport and run one :class:`ConnectionActor`.
 
-        *bound_binding* is set for port-bound non-ASGI protocols (Sprint 50) —
+        *bound_binding* is set for port-bound non-ASGI protocols —
         the connection skips HTTP detection and is handed straight to the
         binding's raw handler.
         """
@@ -532,13 +532,13 @@ class Server:
         self._bind_protocol_sockets(_cfg)
 
     def _bind_protocol_sockets(self, _cfg):
-        """Bind a listening socket per port-bound non-ASGI protocol (Sprint 50).
+        """Bind a listening socket per port-bound non-ASGI protocol.
 
         Each :class:`RawBinding` registered with a ``port`` gets its own
         dual-stack socket set.  ``port=0`` lets the OS pick a free port (used by
         tests); the bound port is recorded in :attr:`protocol_ports`.  Sockets
         are bound bare here; :meth:`run` layers TLS onto the listeners whose
-        binding set ``tls=True`` (Sprint 75), cleartext otherwise.
+        binding set ``tls=True``, cleartext otherwise.
         """
         # Iterate the bindings themselves, not the port-keyed view — several
         # bindings may all ask for port=0 (OS-assigned, common in tests), and
@@ -594,7 +594,7 @@ class Server:
         # servers on exit.  The shared HTTP listener uses client_connected_cb;
         # each port-bound non-ASGI protocol uses its own raw callback.  Raw
         # sockets are cleartext unless the binding was registered with
-        # ``tls=True`` (Sprint 75), which serves them through the same TLS
+        # ``tls=True``, which serves them through the same TLS
         # machinery as the HTTPS listener.
         # LifespanManager drives the ASGI lifespan protocol; nesting it inside
         # SocketManager guarantees: startup completes before serve_forever() is
@@ -673,7 +673,7 @@ class Server:
         self.close_socket()
 
 
-# Backward-compat alias — ``ASGIServer`` was renamed to ``Server`` in Sprint 50
-# when the class gained non-ASGI (raw protocol) listeners.  Existing imports
+# Backward-compat alias: the class was named ``ASGIServer`` before it gained
+# non-ASGI (raw protocol) listeners.  Existing imports
 # (``from blackbull.server import ASGIServer``) keep working.
 ASGIServer = Server

--- a/blackbull/server/websocket_actor.py
+++ b/blackbull/server/websocket_actor.py
@@ -1,4 +1,4 @@
-"""WebSocket Actor — Phase 6 Step 5."""
+"""WebSocket Actor — owns one upgraded connection's frame loop."""
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable

--- a/blackbull/testing.py
+++ b/blackbull/testing.py
@@ -41,7 +41,7 @@ from .websocket import WebSocketDisconnect
 
 import httpx
 
-# ``WebSocketDisconnect`` is re-exported, not redefined.  Sprint 82 gave the
+# ``WebSocketDisconnect`` is re-exported, not redefined.  The
 # server side a handler object that raises the same "the other end closed"
 # exception, and two identically-named classes would mean an ``except``
 # written against one silently missing the other.  One class, both sides:
@@ -230,13 +230,13 @@ class WebSocketTestSession:
             encoded_headers.append((b'cookie', cookie_str.encode('latin-1')))
         # Offer the requested subprotocols the way a real client does — via the
         # Sec-WebSocket-Protocol request header. WebSocket is native now
-        # (Sprint 80): ``conn.subprotocols`` derives from this header, so the
+        #: ``conn.subprotocols`` derives from this header, so the
         # header (not a scope key) is what the server reads.
         if subprotocols:
             encoded_headers.append(
                 (b'sec-websocket-protocol',
                  ', '.join(subprotocols).encode('latin-1')))
-        # WebSocket is native (Sprint 80): drive the app the way BlackBull's own
+        # WebSocket is native: drive the app the way BlackBull's own
         # server does — ``app(conn, receive, send)`` with a typed Connection — so
         # the test path never round-trips through an ASGI scope dict (no
         # ``as_scope`` → ``from_scope`` bounce; that conversion is the external
@@ -247,7 +247,7 @@ class WebSocketTestSession:
         from .headers import Headers  # noqa: PLC0415
         self._conn = Connection(
             method='GET',
-            # Parity with the real server (Sprint 68): ``conn.path`` is the
+            # Parity with the real server: ``conn.path`` is the
             # percent-decoded path component; ``raw_path`` is the undecoded
             # bytes (UTF-8, not latin-1, so a caller-supplied non-ASCII path
             # round-trips as the server would have received it).

--- a/blackbull/websocket.py
+++ b/blackbull/websocket.py
@@ -1,4 +1,4 @@
-"""The high-level WebSocket handler object (Sprint 82).
+"""The high-level WebSocket handler object.
 
 A :class:`WebSocket` wraps the raw ``(conn, receive, send)`` triplet so a
 handler works in **data and methods** instead of event dicts::
@@ -22,7 +22,7 @@ forms run over the same actor, codec, and sender.  Nothing about the wire
 changes — a handler that uses this object produces byte-identical frames to
 one that sends the dicts by hand.
 
-Naming follows the Sprint 80 rule: this is a *native* surface, so it is
+Naming follows the native-surface rule: this is a *native* surface, so it is
 unprefixed and lives outside ``asgi.py``.  The ``ASGIEvent`` dicts it builds
 are the boundary representation, and stay there.
 """

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -274,6 +274,52 @@ Callers must never call `transport.writelines` directly with
 small parts.  The gate is the single decision point, and the
 invariant keeps performance predictable across payload sizes.
 
+## Parse-path invariant
+
+The HTTP/1.1 parser validates bytes with **C-level bulk operations**,
+never with Python-level loops or index arithmetic.  In practice that
+means `bytes.translate`, `bytes.find`, `bytes.split`, `bytes.strip`,
+`bytes.count`, and precompiled regexes — and it means resisting the
+intuition that fewer allocations or fewer passes must be faster.
+
+The idiom used throughout `_parse` is a **delete-the-allowed table**:
+
+```python
+_TCHAR_OCTETS = b"!#$%&'*+-.^_`|~0123456789ABC...xyz"
+
+if key.translate(None, _TCHAR_OCTETS):   # non-empty ⇒ a non-token octet
+    raise BadRequestError(...)
+```
+
+Deleting every permitted octet leaves the empty string for valid
+input, so a non-empty result *is* the rejection — one pass in C, and
+no allocation in the accept case (CPython returns the shared empty
+`bytes`).  Which direction to use depends on the set's size: a large
+allowed set (request-target, tchar) is cheapest as a `translate`
+delete table, a small forbidden set (the Host authority delimiters) as
+a regex character class.
+
+Field values are checked **once for the whole header block** rather
+than once per header.  Deleting everything a block may contain leaves
+only CR, LF and the CTLs a value may not carry; if what remains tiles
+exactly into CRLF pairs, no field value can hold a forbidden octet and
+the per-header check is skipped.  A block that fails the pre-scan
+falls back to the per-header regex, so error messages never change —
+the bulk pass is a fast path, never a rejection.
+
+Three plausible-sounding alternatives were measured and **rejected**;
+do not reintroduce them without new numbers:
+
+| Idea | Why it loses |
+|---|---|
+| `while` + `find()` line loop instead of `split(b'\r\n')` | 1.5–2.2× slower. `split` does the finding *and* the slicing in C; the loop moves the iteration back into Python. |
+| Interning pool for well-known header names | Slower than `key.lower()`. The lookup key is a fresh slice every request, so its hash is never cached and hashing costs more than lowercasing. |
+| Offset arithmetic instead of `value.strip(b' \t')` | ~1.5× slower. Two Python-level scans lose to one C call. |
+
+The through-line: an optimisation that replaces a C bulk operation
+with Python bytecode pays ~30 ns per byte instead of ~2 ns, and no
+reduction in pass count or allocation count makes that back.
+
 ## The pieces around the actor core
 
 The actor hierarchy is the *control* side.  The *data* side is

--- a/docs/guide/extensions.md
+++ b/docs/guide/extensions.md
@@ -294,7 +294,7 @@ hypothetical advice.
 
 ### Pick a `dependencies` floor that matches what you import
 
-`app.extensions` landed in BlackBull 0.36.0 (the Sprint 40 work).
+`app.extensions` landed in BlackBull 0.36.0.
 An extension that touches it must pin at least that floor:
 
 ```toml

--- a/docs/guide/http2.md
+++ b/docs/guide/http2.md
@@ -139,7 +139,7 @@ move as the response body streams.  Applications that need
 live readings (e.g. gRPC server-streaming back-pressure) can
 re-read the dict, though they will see the snapshot value unless
 they keep a reference and the populate site re-fetches it — which
-v0.31 does not do.  Live properties are a future-sprint
+v0.31 does not do.  Live properties are a future
 consideration.
 
 Peer-side receive-window is intentionally absent: BlackBull sends

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -74,7 +74,7 @@ delivery or the broker. The `TapActor`'s inbox is bounded; if taps fall behind,
 the newest messages are dropped (best-effort observability) and a running
 dropped-count is logged. Taps are therefore *not* a reliable delivery path — use
 a real MQTT subscription for that. (`MQTTExtension(tap_mode='inline')` runs taps
-inline on the receiving connection instead — the pre-Sprint-54 behaviour, kept
+inline on the receiving connection instead — the original behaviour, kept
 mainly so the `bench/mqtt/tap_throughput.py` comparison stays reproducible.)
 
 The broker also runs without any handler at all: `on_message` is just how an

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -49,7 +49,7 @@ is registered, and the raw `(scope, receive, send)` form is
 unaffected.
 
 !!! warning "`Request` is deprecated — use `Connection` (since v0.60.0)"
-    `Connection` replaces the old `Request` context object (Sprint 79).
+    `Connection` replaces the old `Request` context object.
     `blackbull.Request` is now a **deprecated alias** of `Connection`
     that emits a `DeprecationWarning` on first use and will be removed
     **no earlier than 2027-08-01**.  Migrate by renaming the import and

--- a/docs/guide/static-files.md
+++ b/docs/guide/static-files.md
@@ -1,9 +1,9 @@
 # Static files
 
-`app.static(url_prefix, root_dir)` registers a `StaticFiles`
-middleware that serves files from `root_dir` for paths starting
-with `url_prefix`.  Useful for CSS, JS, images, fonts, and other
-file-system assets that don't change on every request.
+`app.static(url_prefix, root_dir)` registers a **route** that serves
+files from `root_dir` under `url_prefix`, with a `StaticFiles`
+middleware attached to it.  Useful for CSS, JS, images, fonts, and
+other file-system assets that don't change on every request.
 
 ## Quick start
 
@@ -19,10 +19,23 @@ async def index(scope, receive, send):
     ...
 ```
 
-A request to `/assets/style.css` is intercepted by the global
-middleware before routing and served from
-`public/assets/style.css`.  Requests that don't match the prefix
-fall through to the route handlers normally.
+A request to `/assets/style.css` is routed to the static route and
+served from `public/assets/style.css`.  Requests that don't match the
+prefix are routed normally and never enter `StaticFiles` at all —
+static serving costs a non-static request nothing, because the router
+resolves it without ever consulting the static route.
+
+Each call registers three entries: `<prefix>/{filepath:path}` for
+files, plus `<prefix>` and `<prefix>/` so the [directory
+index](#directory-index) can answer the mount root.  An explicit route
+you registered yourself always wins — `app.static()` never replaces a
+path you already claimed.
+
+!!! note "A miss under the prefix is a 404"
+    Because the static route has matched, `/assets/missing.css` is
+    answered with 404 rather than continuing on to another route that
+    might also match `/assets/...`.  The 404 goes through the normal
+    error path, so `@app.on_error(HTTPStatus.NOT_FOUND)` still applies.
 
 ## Standalone usage
 
@@ -62,7 +75,7 @@ blackbull serve ./public --certfile cert.pem --keyfile key.pem  # HTTPS + HTTP/2
 
 It wires `StaticFiles` with `index='index.html'`; ETag / `304`
 conditional responses are served natively by `StaticFiles` (see
-[Conditional requests](#conditional-requests-etag--last-modified) below)
+[Conditional requests](#conditional-requests-etag-last-modified) below)
 and can be turned off with `--no-etag`.  See
 [Configuration → blackbull serve](configuration.md#serving-static-files-with-blackbull-serve)
 for the full flag list.

--- a/examples/ChatServer/chatserver.py
+++ b/examples/ChatServer/chatserver.py
@@ -166,7 +166,7 @@ def _sse_encode(event: dict) -> bytes:
 # Signed-cookie session (native Connection)
 # ---------------------------------------------------------------------------
 # A self-contained, native replacement for the external ``blackbull-session``
-# package: BlackBull threads a typed :class:`Connection` (Sprint 80), so a
+# package: BlackBull threads a typed :class:`Connection`, so a
 # middleware receives ``conn`` and shares per-request data through ``conn.state``
 # — not by mutating an ASGI scope dict. The session payload is HMAC-SHA256
 # signed so a client cannot forge it.

--- a/examples/PriorityExample/server.py
+++ b/examples/PriorityExample/server.py
@@ -28,7 +28,7 @@ Connection location (BlackBull v0.31+):
   conn.extensions['http.response.priority'] → {'urgency': int, 'incremental': bool}
 
 The legacy top-level ``conn['http2_priority']`` key does not survive the
-native ``Connection`` model (Sprint 80) — only ``conn.extensions`` is
+native ``Connection`` model — only ``conn.extensions`` is
 carried across the boundary. Read the extension key.
 
 Endpoints

--- a/examples/echo_tcp.py
+++ b/examples/echo_tcp.py
@@ -1,4 +1,4 @@
-"""Raw TCP echo server riding BlackBull's Non-ASGI bridge (Sprint 50).
+"""Raw TCP echo server riding BlackBull's Non-ASGI bridge.
 
 One BlackBull process serves HTTP on :8000 *and* a raw TCP echo protocol on
 :9000 — the echo handler bypasses ASGI entirely and speaks the socket directly.

--- a/examples/sse_token_stream.py
+++ b/examples/sse_token_stream.py
@@ -1,6 +1,6 @@
 """Server-Sent Events token-streaming example.
 
-Demonstrates the Sprint 45 streaming surface end-to-end:
+Demonstrates the streaming surface end-to-end:
 
 * A simplified handler returns an :class:`EventSourceResponse` whose
   async generator yields one event per fake LLM token.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.65.0"
+version = "0.66.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/architecture/events/test_before_handler_event.py
+++ b/tests/architecture/events/test_before_handler_event.py
@@ -272,10 +272,10 @@ async def test_before_handler_not_fired_for_websocket():
 async def test_before_handler_exactly_once_with_aggregator():
     """Exactly one before_handler per request under the production actor path.
 
-    Regression for the Sprint 40 candidate-3 double fire: both the actor
+    Regression for the candidate-3 double fire: both the actor
     layer (EventAggregator.on_before_handler) and BlackBull._dispatch used
     to emit before_handler, so a request served by BlackBull's own HTTP/1.1
-    server fired it twice.  Sprint 64 consolidated emission into _dispatch.
+    server fired it twice.  Emission is consolidated into _dispatch.
     """
     from blackbull.event_aggregator import EventAggregator
 

--- a/tests/architecture/events/test_query_method_lifecycle.py
+++ b/tests/architecture/events/test_query_method_lifecycle.py
@@ -1,4 +1,4 @@
-"""Request-lifecycle events for HTTP QUERY requests (RFC 10008, Sprint 78).
+"""Request-lifecycle events for HTTP QUERY requests (RFC 10008).
 
 The four lifecycle events (`request_received`, `before_handler`,
 `after_handler`, `request_completed`) must fire exactly once per QUERY

--- a/tests/architecture/events/test_request_completed_event.py
+++ b/tests/architecture/events/test_request_completed_event.py
@@ -324,7 +324,7 @@ async def test_wire_fields_populated_with_global_buffering_middleware():
 async def test_event_fires_per_stream_on_http2():
     """On HTTP/2, the event fires once per stream (one ASGI dispatch each).
 
-    Sprint 64 moved emission from the server layer (_run_with_log) into
+    Emission moved from the server layer (_run_with_log) into
     BlackBull._dispatch, so per-stream firing is now per-app-call firing.
     The detail's wire fields (status/response_bytes) are sourced from the
     AccessLogRecord the server places in scope['state']['access_log'].

--- a/tests/architecture/events/test_request_received_event.py
+++ b/tests/architecture/events/test_request_received_event.py
@@ -212,7 +212,7 @@ async def test_request_received_exactly_once():
 async def test_request_received_fires_per_http2_stream():
     """On HTTP/2, request_received fires once per stream (one dispatch each).
 
-    Sprint 64 moved emission from the server layer into BlackBull._dispatch,
+    Emission moved from the server layer into BlackBull._dispatch,
     so per-stream firing is now per-app-call firing.
     """
     app = BlackBull()
@@ -297,7 +297,7 @@ async def test_request_received_not_fired_for_websocket():
 async def test_request_received_exactly_once_with_aggregator():
     """Exactly one request_received per request under the production actor path.
 
-    Sprint 64 moved emission from the actor layer into BlackBull._dispatch;
+    Emission moved from the actor layer into BlackBull._dispatch;
     this pins the no-double-fire property when an EventAggregator is wired
     (the production server configuration).
     """

--- a/tests/architecture/events/test_websocket_connected_event.py
+++ b/tests/architecture/events/test_websocket_connected_event.py
@@ -79,7 +79,7 @@ def _make_client_frame(payload: bytes, opcode: int = 0x1, fin: bool = True) -> b
 
 
 def _make_ws_conn(path: str) -> Connection:
-    """The native WebSocket Connection the upgrade path threads (Sprint 80)."""
+    """The native WebSocket Connection the upgrade path threads."""
     return Connection(
         type='websocket',
         http_version='1.1',

--- a/tests/architecture/events/test_websocket_disconnected_event.py
+++ b/tests/architecture/events/test_websocket_disconnected_event.py
@@ -76,7 +76,7 @@ def _make_client_frame(payload: bytes, opcode: int = 0x1, fin: bool = True) -> b
 
 
 def _make_ws_conn(path: str) -> Connection:
-    """The native WebSocket Connection the upgrade path threads (Sprint 80)."""
+    """The native WebSocket Connection the upgrade path threads."""
     return Connection(
         type='websocket',
         http_version='1.1',

--- a/tests/architecture/test_BlackBull.py
+++ b/tests/architecture/test_BlackBull.py
@@ -432,7 +432,7 @@ async def test_dispatch_websocket_calls_handler():
 async def test_raising_shutdown_hook_sends_lifespan_shutdown_failed():
     """ASGI lifespan spec: a raising shutdown hook must answer
     lifespan.shutdown with lifespan.shutdown.failed (+ message), not
-    lifespan.shutdown.complete (bug 1.18)."""
+    lifespan.shutdown.complete."""
     app_ = BlackBull()
 
     @app_.on_shutdown

--- a/tests/architecture/test_BlackBull.py
+++ b/tests/architecture/test_BlackBull.py
@@ -213,7 +213,7 @@ def _validating_ssl_context() -> ssl.SSLContext:
 # listener binds '::' — a runner-network quirk that does not reproduce locally.
 # The test cert's IP:127.0.0.1 SAN lets _validating_ssl_context() verify the
 # chain against the loopback IP, so using '127.0.0.1' matches every other test
-# in this module and keeps the suite green in CI.  See Sprint 52 R8.
+# in this module and keeps the suite green in CI.
 @pytest.mark.asyncio
 async def test_response_200(app):
     async with httpx.AsyncClient(http2=True, verify=_validating_ssl_context()) as c:

--- a/tests/architecture/test_asgi_server.py
+++ b/tests/architecture/test_asgi_server.py
@@ -212,7 +212,7 @@ class TestOpenSocket:
 )
 class TestOpenSocketReusePort:
     """open_socket() must plumb BB_SOCKET_REUSEPORT through to the HTTP
-    listener so forked workers can co-bind the port (Sprint 55 G1, step 1).
+    listener so forked workers can co-bind the port.
 
     Regression: the setting existed but was never passed to
     create_dual_stack_sockets() from open_socket(), so it was silently

--- a/tests/architecture/test_connection_scope_consistency.py
+++ b/tests/architecture/test_connection_scope_consistency.py
@@ -6,7 +6,7 @@ ASGI scope dict literal. All scope construction must go through
 ``Connection`` and hand-rolling a scope dict (the drift hazard §4 exists to
 prevent).
 
-The guard is a source scan. During the Sprint 79 migration (phases 3–5) the
+The guard is a source scan. During the native-Connection migration the
 actors still build scope dicts; those sites are listed in
 ``_MIGRATION_ALLOWLIST`` and removed from it as each phase lands, so the
 allowlist shrinks to empty by Phase 5. An empty allowlist with the scan
@@ -78,7 +78,7 @@ def test_migration_allowlist_entries_exist():
 
 
 def test_native_baseline_request_never_materializes_scope_dict():
-    """Sprint 80 exit invariant: a baseline request served by BlackBull's own
+    """Exit invariant: a baseline request served by BlackBull's own
     dispatch — a bare :class:`Connection` handed to ``app`` (native path), no
     user ``app.use`` middleware, a handler taking neither ``scope`` nor
     ``Request`` — must never build an ASGI scope dict at all. BlackBull is a
@@ -132,7 +132,7 @@ def test_native_baseline_request_never_materializes_scope_dict():
             setattr(Connection, name, orig)
 
     assert built == [], (
-        'Sprint 80 regression: a native baseline request derived an ASGI scope '
+        'Regression: a native baseline request derived an ASGI scope '
         f'dict via {built!r}. Some framework-internal code built a scope instead '
         'of reading the Connection on the hot path.')
     start = [e for e in sent if e.get('type') == 'http.response.start']

--- a/tests/architecture/test_h2_connection_builder.py
+++ b/tests/architecture/test_h2_connection_builder.py
@@ -1,4 +1,4 @@
-"""Sprint 80 alloc hygiene (`.claude/planning/proposals/connection-alloc-hygiene.md`
+"""Alloc hygiene (`.claude/planning/proposals/connection-alloc-hygiene.md`
 Phase 2, 2026-07-24) — architecture guards for the H/2 lean ``Connection``
 builder.
 
@@ -172,7 +172,7 @@ async def test_extensions_sentinel_replaced_before_app_sees_connection():
 def _make_split_get_frames(stream_id: int = 1) -> bytes:
     """A single logical GET request whose HPACK header block is split across
     a HEADERS frame (no END_HEADERS) and a CONTINUATION frame (END_HEADERS) —
-    the sprint-80 follow-up: the single-frame test above only exercises
+    a follow-up: the single-frame test above only exercises
     ``_on_headers_frame``'s complete-in-one-frame branch, but
     ``_apply_priority_and_extensions`` (the thing that makes the shared
     sentinel safe) is called independently from ``_on_continuation_frame``

--- a/tests/architecture/test_http1_actor.py
+++ b/tests/architecture/test_http1_actor.py
@@ -99,7 +99,7 @@ def mock_app():
 # ---------------------------------------------------------------------------
 # Test 1: single request → the app is dispatched once; no error event.
 # (Request-lifecycle Level B events are emitted by BlackBull._dispatch since
-# Sprint 64 — the actor layer only calls the app and reports errors.)
+# The actor layer only calls the app and reports errors.)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -367,7 +367,7 @@ class TestScopePopulation:
 
     @pytest.mark.asyncio
     async def test_cleartext_advertises_pathsend_extension(self):
-        """Sprint 31 — cleartext H1 scope advertises the
+        """Cleartext H1 scope advertises the
         ``http.response.pathsend`` ASGI extension so the static-file
         middleware can hand the file path to the sender (zero-copy
         via ``loop.sendfile``)."""
@@ -407,7 +407,7 @@ class TestScopePopulation:
 
 class TestFillConnectionInfo:
     """HTTP1Actor._fill_connection_info must populate the Connection from
-    constructor args (Sprint 79 Phase 3 — client/server are tuples now)."""
+    constructor args."""
 
     def _make_actor(self, peername=None, sockname=None, ssl=False):
         return HTTP1Actor(
@@ -652,7 +652,7 @@ async def test_ws_upgrade_without_accept_id_generates_unified_format():
 
 
 # ---------------------------------------------------------------------------
-# Alloc-reduction (Sprint 80): the baseline hot path skips the per-request
+# Alloc-reduction: the baseline hot path skips the per-request
 # AccessLogRecord when nothing consumes it. Pins the optimization so a future
 # change can't silently make the record unconditional again.
 # ---------------------------------------------------------------------------

--- a/tests/architecture/test_http2_actor.py
+++ b/tests/architecture/test_http2_actor.py
@@ -307,7 +307,7 @@ async def test_make_sender_uses_current_connection_window(fake_writer, mock_app)
 
     sender = actor.make_sender(stream_id=7)
 
-    # The sender shares the actor's connection window (bug 1.2), so it reads
+    # The sender shares the actor's connection window, so it reads
     # the current budget from the one object rather than a stale copy.
     assert sender.connection_window_size == 4194304, (
         f'Expected connection window 4194304, got {sender.connection_window_size}'

--- a/tests/architecture/test_http2_actor.py
+++ b/tests/architecture/test_http2_actor.py
@@ -128,7 +128,7 @@ def mock_app():
 # ---------------------------------------------------------------------------
 # Test 1: single stream → the app is dispatched once; no error event.
 # (Request-lifecycle Level B events are emitted by BlackBull._dispatch since
-# Sprint 64 — the actor layer only calls the app and reports errors.)
+# The actor layer only calls the app and reports errors.)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -231,7 +231,7 @@ async def test_handshake_sends_settings_initial_window_size(
     """HTTP2Actor.run() must advertise the configured
     ``BB_H2_INITIAL_WINDOW_SIZE`` in the server's SETTINGS frame.
 
-    Sprint 37 lowered BlackBull's default to the RFC 7540 §6.9.2
+    BlackBull's default is the RFC 7540 §6.9.2
     baseline (65535).  This test sets a non-default value via env so
     the emitted frame is unambiguously distinguishable from the RFC
     default and the test asserts the actor honours the configured
@@ -262,7 +262,7 @@ async def test_handshake_sends_connection_window_update(
     """HTTP2Actor.run() must send WINDOW_UPDATE(stream_id=0) when the
     configured connection window exceeds the RFC 7540 default (65535).
 
-    Sprint 37 lowered BlackBull's default to 65535 (no
+    BlackBull's default is 65535 (no
     WINDOW_UPDATE needed at handshake — peer's connection window
     already starts there).  This test sets a non-default to assert
     the actor emits the expansion frame when one is required.
@@ -481,7 +481,7 @@ async def test_stream_semaphore_caps_active_handlers():
 
 
 # ---------------------------------------------------------------------------
-# Alloc-reduction (P2 / Sprint 80): the H2 HEADERS dispatch path skips the
+# Alloc-reduction: the H2 HEADERS dispatch path skips the
 # per-request AccessLogRecord (and the capturing-send wrapper) when nothing
 # consumes it — mirrors the HTTP/1.1 gate (P3). A real EventAggregator is
 # required so has_request_completed_listeners() reports true registration

--- a/tests/architecture/test_mqtt_actor.py
+++ b/tests/architecture/test_mqtt_actor.py
@@ -1,6 +1,6 @@
 """Architecture tests for MQTT protocol detection on the Non-ASGI bridge.
 
-Sprint 53 replaced the procedural ``MQTTActor`` with the ``BrokerActor`` +
+The procedural ``MQTTActor`` was replaced by the ``BrokerActor`` +
 ``MQTT5Actor`` topology; the actor-level behaviour those tests used to
 cover now lives in ``tests/unit/test_mqtt_broker_actor.py`` and
 ``tests/unit/test_mqtt_connection_actor.py``, with the full wire contract in

--- a/tests/architecture/test_multiworker.py
+++ b/tests/architecture/test_multiworker.py
@@ -187,7 +187,7 @@ def test_master_stops_on_sigterm(plain_app, bound_sockets):
 
 
 # ---------------------------------------------------------------------------
-# Sprint 55 G1 — HTTP scales across workers while a stateful protocol
+# HTTP scales across workers while a stateful protocol
 # (here: a raw echo, standing in for MQTT) is owned by worker 0 only.
 # ---------------------------------------------------------------------------
 
@@ -288,7 +288,7 @@ def test_multiworker_http_scales_while_raw_stays_on_worker0(http_and_raw_app):
 
 
 # ---------------------------------------------------------------------------
-# Sprint 55 G1 — serve() no longer forces workers=1 for stateful protocols
+# Serve() no longer forces workers=1 for stateful protocols
 # (except under auto-reload, whose exec handoff does not carry them yet).
 # ---------------------------------------------------------------------------
 

--- a/tests/architecture/test_typing_gate.py
+++ b/tests/architecture/test_typing_gate.py
@@ -202,7 +202,7 @@ def test_pyright_scope_is_narrow():
     it is not.
 
     Growing by a *named module written against the declarations* is the
-    intended way for this list to change — `blackbull/websocket.py` (Sprint
+    intended way for this list to change — `blackbull/websocket.py` (the
     82) constructs the WebSocket event shapes, so type-checking it proves the
     declarations hold where they are actually used.  Each addition is a
     reviewed decision, which is exactly what an assertion on the literal set

--- a/tests/architecture/test_websocket_actor.py
+++ b/tests/architecture/test_websocket_actor.py
@@ -13,7 +13,7 @@ from blackbull.server.ws_codec import encode_frame
 
 
 def _ws_conn(connection_id: str = 'test-id') -> Connection:
-    """A native WebSocket Connection — the arg the WS path threads (Sprint 80)."""
+    """A native WebSocket Connection — the arg the WS path threads."""
     return Connection(method='GET', path='/', raw_path=b'/',
                       headers=Headers([]), type='websocket',
                       connection_id=connection_id)

--- a/tests/conformance/grpc/test_grpc_bidi_streaming.py
+++ b/tests/conformance/grpc/test_grpc_bidi_streaming.py
@@ -1,4 +1,4 @@
-"""Conformance: bidirectional-streaming gRPC over the ASGI bridge (Sprint 60 G1b).
+"""Conformance: bidirectional-streaming gRPC over the ASGI bridge.
 
 Bidi = the request is a stream of messages *and* the response is a stream.  The
 handler is an async generator taking an async iterator (``request_iter``) and

--- a/tests/conformance/grpc/test_grpc_client_streaming.py
+++ b/tests/conformance/grpc/test_grpc_client_streaming.py
@@ -1,4 +1,4 @@
-"""Conformance: client-streaming gRPC over the ASGI bridge (Sprint 60 G1a).
+"""Conformance: client-streaming gRPC over the ASGI bridge.
 
 Client-streaming = the *request* is a stream of messages, the *response* is a
 single message.  The handler takes an async iterator (``request_iter``) instead

--- a/tests/conformance/grpc/test_grpc_compression.py
+++ b/tests/conformance/grpc/test_grpc_compression.py
@@ -1,4 +1,4 @@
-"""Conformance: gRPC message compression (Sprint 60 G2).
+"""Conformance: gRPC message compression.
 
 gRPC carries a per-message Compressed-Flag in the 5-byte LPM prefix; a set flag
 means the body is compressed with the algorithm named in ``grpc-encoding``.

--- a/tests/conformance/grpc/test_grpc_context.py
+++ b/tests/conformance/grpc/test_grpc_context.py
@@ -1,4 +1,4 @@
-"""Conformance: the fuller GrpcContext (Sprint 60 G3).
+"""Conformance: the fuller GrpcContext.
 
 Adds the parts of grpcio's ``ServicerContext`` a raw-bytes transport can honour:
 ``time_remaining()`` (from ``grpc-timeout``), ``peer()`` (from the ASGI

--- a/tests/conformance/grpc/test_grpc_protobuf_interop.py
+++ b/tests/conformance/grpc/test_grpc_protobuf_interop.py
@@ -1,5 +1,5 @@
 """Interop conformance for the **protobuf layer** (`blackbull-protobuf`,
-Sprint 66): a real grpcio client + the official grpcio client-side packages
+A real grpcio client + the official grpcio client-side packages
 driving BlackBull's reflection, health, and rich-error services over a real
 h2c socket.
 
@@ -146,7 +146,7 @@ async def test_reflection_lists_and_invokes_without_proto(grpc_server):
     services, message = await asyncio.to_thread(_reflection_flow, port)
     assert 'bbinterop.Greeter' in services
     assert 'grpc.health.v1.Health' in services
-    # Both reflection package versions are served (Sprint 68): v1alpha for
+    # Both reflection package versions are served: v1alpha for
     # older clients, v1 for the newer ones that probe it first.
     assert 'grpc.reflection.v1alpha.ServerReflection' in services
     assert 'grpc.reflection.v1.ServerReflection' in services

--- a/tests/conformance/grpc/test_grpc_real_client_h2c.py
+++ b/tests/conformance/grpc/test_grpc_real_client_h2c.py
@@ -1,5 +1,5 @@
 """Interop conformance: a **real third-party gRPC client** (grpcio) driving
-BlackBull's unary gRPC over a real h2c socket (Sprint 58).
+BlackBull's unary gRPC over a real h2c socket.
 
 Every other gRPC test in the suite drives the server with BlackBull's own
 ``HTTP2Client`` or the in-process ``serve_grpc`` harness — both of which are
@@ -7,7 +7,7 @@ lenient about the exact HEADERS/DATA/TRAILERS framing.  This module is the only
 one that puts an *external, spec-strict* client (``grpcio``) on the wire, so it
 is what catches interop bugs BlackBull's own client tolerates.
 
-It caught the Trailers-Only framing bug (Sprint 58): the error path emitted
+It caught the Trailers-Only framing bug: the error path emitted
 ``grpc-status`` in a non-terminal HEADERS frame followed by an empty
 END_STREAM DATA frame, which grpcio decoded as UNKNOWN /
 "Stream removed (Data frame with END_STREAM flag received)".  The fix routes
@@ -386,7 +386,7 @@ class TestRealClientContext:
 
 class TestRealClientErrorStatus:
     """A strict client must decode every error class as its gRPC status —
-    not UNKNOWN.  This is the regression the Sprint 58 Trailers-Only fix closes."""
+    not UNKNOWN.  This is the regression the Trailers-Only fix closes."""
 
     @pytest.mark.asyncio
     async def test_handler_crash_is_internal(self, grpc_server_port):
@@ -452,7 +452,7 @@ class TestRealClientServerStreaming:
 
 
 # ---------------------------------------------------------------------------
-# Client-streaming — a real grpcio stream_unary call (Sprint 60 G1a).
+# Client-streaming — a real grpcio stream_unary call.
 # ---------------------------------------------------------------------------
 
 class TestRealClientClientStreaming:
@@ -485,7 +485,7 @@ class TestRealClientClientStreaming:
     async def test_large_request_stream_over_window(self, grpc_server_port):
         # 200 × 1 KiB (~200 KiB) crosses the initial 65535-byte window on the
         # request direction.  Gate for consume-based inbound flow control
-        # (the Sprint 62 deferral): the server credits WINDOW_UPDATE as the
+        #: the server credits WINDOW_UPDATE as the
         # handler consumes, so a slow drain closes the window and
         # back-pressures grpcio instead of overflowing the recipient queue
         # into RST_STREAM(ENHANCE_YOUR_CALM) — the pre-fix failure mode under
@@ -498,7 +498,7 @@ class TestRealClientClientStreaming:
 
 
 # ---------------------------------------------------------------------------
-# Bidirectional streaming — a real grpcio stream_stream call (Sprint 60 G1b).
+# Bidirectional streaming — a real grpcio stream_stream call.
 # ---------------------------------------------------------------------------
 
 class TestRealClientBidiStreaming:
@@ -530,7 +530,7 @@ class TestRealClientBidiStreaming:
     async def test_large_both_directions_over_window(self, grpc_server_port):
         # 200 × 1 KiB echoed back — BOTH directions cross the initial
         # 65535-byte window concurrently.  Gate for consume-based inbound
-        # flow control (the Sprint 62 deferral): when the handler stalls
+        # flow control: when the handler stalls
         # reading (blocked on yield under response back-pressure) it stops
         # crediting, the request-direction window closes, and grpcio
         # back-pressures — pre-fix this overflowed the 64-deep recipient
@@ -559,7 +559,7 @@ class TestRealClientConcurrency:
     @pytest.mark.asyncio
     async def test_concurrent_large_responses_share_connection_window(
             self, grpc_server_port):
-        """Bug 1.2's wire-level gate (the missing Sprint 62 concurrency test):
+        """Bug 1.2's wire-level gate (the missing concurrency test):
         N concurrent streams × 100 KB responses multiplexed on ONE connection.
 
         Cumulative response bytes (10 × 100 KB) dwarf the 65535-byte

--- a/tests/conformance/grpc/test_grpc_real_client_h2c.py
+++ b/tests/conformance/grpc/test_grpc_real_client_h2c.py
@@ -559,7 +559,7 @@ class TestRealClientConcurrency:
     @pytest.mark.asyncio
     async def test_concurrent_large_responses_share_connection_window(
             self, grpc_server_port):
-        """Bug 1.2's wire-level gate (the missing concurrency test):
+        """The wire-level gate (the missing concurrency test):
         N concurrent streams × 100 KB responses multiplexed on ONE connection.
 
         Cumulative response bytes (10 × 100 KB) dwarf the 65535-byte

--- a/tests/conformance/grpc/test_grpc_required_impl.py
+++ b/tests/conformance/grpc/test_grpc_required_impl.py
@@ -272,7 +272,7 @@ class TestRequiredCompressionNegotiation:
         await serve_grpc(reg, _grpc_scope('/svc/Ok'),
                          _receive_with(encode_message(b'')), send)
         start = next(e for e in events if e['type'] == 'http.response.start')
-        # Since Sprint 60 G2 the server decodes gzip as well as identity.
+        # The server decodes gzip as well as identity.
         assert dict(start['headers'])[b'grpc-accept-encoding'] == b'identity,gzip'
 
     @pytest.mark.asyncio

--- a/tests/conformance/grpc/test_grpc_security.py
+++ b/tests/conformance/grpc/test_grpc_security.py
@@ -360,7 +360,7 @@ class TestMessageFramingAttacks:
     async def test_compressed_message_without_encoding_rejected(self):
         """A message with the Compressed-Flag set but no (or an unsupported)
         ``grpc-encoding`` must be rejected with UNIMPLEMENTED.  gzip itself is
-        supported since Sprint 60 G2 (see test_grpc_compression.py); this pins
+        supported (see test_grpc_compression.py); this pins
         the flag-set-but-no-negotiated-codec case."""
         reg = GrpcServiceRegistry()
 

--- a/tests/conformance/grpc/test_grpc_server_streaming.py
+++ b/tests/conformance/grpc/test_grpc_server_streaming.py
@@ -1,4 +1,4 @@
-"""Conformance: server-streaming gRPC over the ASGI bridge (Sprint 58).
+"""Conformance: server-streaming gRPC over the ASGI bridge.
 
 Drives ``serve_grpc`` with the in-process ``_collector`` harness (no socket) to
 assert the ASGI event shape of a server-streaming response and its edge cases:

--- a/tests/conformance/grpc/test_grpc_transport.py
+++ b/tests/conformance/grpc/test_grpc_transport.py
@@ -121,7 +121,7 @@ class TestRstStreamDuringGrpc:
         # An immediate http.disconnect (RST_STREAM before any DATA) makes
         # read_body raise ClientDisconnected, which the bridge maps to the
         # canonical gRPC CANCELLED — not a fabricated INTERNAL over an empty
-        # body (bug 1.11).
+        # body.
         trailers = _trailers_of(events)
         assert trailers.get(b'grpc-status') == str(int(GrpcStatus.CANCELLED)).encode()
 

--- a/tests/conformance/http1/fuzz/fuzz_http1.py
+++ b/tests/conformance/http1/fuzz/fuzz_http1.py
@@ -1,12 +1,12 @@
 #!/usr/bin/python3
 """Atheris coverage-guided fuzz harness for BlackBull's HTTP/1.1 server.
 
-Sprint 17 Phase 5 — switched from the previous ``decode_to_request`` +
+Switched from the previous ``decode_to_request`` +
 ``HTTP1Client.request()`` pipeline to the shared :class:`Scenario`
 abstraction.  Atheris's byte-level mutations now reach the wire
 verbatim via :meth:`Scenario.from_bytes`.
 
-Sprint 18 Phase 3 — when the env vars ``BB_FUZZ_NGINX_HOST`` and
+When the env vars ``BB_FUZZ_NGINX_HOST`` and
 ``BB_FUZZ_NGINX_PORT`` are set, ``TestOneInput`` runs the same
 scenario against nginx and BlackBull and *fails* (raises
 ``AssertionError``) on any non-accepted category — exactly the
@@ -19,7 +19,7 @@ Run::
     # single-server (legacy):
     python fuzz_http1.py -max_total_time=60 corpus/
 
-    # differential (Sprint 18):
+    # differential:
     BB_FUZZ_NGINX_HOST=127.0.0.1 BB_FUZZ_NGINX_PORT=8080 \\
         python fuzz_http1.py -max_total_time=60 corpus/
 
@@ -131,7 +131,7 @@ async def _single_server(scenario: Scenario) -> None:
 
 
 async def _differential(scenario: Scenario) -> Category:
-    """Sprint 18 Phase 3 path — feed *scenario* to both servers,
+    """Feed *scenario* to both servers,
     return the categoriser verdict.  Raises is delegated to
     :func:`TestOneInput`; this helper itself never raises."""
     # _DIFFERENTIAL gates the caller, so both are populated here.

--- a/tests/conformance/http1/fuzz/make_seeds.py
+++ b/tests/conformance/http1/fuzz/make_seeds.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Generate atheris seed scenarios in :class:`Scenario.from_bytes` opcode form.
 
-Sprint 18 epilogue — the pre-Sprint-17 ``l[1-5]_*.txt`` corpus contains
+The legacy ``l[1-5]_*.txt`` corpus contains
 raw HTTP/1.1 wire bytes, but ``fuzz_http1.py``'s ``TestOneInput`` now
 decodes bytes via :meth:`Scenario.from_bytes` (opcode-tagged
 1 byte per step).  Without re-encoding, most existing seeds decode

--- a/tests/conformance/http1/test_client.py
+++ b/tests/conformance/http1/test_client.py
@@ -52,7 +52,7 @@ async def _echo_app(scope, receive, send):
 
     Also accepts WebSocket scopes — echoes every received frame back to the client.
 
-    Sprint 80: BlackBull threads a native ``Connection`` for HTTP requests (the
+    BlackBull threads a native ``Connection`` for HTTP requests (the
     WebSocket path stays ASGI-scope-shaped), so request fields are read via
     :func:`_rget`, which works against either representation.
     """
@@ -279,7 +279,7 @@ class TestHTTP1Client:
 class TestQueryMethod:
     """``request()`` accepts ``str | HTTPMethod``; QUERY (no enum member
     before Python 3.16) exercises the plain-string path with a body over
-    both protocol clients (Sprint 78 P4 pin — no dedicated sugar, the
+    both protocol clients (pinned — no dedicated sugar, the
     clients expose no per-verb helpers)."""
 
     @pytest.mark.asyncio
@@ -397,7 +397,7 @@ class TestWebSocketClient:
 
     @pytest.mark.asyncio
     async def test_close_drains_peer_close_and_stops_reader(self, server_port):
-        # Sprint 72 (1.20c) — close() completes the RFC 6455 §7.1.2 closing
+        # close() completes the RFC 6455 §7.1.2 closing
         # handshake and cancels the background reader task, so nothing
         # outlives the session (no pending-task warning at loop shutdown).
         async with WebSocketClient('127.0.0.1', server_port) as c:

--- a/tests/conformance/http1/test_http11probe_remaining.py
+++ b/tests/conformance/http1/test_http11probe_remaining.py
@@ -1,4 +1,4 @@
-"""Sprint 63 remainder — wire-level round-trips for the last Http11Probe FAILs.
+"""Wire-level round-trips for the last Http11Probe FAILs.
 
 Each test replays the exact probe vector against a live BlackBull server:
 

--- a/tests/conformance/http1/test_http1_differential.py
+++ b/tests/conformance/http1/test_http1_differential.py
@@ -1,6 +1,6 @@
 # tests/conformance/http1/test_http1_differential.py
 #
-# Sprint 17 — Differential fuzzing: BlackBull vs nginx as oracle.
+# Differential fuzzing: BlackBull vs nginx as oracle.
 #
 # nginx (running in a Docker container via testcontainers) is the
 # reference implementation.  Hypothesis generates HTTP/1.1 requests,
@@ -76,8 +76,8 @@ from blackbull.fault_injection import (  # noqa: E402
 # BlackBull side: differential-specific h1_app whose `/` route mirrors the
 # nginx oracle's `return 200 "ok"` for ANY method.  The shared h1_app in
 # conftest.py registers `/` for GET only — that mismatch is what the
-# Sprint 17 Phase 1 minimisation surfaced as the headline status_mismatch.
-# Sprint 17 Phase 3 widens just the differential test's app instead of
+# Minimisation surfaced this as the headline status_mismatch.
+# Widen just the differential test's app instead of
 # touching the shared fixture (which other tests rely on for 405-on-PATCH).
 # ---------------------------------------------------------------------------
 
@@ -248,10 +248,10 @@ def nginx_server(echo_server, docker_network):
 import time as _time  # noqa: E402
 from dataclasses import dataclass, field  # noqa: E402
 
-# Sprint 18 Phase 3 — Category, ACCEPTED_CATEGORIES, SideOutcome,
+# Category, ACCEPTED_CATEGORIES, SideOutcome,
 # normalize_response, categorize, and run_scenario moved out of this
 # pytest module so the atheris fuzz harness could reuse them without
-# importing pytest.  Sprint 46 re-homed them at
+# importing pytest.  They are re-homed at
 # blackbull.fault_injection alongside the new HTTP/2 server surface;
 # imports at the top of the file pull them back in.
 
@@ -260,7 +260,7 @@ from dataclasses import dataclass, field  # noqa: E402
 class DiffContext:
     """A failure-diagnosis snapshot for one Hypothesis example.
 
-    Sprint 17 Phase 5 — ``scenario`` replaces the prior dict-shaped
+    ``scenario`` replaces the prior dict-shaped
     ``req`` field as the source of truth for what went on the wire.
     ``wire_request`` continues to hold the actual bytes captured from
     the *BlackBull* side's :attr:`HTTP1Client.wire_buffer` (the nginx
@@ -311,7 +311,7 @@ def reconstruct_wire_request(req: dict) -> bytes:
 
 # ---------------------------------------------------------------------------
 # Hypothesis strategy — only fields that the helper actually uses
-# (Sprint 17 Phase 0: dropped unused 'query' and 'version' fields.
+# (Unused 'query' and 'version' fields were dropped.
 #  Phase 7 will add a malformed_request_strategy alongside.)
 # ---------------------------------------------------------------------------
 
@@ -352,7 +352,7 @@ http_request_strategy = st.fixed_dictionaries({
 
 
 # ---------------------------------------------------------------------------
-# Sprint 17 Phase 5 — scenario-level strategies
+# Scenario-level strategies
 #
 # A Scenario is the unified shape both this differential test and
 # tests/conformance/http1/fuzz/fuzz_http1.py drive against the server.
@@ -416,7 +416,7 @@ slowloris_scenario_strategy = st.builds(
 
 
 # ---------------------------------------------------------------------------
-# Sprint 17 Phase 7 — malformed_scenario_strategy.
+# Malformed_scenario_strategy.
 #
 # These strategies emit wire bytes that the high-level HTTP1Client.request()
 # would reject up front — garbage request lines, RFC-invalid header values,
@@ -586,7 +586,7 @@ def dump(ctx: DiffContext) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 17 Phase 8 — JSONL corpus capture + regression replay.
+# JSONL corpus capture + regression replay.
 #
 # When the Hypothesis sweep finds an example that lands outside
 # ACCEPTED_CATEGORIES, we serialise the scenario (`diff_*.jsonl`) and
@@ -599,7 +599,7 @@ def dump(ctx: DiffContext) -> str:
 
 import hashlib  # noqa: E402
 
-# Sprint 17 epilogue — the user-curated regression corpus lives under
+# The user-curated regression corpus lives under
 # ``fuzz/user-corpus/``, separate from ``fuzz/corpus/`` which atheris
 # uses as its working directory.  Keeping the two apart means atheris's
 # auto-generated seeds don't pollute the replay set and our curated
@@ -619,9 +619,9 @@ def _maybe_dump_corpus(ctx: DiffContext) -> None:
     """Write ``diff_<hash>.jsonl`` + sidecar metadata when the example
     landed outside ACCEPTED_CATEGORIES.
 
-    Sprint 18 — filename is now hash-only (no timestamp prefix) so
+    Filename is now hash-only (no timestamp prefix) so
     re-captures of the same scenario overwrite rather than create new
-    files.  Pre-Sprint-18 the timestamp prefix meant every run added
+    files.  A timestamp prefix would mean every run added
     another copy under a different ``diff_<ts>_<hash>.jsonl`` name.
     The ``captured_at_unix`` field in the sidecar still records when
     the divergence was last observed.
@@ -647,7 +647,7 @@ def _maybe_dump_corpus(ctx: DiffContext) -> None:
 
 @pytest.mark.docker
 @pytest.mark.xfail(
-    reason='Sprint 17: known divergences from nginx remain (e.g. host: \':\' '
+    reason='Known divergences from nginx remain (e.g. host: \':\' '
            'closes the connection on BlackBull).  Phase 4 categorises them '
            'as BB_TRANSPORT_FAIL; widening ACCEPTED_CATEGORIES is a future '
            'decision once the underlying causes are understood.',

--- a/tests/conformance/http1/test_http1_request_timeout.py
+++ b/tests/conformance/http1/test_http1_request_timeout.py
@@ -1,9 +1,9 @@
-"""Sprint 38 Task B — ``BB_REQUEST_TIMEOUT`` on the HTTP/1.1 path.
+"""``BB_REQUEST_TIMEOUT`` on the HTTP/1.1 path.
 
-Before Sprint 38, ``BB_REQUEST_TIMEOUT`` only applied to HTTP/2
+``BB_REQUEST_TIMEOUT`` once applied to HTTP/2
 streams (``HTTP2Actor._spawn_stream_task`` wrapped each stream's
 coroutine with ``asyncio.wait_for``).  The HTTP/1.1 path had no
-equivalent — the handler ran unbounded.  Sprint 38 adds the
+equivalent — the handler ran unbounded.  It now applies the
 same ``asyncio.wait_for`` guard to the HTTP/1.1 request path
 (``RequestActor.run`` / ``_dispatch_request``), returning
 ``408 Request Timeout`` and closing the connection when the
@@ -16,7 +16,7 @@ These tests verify:
 * A fast handler that finishes within the timeout window is
   unaffected (normal response, connection stays open for
   keep-alive).
-* ``BB_REQUEST_TIMEOUT=0`` (the default) preserves the pre-Sprint-38
+* ``BB_REQUEST_TIMEOUT=0`` (the default) preserves the older
   unbounded behaviour — no artificial deadline is imposed.
 * The timeout guard does not leak exceptions into the event loop
   or crash sibling connections.
@@ -180,7 +180,7 @@ def timeout_server():
     server.open_socket(0)
 
     def _child():
-        # Sprint 10 caution: `get_settings()` is `@functools.cache`-d
+        # `get_settings()` is `@functools.cache`-d
         # and inherited across fork.  Reset in the child so the
         # BB_REQUEST_TIMEOUT override takes effect.
         from blackbull.env import reset_settings_cache
@@ -332,7 +332,7 @@ class TestRequestTimeoutFastHandlerUnaffected:
 
 @pytest.mark.integration
 class TestRequestTimeoutDisabled:
-    """``BB_REQUEST_TIMEOUT=0`` (or unset) must preserve the pre-Sprint-38
+    """``BB_REQUEST_TIMEOUT=0`` (or unset) must preserve the older
     behaviour: handlers run to completion regardless of duration."""
 
     @pytest.fixture(scope='module')

--- a/tests/conformance/http1/test_rfc9112_request_forms.py
+++ b/tests/conformance/http1/test_rfc9112_request_forms.py
@@ -1,6 +1,6 @@
 """RFC 9112 §3.2 — request-target forms + §7.1 chunk framing, on the wire.
 
-Sprint 63 (Http11Probe hardening).  These drive a live BlackBull server with
+Http11Probe hardening.  These drive a live BlackBull server with
 byte-exact requests — the probe vectors that higher-level clients refuse to
 send — and assert the status BlackBull actually returns.
 """

--- a/tests/conformance/http1/test_rfc9112_slowloris.py
+++ b/tests/conformance/http1/test_rfc9112_slowloris.py
@@ -9,10 +9,10 @@ BlackBull's defences are three timeouts in :mod:`blackbull.env`,
 overridden short here so the suite stays fast:
 
   * ``BB_HEADER_TIMEOUT`` — deadline for the header block.
-  * ``BB_BODY_TIMEOUT``   — deadline for the body (Sprint 17 Phase 3).
+  * ``BB_BODY_TIMEOUT``   — deadline for the body.
   * ``BB_KEEP_ALIVE_TIMEOUT`` — deadline for idle persistent connections.
 
-Sprint 17 Phase 5 merged the previous ``test_http1_slowloris.py`` into
+This module absorbed the former ``test_http1_slowloris.py`` into
 this file and rewrote every test on top of the
 :class:`blackbull.client.Scenario` abstraction — the same shape the
 Hypothesis-driven differential test and the atheris fuzz harness
@@ -232,7 +232,7 @@ class TestIncrementalRequest:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 17 Phase 5 additions — body-timeout, keep-alive timeout, and
+# Body-timeout, keep-alive timeout, and
 # CL.CL / CL+TE smuggling defences.
 # ---------------------------------------------------------------------------
 

--- a/tests/conformance/http2/fuzz/make_seeds.py
+++ b/tests/conformance/http2/fuzz/make_seeds.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Generate Atheris seed corpus for HTTP/2 fuzz harness — expanded with
-known attacks, CVE patterns, and Sprint 57 test failures.
+known attacks, CVE patterns, and observed test failures.
 
 Categories:
   A. Valid baseline (GET, POST, multi-stream)
-  B. Sprint 57 flow-control deadlock patterns (bug #2 boundary)
+  B. Flow-control deadlock patterns (bug #2 boundary)
   C. RFC 9113 gap test failures (G13 — CR/LF/NUL in field values)
   D. Known CVE patterns (Rapid Reset, CONTINUATION flood, SETTINGS flood)
   E. Protocol edge cases (WU=0, RST on 0, GOAWAY on 1, DATA after RST)
@@ -55,7 +55,7 @@ _write('a04_five_gets.bin',       b''.join(_h2_frame(0x01,0x05,s,_GET_HD) for s 
 _write('a05_large_body.bin',      _h2_frame(0x01,0x04,1,_POST_HD)+_h2_frame(0x00,0x01,1,b'\x42'*16384))
 _write('a06_empty_body.bin',      _h2_frame(0x01,0x04,1,_POST_HD)+_h2_frame(0x00,0x01,1,b''))
 
-# ── B. Sprint 57 flow-control boundary ──
+# ── B. Flow-control boundary ──
 for sz,label in [(65530,'65530'),(65531,'65531'),(65535,'65535'),(131070,'131070')]:
     _write(f'b{["30","31","35","70"][[65530,65531,65535,131070].index(sz)]}_window_{label}.bin',
            _h2_frame(0x01,0x04,1,_POST_HD)+_h2_frame(0x00,0x01,1,b'\x00'*sz))

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -68,7 +68,7 @@ def test_senders_share_one_connection_window():
     conn = ConnectionWindow(1000)
     a = _new_sender(factory, 1, conn)
     b = _new_sender(factory, 3, conn)
-    # Both senders point at the same window object (bug 1.2 — not private copies).
+    # Both senders point at the same window object (not private copies).
     assert a._conn_window is conn and b._conn_window is conn
     # A debit through one sender is visible to the other immediately.
     a._conn_window.size -= 400
@@ -156,7 +156,7 @@ async def test_goaway_early_return_signals_recipients():
     handler._recipients = {1: recipient}
     handler._goaway_sent = True  # a prior frame already triggered a conn error
     # A queued frame arrives after the error; the goaway early-return must
-    # inject http.disconnect into blocked recipients (bug 1.8) rather than
+    # inject http.disconnect into blocked recipients rather than
     # returning and leaving a stream task waiting on receive() forever.
     handler.receive = AsyncMock(side_effect=[
         _make_h2_frame(FrameTypes.PING, 0, 0, b'\x00' * 8), None])
@@ -179,7 +179,7 @@ async def test_priority_unknown_dependency_does_not_crash():
     frame.exclusion = False
     frame.weight = 16
     # Must not raise AttributeError (find_child(99) → None); the stream is
-    # parented under the root instead (bug 1.10).
+    # parented under the root instead.
     await PriorityResponder(frame).respond(handler)
     assert handler.root_stream.find_child(7) is not None
 
@@ -191,7 +191,7 @@ async def test_priority_unknown_dependency_does_not_crash():
 @pytest.mark.asyncio
 async def test_receive_refuses_to_buffer_oversized_frame():
     """receive() detects an over-sized frame from its 9-byte header and returns
-    without ever reading (buffering) the declared payload (bug 1.14 #3)."""
+    without ever reading (buffering) the declared payload.  (#3)."""
     from blackbull.server.recipient import AbstractReader
     declared = DEFAULT_MAX_FRAME_SIZE + 1_000_000
     header = (declared.to_bytes(3, 'big') + FrameTypes.DATA
@@ -220,7 +220,7 @@ async def test_receive_refuses_to_buffer_oversized_frame():
 @pytest.mark.asyncio
 async def test_oversized_frame_len_drives_frame_size_error():
     """When receive() flags an over-sized frame, the frame loop raises a
-    connection FRAME_SIZE_ERROR (bug 1.14 #3)."""
+    connection FRAME_SIZE_ERROR."""
     handler = _make_actor()
     settings = _make_h2_frame(FrameTypes.SETTINGS, 0, 0, b'')
     header = ((DEFAULT_MAX_FRAME_SIZE + 1_000_000).to_bytes(3, 'big')
@@ -282,7 +282,7 @@ async def test_trailers_do_not_respawn_request():
         side_effect=[settings, headers, body, trailers, None])
     await handler.run()
     # The app was dispatched exactly once — the trailers HEADERS did not spawn
-    # a second request over the live stream (bug 1.14).
+    # a second request over the live stream.
     assert calls == ['/x']
     # No PROTOCOL_ERROR was raised for the (valid, END_STREAM-carrying) trailers.
     assert not [c.args[0] for c in handler.send_frame.call_args_list

--- a/tests/conformance/http2/test_audit_sprint62.py
+++ b/tests/conformance/http2/test_audit_sprint62.py
@@ -1,4 +1,4 @@
-"""Regression tests for the Sprint 62 HTTP/2 flow-control + lifecycle batch.
+"""Regression tests for an HTTP/2 flow-control + lifecycle audit batch.
 
 Pins the bugs from the 2026-07-07 comprehensive audit:
 
@@ -10,7 +10,7 @@ Pins the bugs from the 2026-07-07 comprehensive audit:
 - 1.14 (#3) 16 MiB allocation before frame-size validation
 - 2.5  stream_window_size dict-of-one → int
 
-Plus the Sprint 62 deferral landed later: consume-based inbound flow control
+Plus the deferral that landed later: consume-based inbound flow control
 (proposals/consume-based-inbound-flow-control.md) — WINDOW_UPDATE credit for a
 DATA frame is replayed when the app pops the event off the recipient queue,
 not when the frame is enqueued, so a stalled handler closes the window and
@@ -290,7 +290,7 @@ async def test_trailers_do_not_respawn_request():
 
 
 # ---------------------------------------------------------------------------
-# Consume-based inbound flow control (the Sprint 62 deferral) — credit is
+# Consume-based inbound flow control — credit is
 # replayed when the app pops the event, not when the DATA frame is enqueued.
 # ---------------------------------------------------------------------------
 

--- a/tests/conformance/http2/test_h2_flow_control_deadlock.py
+++ b/tests/conformance/http2/test_h2_flow_control_deadlock.py
@@ -1,5 +1,5 @@
 """Conformance test: H2 flow-control for payloads above the 65535-byte
-initial window (Sprint 57).
+initial window.
 
 Four sequential RFC-compliance checks in one test function — each
 step gates the next.  Steps 1-3 pin the three fixed bugs at the window
@@ -12,7 +12,6 @@ teardown).  **However, the scenario logic lives in plain async
 functions in this file — no embedded script strings.**
 
 Full analysis: ``.claude/planning/archives/h2-flow-control-deadlock.md``
-Sprint log: ``bench/sprint-logs/sprint-57.md``
 """
 from __future__ import annotations
 

--- a/tests/conformance/http2/test_hpack_fastpath.py
+++ b/tests/conformance/http2/test_hpack_fastpath.py
@@ -1,4 +1,4 @@
-"""Wire-equivalence tests for the Sprint 21 Phase C HPACK fast path.
+"""Wire-equivalence tests for the HPACK fast path.
 
 The fast path in ``blackbull/protocol/hpack_fastpath.py`` precomputes the
 single-byte ``Indexed Header Field`` encoding for RFC 7541 Appendix A
@@ -151,7 +151,7 @@ def test_status_only_response_is_single_byte():
 
 
 # ---------------------------------------------------------------------------
-# Sprint 24 — request-side fastpath (PUSH_PROMISE pseudo-headers)
+# Request-side fastpath (PUSH_PROMISE pseudo-headers)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("name,value,expected_byte", [
@@ -163,7 +163,7 @@ def test_status_only_response_is_single_byte():
     (b":scheme", b"https",       0x80 | 7),
 ])
 def test_pseudo_fast_bytes_static_entries(name: bytes, value: bytes, expected_byte: int):
-    """Sprint 24 — every static-table entry with both name and value
+    """Every static-table entry with both name and value
     defined returns the expected single-byte Indexed Header Field."""
     wire = hpack_fastpath.pseudo_fast_bytes(name, value)
     assert wire == bytes((expected_byte,))

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -230,7 +230,7 @@ class TestHTTP2FlowControl:
 
     # ----- RFC 9113 §6.9.1 connection-level credit (regression lock) ------
     #
-    # Before Sprint 39, the server only emitted stream-level WINDOW_UPDATE
+    # The server once emitted only stream-level WINDOW_UPDATE
     # on inbound DATA.  The connection-level window depleted toward zero
     # across requests, and any single body — or cumulative inbound across
     # a keep-alive H2 connection — past 65,535 bytes stalled waiting for

--- a/tests/conformance/http2/test_http2_dispatch.py
+++ b/tests/conformance/http2/test_http2_dispatch.py
@@ -127,7 +127,7 @@ class TestHTTP2FlowControl:
         await handler.run()
 
         # _senders is pruned on stream completion (memory-leak fix); assert the
-        # shared connection window (bug 1.2) that seeds new senders instead.
+        # shared connection window that seeds new senders instead.
         assert handler._conn_window.size >= 65535, (
             f'Expected handler._conn_window.size >= 65535 after WINDOW_UPDATE, '
             f'got {handler._conn_window.size}'
@@ -473,7 +473,7 @@ class TestHTTP2MaxConcurrentStreams:
             'stream task map not cleaned up after inbound RST_STREAM'
 
     async def test_refused_multiframe_headers_consumes_continuation(self):
-        """Bug 1.14 #2 — refusing a HEADERS with END_HEADERS=0 must not turn
+        """Refusing a HEADERS with END_HEADERS=0 must not turn
         the peer's legal CONTINUATION into a bogus connection error.
 
         RFC 9113 §6.10: after HEADERS without END_HEADERS the peer MUST send

--- a/tests/conformance/http2/test_rfc8441_interop.py
+++ b/tests/conformance/http2/test_rfc8441_interop.py
@@ -86,7 +86,7 @@ def rfc8441_server_port():
     server.open_socket(0)
 
     def _child():
-        # Sprint 10 caution — settings cache is `@functools.cache`-d on
+        # Settings cache is `@functools.cache`-d on
         # `get_settings()`; without this reset the child would inherit
         # the parent's cache and BB_H2_ENABLE_WEBSOCKET=1 would silently
         # no-op.

--- a/tests/conformance/http2/test_rfc9113_authority.py
+++ b/tests/conformance/http2/test_rfc9113_authority.py
@@ -1,11 +1,11 @@
 """RFC 9113 §8.3.1 — ``:authority`` validation and ASGI ``host`` mapping.
 
-Sprint 72 F.1 (audit follow-up 2026-07-14): HTTP/2 requests must carry a
+HTTP/2 requests must carry a
 host authority — either the ``:authority`` pseudo-header or a literal
 ``Host`` field — and ``:authority`` must be surfaced to the application
 as the ``host`` header in ``scope.headers`` (ASGI HTTP spec), mirroring
 HTTP/1.1's absolute-form-overrides-Host semantics (RFC 9112 §3.2.2) and
-its userinfo/grammar rejection (the 1.25 fix, Sprint 63).
+its userinfo/grammar rejection (the 1.25 fix).
 
 Raw-frame tests drive ``HTTP2Actor`` directly via in-process fakes (same
 helpers as ``test_rfc9113_gaps.py``); scope-mapping tests call

--- a/tests/conformance/http2/test_rfc9113_trailers.py
+++ b/tests/conformance/http2/test_rfc9113_trailers.py
@@ -1,9 +1,9 @@
-"""Sprint 38 Task A — HTTP/2 response trailers (``http.response.trailers``) emit-path tests.
+"""HTTP/2 response trailers (``http.response.trailers``) emit-path tests.
 
-Per the sprint plan, the HTTP/2 sender at
+The HTTP/2 sender at
 ``blackbull/server/sender.py`` lacked a case for
 ``ASGIEvent.HTTP_RESPONSE_TRAILERS`` — it logged "unhandled event
-type".  Sprint 38 adds the emit path: a HEADERS frame carrying
+type".  The emit path sends a HEADERS frame carrying
 regular (non-pseudo) header fields with the END_STREAM flag set,
 sent after the final DATA frame which carries ``END_STREAM`` clear.
 
@@ -434,7 +434,7 @@ class TestH2TrailersSenderContract:
 
 @pytest.mark.asyncio
 class TestH2TrailersCrossProtocolSymmetry:
-    """Sprint 38 Task A is driven by the asymmetry where HTTP/1.1 trailers
+    """Driven by the asymmetry where HTTP/1.1 trailers
     are fully wired but HTTP/2 trailers logged "unhandled event type".
     These tests verify the H2 path now handles the same event types that
     the H1 path accepts, matching the field name shape."""
@@ -459,7 +459,7 @@ class TestH2TrailersCrossProtocolSymmetry:
 
 @pytest.mark.asyncio
 class TestH2TrailersNoLongerUnhandled:
-    """Before Sprint 38 Task A, the H2 sender fell through to the default
+    """The H2 sender once fell through to the default
     ``else`` branch and logged ``HTTP2Sender: unhandled event type
     'http.response.trailers'``.  After the fix, the event must be
     dispatched to the trailers emit path — no log warning emitted."""
@@ -512,7 +512,7 @@ class TestH2TrailersNoLongerUnhandled:
 @pytest.mark.asyncio
 class TestH2EndStreamGuardBytesPath:
     """RFC 9113 §8.1 — frames after END_STREAM are a protocol error.
-    The guard added in Sprint 38 covered the dict-event branch; this
+    The guard covers the dict-event branch; this
     section locks in the symmetric coverage on the bytes branch so a
     misbehaving ASGI app that bytes-sends after stream end gets a
     logged warning instead of a wire violation."""

--- a/tests/conformance/http2/test_server_response.py
+++ b/tests/conformance/http2/test_server_response.py
@@ -102,7 +102,7 @@ async def test_ping_responder_sends_ack():
 @pytest.mark.asyncio
 async def test_window_update_connection_level_credits_shared_window():
     """Connection-level WINDOW_UPDATE credits the ONE shared connection window
-    (bug 1.2) — not a private copy per sender — and wakes every stream sender."""
+    — not a private copy per sender — and wakes every stream sender."""
     from blackbull.server.sender import ConnectionWindow
     frame = MagicMock()
     frame.stream_id = 0

--- a/tests/conformance/http2/test_server_response.py
+++ b/tests/conformance/http2/test_server_response.py
@@ -171,7 +171,7 @@ def _decode_h2_headers(written: bytes, factory: FrameFactory) -> list[tuple[byte
 
 # ---------------------------------------------------------------------------
 # RFC 9110 §6.6.1 — Date SHOULD be present in HTTP responses.
-# Sprint 11 brought HTTP/2 to parity with HTTP/1.1 here; the cache lives
+# HTTP/2 is at parity with HTTP/1.1 here; the cache lives
 # in _http_date() so the per-response cost is one int comparison.
 # ---------------------------------------------------------------------------
 
@@ -228,7 +228,7 @@ async def test_http2_sender_auto_emits_date_on_asgi_event_path():
 
 
 # ---------------------------------------------------------------------------
-# Trailers-coalesced auto-flush (v0.59.1 #173; Sprint 79 single-hop rework).
+# Trailers-coalesced auto-flush (v0.59.1 #173; single-hop rework).
 # The trailers-coalescing fast path holds the first body chunk so HEADERS +
 # DATA + trailing HEADERS coalesce into one write for a unary RPC.  A
 # server-streaming handler that sets ``trailers: True`` then PARKS after the
@@ -241,7 +241,7 @@ async def test_http2_sender_auto_emits_date_on_asgi_event_path():
 @pytest.mark.asyncio
 async def test_http2_sender_auto_flushes_buffered_body_when_producer_parks():
     """Deadlock-fix: a buffered first chunk flushes unprompted when the producer
-    parks (no trailers arrive).  Sprint 79 collapsed the former
+    parks (no trailers arrive).  This collapsed the former
     ``call_soon`` → ``ensure_future`` two-hop to a single ``ensure_future``, so
     the flush now lands after exactly **one** event-loop turn."""
     from blackbull.server.sender import HTTP2Sender, AsyncioWriter

--- a/tests/conformance/mqtt/__init__.py
+++ b/tests/conformance/mqtt/__init__.py
@@ -1,1 +1,1 @@
-# MQTT 5.0 conformance tests (Sprint 52)
+# MQTT 5.0 conformance tests

--- a/tests/conformance/mqtt/conftest.py
+++ b/tests/conformance/mqtt/conftest.py
@@ -32,7 +32,7 @@ def mqtt_ctx():
 
 
 # ---------------------------------------------------------------------------
-# Broker oracle seam (Sprint 53)
+# Broker oracle seam
 # ---------------------------------------------------------------------------
 #
 # The broker-driving conformance tests assert on the *packets the broker emits*
@@ -41,7 +41,7 @@ def mqtt_ctx():
 # poking module globals, which couples them to the broker's internal structure.
 #
 # This harness is the single seam between those tests and the broker.  Today it
-# wraps the procedural broker; after the Sprint 53 actor refactor only this class
+# wraps the procedural broker; after the actor refactor only this class
 # changes (to spin up a ``BrokerActor`` + per-connection actor) — the call sites
 # and their assertions are untouched, so the same suite proves the refactor
 # preserved wire behaviour.  That is what makes it a regression oracle rather

--- a/tests/conformance/mqtt/test_mqtt_connect.py
+++ b/tests/conformance/mqtt/test_mqtt_connect.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 CONNECT / CONNACK / DISCONNECT conformance tests — Sprint 52.
+MQTT 5.0 CONNECT / CONNACK / DISCONNECT conformance tests.
 
 Verifies session establishment and graceful teardown against the MQTT 5.0
 OASIS Standard.

--- a/tests/conformance/mqtt/test_mqtt_edge_cases.py
+++ b/tests/conformance/mqtt/test_mqtt_edge_cases.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 edge cases and server capability tests — Sprint 52.
+MQTT 5.0 edge cases and server capability tests.
 
 Covers remaining spec areas not in other test files.
 

--- a/tests/conformance/mqtt/test_mqtt_integration.py
+++ b/tests/conformance/mqtt/test_mqtt_integration.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 integration scenario tests — Sprint 52.
+MQTT 5.0 integration scenario tests.
 
 End-to-end tests that exercise multiple MQTT features together in realistic
 usage patterns.  These verify that the broker correctly handles complex

--- a/tests/conformance/mqtt/test_mqtt_keepalive.py
+++ b/tests/conformance/mqtt/test_mqtt_keepalive.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Keep-Alive (PINGREQ/PINGRESP) conformance tests — Sprint 52.
+MQTT 5.0 Keep-Alive (PINGREQ/PINGRESP) conformance tests.
 
 Verifies heartbeat mechanism against the MQTT 5.0 OASIS Standard.
 

--- a/tests/conformance/mqtt/test_mqtt_operational.py
+++ b/tests/conformance/mqtt/test_mqtt_operational.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Flow Control, Message Ordering, and QoS limiting tests — Sprint 52.
+MQTT 5.0 Flow Control, Message Ordering, and QoS limiting tests.
 
 Covers operational behaviours not in the per-packet tests.
 

--- a/tests/conformance/mqtt/test_mqtt_packet_structure.py
+++ b/tests/conformance/mqtt/test_mqtt_packet_structure.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Control Packet structure tests — Sprint 52.
+MQTT 5.0 Control Packet structure tests.
 
 Tests for MQTT 5.0 packet encoding/decoding at the wire-format level.
 Verifies compliance with MQTT Version 5.0 OASIS Standard.

--- a/tests/conformance/mqtt/test_mqtt_properties.py
+++ b/tests/conformance/mqtt/test_mqtt_properties.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Properties and AUTH exchange conformance tests — Sprint 52.
+MQTT 5.0 Properties and AUTH exchange conformance tests.
 
 Verifies the MQTT 5.0 enhanced authentication and property system
 against the OASIS Standard.

--- a/tests/conformance/mqtt/test_mqtt_publish_qos.py
+++ b/tests/conformance/mqtt/test_mqtt_publish_qos.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 PUBLISH QoS 0/1/2 conformance tests — Sprint 52.
+MQTT 5.0 PUBLISH QoS 0/1/2 conformance tests.
 
 Verifies PUBLISH delivery at all three QoS levels against the MQTT 5.0
 OASIS Standard.

--- a/tests/conformance/mqtt/test_mqtt_retained_message.py
+++ b/tests/conformance/mqtt/test_mqtt_retained_message.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Retained Message conformance tests — Sprint 52.
+MQTT 5.0 Retained Message conformance tests.
 
 Verifies retained message behaviour against the MQTT 5.0 OASIS Standard.
 

--- a/tests/conformance/mqtt/test_mqtt_session.py
+++ b/tests/conformance/mqtt/test_mqtt_session.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Session State persistence conformance tests — Sprint 52.
+MQTT 5.0 Session State persistence conformance tests.
 
 Verifies session management against the MQTT 5.0 OASIS Standard.
 

--- a/tests/conformance/mqtt/test_mqtt_subscribe.py
+++ b/tests/conformance/mqtt/test_mqtt_subscribe.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 SUBSCRIBE / SUBACK / UNSUBSCRIBE / UNSUBACK conformance tests — Sprint 52.
+MQTT 5.0 SUBSCRIBE / SUBACK / UNSUBSCRIBE / UNSUBACK conformance tests.
 
 Verifies subscription management against the MQTT 5.0 OASIS Standard.
 

--- a/tests/conformance/mqtt/test_mqtt_topic_matching.py
+++ b/tests/conformance/mqtt/test_mqtt_topic_matching.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Topic Name and Topic Filter matching conformance tests — Sprint 52.
+MQTT 5.0 Topic Name and Topic Filter matching conformance tests.
 
 Verifies topic matching rules against the MQTT 5.0 OASIS Standard.
 

--- a/tests/conformance/mqtt/test_mqtt_will_message.py
+++ b/tests/conformance/mqtt/test_mqtt_will_message.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 Will Message (Last-Will Testament) conformance tests — Sprint 52.
+MQTT 5.0 Will Message (Last-Will Testament) conformance tests.
 
 Verifies LWT behaviour against the MQTT 5.0 OASIS Standard.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,6 @@
 """Shared helpers for integration tests.
 
-Sprint 22 collapsed the per-instance ``app.create_server`` / ``app.run`` /
+The per-instance ``app.create_server`` / ``app.run`` /
 ``app.wait_for_port`` / ``app.stop`` API into a single sync ``app.run()``
 on :class:`BlackBull`, plus a dedicated :class:`ASGIServer` for embedded
 use (pre-binding sockets, mTLS configuration, integration tests).

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -115,7 +115,7 @@ def test_cli_serves_blackbull_app(tmp_path: Path):
 def test_cli_serves_over_unix_domain_socket(tmp_path: Path):
     """``blackbull module:app --bind unix:/path`` serves traffic through AF_UNIX.
 
-    Sprint 12a — nginx → BlackBull deployments use UDS to avoid exposing
+    Nginx → BlackBull deployments use UDS to avoid exposing
     a TCP port.  Verify the CLI parses the spec, ASGIServer binds AF_UNIX,
     and a client can complete a request through the socket file.
     """
@@ -197,7 +197,7 @@ def test_cli_serves_over_unix_domain_socket(tmp_path: Path):
 def test_cli_serves_raw_asgi_callable(tmp_path: Path):
     """``blackbull`` can serve a plain ASGI callable (no BlackBull instance).
 
-    This is the path the benchmark harness will take after Sprint 11 —
+    This is the path the benchmark harness takes —
     pointing the CLI at ``bench.peers.asgi_app:app`` (a raw ASGI app)
     just like every other peer server.
     """
@@ -224,7 +224,7 @@ def test_cli_serves_raw_asgi_callable(tmp_path: Path):
     env = os.environ.copy()
     env['BB_ACCESS_LOG'] = '0'
     env['PYTHONUNBUFFERED'] = '1'
-    # Sprint 80: BlackBull is a native-Connection framework — its server hands
+    # BlackBull is a native-Connection framework — its server hands
     # the app a typed ``Connection`` by default. A *raw* ASGI callable (no
     # BlackBull instance) reads ``scope['type']``/``scope['path']``, so it must
     # opt into the ASGI-scope compat lane via ``BB_FORCE_ASGI_SCOPE=1``.

--- a/tests/integration/test_grpc.py
+++ b/tests/integration/test_grpc.py
@@ -9,7 +9,7 @@ through the whole app (``BlackBull.__call__`` → ``_dispatch`` →
 
    These tests originally ran in-process over ``TestClient``
    (``httpx.ASGITransport``).  That transport has no support for the
-   ``http.response.trailers`` ASGI event, and since Sprint 58 every gRPC
+   ``http.response.trailers`` ASGI event, and every gRPC
    response — success *and* error — reports its status in **trailing
    headers** (the framing real gRPC clients require).  httpx therefore never
    observed response completion and its transport asserted

--- a/tests/integration/test_grpc.py
+++ b/tests/integration/test_grpc.py
@@ -13,7 +13,7 @@ through the whole app (``BlackBull.__call__`` → ``_dispatch`` →
    response — success *and* error — reports its status in **trailing
    headers** (the framing real gRPC clients require).  httpx therefore never
    observed response completion and its transport asserted
-   (``response_complete.is_set()``) on all gRPC calls — bug 1.23 in the
+   (``response_complete.is_set()``) on all gRPC calls — in the
    2026-07-07 audit.  ``HTTP2Client`` handles trailers natively, and folds
    them into ``res.headers``.
 

--- a/tests/integration/test_mtls.py
+++ b/tests/integration/test_mtls.py
@@ -140,7 +140,7 @@ def mtls_server(pki):
 
     Uses ASGIServer directly so the SSL context can be overridden to
     set ``verify_mode = CERT_REQUIRED`` before the worker forks.  The
-    pre-Sprint-22 form mutated ``app.server.ssl_context``; the
+    older form mutated ``app.server.ssl_context``; the
     ``app.server`` attribute no longer exists, so this fixture holds
     the server reference itself.
     """

--- a/tests/integration/test_non_http_bridge.py
+++ b/tests/integration/test_non_http_bridge.py
@@ -1,4 +1,4 @@
-"""Integration test for the Non-ASGI bridge — Raw TCP echo (Sprint 50).
+"""Integration test for the Non-ASGI bridge — Raw TCP echo.
 
 Spins up a single BlackBull ``Server`` that serves HTTP on one port and a raw
 TCP echo protocol on another, then exercises both to prove coexistence

--- a/tests/integration/test_raw_binding_tls.py
+++ b/tests/integration/test_raw_binding_tls.py
@@ -1,4 +1,4 @@
-"""Integration tests for TLS on raw protocol bindings (Sprint 75).
+"""Integration tests for TLS on raw protocol bindings.
 
 A raw binding registered with ``tls=True`` is served through the same TLS
 machinery as the HTTPS listener (``mqtts://``-style deployments).  Bindings

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -1,4 +1,4 @@
-"""End-to-end test for auto-reload (Sprint 10).
+"""End-to-end test for auto-reload.
 
 What this test exercises:
   1. ``app.run(reload=True)`` is launched as a subprocess against a

--- a/tests/integration/test_websocket_examples.py
+++ b/tests/integration/test_websocket_examples.py
@@ -1,6 +1,6 @@
 """The shipped WebSocket examples must actually complete a handshake.
 
-Sprint 82 changed who may drive the WebSocket handshake and how that is
+Covers who may drive the WebSocket handshake and how that is
 recorded, which is precisely the part of an example that an import check
 cannot see: `examples/…` modules import fine while their handlers hang or
 mis-sequence the connect event.

--- a/tests/properties/test_h2_properties.py
+++ b/tests/properties/test_h2_properties.py
@@ -1,6 +1,6 @@
 """Hypothesis property tests for H2 field validation and frame parsing.
 
-Covers patterns discovered during Sprint 57 fuzz testing and RFC 9113 audit:
+Covers patterns discovered during fuzz testing and the RFC 9113 audit:
   - Field value character validation (CR, LF, NUL — G13 failures)
   - Frame header parsing robustness (truncated headers, invalid lengths)
   - Flow-control window edge cases
@@ -149,7 +149,7 @@ class TestFieldValidationProperties:
 
 class TestFlowControlInvariants:
     """RFC 9113 §6.9: Flow-control window invariants discovered during
-    Sprint 57 bug hunting."""
+    fuzz-driven bug hunting."""
 
     @given(
         initial=st.integers(min_value=65535, max_value=65535),

--- a/tests/properties/test_mqtt_packets.py
+++ b/tests/properties/test_mqtt_packets.py
@@ -1,5 +1,5 @@
 """
-Property-based tests for MQTT 5.0 packet serialization — Sprint 52.
+Property-based tests for MQTT 5.0 packet serialization.
 
 Uses Hypothesis to verify invariants across a wide range of inputs,
 complementing the example-based conformance tests.

--- a/tests/unit/client/test_http1_client_primitives.py
+++ b/tests/unit/client/test_http1_client_primitives.py
@@ -1,4 +1,4 @@
-"""Sprint 17 Phase 2 — unit tests for ``HTTP1Client``'s low-level primitives.
+"""Unit tests for ``HTTP1Client``'s low-level primitives.
 
 These methods bypass HTTP1RequestSender's framing safeguards and exist so
 differential tests can put deliberately malformed or trickled bytes on the
@@ -212,7 +212,7 @@ class TestSendRequestLine:
 
     @pytest.mark.asyncio
     async def test_method_with_leading_space_emitted_verbatim(self):
-        # Sprint 17 deliberately allows malformed request lines — the
+        # The client deliberately allows malformed request lines — the
         # differential test uses this to probe how nginx and BlackBull
         # diverge on RFC-invalid input.
         c, w = _client_with_fakes()
@@ -334,7 +334,7 @@ class TestReadResponse:
         # has produced enough bytes.  Use Content-Length: 0 explicitly —
         # HTTP1ResponseRecipient currently mis-handles absent
         # Content-Length (Headers.get returns b'', the `cl_raw is not
-        # None` check then fires int(b'') → ValueError).  That pre-Sprint-17
+        # None` check then fires int(b'') → ValueError).  That older
         # bug is logged for a separate fix; it's not in Phase 2 scope.
         reader = _CannedReader(
             b'HTTP/1.1 204 No Content\r\n'

--- a/tests/unit/client/test_http2_client_window.py
+++ b/tests/unit/client/test_http2_client_window.py
@@ -1,4 +1,4 @@
-"""Sprint 72 — client-side H2 window seeding (audit bugs 1.20a + 2.11).
+"""Client-side H2 window seeding (audit bugs 1.20a + 2.11).
 
 RFC 9113 §6.9.2: SETTINGS_INITIAL_WINDOW_SIZE governs the *initial* send
 window of streams the peer has not yet opened; existing streams are

--- a/tests/unit/client/test_http2_client_window.py
+++ b/tests/unit/client/test_http2_client_window.py
@@ -1,4 +1,4 @@
-"""Client-side H2 window seeding (audit bugs 1.20a + 2.11).
+"""Client-side H2 window seeding.
 
 RFC 9113 §6.9.2: SETTINGS_INITIAL_WINDOW_SIZE governs the *initial* send
 window of streams the peer has not yet opened; existing streams are
@@ -29,7 +29,7 @@ def _client() -> HTTP2Client:
 
 class TestClientWindowSeeding:
     def test_sender_created_after_settings_is_seeded(self):
-        """Bug 1.20a — a sender made after the SETTINGS exchange must start
+        """A sender made after the SETTINGS exchange must start
         at the peer's announced initial window, not the RFC default."""
         c = _client()
         c._on_initial_window_size(123456)

--- a/tests/unit/client/test_scenario.py
+++ b/tests/unit/client/test_scenario.py
@@ -1,4 +1,4 @@
-"""Sprint 17 Phase 5 — unit tests for the Scenario abstraction.
+"""Unit tests for the Scenario abstraction.
 
 Covers:
   * ``Scenario.to_json`` / ``from_json`` round-trip for every step type

--- a/tests/unit/client/test_websocket_close.py
+++ b/tests/unit/client/test_websocket_close.py
@@ -1,4 +1,4 @@
-"""Sprint 72 (1.20c) — H1 client close discipline + recipient shutdown.
+"""H1 client close discipline + recipient shutdown.
 
 ``WebSocketSession.close()`` previously sent a best-effort CLOSE frame and
 returned: the peer's echoed CLOSE was never drained and the recipient's

--- a/tests/unit/client/test_websocket_h2_session.py
+++ b/tests/unit/client/test_websocket_h2_session.py
@@ -1,4 +1,4 @@
-"""Sprint 72 — WebSocketH2Session on the shared WS codec (1.20b / F.2, 1.20c).
+"""WebSocketH2Session on the shared WS codec (1.20b / F.2, 1.20c).
 
 The session previously rolled a third, private WebSocket frame parser that
 ignored FIN, RSV, and MASK bits entirely — no fragmentation reassembly, no

--- a/tests/unit/test_adapt_zero_overhead.py
+++ b/tests/unit/test_adapt_zero_overhead.py
@@ -1,15 +1,15 @@
-"""The Sprint 74 zero-overhead pin for ``_adapt_handler``.
+"""The zero-overhead pin for ``_adapt_handler``.
 
 The anti-FastAPI design point: query params and ``Depends`` are resolved at
 registration time, so a handler using *neither* feature compiles to exactly
-the wrapper it compiled to before Sprint 74 — the same (shared) code object,
+the plain wrapper — the same (shared) code object,
 with no reference to the DI or query machinery.  FastAPI, by contrast, runs
 ``solve_dependencies()`` + two ``AsyncExitStack``s per request even with no
 dependencies declared.
 """
 from dataclasses import dataclass
 
-from blackbull import Depends, Connection as Request  # Sprint 79 alias
+from blackbull import Depends, Connection as Request  # deprecated alias
 from blackbull.router import _adapt_handler
 
 

--- a/tests/unit/test_asyncio_writer.py
+++ b/tests/unit/test_asyncio_writer.py
@@ -1,5 +1,5 @@
 """Unit tests for AsyncioWriter — focused on the ``write_timeout``
-slow-read defence introduced in Sprint 30 Tier 1.1.
+slow-read defence.
 
 The defence: a peer that reads the response 1 byte/sec eventually fills
 the kernel send buffer; ``StreamWriter.drain()`` then blocks indefinitely
@@ -276,7 +276,7 @@ async def test_concurrent_drains_share_one_window_and_one_verdict():
 
 
 # ---------------------------------------------------------------------------
-# Sprint 31 — ``http.response.pathsend`` / sendfile path
+# ``http.response.pathsend`` / sendfile path
 # ---------------------------------------------------------------------------
 
 class _SendfileLoopProxy:

--- a/tests/unit/test_audit_sprint61.py
+++ b/tests/unit/test_audit_sprint61.py
@@ -14,7 +14,7 @@ Each test pins a specific bug from the 2026-07-07 comprehensive audit
 - 1.22a fault-injection production guard keyed on the wrong env var
 - 1.22b ``make_self_signed_h2_context`` leaks the private key on disk
 
-(Bug 1.12 — malformed dataclass body → 400 — is covered in
+(A malformed dataclass body → 400 is covered in
 ``tests/unit/test_router.py::TestDataclassBodyDeserialization``.)
 """
 import asyncio
@@ -45,7 +45,7 @@ class _DribbleReader(AbstractReader):
     ``AbstractReader`` base loops over ``read`` to satisfy those.  This is the
     fragmented-delivery case that the conformance ``_FakeReader`` (whole wire in
     one buffer) can never exercise: with the old ``read(chunk_size)`` the
-    recipient would take a one-byte short read as the whole chunk (bug 1.1).
+    recipient would take a one-byte short read as the whole chunk.
     """
 
     def __init__(self, data: bytes) -> None:
@@ -255,7 +255,7 @@ def test_upgrade_h2c_is_ignored_not_fatal():
                b'Upgrade: h2c\r\n\r\n')
     scope = actor._parse(request)
     # A non-websocket Upgrade token is ignored: the request stays plain HTTP
-    # rather than becoming scope['type']='h2c' and crashing dispatch (bug 1.5).
+    # rather than becoming scope['type']='h2c' and crashing dispatch.
     assert scope.type == 'http'
 
 

--- a/tests/unit/test_audit_sprint61.py
+++ b/tests/unit/test_audit_sprint61.py
@@ -1,4 +1,4 @@
-"""Regression tests for the Sprint 61 HTTP/1.1 correctness batch.
+"""Regression tests for an HTTP/1.1 correctness audit batch.
 
 Each test pins a specific bug from the 2026-07-07 comprehensive audit
 (``.claude/planning/recommendations/comprehensive-audit-2026-07-07.md``):

--- a/tests/unit/test_audit_sprint63.py
+++ b/tests/unit/test_audit_sprint63.py
@@ -1,4 +1,4 @@
-"""Sprint 63 regression tests — Http11Probe hardening + audit bug 1.16.
+"""Http11Probe hardening + audit bug 1.16.
 
 Covers:
 
@@ -358,7 +358,7 @@ class TestXForwardedPrefixTrust:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 63 remainder — chunk-line length bound (bug 1.24, MAL-CHUNK-EXT-64K)
+# Chunk-line length bound (bug 1.24, MAL-CHUNK-EXT-64K)
 # ---------------------------------------------------------------------------
 
 class TestChunkLineLengthBound:
@@ -410,7 +410,7 @@ class TestChunkLineLengthBound:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 63 remainder — trailer-section strictness (SMUG-CHUNK-LF-TRAILER,
+# Trailer-section strictness (SMUG-CHUNK-LF-TRAILER,
 # prohibited trailer fields per RFC 9110 §6.5.1)
 # ---------------------------------------------------------------------------
 
@@ -464,7 +464,7 @@ class TestChunkedTrailerSection:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 63 remainder — request-line / header validation (bugs 1.25, WARN
+# Request-line / header validation (bugs 1.25, WARN
 # hardening: strict Content-Length, underscore framing-header names)
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_audit_sprint63.py
+++ b/tests/unit/test_audit_sprint63.py
@@ -1,4 +1,4 @@
-"""Http11Probe hardening + audit bug 1.16.
+"""Http11Probe hardening + ``X-Forwarded-Prefix`` trust.
 
 Covers:
 
@@ -11,7 +11,7 @@ Covers:
 * Phase 3 (probe Cluster C, cheap wins) — userinfo-in-Host, non-ASCII
   request-target, ``Transfer-Encoding`` where chunked is not final,
   duplicate Content-Type.
-* Bug 1.16 — ``X-Forwarded-Prefix`` is only honoured via ``TrustedProxy``,
+* ``X-Forwarded-Prefix`` is only honoured via ``TrustedProxy``,
   never straight off the wire.
 """
 from http import HTTPStatus
@@ -297,7 +297,7 @@ class TestProtocolValidation:
 
 
 # ---------------------------------------------------------------------------
-# Bug 1.16 — X-Forwarded-Prefix only honoured via TrustedProxy
+# X-Forwarded-Prefix only honoured via TrustedProxy
 # ---------------------------------------------------------------------------
 
 class TestXForwardedPrefixTrust:
@@ -358,7 +358,7 @@ class TestXForwardedPrefixTrust:
 
 
 # ---------------------------------------------------------------------------
-# Chunk-line length bound (bug 1.24, MAL-CHUNK-EXT-64K)
+# Chunk-line length bound (MAL-CHUNK-EXT-64K)
 # ---------------------------------------------------------------------------
 
 class TestChunkLineLengthBound:

--- a/tests/unit/test_audit_sprint72.py
+++ b/tests/unit/test_audit_sprint72.py
@@ -1,4 +1,4 @@
-"""Sprint 72 audit follow-up — protocol-uniformity contracts.
+"""Up — protocol-uniformity contracts.
 
 F.1b: the same authority must reach the application identically whether it
 arrives as an HTTP/1.1 absolute-form request-target (RFC 9112 §3.2.2) or as
@@ -56,7 +56,7 @@ def _h2_scope(fields: list[tuple[bytes, bytes]]):
     raw = (len(block).to_bytes(3, 'big') + FrameTypes.HEADERS
            + bytes([flags]) + (1).to_bytes(4, 'big') + block)
     frame = FrameFactory().load(raw)
-    conn = parse_headers(frame)          # Sprint 79 Phase 4 — native Connection
+    conn = parse_headers(frame)          # native Connection
     assert not frame.malformed
     return conn
 

--- a/tests/unit/test_cache_middleware.py
+++ b/tests/unit/test_cache_middleware.py
@@ -32,7 +32,7 @@ from blackbull.middleware.cache import (
 
 def _scope(method: str = 'GET', path: str = '/', query: bytes = b'',
            headers: list[tuple[bytes, bytes]] | None = None):
-    # Sprint 80: HTTP is dispatched as a native Connection, not an ASGI scope.
+    # HTTP is dispatched as a native Connection, not an ASGI scope.
     from blackbull.connection import Connection
     return Connection.from_scope({
         'type': 'http',

--- a/tests/unit/test_cap_log_sites.py
+++ b/tests/unit/test_cap_log_sites.py
@@ -1,4 +1,4 @@
-"""Sprint 44 coverage gate — each cap in the inventory has a unit test
+"""Each cap in the inventory has a unit test
 asserting it logs at the rejection site.
 
 If a future PR adds a new cap (``BB_*`` env var that rejects traffic)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -198,7 +198,7 @@ def test_main_warns_on_specific_host(capsys, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _load_config — Sprint 12c
+# _load_config
 # ---------------------------------------------------------------------------
 
 def test_load_config_maps_server_workers(tmp_path):

--- a/tests/unit/test_compression_backpressure.py
+++ b/tests/unit/test_compression_backpressure.py
@@ -1,5 +1,5 @@
 """Unit tests for the Compression middleware's executor backpressure
-(Sprint 29 #3).
+Backpressure on the compression path.
 
 When the asyncio executor already has ``executor_max_inflight`` compressions
 running, the middleware skips compression on additional eligible responses
@@ -157,7 +157,7 @@ async def test_skip_path_emits_exactly_one_start_event():
     serving a precompressed sibling), the middleware must emit **one**
     response.start event and **one** body event — not duplicate them.
 
-    Regression for the Sprint 29 bug where the outer code path forwarded a
+    Regression for the bug where the outer code path forwarded a
     second start+empty-body pair after the skip-path had already inline-
     forwarded the real response, producing two start events on the same
     response and causing the HTTP/1.1 sender to close the connection after
@@ -171,7 +171,7 @@ async def test_skip_path_emits_exactly_one_start_event():
 
     async def upstream(scope, receive, send_):
         # Upstream sets Content-Encoding itself — typical precompressed
-        # static-file serving (Sprint 29 #1).
+        # static-file serving.
         await send_({
             'type': 'http.response.start',
             'status': 200,
@@ -213,7 +213,7 @@ async def test_small_body_under_threshold_ignores_inflight_cap():
 
 
 # ---------------------------------------------------------------------------
-# Sprint 33 — pass-through fast path + Accept-Encoding selection cache
+# Pass-through fast path + Accept-Encoding selection cache
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -223,7 +223,7 @@ async def test_passthrough_skips_event_reparsing(monkeypatch):
     ``intercepting_send`` must forward subsequent body events verbatim —
     no second ``parse_response_event`` call.
 
-    This is what gives the static-file cache-hit path its Sprint 33 win.
+    This is what gives the static-file cache-hit path its win.
     Without the fast path, ``parse_response_event`` runs once per ASGI
     event; the precompressed-sibling response is 2 events so the cost
     doubles for no useful work."""

--- a/tests/unit/test_compression_vary.py
+++ b/tests/unit/test_compression_vary.py
@@ -171,3 +171,53 @@ class TestMergeVaryHelper:
         hdrs = [(b'vary', b'*')]
         _merge_vary(hdrs)
         assert hdrs == [(b'vary', b'*')]
+
+
+class TestNoCodecPathForwardsBodiesUntouched:
+    """The no-codec send wrapper exists to stamp ``Vary`` on the response
+    start.  It must be transparent to everything else — in particular a
+    streamed body, whose chunks pass through the wrapper one by one."""
+
+    @pytest.mark.asyncio
+    async def test_streamed_body_chunks_are_forwarded_verbatim(self):
+        events: list[dict] = []
+
+        async def send(event):
+            events.append(event)
+
+        chunks = [b'alpha', b'beta', b'gamma']
+
+        async def call_next(scope, receive, send):
+            await send({'type': 'http.response.start', 'status': 200,
+                        'headers': [(b'content-type', b'text/plain')]})
+            for i, chunk in enumerate(chunks):
+                await send({'type': 'http.response.body', 'body': chunk,
+                            'more_body': i < len(chunks) - 1})
+
+        # accept=b'' → no codec overlap, so the Vary-only wrapper is in play.
+        await Compression()(_scope(b''), _noop_receive, send, call_next)
+
+        bodies = [e for e in events if e['type'] == 'http.response.body']
+        assert [e['body'] for e in bodies] == chunks
+        assert [e['more_body'] for e in bodies] == [True, True, False]
+        # The start event still carries Vary — the wrapper's actual job.
+        start = next(e for e in events if e['type'] == 'http.response.start')
+        assert _has_vary_accept_encoding(start['headers'])
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_pass_through(self):
+        events: list[dict] = []
+
+        async def send(event):
+            events.append(event)
+
+        async def call_next(scope, receive, send):
+            await send({'type': 'http.response.start', 'status': 200,
+                        'headers': [(b'content-type', b'text/plain')]})
+            await send({'type': 'http.response.trailers', 'headers': [(b'x-t', b'1')]})
+            await send({'type': 'http.response.body', 'body': b'x', 'more_body': False})
+
+        await Compression()(_scope(b''), _noop_receive, send, call_next)
+        trailers = [e for e in events if e['type'] == 'http.response.trailers']
+        assert trailers == [{'type': 'http.response.trailers',
+                             'headers': [(b'x-t', b'1')]}]

--- a/tests/unit/test_compression_vary.py
+++ b/tests/unit/test_compression_vary.py
@@ -1,5 +1,5 @@
 """Unit tests for the Compression middleware's ``Vary: Accept-Encoding``
-emission (bug 1.21a).
+emission.
 
 A compressed response's body depends on the request ``Accept-Encoding``;
 without ``Vary: Accept-Encoding`` a shared cache may replay the encoded

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,4 +1,4 @@
-"""Phase 2 — `Connection` core + the drift-prevention harness (Sprint 79).
+"""Phase 2 — `Connection` core + the drift-prevention harness.
 
 `Connection` (blackbull/connection.py) is the single internal request
 representation; the ASGI scope dict is a *derived* view produced by

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -14,7 +14,7 @@ def _make_scope(method='GET', origin=None, headers=None, type_='http'):
         'method': method,
         'headers': Headers(raw),
     }
-    # Sprint 80: HTTP is dispatched as a native Connection; non-HTTP (websocket)
+    # HTTP is dispatched as a native Connection; non-HTTP (websocket)
     # still travels as an ASGI scope dict, exactly as the middleware sees it.
     if type_ == 'http':
         from blackbull.connection import Connection

--- a/tests/unit/test_deadline.py
+++ b/tests/unit/test_deadline.py
@@ -1,7 +1,7 @@
 """Unit tests for :class:`blackbull.server.deadline.ConnectionDeadline`.
 
 The deadline replaces ``asyncio.timeout`` on the per-request hot path
-(Sprint 23).  These tests pin down the behaviours the server stack
+These tests pin down the behaviours the server stack
 relies on:
 
 * a fired deadline surfaces as ``TimeoutError`` via :meth:`guard`
@@ -119,7 +119,7 @@ async def test_guard_does_not_leak_cancel_after_timeout():
 @pytest.mark.asyncio
 async def test_guard_propagates_non_cancel_exception():
     """If the body raises a non-CancelledError exception, ``guard`` must
-    propagate it unchanged and still disarm the pending timer (Sprint 26
+    propagate it unchanged and still disarm the pending timer (the
     Phase A — parity case 2 from the contextmanager-era implementation)."""
     dl = ConnectionDeadline()
     with pytest.raises(ValueError, match='boom'):
@@ -134,7 +134,7 @@ async def test_guard_propagates_non_cancel_exception():
 @pytest.mark.asyncio
 async def test_guard_same_tick_race_raises_timeout():
     """Same-tick race: the body completes normally but ``_fired`` is set
-    in the same loop iteration (Sprint 26 Phase A — parity case 5).
+    in the same loop iteration.
     This is the convention ``asyncio.timeout`` uses: a deadline that
     fired wins even if the awaited read also produced a value."""
     dl = ConnectionDeadline()
@@ -174,7 +174,7 @@ async def test_arm_cancels_previous_handle():
     dl.disarm()
 
 
-# --- Scanner-architecture-specific tests (Sprint 26 Phase B) ---
+# --- Scanner-architecture-specific tests ---
 
 
 @pytest.mark.asyncio
@@ -218,7 +218,7 @@ async def test_scanner_handles_multiple_independent_deadlines():
 async def test_scanner_fires_short_deadline_within_tick_window():
     """End-to-end: a deadline armed past ``_TICK_S`` must fire through
     the scanner.  Uses guard() which translates the cancellation into
-    ``TimeoutError`` — same observable shape as Sprint 23."""
+    ``TimeoutError`` — the same observable shape as the per-connection timer."""
     dl = ConnectionDeadline()
     with pytest.raises(TimeoutError):
         with dl.guard(0.05):

--- a/tests/unit/test_depends.py
+++ b/tests/unit/test_depends.py
@@ -1,4 +1,4 @@
-"""``Depends`` provider injection for simplified handlers (Sprint 74).
+"""``Depends`` provider injection for simplified handlers.
 
 Registration-time resolution on the ``_adapt_handler`` seam: a parameter
 whose *default value* is a ``Depends`` instance receives the provider's

--- a/tests/unit/test_error_routing.py
+++ b/tests/unit/test_error_routing.py
@@ -281,7 +281,7 @@ class TestDevErrorPageTraceback:
 class TestDevClientErrorPage:
     """DEV mode, 4xx HTTPException: the framework already diagnosed the
     client's mistake, so the page carries the status + detail line but no
-    Python traceback (Sprint 74).  Tracebacks are for *unexpected* server
+    Python traceback.  Tracebacks are for *unexpected* server
     faults — 5xx and non-HTTPException — which keep the full frames."""
 
     @staticmethod

--- a/tests/unit/test_extension.py
+++ b/tests/unit/test_extension.py
@@ -1,4 +1,4 @@
-"""Unit tests for the generic Extension mechanism (Sprint 53).
+"""Unit tests for the generic Extension mechanism.
 
 Covers the core `Extension` ABC + `BlackBull.add_extension`: registration,
 return-for-chaining, duplicate-key guard, duck-typing of legacy extensions,

--- a/tests/unit/test_extensions.py
+++ b/tests/unit/test_extensions.py
@@ -187,7 +187,7 @@ class TestInitAppConvention:
                "exception that becomes 500). A handler that explicitly "
                "returns Response(status=403) is an emission, not an error "
                "event — wiring status-code matching to handler-returned "
-               "responses requires intercepting send and is out of Sprint 40 "
+               "responses requires intercepting send and is out of "
                "scope.",
         strict=True,
     )

--- a/tests/unit/test_grpc_error_trailing_metadata.py
+++ b/tests/unit/test_grpc_error_trailing_metadata.py
@@ -1,4 +1,4 @@
-"""Error paths carry handler-set trailing metadata (Sprint 66 core hook).
+"""Error paths carry handler-set trailing metadata.
 
 grpcio delivers ``set_trailing_metadata`` even when the call ends non-OK —
 that is what the rich-error model rides on: ``google.rpc.Status`` bytes in a

--- a/tests/unit/test_grpc_stream_flush.py
+++ b/tests/unit/test_grpc_stream_flush.py
@@ -1,7 +1,7 @@
 """Interactive server-streaming must not withhold yielded messages.
 
-The write-coalescing batcher (Sprint 63's streaming-collapse fix) buffers
-consecutive messages into one DATA frame.  Sprint 66's health ``Watch``
+The write-coalescing batcher buffers
+consecutive messages into one DATA frame.  The health ``Watch``
 interop exposed the gap: a producer that *blocks indefinitely* between yields
 (a status watch, a chat stream, a notification feed) had its buffered
 message(s) withheld until the next message completed — for ``Watch``, i.e.

--- a/tests/unit/test_headers.py
+++ b/tests/unit/test_headers.py
@@ -136,3 +136,79 @@ def test_get_sf_item_multiple_lines_of_single_item_is_malformed():
     # Joining two lines of an Item-typed field cannot parse as one Item.
     h = Headers([(b'x-thing', b'1'), (b'x-thing', b'2')])
     assert h.get_sf_item(b'x-thing') is None
+
+
+# ---- probe-first lookup fast path -------------------------------------------
+#
+# `_index` is keyed on lowercased names, so a probe with the caller's bytes
+# can only hit on a key the `.lower()` path would also have found.  These
+# tests pin that equivalence rather than the optimisation: every accessor
+# must answer identically whatever case the caller passes.
+
+@pytest.mark.parametrize('name', [b'content-type', b'Content-Type',
+                                  b'CONTENT-TYPE', b'cOnTeNt-TyPe'])
+def test_lookup_is_case_insensitive_on_every_accessor(h, name):
+    assert (name in h) is True
+    assert h[name] == [(b'content-type', b'text/html')]
+    assert h.getlist(name) == [(b'content-type', b'text/html')]
+    assert h.get(name) == b'text/html'
+
+
+@pytest.mark.parametrize('name', [b'x-absent', b'X-Absent'])
+def test_absent_name_answers_identically_in_any_case(h, name):
+    assert (name in h) is False
+    assert h.getlist(name) == []
+    assert h.get(name) == b''
+    assert h.get(name, b'fallback') == b'fallback'
+    with pytest.raises(KeyError):
+        _ = h[name]
+
+
+def test_mixed_case_lookup_returns_the_same_object_as_lowercase(h):
+    # The cold path must reach the identical bucket, not a copy of it.
+    assert h.getlist(b'Content-Type') is h.getlist(b'content-type')
+    assert h[b'CONTENT-TYPE'] is h[b'content-type']
+
+
+def test_stored_mixed_case_name_is_found_by_lowercase_probe():
+    # Input casing is preserved on iteration but indexed lowercased, so the
+    # hot probe (a lowercase literal) must still find a mixed-case field.
+    h = Headers([(b'Content-Type', b'text/plain')])
+    assert h.get(b'content-type') == b'text/plain'
+    assert list(h) == [(b'Content-Type', b'text/plain')]
+
+
+def test_sf_accessors_are_case_insensitive():
+    h = Headers([(b'Priority', b'u=2, i')])
+    assert h.get_sf_dict(b'priority') == {'u': (2, {}), 'i': (True, {})}
+    assert h.get_sf_dict(b'PRIORITY') == {'u': (2, {}), 'i': (True, {})}
+
+
+# ---- from_lowered -----------------------------------------------------------
+
+def test_from_lowered_matches_the_normal_constructor():
+    pairs = [(b'host', b'a'), (b'set-cookie', b'x=1'), (b'set-cookie', b'y=2')]
+    fast = Headers.from_lowered(list(pairs))
+    slow = Headers(pairs)
+    assert fast == slow
+    assert list(fast) == list(slow)
+    assert fast.getlist(b'set-cookie') == slow.getlist(b'set-cookie')
+    assert fast.get(b'host') == slow.get(b'host')
+
+
+def test_from_lowered_preserves_duplicate_order():
+    h = Headers.from_lowered([(b'set-cookie', b'a=1'), (b'set-cookie', b'b=2')])
+    assert h.getlist(b'set-cookie') == [(b'set-cookie', b'a=1'),
+                                        (b'set-cookie', b'b=2')]
+
+
+def test_from_lowered_stays_case_insensitive_for_callers():
+    h = Headers.from_lowered([(b'content-type', b'text/html')])
+    assert h.get(b'Content-Type') == b'text/html'
+    assert b'CONTENT-TYPE' in h
+
+
+def test_from_lowered_empty():
+    h = Headers.from_lowered([])
+    assert len(h) == 0
+    assert h.get(b'host') == b''

--- a/tests/unit/test_http2_extensions.py
+++ b/tests/unit/test_http2_extensions.py
@@ -1,4 +1,4 @@
-"""Sprint 32 — HTTP/2 scope extensions surface.
+"""HTTP/2 scope extensions surface.
 
 Covers:
 
@@ -47,7 +47,7 @@ class TestBuildExtensions:
 
     def test_push_marker_is_empty_dict(self, default_extensions):
         """Push is signalled by the *presence* of the key, not by
-        contents — matches BlackBull's pre-Sprint-32 behaviour."""
+        contents — matches BlackBull's older behaviour."""
         assert default_extensions[ASGIEvent.HTTP_RESPONSE_PUSH] == {}
 
     def test_priority_contents_match_rfc_9218_default(self, default_extensions):

--- a/tests/unit/test_max_connections_503.py
+++ b/tests/unit/test_max_connections_503.py
@@ -1,13 +1,13 @@
 """Unit tests for the BB_MAX_CONNECTIONS cap behaviour.
 
-Sprint 30 Tier 1.3 + 1.4: when the per-worker cap is hit, new
+When the per-worker cap is hit, new
 connections receive HTTP/1.1 ``503 Service Unavailable`` with
 ``Retry-After: 1`` (well-formed response, not a silent reset).
 
 These tests exercise ``ASGIServer.client_connected_cb`` directly with
 mocked reader/writer pairs so we can assert on the wire bytes.
 
-Sprint 44 (cap-hit observability): the test that drives the cap also
+Cap-hit observability: the test that drives the cap also
 asserts the ``blackbull.caps`` WARNING record fires.
 """
 from __future__ import annotations
@@ -79,7 +79,7 @@ async def _noop_app(scope, receive, send):
 @pytest.mark.asyncio
 async def test_below_cap_no_cap_hit_log(caplog):
     """When _active_connections < max, the connection proceeds normally
-    and no cap-hit log is emitted.  (Sanity + Sprint 44 negative test.)"""
+    and no cap-hit log is emitted.  (Sanity + cap-hit-observability negative test.)"""
     caplog.set_level(logging.WARNING, logger='blackbull.caps')
 
     srv = ASGIServer(_noop_app, max_connections=2)
@@ -98,7 +98,7 @@ async def test_at_cap_sends_503_with_retry_after_and_closes(caplog):
     constructed (verified by the writer's recording — only the 503
     bytes appear, no protocol-specific output).
 
-    Sprint 44: also asserts the cap-hit log fires on blackbull.caps."""
+    Also asserts the cap-hit log fires on blackbull.caps."""
     caplog.set_level(logging.WARNING, logger='blackbull.caps')
 
     srv = ASGIServer(_noop_app, max_connections=1)
@@ -132,7 +132,7 @@ async def test_at_cap_sends_503_with_retry_after_and_closes(caplog):
     # for the rejected connection.
     assert srv._active_connections == 1
 
-    # Sprint 44: cap-hit log must fire.
+    # Cap-hit log must fire.
     caps_records = [
         r for r in caplog.records
         if r.name == 'blackbull.caps' and getattr(r, 'cap', None) == 'max_connections'

--- a/tests/unit/test_middleware_capabilities.py
+++ b/tests/unit/test_middleware_capabilities.py
@@ -46,7 +46,7 @@ async def test_post_processing_runs_after_handler(app):
 
 @pytest.mark.asyncio
 async def test_state_mutation_visible_in_handler(app):
-    # Sprint 80: BlackBull threads a native Connection, so middleware share
+    # BlackBull threads a native Connection, so middleware share
     # per-request data with the handler via ``conn.state`` (the ASGI
     # ``scope['key'] = ...`` grab-bag idiom is gone).
     async def inject_user(scope, receive, send, call_next):

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -431,7 +431,7 @@ class TestHTTPCompression:
     async def test_woff_font_types_not_recompressed(self, content_type):
         """WOFF (zlib-wrapped) and WOFF2 (brotli-wrapped) are pre-compressed —
         re-running brotli on them is high-entropy worst-case CPU work for ~zero
-        size gain.  Sprint 35 phase trace traced a 30-60 ms per-request CPU tail
+        size gain.  A phase trace attributed a 30-60 ms per-request CPU tail
         on HttpArena's regular.woff2 / bold.woff2 to this case.  ``font/ttf``
         and ``font/otf`` stay OFF the skip list — those are uncompressed font
         tables and DO benefit from gzip/brotli."""

--- a/tests/unit/test_mqtt_broker_actor.py
+++ b/tests/unit/test_mqtt_broker_actor.py
@@ -1,4 +1,4 @@
-"""Isolated unit tests for the MQTT ``BrokerActor`` (Sprint 53, Phase 1).
+"""Isolated unit tests for the MQTT ``BrokerActor``.
 
 These drive ``BrokerActor._handle`` directly with recording connection actors,
 so the broker's routing/session/retained/Will logic is verified without sockets,

--- a/tests/unit/test_mqtt_connection_actor.py
+++ b/tests/unit/test_mqtt_connection_actor.py
@@ -1,4 +1,4 @@
-"""End-to-end wiring tests for the two-actor MQTT topology (Sprint 53, Phase 2).
+"""End-to-end wiring tests for the two-actor MQTT topology.
 
 These drive ``serve_connection`` against a live ``BrokerActor`` task using fake
 reader/writer pairs — proving the per-connection actor, its reader loop, and the

--- a/tests/unit/test_mqtt_hardening.py
+++ b/tests/unit/test_mqtt_hardening.py
@@ -1,4 +1,4 @@
-"""Behaviour-level tests for the Sprint 70 MQTT-broker hardening cluster (1.19).
+"""Behaviour-level tests for the MQTT-broker hardening cluster (1.19).
 
 The pre-existing MQTT suite asserted mostly *codec round-trips* — which is
 exactly why the broker-behaviour gaps in this cluster (keep-alive enforcement,
@@ -312,7 +312,7 @@ class TestSubscriptionOptions:
         assert delivered.retain is False
 
     async def test_shared_subscription_granted(self):
-        """Spec change (Sprint 75): §4.8.2 shared subscriptions are now
+        """Spec change: §4.8.2 shared subscriptions are now
         implemented — a well-formed ``$share`` filter is granted, never 0x9E.
         Full behaviour matrix: ``test_mqtt_shared_subscriptions.py``."""
         broker, conn = BrokerActor(), RecordingConn()

--- a/tests/unit/test_mqtt_messages.py
+++ b/tests/unit/test_mqtt_messages.py
@@ -1,5 +1,5 @@
 """
-MQTT 5.0 message dataclass unit tests — Sprint 52.
+MQTT 5.0 message dataclass unit tests.
 
 Tests individual MQTT message dataclasses in isolation (no I/O, no Actor).
 Verifies that message objects behave correctly (construction, equality,

--- a/tests/unit/test_mqtt_shared_subscriptions.py
+++ b/tests/unit/test_mqtt_shared_subscriptions.py
@@ -1,4 +1,4 @@
-"""MQTT 5 §4.8.2 Shared Subscriptions — BrokerActor unit tests (Sprint 75).
+"""MQTT 5 §4.8.2 Shared Subscriptions — BrokerActor unit tests.
 
 Drives ``BrokerActor._handle`` directly with recording connection actors, same
 harness as ``test_mqtt_broker_actor.py``.  Covers the load-balanced fan-out
@@ -75,7 +75,7 @@ async def _group(broker, n, filter_='$share/pool/t', qos=0):
 
 
 # ===========================================================================
-# SUBACK contract — the 0x9E fence is gone (spec change vs Sprint 70)
+# SUBACK contract — the 0x9E fence is gone (spec change)
 # ===========================================================================
 
 class TestSharedSubscribeAccepted:

--- a/tests/unit/test_mqtt_tap.py
+++ b/tests/unit/test_mqtt_tap.py
@@ -1,4 +1,4 @@
-"""Unit tests for the MQTT tap layer (Sprint 54).
+"""Unit tests for the MQTT tap layer.
 
 Covers the ``{name}`` capture compilation/binding, the shared ``run_taps``
 dispatch path, and the decoupled bounded :class:`TapActor` (drop-newest).
@@ -144,7 +144,7 @@ async def test_tap_actor_drops_newest_on_overflow_and_counts():
 
 @asyncio_test
 async def test_extension_tap_registered_after_construction_fires():
-    """Regression (Sprint 73): MQTTExtension builds its TapActor in
+    """Regression: MQTTExtension builds its TapActor in
     __init__, but ``@mqtt.on_message`` registrations happen afterwards —
     the actor must pick them up, not act on a snapshot of the (empty)
     handler list taken at construction time."""

--- a/tests/unit/test_openapi.py
+++ b/tests/unit/test_openapi.py
@@ -376,7 +376,7 @@ class TestHandlerIntrospection:
 
 
 # ---------------------------------------------------------------------------
-# OpenAPIExtension — the reference implementation of the Sprint 40
+# OpenAPIExtension — the reference implementation of the
 # init_app(app) extension convention.
 # ---------------------------------------------------------------------------
 
@@ -496,7 +496,7 @@ def test_extension_emits_spec_that_validates(_spec_validator):
 
 
 class TestQueryParamEmission:
-    """Sprint 74: query params of simplified handlers appear in the minimal
+    """Query params of simplified handlers appear in the minimal
     tier — ``in: query``, schema from the annotation, ``required`` from
     default-presence.  ``Depends`` params are not request inputs and are
     excluded."""

--- a/tests/unit/test_parse_octet_tables.py
+++ b/tests/unit/test_parse_octet_tables.py
@@ -1,0 +1,162 @@
+"""Octet classifiers in `_parse` must be byte-for-byte what they replaced.
+
+The request-target and Host authority scans were per-byte Python generator
+expressions; they are now C-level bulk operations (`bytes.translate` for the
+target's large allowed set, a precompiled regex for Host's small forbidden
+set).  Both rewrites are only safe if they classify all 256 octets exactly as
+the predicates did, so that is what these tests assert — against a literal
+copy of the original predicate, not against a restatement of the new one.
+"""
+import pytest
+
+from blackbull.server.http1_actor import (
+    _HOST_FORBIDDEN_BYTES,
+    _HOST_FORBIDDEN_RE,
+    _TARGET_ALLOWED_OCTETS,
+    BadRequestError,
+    HTTP1Actor,
+)
+
+
+def _target_forbidden_reference(b: int) -> bool:
+    """The predicate as it stood before the table: RFC 9112 §2.1 / RFC 3986."""
+    return b < 0x21 or b == 0x7F or b >= 0x80
+
+
+def _target_rejects(data: bytes) -> bool:
+    return bool(data.translate(None, _TARGET_ALLOWED_OCTETS))
+
+
+@pytest.fixture
+def actor():
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def test_target_table_classifies_all_256_octets_identically():
+    mismatched = [b for b in range(256)
+                  if _target_rejects(bytes([b])) is not _target_forbidden_reference(b)]
+    assert mismatched == []
+
+
+def test_target_table_finds_a_bad_octet_at_any_position():
+    # `translate` scans the whole string, but pin it: a forbidden byte must be
+    # caught mid-target, not only when it leads.
+    for bad in (0x00, 0x1F, 0x20, 0x7F, 0x80, 0xFF):
+        assert _target_rejects(b'/a' + bytes([bad]) + b'/b'), hex(bad)
+
+
+def test_target_table_accepts_a_realistic_target():
+    assert not _target_rejects(b'/api/v1/x?q=1&r=%20#frag')
+
+
+def test_host_regex_classifies_all_256_octets_identically():
+    mismatched = [b for b in range(256)
+                  if bool(_HOST_FORBIDDEN_RE.search(bytes([b]))) is not (b in _HOST_FORBIDDEN_BYTES)]
+    assert mismatched == []
+
+
+def test_host_regex_is_derived_from_the_frozenset():
+    # The two must not be able to drift; the set is the single source of truth.
+    for b in _HOST_FORBIDDEN_BYTES:
+        assert _HOST_FORBIDDEN_RE.search(b'example.com' + bytes([b]))
+
+
+# ---- the same decisions, through the real parser ---------------------------
+
+def _req(target: bytes = b'/', host: bytes = b'localhost') -> bytes:
+    return b'GET ' + target + b' HTTP/1.1\r\nHost: ' + host + b'\r\n\r\n'
+
+
+@pytest.mark.parametrize('bad', [b'\x00', b'\x1f', b'\x7f', b'\x80', b'\xff'])
+def test_parse_rejects_forbidden_target_octet(actor, bad):
+    with pytest.raises(BadRequestError):
+        actor._parse(_req(target=b'/a' + bad + b'b'))
+
+
+@pytest.mark.parametrize('bad', [b'/', b'?', b'#', b' ', b'\t', b'@'])
+def test_parse_rejects_forbidden_host_octet(actor, bad):
+    with pytest.raises(BadRequestError):
+        actor._parse(_req(host=b'exam' + bad + b'ple'))
+
+
+def test_parse_accepts_a_clean_request(actor):
+    conn = actor._parse(_req(target=b'/api/v1/x?q=1', host=b'localhost:8080'))
+    assert conn.path == '/api/v1/x'
+    assert conn.query_string == b'q=1'
+    assert conn.headers.get(b'host') == b'localhost:8080'
+
+
+def test_parse_rejects_empty_target(actor):
+    # `not path` guarded this before the table and still has to: an empty
+    # target survives `translate` (nothing to reject) but is not a target.
+    with pytest.raises(BadRequestError):
+        actor._parse(b'GET  HTTP/1.1\r\nHost: localhost\r\n\r\n')
+
+
+# ---- field-name (tchar) table ----------------------------------------------
+
+def test_tchar_table_classifies_all_256_octets_identically():
+    from blackbull.server.http1_actor import _FIELD_NAME_INVALID_RE, _TCHAR_OCTETS
+    mismatched = [
+        b for b in range(256)
+        if bool(bytes([b]).translate(None, _TCHAR_OCTETS))
+        is not bool(_FIELD_NAME_INVALID_RE.search(bytes([b])))
+    ]
+    assert mismatched == []
+
+
+@pytest.mark.parametrize('name', [b'x y', b'x\x00y', b'x(y', b'x\ty', b'x\x80y'])
+def test_parse_rejects_non_token_header_name(actor, name):
+    with pytest.raises(BadRequestError):
+        actor._parse(b'GET / HTTP/1.1\r\nHost: h\r\n' + name + b': v\r\n\r\n')
+
+
+def test_parse_accepts_every_tchar_in_a_header_name(actor):
+    from blackbull.server.http1_actor import _TCHAR_OCTETS
+    conn = actor._parse(b'GET / HTTP/1.1\r\nHost: h\r\n' + _TCHAR_OCTETS + b': v\r\n\r\n')
+    assert conn.headers.get(_TCHAR_OCTETS.lower()) == b'v'
+
+
+# ---- whole-block CTL pre-scan ----------------------------------------------
+#
+# The per-value regex is skipped when one C-level pass proves no field value
+# can contain a forbidden octet.  The pre-scan is a fast path, never a
+# rejection: when it trips, the per-header regex still runs and still raises
+# the original error.  So what these tests pin is that nothing changes.
+
+def _hdr(extra: bytes) -> bytes:
+    return b'GET / HTTP/1.1\r\nHost: h\r\n' + extra + b'\r\n\r\n'
+
+
+@pytest.mark.parametrize('bad', [b'\x00', b'\x01', b'\x08', b'\x0b', b'\x0c',
+                                 b'\x1f', b'\x7f'])
+def test_parse_rejects_ctl_in_header_value(actor, bad):
+    with pytest.raises(BadRequestError):
+        actor._parse(_hdr(b'X-Thing: a' + bad + b'b'))
+
+
+@pytest.mark.parametrize('bad', [b'\r', b'\n'])
+def test_parse_rejects_bare_cr_or_lf_in_header_value(actor, bad):
+    # Neither is a line terminator on its own; both are smuggling vectors.
+    with pytest.raises(BadRequestError):
+        actor._parse(_hdr(b'X-Thing: a' + bad + b'b'))
+
+
+def test_parse_allows_htab_inside_a_header_value(actor):
+    # HTAB is the one CTL a field value may carry (RFC 9110 §5.5).
+    conn = actor._parse(_hdr(b'X-Thing: a\tb'))
+    assert conn.headers.get(b'x-thing') == b'a\tb'
+
+
+def test_parse_allows_obs_text_in_a_header_value(actor):
+    conn = actor._parse(_hdr(b'X-Thing: caf\xc3\xa9'))
+    assert conn.headers.get(b'x-thing') == b'caf\xc3\xa9'
+
+
+def test_ctl_in_request_line_still_reports_the_request_line_error(actor):
+    # The pre-scan covers the whole block, so a CTL in the request target
+    # trips it — but the target check must still be what rejects the request.
+    with pytest.raises(BadRequestError, match='request-target'):
+        actor._parse(b'GET /a\x01b HTTP/1.1\r\nHost: h\r\n\r\n')

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -15,12 +15,12 @@ from blackbull.server.parser import parse_headers as _real_parse_headers
 def _parse_headers(frame) -> dict:
     """Parse an HTTP/2 HEADERS frame and return the derived ASGI scope.
 
-    Sprint 79 Phase 4 — ``parse_headers`` now returns a native ``Connection``;
+    ``parse_headers`` now returns a native ``Connection``;
     this suite asserts on the derived ASGI scope shape (the H/2 actor bridge
     materializes the same view), so convert via the single ``as_scope()``
     builder (headers therefore appear in the ASGI ``list[tuple]`` form).
 
-    ``parse_headers`` returns ``None`` on malformed input (Sprint 79 — no
+    ``parse_headers`` returns ``None`` on malformed input (no
     throwaway Connection on the error path); this wrapper is only fed
     well-formed frames, so a ``None`` here is a test-setup error.
     """
@@ -32,7 +32,7 @@ def _parse_headers(frame) -> dict:
 def _get_scope(raw_request: bytes) -> dict:
     """Parse raw HTTP/1.1 request bytes and return the derived ASGI scope.
 
-    Sprint 79 Phase 3 — ``_parse`` now returns a native ``Connection``; this
+    ``_parse`` now returns a native ``Connection``; this
     suite asserts on the derived ASGI scope shape, so materialize it via the
     single ``as_scope()`` builder (headers therefore appear in the ASGI
     ``list[tuple]`` form, not as a ``Headers`` object).
@@ -146,7 +146,7 @@ class TestParse:
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
     def test_root_path_ignores_x_forwarded_prefix_off_the_wire(self, prefix):
-        # Spec change (audit bug 1.16, Sprint 63): a client-controlled
+        # Spec change (audit bug 1.16): a client-controlled
         # X-Forwarded-Prefix must NOT set root_path at the parser layer —
         # it is only honoured behind TrustedProxy (see
         # tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).
@@ -169,10 +169,10 @@ class TestParse:
         assert _get_scope(_http_request(path='/tasks'))['query_string'] == b''
 
     # ------------------------------------------------------------------
-    # Sprint 25 Phase A / Sprint 68 — _parse URL splitter boundary cases.
+    # _parse URL splitter boundary cases.
     #
     # http1_actor._parse splits the byte request-target with a partition
-    # chain: strip #fragment, separate ?query.  Sprint 68 stopped dropping
+    # chain: strip #fragment, separate ?query.  It does not drop
     # ;params — RFC 3986 treats ';' as an ordinary path sub-delimiter (the
     # ;params grammar is obsolete RFC 2396), so both `path` and `raw_path`
     # now preserve it (uvicorn parity; the two fields must be the same
@@ -182,13 +182,13 @@ class TestParse:
 
     def test_path_strips_fragment(self):
         """RFC 7230 §5.3 — fragment must not appear in request-target;
-        it is silently stripped.  Pre-Sprint-25 behaviour preserved."""
+        it is silently stripped."""
         scope = _get_scope(_http_request(path='/api#frag'))
         assert scope['path'] == '/api'
         assert scope['query_string'] == b''
 
     def test_path_keeps_semicolon_params(self):
-        """Sprint 68 — ';' is an RFC 3986 path sub-delimiter, not a params
+        """';' is an RFC 3986 path sub-delimiter, not a params
         separator; it stays in the path (and in raw_path)."""
         scope = _get_scope(_http_request(path='/cart;sid=abc'))
         assert scope['path'] == '/cart;sid=abc'
@@ -230,7 +230,7 @@ class TestParse:
 
     def test_raw_path_is_undecoded_path_component(self):
         """ASGI: raw_path is the path component only — undecoded bytes,
-        query string excluded, ;params kept (spec change, Sprint 68 W1;
+        query string excluded, ;params kept (spec change;
         previously the full request target including the query)."""
         scope = _get_scope(_http_request(path='/cart;sid=abc?x=1'))
         assert scope['raw_path'] == b'/cart;sid=abc'
@@ -242,7 +242,7 @@ class TestParse:
         assert _get_scope(_http_request(version='HTTP/1.1'))['http_version'] == '1.1'
 
     # ------------------------------------------------------------------
-    # Sprint 25 Phase B — compiled-regex header validators.
+    # Compiled-regex header validators.
     #
     # Replaced per-byte `any(...)` scans in _parse with compiled
     # `_FIELD_NAME_INVALID_RE.search(...)` and
@@ -266,7 +266,7 @@ class TestParse:
         0x22,  # " — separator
         0x28,  # ( — separator
         0x40,  # @ — separator
-        0x7B,  # { — separator (Sprint 25 Phase B boundary)
+        0x7B,  # { — separator
         0x7F,  # DEL — CTL
     ])
     def test_non_tchar_rejected_in_method(self, bad_byte):
@@ -364,7 +364,7 @@ class TestHTTP2ScopeFields:
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
     def test_x_forwarded_prefix_ignored_off_the_wire(self, prefix):
-        # Bug 1.16 (Sprint 63): same contract on the H2 path — the frame-level
+        # Bug 1.16: same contract on the H2 path — the frame-level
         # parser must not trust a client-supplied X-Forwarded-Prefix.  Only
         # the TrustedProxy middleware may set root_path, after verifying the
         # peer (see tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).
@@ -376,8 +376,7 @@ class TestHTTP2ScopeFields:
 
 
 class TestParseHeadersNoneContract:
-    """Sprint 80 alloc hygiene (`connection-alloc-hygiene.md` Phase 1,
-    2026-07-24): ``parse_headers`` returns ``None`` on every path that marks
+    """Alloc hygiene: ``parse_headers`` returns ``None`` on every path that marks
     the frame malformed, uniformly — including host-authority validation
     failure, which the pre-refactor version answered with a half-built
     ``Connection`` instead (never observed by the real actor, which checks
@@ -421,7 +420,7 @@ class TestParseHeadersNoneContract:
 
 
 class TestPathPercentDecodingH1:
-    """Sprint 68 W1 — ASGI conformance: ``scope['path']`` carries the
+    """ASGI conformance: ``scope['path']`` carries the
     percent-decoded (UTF-8) path component; ``scope['raw_path']`` carries
     the undecoded path-component bytes (query excluded); the query string
     stays raw on the wire encoding.
@@ -508,7 +507,7 @@ class TestPathPercentDecodingH2:
         assert self._scope('/a%41b?x=1')['raw_path'] == b'/a%41b'
 
     def test_semicolon_params_preserved(self):
-        # Sprint 68 — urlsplit (not urlparse) keeps ';params' in the path,
+        # Urlsplit (not urlparse) keeps ';params' in the path,
         # so both path and raw_path carry the sub-delimiter (the latent H2
         # raw_path-stripping bug is fixed).
         scope = self._scope('/cart;sid=abc?x=1')

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -146,7 +146,7 @@ class TestParse:
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
     def test_root_path_ignores_x_forwarded_prefix_off_the_wire(self, prefix):
-        # Spec change (audit bug 1.16): a client-controlled
+        # Spec change: a client-controlled
         # X-Forwarded-Prefix must NOT set root_path at the parser layer —
         # it is only honoured behind TrustedProxy (see
         # tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).
@@ -364,7 +364,7 @@ class TestHTTP2ScopeFields:
 
     @given(prefix=st.from_regex(r'/[a-zA-Z0-9/_-]{0,40}', fullmatch=True))
     def test_x_forwarded_prefix_ignored_off_the_wire(self, prefix):
-        # Bug 1.16: same contract on the H2 path — the frame-level
+        # Same contract on the H2 path — the frame-level
         # parser must not trust a client-supplied X-Forwarded-Prefix.  Only
         # the TrustedProxy middleware may set root_path, after verifying the
         # peer (see tests/unit/test_audit_sprint63.py::TestXForwardedPrefixTrust).

--- a/tests/unit/test_protocol_events.py
+++ b/tests/unit/test_protocol_events.py
@@ -1,4 +1,4 @@
-"""Protocol-agnostic Level B events (Sprint 50).
+"""Protocol-agnostic Level B events.
 
 Uses a real EventDispatcher with *interceptor* handlers (awaited inline by
 emit) so emission is deterministic without draining fire-and-forget tasks.

--- a/tests/unit/test_protocol_registry.py
+++ b/tests/unit/test_protocol_registry.py
@@ -1,4 +1,4 @@
-"""Unit tests for the unified protocol registry (Sprint 50/51)."""
+"""Unit tests for the unified protocol registry."""
 import pytest
 
 from blackbull.server.protocol_registry import (

--- a/tests/unit/test_proxy_middleware.py
+++ b/tests/unit/test_proxy_middleware.py
@@ -125,7 +125,7 @@ async def test_forwarded_header_for_only():
 async def test_forwarded_multi_element_uses_leftmost():
     """RFC 7239 §4 — elements are comma-separated; parse the leftmost only.
 
-    Bug 1.21e: splitting on ';' alone folded the second element's ``for=``
+    Splitting on ';' alone folded the second element's ``for=``
     into the first value, poisoning ``scope['client']``.
     """
     mw = TrustedProxy('127.0.0.1')

--- a/tests/unit/test_query_accept_query.py
+++ b/tests/unit/test_query_accept_query.py
@@ -1,4 +1,4 @@
-"""RFC 10008 §2.2 / §3 — QUERY normative response semantics (Sprint 78 P2).
+"""RFC 10008 §2.2 / §3 — QUERY normative response semantics.
 
 A QUERY route may declare the request media types it accepts via the
 ``accept_query=[...]`` route option.  That drives two behaviours:

--- a/tests/unit/test_query_method.py
+++ b/tests/unit/test_query_method.py
@@ -1,4 +1,4 @@
-"""HTTP QUERY method support (RFC 10008) — Sprint 78 P1.
+"""HTTP QUERY method support (RFC 10008).
 
 QUERY (RFC 10008, June 2026) is the first new standard HTTP method since
 PATCH: safe + idempotent + cacheable, **with a request body**.  The stdlib
@@ -16,7 +16,7 @@ from http import HTTPMethod
 
 import pytest
 
-from blackbull import BlackBull, Connection as Request, QUERY  # Sprint 79 alias
+from blackbull import BlackBull, Connection as Request, QUERY  # deprecated alias
 from blackbull.router import Router, MethodNotApplicable
 from blackbull.utils import Scheme
 from blackbull.testing import TestClient
@@ -143,7 +143,7 @@ class TestQueryDispatch:
 
 
 # ---------------------------------------------------------------------------
-# OpenAPI: QUERY routes are excluded under the 3.1 emitter (Sprint 78 P3)
+# OpenAPI: QUERY routes are excluded under the 3.1 emitter
 # ---------------------------------------------------------------------------
 
 class TestQueryOpenAPI:

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -1,4 +1,4 @@
-"""Query-param resolution in the simplified handler model (Sprint 74).
+"""Query-param resolution in the simplified handler model.
 
 Handler parameters that are neither path params, ``body``, ``scope``,
 ``Request``, a dataclass body, nor ``Depends(...)`` resolve from
@@ -218,7 +218,7 @@ class TestQueryParamRegistration:
 
     @pytest.mark.asyncio
     async def test_request_name_with_scalar_annotation_is_query_param(self):
-        # Spec change (Sprint 74): a param named 'request' with a scalar
+        # Spec change: a param named 'request' with a scalar
         # annotation used to be a registration-time TypeError; it is now an
         # ordinary query param.  Request injection still requires the Request
         # annotation or the bare name 'request' (unannotated).

--- a/tests/unit/test_reload.py
+++ b/tests/unit/test_reload.py
@@ -163,7 +163,7 @@ def test_reload_disables_reuseport(monkeypatch):
     from blackbull.server.multiworker import MultiWorkerServer
     from blackbull import BlackBull
 
-    # Pre-bind a master socket the way bench/aws/run.sh does — Sprint 22.
+    # Pre-bind a master socket the way bench/aws/run.sh does.
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(('127.0.0.1', 0))

--- a/tests/unit/test_request_object.py
+++ b/tests/unit/test_request_object.py
@@ -1,5 +1,5 @@
 """Unit tests for the opt-in HTTP handler context object — now
-:class:`blackbull.connection.Connection` (Sprint 79 Phase 5; ``Request`` is a
+:class:`blackbull.connection.Connection` (``Request`` is a
 deprecated alias of it).
 
 Pure-unit layer: hand-built scope dicts and fake receive callables, no I/O.

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -1106,7 +1106,7 @@ class TestDataclassBodyDeserialization:
 
     @pytest.mark.asyncio
     async def test_missing_required_field_raises(self):
-        """A body missing a required field is a client error → 400 (bug 1.12)."""
+        """A body missing a required field is a client error → 400."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')
         with pytest.raises(HTTPException) as exc_info:
@@ -1115,7 +1115,7 @@ class TestDataclassBodyDeserialization:
 
     @pytest.mark.asyncio
     async def test_unknown_field_raises(self):
-        """An unknown body field is a client error → 400 (bug 1.12)."""
+        """An unknown body field is a client error → 400."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')
         with pytest.raises(HTTPException, match='Unknown field') as exc_info:
@@ -1176,7 +1176,7 @@ class TestDataclassBodyDeserialization:
 
     @pytest.mark.asyncio
     async def test_invalid_json_raises(self):
-        """Malformed JSON in the body is a client error → 400 (bug 1.12),
+        """Malformed JSON in the body is a client error → 400,
         not the raw JSONDecodeError that used to surface as a 500."""
         async def fn(body: _Item): pass
         wrapper = _adapt_handler(fn, '/items')

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -27,7 +27,7 @@ from blackbull.router import (
     PathNotRegistered, MethodNotApplicable, ConfigurationError, HTTPException,
 )
 from blackbull import BlackBull, Response, JSONResponse
-from blackbull import Connection as Request  # Sprint 79: Request is a deprecated Connection alias
+from blackbull import Connection as Request  # ``Request`` is a deprecated Connection alias
 from blackbull.router import RouteGroup
 
 logger = getLogger(__name__)
@@ -142,7 +142,7 @@ def test_router_regex(router):
 async def test_router_regex_with_group_name1(router):
     # Custom regex routes take a compiled re.Pattern (the documented
     # contract).  A raw regex *string* is rejected at registration since
-    # Sprint 64 — see test_router_regex_source_string_rejected.
+    # See test_router_regex_source_string_rejected.
     path = re.compile(r'^test/(?P<id_>\d+)$')
     scheme = Scheme.http
 
@@ -573,7 +573,7 @@ class TestSimplifiedHandlerDetection:
 
 
 class TestSimplifiedHandlerFailFast:
-    # Spec change (Sprint 74): a scalar param that matches no path
+    # Spec change: a scalar param that matches no path
     # placeholder is now a *query param*, not a registration error — the
     # fail-fast contract holds only for annotations no category can resolve.
     def test_unresolvable_annotation_raises_at_registration(self):
@@ -756,7 +756,7 @@ class TestSimplifiedHandlerBodyInjection:
 
 
 class TestSimplifiedHandlerRequestInjection:
-    """Injection matrix for the opt-in Request context object (Sprint 65)."""
+    """Injection matrix for the opt-in Request context object."""
 
     @staticmethod
     def _counting_receive(body: bytes = b'hello'):
@@ -853,7 +853,7 @@ class TestSimplifiedHandlerRequestInjection:
         assert len(calls) == 1
 
     def test_request_name_with_foreign_annotation_is_not_request_injected(self):
-        # Spec change (Sprint 74): 'request' with a scalar annotation used to
+        # Spec change: 'request' with a scalar annotation used to
         # be a registration TypeError; it is now an ordinary query param
         # (asserted in test_query_params.py).  An unresolvable annotation on
         # the name still fails fast — proving no Request fallback kicks in.
@@ -1285,7 +1285,7 @@ class TestRouterEdgeCases:
     def test_route_fn_invalid_method_token_raises(self):
         """Method strings must be valid RFC 9110 §5.6.2 tokens.
 
-        Valid str methods like 'BREW' are accepted (Sprint 47).
+        Valid str methods like 'BREW' are accepted.
         Strings containing spaces, control characters, or separator
         characters are not valid tokens and must raise ValueError.
         """

--- a/tests/unit/test_router_trie.py
+++ b/tests/unit/test_router_trie.py
@@ -112,7 +112,7 @@ def test_trie_multiple_params():
 
 
 # ---------------------------------------------------------------------------
-# Backtracking pins (Sprint 77) — behaviours the lookup fast path must keep
+# Backtracking pins — behaviours the lookup fast path must keep
 # ---------------------------------------------------------------------------
 
 def test_trie_backtracks_to_param_when_static_dead_ends_deeper():
@@ -365,7 +365,7 @@ async def test_lookup_cache_parametrized_route_injects_correct_params():
     fn = router[key]
     assert key in router._cache
 
-    # Cached closure injects params correctly (Sprint 79: onto conn.path_params)
+    # Cached closure injects params correctly
     scope: dict = {}
     await fn(scope, None, None)
     assert scope['_connection'].path_params == {'task_id': '42'}
@@ -379,7 +379,7 @@ async def test_lookup_cache_parametrized_route_injects_correct_params():
 
 
 # ---------------------------------------------------------------------------
-# _LookupCache — swappable cache-strategy extraction (Sprint 68 follow-up)
+# _LookupCache — swappable cache-strategy extraction
 # ---------------------------------------------------------------------------
 
 def test_router_uses_lookupcache_instance():

--- a/tests/unit/test_rsock.py
+++ b/tests/unit/test_rsock.py
@@ -282,11 +282,11 @@ class TestCreateDualStackSockets:
 
 
 # ---------------------------------------------------------------------------
-# create_unix_socket — Sprint 12a
+# create_unix_socket
 # ---------------------------------------------------------------------------
 
 class TestCreateUnixSocket:
-    """Tests for the AF_UNIX bind helper added in Sprint 12a."""
+    """Tests for the AF_UNIX bind helper."""
 
     def test_binds_listens_and_returns_socket(self, tmp_path):
         path = str(tmp_path / 'bb.sock')
@@ -355,11 +355,11 @@ class TestCreateUnixSocket:
 
 
 # ---------------------------------------------------------------------------
-# adopt_listening_fd — Sprint 12b
+# adopt_listening_fd
 # ---------------------------------------------------------------------------
 
 class TestAdoptListeningFd:
-    """Tests for adopt_listening_fd() added in Sprint 12b."""
+    """Tests for adopt_listening_fd()."""
 
     @pytest.fixture()
     def listening_sock(self):

--- a/tests/unit/test_slots_microbench.py
+++ b/tests/unit/test_slots_microbench.py
@@ -10,7 +10,7 @@ regression hits a benchmark.
 
 The printed sizes are informational only: ``sys.getsizeof`` reports the
 base object size, not the recursive footprint of the slot values, but
-that's the dimension this sprint set out to compress.
+that's the dimension this work set out to compress.
 """
 import sys
 
@@ -106,7 +106,7 @@ def test_print_per_instance_sizes(capsys):
         'WebSocketSender':  _sizeof(WebSocketSender(_FakeWriter())),
     }
     # Print under pytest -s (or always — captured otherwise) so the values
-    # land in the test log when the sprint-close measurement is taken.
+    # land in the test log when the measurement is taken.
     print('\nPer-instance sizes (sys.getsizeof, bytes):')
     for name, size in sizes.items():
         print(f'  {name:<20s} {size:>4d}')

--- a/tests/unit/test_sse.py
+++ b/tests/unit/test_sse.py
@@ -1,4 +1,4 @@
-"""Sprint 45 — Server-Sent Events / streaming surface.
+"""Server-Sent Events / streaming surface.
 
 Three things to gate:
 

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -19,7 +19,7 @@ from blackbull.headers import Headers
 
 def _scope(method: str = 'GET', path: str = '/',
            headers: dict[str, str] | None = None) -> 'Connection':
-    # Sprint 80: BlackBull threads a native Connection (not an ASGI scope dict)
+    # BlackBull threads a native Connection (not an ASGI scope dict)
     # through the middleware/handler pipeline for HTTP.
     from blackbull.connection import Connection
     raw = [(k.lower().encode(), v.encode())
@@ -122,7 +122,7 @@ class TestStaticFilesBasic:
             self, static_dir, filename, expected_ct):
         """Common web asset MIME types must resolve correctly even when
         the host's ``/etc/mime.types`` is missing or sparse (e.g.
-        ``python:3.13-slim`` containers).  Sprint 35 phase-trace traced
+        ``python:3.13-slim`` containers).  A phase trace attributed
         a 30-60 ms per-request CPU tail on woff2 files to this case:
         no mime entry → ``application/octet-stream`` Content-Type →
         Compression middleware brotli-encoded already-compressed bytes.
@@ -363,7 +363,7 @@ class TestBlackBullStaticRegistration:
 
 
 # ---------------------------------------------------------------------------
-# Precompressed-variant serving (Sprint 29 #1)
+# Precompressed-variant serving
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
@@ -515,7 +515,7 @@ class TestPrecompressedVariant:
 
 
 # ---------------------------------------------------------------------------
-# Sprint 31 — ``http.response.pathsend`` extension wiring
+# ``http.response.pathsend`` extension wiring
 # ---------------------------------------------------------------------------
 
 @pytest.fixture

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -342,24 +342,24 @@ class TestBlackBullStaticRegistration:
         app.static('/b', str(other))
         assert len(app._static_roots) == 2
 
-    async def test_static_injects_staticfiles_into_global_chain(self, static_dir):
+    async def test_static_adds_no_global_middleware(self, static_dir):
+        # `app.static()` registers a route, so requests that are not for a
+        # static path never run this middleware at all.  Nothing global.
         from blackbull import BlackBull
-        from blackbull.middleware.static import StaticFiles
         app = BlackBull()
         app.static('/assets', str(static_dir))
-        assert len(app._global_middlewares) == 1
-        assert isinstance(app._global_middlewares[0], StaticFiles)
+        assert app._global_middlewares == []
 
     async def test_prefix_file_served_end_to_end(self, static_dir):
-        """Global middleware serves /assets/hello.txt when registered via app.static()."""
+        """/assets/hello.txt is served through the route registered by static()."""
         from blackbull import BlackBull
+        from blackbull.testing import TestClient
         app = BlackBull()
         app.static('/assets', str(static_dir))
-        # Exercise the StaticFiles middleware directly (avoids _wrap_send adapter)
-        mw = app._global_middlewares[0]
-        start, body = await _collect(mw, _scope(path='/assets/hello.txt'))
-        assert start['status'] == 200
-        assert body == b'Hello, static world!'
+        with TestClient(app) as client:
+            response = client.get('/assets/hello.txt')
+        assert response.status_code == 200
+        assert response.content == b'Hello, static world!'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_static.py
+++ b/tests/unit/test_static.py
@@ -614,7 +614,7 @@ def _headers_of(start: dict) -> dict[bytes, bytes]:
 class TestStaticFilesMalformedRange:
     """A crafted Range header must be ignored (200) or answered 416 — never 500.
 
-    Bug 1.21c: bare ``int()`` on the range bounds raised ``ValueError`` out
+    Bare ``int()`` on the range bounds raised ``ValueError`` out
     of ``_serve`` on inputs like ``bytes=abc-def``.
     """
 

--- a/tests/unit/test_static_routing.py
+++ b/tests/unit/test_static_routing.py
@@ -1,0 +1,181 @@
+"""`app.static()` behaviour that must survive the move to a route middleware.
+
+These are end-to-end through `TestClient`, deliberately: the point of the
+change is *where* static serving is dispatched from, so a test that pokes
+the middleware object directly would not notice if dispatch broke.
+
+Written against the global-middleware implementation and expected to pass
+unchanged afterwards — the bare-prefix cases in particular, since the `path`
+converter is `r'.+'` and cannot match an empty segment.
+"""
+import pathlib
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.testing import TestClient
+
+
+@pytest.fixture
+def site(tmp_path: pathlib.Path) -> pathlib.Path:
+    (tmp_path / 'hello.txt').write_bytes(b'Hello, static world!')
+    (tmp_path / 'index.html').write_bytes(b'<h1>root index</h1>')
+    sub = tmp_path / 'sub'
+    sub.mkdir()
+    (sub / 'deep.txt').write_bytes(b'deep')
+    (sub / 'index.html').write_bytes(b'<h1>sub index</h1>')
+    return tmp_path
+
+
+def _app(site: pathlib.Path, *, prefix: str = '/assets', **kw) -> BlackBull:
+    app = BlackBull()
+    app.static(prefix, str(site), **kw)
+
+    @app.route(path='/')
+    async def home():
+        return 'home'
+
+    return app
+
+
+class TestFileServing:
+    def test_serves_a_file_under_the_prefix(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/hello.txt')
+        assert r.status_code == 200
+        assert r.content == b'Hello, static world!'
+
+    def test_serves_a_nested_file(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/sub/deep.txt')
+        assert r.status_code == 200
+        assert r.content == b'deep'
+
+    def test_missing_file_under_the_prefix_is_404(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/nope.txt')
+        assert r.status_code == 404
+
+    def test_non_static_route_is_untouched(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/')
+        assert r.status_code == 200
+        assert r.text == 'home'
+
+    def test_traversal_out_of_root_is_rejected(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/../../etc/passwd')
+        assert r.status_code in (400, 404)
+
+    def test_head_is_served(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.head('/assets/hello.txt')
+        assert r.status_code == 200
+
+
+class TestBarePrefixWithIndex:
+    """The compatibility risk called out in the proposal §7.4.
+
+    With `index=` set, a request for the prefix itself resolves to the root
+    directory and serves the index file.  `/assets/{filepath:path}` cannot
+    match either spelling, so the route form has to register the bare prefix
+    too or these regress.
+    """
+
+    def test_prefix_with_trailing_slash_serves_index(self, site):
+        with TestClient(_app(site, index='index.html')) as client:
+            r = client.get('/assets/')
+        assert r.status_code == 200
+        assert r.content == b'<h1>root index</h1>'
+
+    def test_prefix_without_trailing_slash_serves_index(self, site):
+        with TestClient(_app(site, index='index.html')) as client:
+            r = client.get('/assets')
+        assert r.status_code == 200
+        assert r.content == b'<h1>root index</h1>'
+
+    def test_subdirectory_serves_its_index(self, site):
+        with TestClient(_app(site, index='index.html')) as client:
+            r = client.get('/assets/sub/')
+        assert r.status_code == 200
+        assert r.content == b'<h1>sub index</h1>'
+
+    def test_directory_without_index_option_is_not_listed(self, site):
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/sub/')
+        assert r.status_code == 404
+
+
+class TestMultipleStaticMounts:
+    def test_each_prefix_serves_its_own_root(self, tmp_path):
+        a, b = tmp_path / 'a', tmp_path / 'b'
+        a.mkdir(), b.mkdir()
+        (a / 'f.txt').write_bytes(b'from-a')
+        (b / 'f.txt').write_bytes(b'from-b')
+        app = BlackBull()
+        app.static('/a', str(a))
+        app.static('/b', str(b))
+        with TestClient(app) as client:
+            assert client.get('/a/f.txt').content == b'from-a'
+            assert client.get('/b/f.txt').content == b'from-b'
+
+    def test_static_roots_records_every_mount(self, tmp_path):
+        a, b = tmp_path / 'a', tmp_path / 'b'
+        a.mkdir(), b.mkdir()
+        app = BlackBull()
+        app.static('/a', str(a))
+        app.static('/b', str(b))
+        assert len(app._static_roots) == 2
+
+
+class TestProductionGate:
+    def test_production_does_not_serve_static(self, site, monkeypatch):
+        monkeypatch.setenv('BLACKBULL_ENV', 'production')
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/hello.txt')
+        assert r.status_code == 404
+
+    def test_development_serves_static(self, site, monkeypatch):
+        monkeypatch.setenv('BLACKBULL_ENV', 'development')
+        with TestClient(_app(site)) as client:
+            r = client.get('/assets/hello.txt')
+        assert r.status_code == 200
+
+
+class TestExplicitRoutesWin:
+    """Registering a path twice replaces the first entry silently, so
+    `static()` must not claim a bare prefix an explicit route already owns."""
+
+    def test_root_mount_does_not_eat_the_apps_own_root_route(self, site):
+        app = BlackBull()
+
+        @app.route(path='/')
+        async def home():
+            return 'home'
+
+        app.static('/', str(site), index='index.html')
+        with TestClient(app) as client:
+            r = client.get('/')
+            asset = client.get('/hello.txt')
+        assert r.text == 'home'
+        assert asset.content == b'Hello, static world!'
+
+    def test_root_mount_serves_index_when_no_root_route_exists(self, site):
+        app = BlackBull()
+        app.static('/', str(site), index='index.html')
+        with TestClient(app) as client:
+            r = client.get('/')
+        assert r.status_code == 200
+        assert r.content == b'<h1>root index</h1>'
+
+    def test_explicit_route_on_the_prefix_wins(self, site):
+        app = BlackBull()
+
+        @app.route(path='/assets')
+        async def listing():
+            return 'listing'
+
+        app.static('/assets', str(site), index='index.html')
+        with TestClient(app) as client:
+            assert client.get('/assets').text == 'listing'
+            assert client.get('/assets/hello.txt').content == b'Hello, static world!'

--- a/tests/unit/test_streaming.py
+++ b/tests/unit/test_streaming.py
@@ -123,7 +123,7 @@ class TestHTTP1SenderChunked:
 
 
 # ---------------------------------------------------------------------------
-# TestHTTP1SenderPathsend  (Sprint 31)
+# TestHTTP1SenderPathsend 
 # ---------------------------------------------------------------------------
 
 class TestHTTP1SenderPathsend:
@@ -381,7 +381,7 @@ class TestUseWarning:
 
 
 # ---------------------------------------------------------------------------
-# TestHTTP1SenderRenderStart  (Sprint refactor — lock the wire format)
+# TestHTTP1SenderRenderStart  (lock the wire format)
 # ---------------------------------------------------------------------------
 
 class TestHTTP1SenderRenderStart:
@@ -406,8 +406,8 @@ class TestHTTP1SenderRenderStart:
         assert out == b'HTTP/1.1 204 No Content\r\n\r\n'
 
     def test_reset_per_request_state_clears_all_slots(self):
-        # Sprint refactor — guard against the "I added a slot and forgot to
-        # reset it" regression that bit Sprint 38 (BB_REQUEST_TIMEOUT 408
+        # Guard against the "I added a slot and forgot to
+        # reset it" regression (BB_REQUEST_TIMEOUT 408
         # skipped on the second keep-alive request because `_started`
         # stayed True).
         from http import HTTPStatus

--- a/tests/unit/test_testclient.py
+++ b/tests/unit/test_testclient.py
@@ -121,7 +121,7 @@ def test_post_body_round_trip_via_simplified_handler() -> None:
 
 def test_request_object_end_to_end() -> None:
     """A handler taking the opt-in Request sees method/headers/cookies/body."""
-    from blackbull import Connection as Request  # Sprint 79 alias
+    from blackbull import Connection as Request  # deprecated alias
 
     app = BlackBull()
 
@@ -181,9 +181,9 @@ def test_websocket_text_round_trip() -> None:
 
 
 def test_ws_testclient_conn_matches_server_decoding() -> None:
-    """Sprint 68 — the WS test client must build the same request fields the
+    """The WS test client must build the same request fields the
     real server would: percent-decoded ``path``, undecoded UTF-8 ``raw_path``,
-    query excluded from both. WebSocket is native (Sprint 80), so the session
+    query excluded from both. WebSocket is native, so the session
     threads a Connection — assert on ``conn.*``, not a scope dict."""
     session = WebSocketTestSession(app=None, path='/chat/caf%C3%A9?x=%41')
     assert session._conn.path == '/chat/café'
@@ -199,7 +199,7 @@ def test_ws_testclient_plain_path_unchanged() -> None:
 
 def test_ws_testclient_non_ascii_query_string_utf8() -> None:
     """query_string is UTF-8 encoded, for parity with raw_path and the real
-    server — a non-ASCII query must not raise (was latin-1, Sprint 68 follow-up)."""
+    server — a non-ASCII query must not raise (it was latin-1)."""
     session = WebSocketTestSession(app=None, path='/search?q=café')
     assert session._conn.query_string == 'q=café'.encode('utf-8')
 

--- a/tests/unit/test_websocket_injection.py
+++ b/tests/unit/test_websocket_injection.py
@@ -1,6 +1,6 @@
-"""Signature injection into WebSocket handlers (Sprint 83).
+"""Signature injection into WebSocket handlers.
 
-Sprint 82 gave a WebSocket handler its object; this covers what the *signature*
+A WebSocket handler gets its object; this covers what the *signature*
 may declare alongside it — path params, query params, and ``Depends`` — plus
 the registration-time errors that keep an unresolvable parameter loud.
 
@@ -143,7 +143,7 @@ def test_unresolvable_parameter_still_fails_at_registration_through_the_router()
 
 
 # ---------------------------------------------------------------------------
-# The ws-only fast path is untouched (Sprint 83 gate)
+# The ws-only fast path is untouched
 # ---------------------------------------------------------------------------
 
 def test_lone_ws_still_compiles_to_the_fast_path_wrapper():
@@ -278,7 +278,7 @@ async def test_depends_teardown_runs_on_clean_return():
 
 @pytest.mark.asyncio
 async def test_depends_teardown_runs_on_abrupt_disconnect():
-    """The sprint gate: teardown must not be tied to a *clean* close.
+    """The gate: teardown must not be tied to a *clean* close.
 
     ``WebSocketDisconnect`` propagating out of the handler is what an abrupt
     peer loss looks like from inside one. Note the ``try/finally`` — see
@@ -360,7 +360,7 @@ async def test_bare_yield_provider_does_not_tear_down_on_an_exception():
 
 @pytest.mark.asyncio
 async def test_dependency_is_resolved_once_per_connection_not_per_message():
-    """The Sprint 82 rule — object per connection — governs dependencies too."""
+    """The rule — object per connection — governs dependencies too."""
     setups = []
 
     async def provider():
@@ -402,7 +402,7 @@ async def test_cached_dependency_is_shared_between_parameters():
 
 @pytest.mark.asyncio
 async def test_everything_together():
-    """The signature the sprint set out to make work."""
+    """The signature the feature set out to make work."""
     seen = {}
 
     async def get_db():

--- a/tests/unit/test_websocket_injection_e2e.py
+++ b/tests/unit/test_websocket_injection_e2e.py
@@ -1,4 +1,4 @@
-"""Signature injection over the real stack (Sprint 83).
+"""Signature injection over the real stack.
 
 ``test_websocket_injection.py`` pins the plan and the wrapper against a
 scripted channel. This file drives the same signatures through
@@ -117,7 +117,7 @@ def test_dependency_is_live_for_the_whole_socket_and_torn_down_after_it():
     """One resolution serves every message, and release happens on disconnect.
 
     The teardown assertion sits *outside* the client block: the handler only
-    exits when the peer goes away, which is exactly the lifetime this sprint
+    exits when the peer goes away, which is exactly the lifetime the feature
     documents.
     """
     app = _make_app()

--- a/tests/unit/test_websocket_object.py
+++ b/tests/unit/test_websocket_object.py
@@ -1,4 +1,4 @@
-"""The high-level :class:`~blackbull.websocket.WebSocket` handler object (Sprint 82).
+"""The high-level :class:`~blackbull.websocket.WebSocket` handler object.
 
 Two layers are covered here:
 

--- a/tests/unit/test_websocket_object_e2e.py
+++ b/tests/unit/test_websocket_object_e2e.py
@@ -1,4 +1,4 @@
-"""The :class:`~blackbull.WebSocket` object over the real stack (Sprint 82).
+"""The :class:`~blackbull.WebSocket` object over the real stack.
 
 ``test_websocket_object.py`` pins the wrapper against a scripted channel.
 This file drives it through :class:`~blackbull.testing.TestClient` — the
@@ -6,7 +6,7 @@ router, the WebSocket actor, the recipient, the codec, and the sender — so
 the object's events are proven to be the ones the actor actually accepts.
 
 The load-bearing pair is :func:`test_object_and_raw_forms_are_indistinguishable_on_the_wire`
-and its neighbours: the whole premise of the sprint is that this is a
+and its neighbours: the whole premise of the feature is that this is a
 *handler-side* convenience with no protocol consequence.
 """
 import pytest

--- a/tests/unit/test_websocket_protocol.py
+++ b/tests/unit/test_websocket_protocol.py
@@ -893,7 +893,7 @@ class TestFramePayloadSizeGuard:
     async def test_oversize_declared_length_triggers_close_1009(self):
         from blackbull.server.constants import WSCloseCode
         # Pin an explicit 64 KiB cap for the test — the global default
-        # is 64 MiB (Sprint 43, BB_WS_MAX_FRAME_PAYLOAD).  Asserting the
+        # is 64 MiB.  Asserting the
         # rejection mechanism doesn't need the default to be small; pinning
         # in-test keeps this assertion stable across default changes.
         # Declare 1 MiB payload but supply only 16 actual bytes — the cap


### PR DESCRIPTION
Two sprints ship as one MINOR. Sprint 85 closed without a release — its only
content was a perf change plus a CI lane — so its notes ride here.

## Measured

`bench/hotpath/parser_micro.py`, Zen 4, one session, min-of-7 × 20k iters:

| headers | before | after | Δ |
|---|---:|---:|---:|
| 1 | 4.53 µs | 3.57 µs | −21 % |
| 8 | 8.12 µs | 5.99 µs | −26 % |
| 32 | 20.33 µs | 14.25 µs | −30 % |

Per-header slope **0.510 → 0.346 µs** (least squares over 1..32; the 1→8
endpoint pair agrees to 0.001). Ratio to httptools at 32 headers: 6.3× → 4.3×.

Sprint 85 separately measured +6.6–8.4 % on the stock event loop and took
HTTP/1.1 to 2.06 loop touches per request — the bare `asyncio.start_server`
floor.

## Gates

- **Http11Probe** 159/159 scored, 0 failed, 0 errors — and the **per-test
  verdict diff against the pre-change baseline is empty across all 213
  vectors**, which is the assertion that matters rather than equal totals.
- **Loop touches** unchanged: H/1.1 2.06, H/2 5.20, WS 4.09.
- `just typecheck`: 5518 passed, 261 skipped under beartype.
- `mkdocs build --strict`: clean.

## How the parser got faster

Not a better algorithm — more work pushed into the C bulk operations CPython
already ships. The idiom is a delete-the-allowed table: deleting every
permitted octet leaves the empty string for valid input, so a non-empty result
*is* the rejection, in one C pass with no allocation on accept.

Field values are checked **once for the whole header block** instead of once
per header. Deleting everything a block may contain leaves only CR, LF and the
CTLs a value may not carry; a residue that tiles exactly into CRLF pairs proves
no value can hold a forbidden octet. A block that fails the pre-scan falls back
to the per-header regex, so the bulk pass is a fast path and never a rejection
— every error message and status code is unchanged.

Three plausible optimisations were measured and **rejected**, with the reasons
recorded in `docs/about/internals.md` §Parse-path invariant so they are not
retried blind: a `find()`+slice line loop (1.5–2.2× slower than `split`, which
does finding, slicing *and* the list build in C), an interning pool for
well-known header names (33.1 vs 22.1 ns/header — the parser's lookup key is a
fresh slice, so its hash is never cached and hashing costs more than
lowercasing), and offset arithmetic in place of `bytes.strip`.

## Behaviour change to review

`app.static()` registers a route instead of global middleware, so a request
that is not for a static path never enters `StaticFiles`. **A miss under the
prefix is now answered 404 by the static route** rather than falling through to
another route that also matches the prefix. Fully-static routes still resolve
first, so only an overlapping *parametrised* route is affected. The 404 takes
the normal error path, so `@app.on_error(HTTPStatus.NOT_FOUND)` still applies.
An explicit route on the bare prefix always wins — `app.static()` never
silently replaces a path you registered yourself, which matters because a mount
at `/` (what `blackbull serve` does) would otherwise have eaten the app's own
root route.

## Docs hygiene

Sprint numbers and private defect IDs removed from comments and docstrings
across 249 files. A docstring is read by users, who cannot resolve `Sprint 79`
or `bug 1.16`; `git log`, the changelog and the sprint logs own the timeline.
Externally resolvable references are kept — RFC and CVE citations,
Http11Probe/Autobahn vector names, GitHub issue numbers — and the *record*
(`bench/results/**`, `bench/CHARACTERIZATION.md`,
`docs/about/grpc-assessment.md`) is untouched.

The pre-release audit also caught real drift: `KNOWN_LIMITATIONS.md` claimed
`StaticFiles` emits no `ETag` and needed the `Cache` middleware, which has been
false since `conditional=True` became the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)