### PR TITLE
release: v0.67.0 — Sprint 87: two-tier header-line cache + response tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,81 @@ so the editable install's metadata catches up.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Header lines whose values a specification enumerates are validated once at
+  import, not once per request.**  A process-wide table seeds Fetch Metadata's
+  `Sec-Fetch-*`, the UA client hints' boolean/platform forms and RFC 9110's
+  fixed tokens (`Connection`, `TE`, `Pragma`, `Upgrade-Insecure-Requests`,
+  `DNT`) — **56 % of all header lines** on captured browser traffic, and a
+  share that does not decay with connection churn.  It is the HPACK *static*
+  table's idea, which HTTP/1.1 has no wire form for.  Entries are admitted
+  only because a spec fixes their value set, never because they were frequent
+  in a capture; framing names (`Content-Length`, `Transfer-Encoding`, `Host`,
+  `Expect`, `Upgrade`) are excluded by a check that raises at import; and each
+  entry is asserted equal to what parsing that line actually produces.  This is
+  what makes the win survive short-lived connections: at one request per
+  connection the per-connection cache alone was **21 % slower** than no cache,
+  and with the shared table it is **6 % faster**.
+- **Keep-alive connections stop re-validating header lines they have already
+  validated.**  A peer that resends a byte-identical header line — which every
+  browser does for `User-Agent`, `Accept`, `Accept-Language` and `Cookie` —
+  now gets that line answered from a per-connection cache of
+  `raw line bytes → (name, value)` pairs, replacing the colon split, token
+  check, lowercase, OWS strip and value scan with one dict lookup.  Scored on
+  **captured** traffic — a real Chromium loading a real page, every request
+  head recorded as it arrived — 21 requests carried 275 header lines drawn from
+  only 26 distinct ones, and parse cost falls **8.96 → 5.85 µs (−35 %)** at the
+  observed single connection, **−27 %** when the same requests are re-dealt
+  across the six connections Chromium opens per origin.  The cache is keyed per
+  *line*, so a request that changes four of its thirteen lines still hits on
+  the other nine, and header **order** changing between navigations and
+  subresources costs it nothing.  Against an adversarial peer whose every
+  header value is unique it is still **5 %** faster, so no input shape
+  regresses.  Because the key is attacker-controlled the cache is bounded by
+  **bytes, not entries** — lines over 1 KiB skip it entirely (lookup included)
+  and a per-connection 8 KiB budget caps admission — which holds the worst case
+  to **16 KiB/connection and +19.2 % CPU** under a peer sending 64
+  never-repeating 128-byte headers per request.  An entry-count bound alone
+  would have retained ~1 MiB per connection (9.6 GiB across 10k connections)
+  against 988 B of real need.  The per-header slope falls
+  **0.413 → 0.174 µs** (−58 %) and a 32-header request **17.06 → 8.78 µs**.
+  Nothing enters the
+  cache unvalidated, the key is the exact line bytes so one changed byte is a
+  miss, the cache is per connection so validated lines never cross a tenant,
+  and it is bounded at 64 entries so an attacker cycling unique names cannot
+  grow it.  Requests parse to exactly what they parsed to before — asserted by
+  a differential test, and by an unchanged 213-test Http11Probe verdict.
+- **The HTTP/1.1 header-size limit is read once per connection, not once per
+  request.**  `_parse` ran a `from ..env import get_settings` statement on
+  every call; the limit is connection-scoped, so it is memoised on the actor.
+  This is what makes the cache-miss path faster too.
+- **The status line and small Content-Length values come from tables.**  Both
+  were rebuilt per response (`f'HTTP/1.1 {status} {status.phrase}'.encode()`
+  and `str(n).encode()`); they are now precomputed at import for every
+  `HTTPStatus` member and for lengths `0…8192`, each falling back to the
+  original expression outside that domain.
+- **`EventDispatcher.has_listeners` answers from a registration index.**  It
+  probed three dicts, once per lifecycle emit site per request; it is now one
+  set lookup.
+
+Measured end to end on one box in one session, one worker, medians of five
+interleaved sweeps: **+6.7 % to +10.9 %** req/s, the larger figure on
+browser-shaped header sets.
+
+### Fixed
+
+- **`HEAD` requests were answered `405 Method Not Allowed` under
+  `BB_FORCE_ASGI_SCOPE=1`.**  BlackBull synthesises a HEAD response by
+  rewriting the method to `GET` and stripping the body, but the compat lane
+  materialised its scope *snapshot* before that rewrite, so the router saw
+  `HEAD`, found no HEAD route, and answered 405 where the native lane answered
+  200 (`COMP-HEAD-NO-BODY`, RFC 9110 §9.3.2).  The app argument is now built
+  after every pre-dispatch mutation of the `Connection`.  Both lanes now score
+  an identical 159/159.
+
 ## [0.66.0] — 2026-07-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ so the editable install's metadata catches up.
 
 ---
 
-## [Unreleased]
+## [0.67.0] — 2026-07-31
 
 ### Changed
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.67.x  | :white_check_mark: |
 | 0.66.x  | :white_check_mark: |
-| 0.65.x  | :white_check_mark: |
-| < 0.65  | :x:                |
+| < 0.66  | :x:                |
 
 This table updates with each minor release.
 

--- a/bench/hotpath/capture_browser_headers.py
+++ b/bench/hotpath/capture_browser_headers.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Capture the header lines a *real* browser sends, per connection.
+
+`line_cache_realistic.py` encodes an assumption about what Chrome sends and how
+it varies.  An assumption about the input is exactly the thing a measurement
+should not rest on, and the classic web-workload literature (SURGE and
+descendants) does not help here — it models *which resources are requested*,
+their sizes, popularity and temporal locality, not the header lines that
+accompany them.
+
+So this takes the ground truth instead: serve a page with real subresources,
+point a real Chromium at it, and record the exact bytes of every request head,
+grouped by TCP connection.  The output is a JSON file of
+``[[line, ...], ...]`` per connection, which `line_cache_hitrate.py` scores.
+
+Two properties of real browser behaviour that a hand-written model is likely to
+get wrong, and that this captures for free:
+
+- **Connection parallelism.**  Chromium opens up to six connections per origin
+  and spreads a page's requests across them, so each connection sees a fraction
+  of the page — which lowers the per-connection repeat rate.
+- **Header variation the model did not think of.**  Whatever Chrome actually
+  does with `Priority`, `Sec-Fetch-*`, client hints and conditional requests.
+
+    python bench/hotpath/capture_browser_headers.py --out capture.json
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+import subprocess
+import tempfile
+
+# A page shaped like a real one: stylesheets, scripts, fonts, images, and an
+# XHR issued after load.  Counts are what matters, not the bytes.
+IMAGES = [f'/img/thumb-{i}.png' for i in range(12)]
+SUBRESOURCES = (['/static/app.css', '/static/theme.css']
+                + ['/static/vendor.js', '/static/app.js', '/static/analytics.js']
+                + IMAGES)
+
+INDEX = """<!doctype html><html><head><meta charset=utf-8><title>capture</title>
+<link rel=stylesheet href=/static/app.css><link rel=stylesheet href=/static/theme.css>
+<script src=/static/vendor.js></script><script src=/static/app.js></script>
+</head><body>
+""" + ''.join(f'<img src="{p}" width=10 height=10>' for p in IMAGES) + """
+<script src=/static/analytics.js></script>
+<script>
+fetch('/api/session', {headers: {'X-Requested-With': 'XMLHttpRequest'}})
+  .then(() => fetch('/api/prefs'))
+  .then(() => setTimeout(() => { document.title = 'done'; }, 300));
+</script>
+</body></html>"""
+
+BODIES = {
+    '/': (b'text/html; charset=utf-8', INDEX.encode()),
+    '/api/session': (b'application/json', b'{"ok":true}'),
+    '/api/prefs': (b'application/json', b'{"theme":"dark"}'),
+}
+for _p in SUBRESOURCES:
+    if _p.endswith('.css'):
+        BODIES[_p] = (b'text/css', b'body{margin:0}')
+    elif _p.endswith('.js'):
+        BODIES[_p] = (b'application/javascript', b'/*x*/')
+    else:
+        # 1x1 PNG
+        BODIES[_p] = (b'image/png', bytes.fromhex(
+            '89504e470d0a1a0a0000000d4948445200000001000000010806000000'
+            '1f15c4890000000a49444154789c6300010000050001'
+            '0d0a2db40000000049454e44ae426082'))
+
+
+class Capture(asyncio.Protocol):
+    """Minimal HTTP/1.1 responder that records each request's header lines."""
+
+    def __init__(self, sink: list[list[list[str]]]) -> None:
+        self._sink = sink
+        self._mine: list[list[str]] = []
+        self._buf = b''
+
+    def connection_made(self, transport) -> None:
+        self._t = transport
+        self._sink.append(self._mine)
+
+    def data_received(self, data: bytes) -> None:
+        self._buf += data
+        while b'\r\n\r\n' in self._buf:
+            head, _, self._buf = self._buf.partition(b'\r\n\r\n')
+            lines = head.split(b'\r\n')
+            # Record the header lines only; the request line is not cacheable
+            # (its target differs every time by construction).
+            self._mine.append([ln.decode('latin-1') for ln in lines[1:] if ln])
+            target = lines[0].split(b' ')[1].decode('latin-1')
+            ctype, body = BODIES.get(target, (b'text/plain', b'nope'))
+            self._t.write(
+                b'HTTP/1.1 200 OK\r\ncontent-type: ' + ctype
+                + b'\r\ncontent-length: ' + str(len(body)).encode()
+                # no-store so a second load re-requests everything rather than
+                # answering from cache and hiding the header sets.
+                + b'\r\ncache-control: no-store\r\n'
+                b'access-control-allow-origin: *\r\n\r\n' + body)
+
+
+async def serve(sink, port: int):
+    loop = asyncio.get_running_loop()
+    server = await loop.create_server(lambda: Capture(sink), '0.0.0.0', port)
+    return server
+
+
+EDGE = '/mnt/c/Program Files (x86)/Microsoft/Edge/Application/msedge.exe'
+
+
+async def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--out', type=pathlib.Path, required=True)
+    ap.add_argument('--port', type=int, default=8788)
+    ap.add_argument('--browser', default=EDGE)
+    ap.add_argument('--settle', type=float, default=8.0)
+    args = ap.parse_args()
+
+    sink: list[list[list[str]]] = []
+    server = await serve(sink, args.port)
+
+    profile = tempfile.mkdtemp(prefix='hdrcap-')
+    # Windows-side Chromium reaches a WSL2 listener through localhost
+    # forwarding.  A throwaway profile keeps a warm cache or an existing
+    # session from suppressing requests.
+    proc = subprocess.Popen(
+        [args.browser, '--headless=new', '--disable-gpu', '--no-first-run',
+         f'--user-data-dir={profile}'.replace('/mnt/c', 'C:').replace('/', '\\'),
+         '--disable-features=NetworkServiceInProcess',
+         f'http://localhost:{args.port}/'],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        await asyncio.sleep(args.settle)
+    finally:
+        proc.terminate()
+        server.close()
+        await server.wait_closed()
+
+    conns = [c for c in sink if c]
+    args.out.write_text(json.dumps(conns, indent=1))
+    reqs = sum(len(c) for c in conns)
+    print(f'captured {reqs} requests over {len(conns)} connections '
+          f'-> {args.out}')
+    for i, c in enumerate(conns):
+        print(f'  conn {i}: {len(c)} requests')
+    return 0 if reqs else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/bench/hotpath/line_cache_churn.py
+++ b/bench/hotpath/line_cache_churn.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Where does the header-line cache break even, in requests per connection?
+
+The cache is per connection, so the first request on every connection pays for
+it and gets nothing back: every lookup misses and every line is admitted into a
+dict that is discarded when the connection closes.  Only from the second
+request does any of that work get repaid.  A workload that reconnects often
+therefore pays the setup repeatedly and collects less of the benefit — and
+HttpArena's `limited-conn` profile (upstream `n`) is exactly that shape:
+**connections that close after 10 requests**.
+
+So the honest characterisation is not one number but a break-even point.  This
+replays captured browser header sets with a fresh actor every K requests and
+sweeps K, against a build with no cache at all.
+
+    python bench/hotpath/line_cache_churn.py capture.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[0]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from provenance import stamp  # noqa: E402
+
+from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def build(lines: list[str]) -> bytes:
+    head = [b'GET /baseline11?a=1 HTTP/1.1']
+    head += [ln.encode('latin-1') for ln in lines]
+    return b'\r\n'.join(head) + b'\r\n\r\n'
+
+
+def bench(requests: list[bytes], per_conn: int, iters: int) -> float:
+    """µs/request when the connection is torn down every *per_conn* requests."""
+    best = []
+    for _ in range(7):
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            actor = _actor()
+            for i, raw in enumerate(requests):
+                if i and i % per_conn == 0:
+                    actor = _actor()          # reconnect: cache is discarded
+                actor._parse(raw)
+        best.append((time.perf_counter_ns() - t0)
+                    / (iters * len(requests)) / 1000)
+    return min(best)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('capture', type=pathlib.Path)
+    ap.add_argument('--iters', type=int, default=300)
+    args = ap.parse_args()
+
+    print(stamp() + '\n')
+    conns = json.loads(args.capture.read_text())
+    reqs = [build(r) for c in conns for r in c]
+    # Repeat the capture so the longer per-conn settings get whole connections
+    # rather than one truncated one.
+    reqs = reqs * 4
+
+    print(f'{len(reqs)} requests replayed, reconnecting every K\n')
+    print(f'  {"req/conn":>9}  {"µs/req":>8}')
+    for k in (1, 2, 3, 5, 10, 20, len(reqs)):
+        label = 'keep-alive' if k == len(reqs) else str(k)
+        print(f'  {label:>9}  {bench(reqs, k, args.iters):8.2f}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bench/hotpath/line_cache_hitrate.py
+++ b/bench/hotpath/line_cache_hitrate.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Score the header-line cache against *captured* browser traffic.
+
+Takes the JSON `capture_browser_headers.py` writes — real header lines from a
+real Chromium, grouped by the TCP connection they arrived on — and reports both
+the achieved hit rate and the parse cost, so the win is measured on observed
+input rather than on a hand-written model of it.
+
+Also sweeps the **connection split**, which is the one thing a single capture
+cannot settle: Chromium opens up to six connections per origin and spreads a
+page across them under real latency, and a cache that lives per connection sees
+fewer repeats the more the page is spread.  Re-dealing the same requests over
+N connections bounds that.
+
+    python bench/hotpath/line_cache_hitrate.py capture.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[0]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from provenance import stamp  # noqa: E402
+
+try:
+    from blackbull.server.http1_actor import _DEFAULT_LINES  # noqa: E402
+except ImportError:                       # a build without the shared table
+    _DEFAULT_LINES = {}
+
+from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def build(lines: list[str], target: str = '/x') -> bytes:
+    head = [f'GET {target} HTTP/1.1'.encode()]
+    head += [ln.encode('latin-1') for ln in lines]
+    return b'\r\n'.join(head) + b'\r\n\r\n'
+
+
+def deal(conns: list[list[list[str]]], n: int) -> list[list[list[str]]]:
+    """Re-deal every captured request round-robin over *n* connections."""
+    flat = [r for c in conns for r in c]
+    out: list[list[list[str]]] = [[] for _ in range(n)]
+    for i, req in enumerate(flat):
+        out[i % n].append(req)
+    return [c for c in out if c]
+
+
+def hit_rate(conns) -> tuple[float, int, int, int]:
+    """(combined rate, shared-table hits, per-connection hits, total lines).
+
+    Both sources are counted: a line answered from the process-wide spec table
+    was not re-validated any more than one answered from this connection's own
+    cache.  They are reported apart because only the second needs warming —
+    the split is what says how much of the win survives connection churn.
+    """
+    shared = learned = total = 0
+    for conn in conns:
+        actor = _actor()
+        for req in conn:
+            cache = getattr(actor, '_line_cache', None) or {}
+            for ln in req:
+                total += 1
+                key = ln.encode('latin-1')
+                if key in cache:
+                    learned += 1
+                elif key in _DEFAULT_LINES:
+                    shared += 1
+            actor._parse(build(req))
+    rate = (shared + learned) / total if total else 0.0
+    return rate, shared, learned, total
+
+
+def bench(conns, iters: int) -> float:
+    """µs per request over the whole capture, replayed *iters* times."""
+    prebuilt = [[build(r) for r in c] for c in conns]
+    n_req = sum(len(c) for c in prebuilt)
+    best = []
+    for _ in range(7):
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            for conn in prebuilt:
+                actor = _actor()
+                for raw in conn:
+                    actor._parse(raw)
+        best.append((time.perf_counter_ns() - t0) / (iters * n_req) / 1000)
+    return min(best)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('capture', type=pathlib.Path)
+    ap.add_argument('--iters', type=int, default=400)
+    args = ap.parse_args()
+
+    print(stamp() + '\n')
+    conns = json.loads(args.capture.read_text())
+    n_req = sum(len(c) for c in conns)
+    n_lines = sum(len(r) for c in conns for r in c)
+    distinct = len({ln for c in conns for r in c for ln in r})
+
+    print(f'capture: {n_req} requests, {len(conns)} connection(s), '
+          f'{n_lines} header lines, {distinct} distinct')
+    print(f'learn-only ceiling: {(n_lines - distinct) / n_lines:.1%} '
+          f'(a purely learned cache must miss each distinct line once;'
+          f' a pre-seeded line never misses, so the shared table exceeds it)\n')
+
+    print(f'  shared spec table: {len(_DEFAULT_LINES)} entries\n')
+    print('  connections   hit rate  shared learned    parse µs/req')
+    for n in (1, 2, 4, 6, 12):
+        if n > n_req:
+            break
+        dealt = deal(conns, n)
+        rate, shared, learned, tot = hit_rate(dealt)
+        cost = bench(dealt, args.iters)
+        note = '   <- as captured' if n == len(conns) else ''
+        print(f'  {n:>11}   {rate:7.1%} {shared / tot:7.1%} {learned / tot:7.1%}'
+              f'   {cost:8.2f}{note}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bench/hotpath/line_cache_miss.py
+++ b/bench/hotpath/line_cache_miss.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""What the validated header-line cache costs when it never hits.
+
+`parser_micro.py` reuses one actor and one byte-identical request, which is the
+keep-alive case the cache is designed for and therefore its best case.  This is
+the other end: every request carries header *values* this connection has never
+seen, so every lookup misses and the dict work is pure overhead.  A real client
+sits between the two, but the sprint should not ship a win it has only measured
+on the favourable side.
+
+Three arms, all on one actor (one connection):
+
+  hit      byte-identical requests — the keep-alive shape
+  miss     every value unique — the cache is admitted-then-never-reused
+  miss-full  unique values *after* the cache is full, so admission is refused
+             and the `len(cache) < MAX` branch is what runs
+
+    python bench/hotpath/line_cache_miss.py [--iters N] [--headers N]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[0]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from provenance import stamp  # noqa: E402
+
+from blackbull.server.http1_actor import (  # noqa: E402
+    _LINE_CACHE_MAX,
+    HTTP1Actor,
+)
+
+NAMES = [
+    b'User-Agent', b'Accept', b'Accept-Encoding', b'Accept-Language',
+    b'Cookie', b'Referer', b'Origin', b'X-Request-Id',
+]
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def request_bytes(n: int, salt: int | None) -> bytes:
+    lines = [b'GET /baseline11?a=1 HTTP/1.1', b'Host: 127.0.0.1:8501']
+    for i in range(n):
+        name = NAMES[i % len(NAMES)] + (b'-%d' % (i // len(NAMES)))
+        value = b'v' if salt is None else b'v%d-%d' % (salt, i)
+        lines.append(name + b': ' + value)
+    return b'\r\n'.join(lines) + b'\r\n\r\n'
+
+
+def bench(fn, iters: int) -> float:
+    best = []
+    for _ in range(7):
+        t0 = time.perf_counter_ns()
+        for i in range(iters):
+            fn(i)
+        best.append((time.perf_counter_ns() - t0) / iters / 1000)
+    return min(best)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--iters', type=int, default=20000)
+    ap.add_argument('--headers', type=int, default=8)
+    args = ap.parse_args()
+    print(stamp() + '\n')
+    n = args.headers
+
+    hit_actor = _actor()
+    same = request_bytes(n, None)
+    hit_actor._parse(same)
+    hit = bench(lambda _i: hit_actor._parse(same), args.iters)
+
+    miss_actor = _actor()
+    miss = bench(lambda i: miss_actor._parse(request_bytes(n, i)), args.iters)
+
+    full_actor = _actor()
+    # Fill the cache with lines that will never be seen again.
+    for i in range(_LINE_CACHE_MAX + 8):
+        full_actor._parse(request_bytes(n, 10_000_000 + i))
+    assert len(full_actor._line_cache) == _LINE_CACHE_MAX
+    full = bench(lambda i: full_actor._parse(request_bytes(n, i)), args.iters)
+
+    # The miss arms rebuild the request bytes inside the timed loop; charge
+    # that to neither by measuring it alone and subtracting.
+    build = bench(lambda i: request_bytes(n, i), args.iters)
+
+    print(f'{n} headers, {args.iters} iters (min of 7)\n')
+    print(f'  hit        {hit:6.2f} µs')
+    print(f'  miss       {miss - build:6.2f} µs   '
+          f'({(miss - build) / hit - 1:+.1%} vs hit)')
+    print(f'  miss-full  {full - build:6.2f} µs   '
+          f'({(full - build) / hit - 1:+.1%} vs hit)')
+    print(f'\n  (request construction, subtracted: {build:.2f} µs)')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bench/hotpath/line_cache_realistic.py
+++ b/bench/hotpath/line_cache_realistic.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Does the header-line cache pay on *real* traffic, or only on benchmarks?
+
+`parser_micro.py` replays one byte-identical request and `wrk` sends the same
+bytes every time — both are 100 % hit rate, which is the cache's best case and
+not what a browser does.  A real client keeps the connection alive but varies
+part of its header set per request: `Accept`, `Referer` and the `Sec-Fetch-*`
+family all change between a navigation, a stylesheet, a script, an image and an
+XHR, while `User-Agent`, `Accept-Encoding`, `Accept-Language`, `Cookie` and the
+client hints stay byte-identical.
+
+This models that: one connection, one page load, Chrome's real header sets in
+real request order.  It reports the achieved **per-line hit rate** alongside the
+timing, because the cache is keyed per *line* rather than per request — which is
+the property that decides whether it degrades gracefully or all-or-nothing.
+
+    python bench/hotpath/line_cache_realistic.py [--iters N]
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import statistics
+import sys
+import time
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[0]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from provenance import stamp  # noqa: E402
+
+from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
+
+HOST = b'127.0.0.1:8501'
+
+# Byte-identical on every request a browser sends over one connection.
+STABLE = [
+    b'Host: ' + HOST,
+    b'Connection: keep-alive',
+    b'sec-ch-ua: "Chromium";v="130", "Not?A_Brand";v="99"',
+    b'sec-ch-ua-mobile: ?0',
+    b'sec-ch-ua-platform: "Linux"',
+    b'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    b'Accept-Encoding: gzip, deflate, br',
+    b'Accept-Language: en-US,en;q=0.9',
+    b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543',
+    b'DNT: 1',
+]
+
+# One page load: document, two stylesheets, two scripts, four images, an XHR.
+# `Accept`, `Sec-Fetch-*` and `Referer` vary by destination, exactly as Chrome
+# varies them; the target varies on every request.
+PAGE = [
+    ('/', [b'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+           b'Sec-Fetch-Site: none', b'Sec-Fetch-Mode: navigate',
+           b'Sec-Fetch-User: ?1', b'Sec-Fetch-Dest: document',
+           b'Upgrade-Insecure-Requests: 1', b'Cache-Control: max-age=0']),
+    ('/static/app.css', [b'Accept: text/css,*/*;q=0.1',
+                         b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                         b'Sec-Fetch-Dest: style', b'Referer: http://' + HOST + b'/']),
+    ('/static/theme.css', [b'Accept: text/css,*/*;q=0.1',
+                           b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                           b'Sec-Fetch-Dest: style', b'Referer: http://' + HOST + b'/']),
+    ('/static/app.js', [b'Accept: */*', b'Sec-Fetch-Site: same-origin',
+                        b'Sec-Fetch-Mode: no-cors', b'Sec-Fetch-Dest: script',
+                        b'Referer: http://' + HOST + b'/']),
+    ('/static/vendor.js', [b'Accept: */*', b'Sec-Fetch-Site: same-origin',
+                           b'Sec-Fetch-Mode: no-cors', b'Sec-Fetch-Dest: script',
+                           b'Referer: http://' + HOST + b'/']),
+    ('/img/logo.png', [b'Accept: image/avif,image/webp,image/apng,*/*;q=0.8',
+                       b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                       b'Sec-Fetch-Dest: image', b'Referer: http://' + HOST + b'/']),
+    ('/img/hero.jpg', [b'Accept: image/avif,image/webp,image/apng,*/*;q=0.8',
+                       b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                       b'Sec-Fetch-Dest: image', b'Referer: http://' + HOST + b'/']),
+    ('/img/icon-1.svg', [b'Accept: image/avif,image/webp,image/apng,*/*;q=0.8',
+                         b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                         b'Sec-Fetch-Dest: image', b'Referer: http://' + HOST + b'/']),
+    ('/img/icon-2.svg', [b'Accept: image/avif,image/webp,image/apng,*/*;q=0.8',
+                         b'Sec-Fetch-Site: same-origin', b'Sec-Fetch-Mode: no-cors',
+                         b'Sec-Fetch-Dest: image', b'Referer: http://' + HOST + b'/']),
+    ('/api/session', [b'Accept: application/json', b'Sec-Fetch-Site: same-origin',
+                      b'Sec-Fetch-Mode: cors', b'Sec-Fetch-Dest: empty',
+                      b'X-Requested-With: XMLHttpRequest',
+                      b'Referer: http://' + HOST + b'/']),
+]
+
+
+def build(target: str, varying: list[bytes]) -> bytes:
+    lines = [f'GET {target} HTTP/1.1'.encode(), *STABLE, *varying]
+    return b'\r\n'.join(lines) + b'\r\n\r\n'
+
+
+REQUESTS = [build(t, v) for t, v in PAGE]
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def hit_rate() -> tuple[float, int, int]:
+    """Fraction of header lines served from the cache over one page load.
+
+    Measured by instrumenting the dict rather than by timing, so it is exact.
+    Returns ``(rate, hits, total)``; ``(0, 0, n)`` when the build has no cache.
+    """
+    actor = _actor()
+    actor._parse(REQUESTS[0])          # first request populates
+    cache = getattr(actor, '_line_cache', None)
+
+    hits = total = 0
+    for raw in REQUESTS[1:]:
+        for line in raw.split(b'\r\n')[1:]:
+            if not line:
+                continue
+            total += 1
+            # ``cache is None`` is a build without the feature: same denominator,
+            # zero hits, so the two trees report against one counting rule.
+            if cache is not None and line in cache:
+                hits += 1
+        actor._parse(raw)
+    return hits / total, hits, total
+
+
+def bench(iters: int) -> float:
+    """µs per request, averaged over whole page loads on one connection."""
+    best = []
+    for _ in range(7):
+        actor = _actor()
+        t0 = time.perf_counter_ns()
+        for _ in range(iters):
+            for raw in REQUESTS:
+                actor._parse(raw)
+        elapsed = time.perf_counter_ns() - t0
+        best.append(elapsed / (iters * len(REQUESTS)) / 1000)
+    return min(best)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--iters', type=int, default=3000)
+    args = ap.parse_args()
+
+    print(stamp() + '\n')
+    rate, hits, total = hit_rate()
+    per_req = bench(args.iters)
+    n_hdr = statistics.fmean(len(r.split(b'\r\n')) - 2 for r in REQUESTS)
+
+    print(f'one connection, one page load ({len(REQUESTS)} requests, '
+          f'{n_hdr:.1f} headers avg)\n')
+    print(f'  per-line cache hit rate  {rate:6.1%}   ({hits}/{total} lines)')
+    print(f'  parse cost               {per_req:6.2f} µs/req')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bench/hotpath/line_cache_worst_case.py
+++ b/bench/hotpath/line_cache_worst_case.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""The header-line cache's worst case, stated in numbers rather than adjectives.
+
+Every other harness here measures where the cache is *meant* to help.  This one
+measures where it cannot help and can only cost, because a bound that has only
+been exercised on friendly input is not a bound that has been tested.
+
+The cache key is attacker-controlled, so the adversary's move is obvious: send
+header lines that are (a) always unique, so every lookup misses, and (b) as
+large as the limits allow, so each miss pays a hash over the maximum number of
+bytes and each admission retains the maximum number of bytes.
+
+Two costs, measured separately because they have different shapes:
+
+**CPU** — pure waste per request: hash the line, miss, and (until the cache
+fills) insert.  Compared against a build with no cache at all.
+
+**Memory** — the one that does not show up in a throughput benchmark at all.
+Without the cache, header bytes are transient and freed after the parse.  With
+it, up to ``_LINE_CACHE_MAX`` lines stay reachable for the lifetime of the
+connection — and an entry retains the key *and* the name/value slices.  An
+attacker pays that cost once, in traffic, and the server pays it continuously,
+in resident memory, for as long as the connection is kept alive.
+
+    python bench/hotpath/line_cache_worst_case.py
+"""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+import time
+import tracemalloc
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[0]))
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from provenance import stamp  # noqa: E402
+
+from blackbull.env import get_settings  # noqa: E402
+from blackbull.server.http1_actor import HTTP1Actor  # noqa: E402
+
+try:
+    from blackbull.server.http1_actor import _LINE_CACHE_MAX
+except ImportError:                      # a build without the cache
+    _LINE_CACHE_MAX = 0
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def hostile_request(seq: int, n_lines: int, line_len: int) -> bytes:
+    """*n_lines* maximally long, never-repeating header lines."""
+    out = [b'GET /x HTTP/1.1', b'Host: h']
+    for i in range(n_lines):
+        name = b'X-P%d' % i
+        # A unique prefix per request guarantees a miss; the padding makes the
+        # hash on that miss as expensive as the line limit allows.
+        pad = b'a' * max(0, line_len - len(name) - 24)
+        out.append(b'%s: %012d-%08d-%s' % (name, seq, i, pad))
+    return b'\r\n'.join(out) + b'\r\n\r\n'
+
+
+def bench_cpu(n_lines: int, line_len: int, iters: int) -> float:
+    actor = _actor()          # one connection, kept alive
+    reqs = [hostile_request(i, n_lines, line_len) for i in range(iters)]
+    best = []
+    for _ in range(5):
+        t0 = time.perf_counter_ns()
+        for raw in reqs:
+            actor._parse(raw)
+        best.append((time.perf_counter_ns() - t0) / iters / 1000)
+    return min(best)
+
+
+def measure_memory(n_lines: int, line_len: int) -> tuple[int, int]:
+    """Bytes retained by one connection's cache: (accounted, tracemalloc)."""
+    actor = _actor()
+    tracemalloc.start()
+    before = tracemalloc.get_traced_memory()[0]
+    seq = 0
+    # Feed until the cache stops growing (or forever-loop guard trips).
+    while seq < 400:
+        actor._parse(hostile_request(seq, n_lines, line_len))
+        cache = getattr(actor, '_line_cache', None)
+        if cache is not None and len(cache) >= _LINE_CACHE_MAX:
+            break
+        seq += 1
+    after = tracemalloc.get_traced_memory()[0]
+    tracemalloc.stop()
+
+    cache = getattr(actor, '_line_cache', None) or {}
+    accounted = sum(len(k) + len(v[0]) + len(v[1]) for k, v in cache.items())
+    return accounted, max(0, after - before)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--iters', type=int, default=300)
+    args = ap.parse_args()
+
+    print(stamp() + '\n')
+    cfg = get_settings()
+    print(f'limits: header_max_line={cfg.header_max_line}  '
+          f'header_max_total={cfg.header_max_total}  '
+          f'_LINE_CACHE_MAX={_LINE_CACHE_MAX}\n')
+
+    # The adversary picks the line length, so sweep it rather than assume one.
+    # A per-line admission cap moves the worst case *down* to just under that
+    # cap — long lines stop being cached at all — so the maximum has to be
+    # searched for, not guessed.
+    lengths = [64, 128, 256, 512, 1000, 1024, 1025, 2048, 4096,
+               cfg.header_max_line]
+    print(f'{"line B":>8} {"lines/req":>10} {"CPU µs/req":>11} '
+          f'{"retained B":>12} {"KiB/conn":>9} {"GiB @10k":>9}')
+    worst = (0, 0)
+    for line_len in lengths:
+        n_lines = max(1, (cfg.header_max_total - 64) // (line_len + 2))
+        n_lines = min(n_lines, 64)         # keep the sweep's cost sane
+        cpu = bench_cpu(n_lines, line_len, args.iters)
+        accounted, _ = measure_memory(n_lines, line_len)
+        print(f'{line_len:>8} {n_lines:>10} {cpu:>11.2f} {accounted:>12,d} '
+              f'{accounted / 1024:>9.1f} {accounted * 10_000 / 1024**3:>9.2f}')
+        worst = max(worst, (accounted, line_len))
+
+    print(f'\nworst retention: {worst[0]:,d} B/conn at {worst[1]} B lines '
+          f'-> {worst[0] * 10_000 / 1024**2:.0f} MiB at 10k connections')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bench/hotpath/provenance.py
+++ b/bench/hotpath/provenance.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""One environment stamp, shared by every hot-path harness.
+
+A microbenchmark number without its machine, interpreter and tree is not a
+result — it is an anecdote.  `bench/aws/httparena_compare.sh` already writes a
+`provenance.md` for cloud runs; the local harnesses had nothing, so numbers
+from them reached the docs with no way to check what produced them.
+
+Import and call :func:`stamp` (human-readable) or :func:`as_dict` (for JSON
+output).  Every harness in this directory prints it, so a pasted result carries
+its own provenance.
+
+    python bench/hotpath/provenance.py        # print the current stamp
+"""
+from __future__ import annotations
+
+import datetime
+import os
+import pathlib
+import platform
+import re
+import subprocess
+import sys
+
+
+def _run(cmd: list[str]) -> str:
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ''
+
+
+def _cpu_model() -> str:
+    try:
+        text = pathlib.Path('/proc/cpuinfo').read_text()
+        m = re.search(r'^model name\s*:\s*(.+)$', text, re.MULTILINE)
+        if m:
+            return m.group(1).strip()
+    except OSError:
+        pass
+    return platform.processor() or 'unknown'
+
+
+def _git(repo: pathlib.Path) -> tuple[str, bool]:
+    """(short commit, dirty).  A dirty tree makes the run unreproducible from
+    a commit alone, which is worth saying out loud rather than hiding."""
+    commit = _run(['git', '-C', str(repo), 'rev-parse', '--short', 'HEAD'])
+    status = _run(['git', '-C', str(repo), 'status', '--porcelain'])
+    tracked_dirty = any(not ln.startswith('??') for ln in status.splitlines())
+    return commit or 'unknown', tracked_dirty
+
+
+def _is_wsl() -> bool:
+    return pathlib.Path('/proc/sys/fs/binfmt_misc/WSLInterop').exists() \
+        or 'microsoft' in platform.release().lower()
+
+
+def as_dict() -> dict:
+    repo = pathlib.Path(__file__).resolve().parents[2]
+    commit, dirty = _git(repo)
+    try:
+        import blackbull
+        version = blackbull.__version__
+    except Exception:                                    # noqa: BLE001
+        version = 'unknown'
+    return {
+        'timestamp': datetime.datetime.now(datetime.UTC)
+                     .strftime('%Y-%m-%dT%H:%M:%SZ'),
+        'cpu': _cpu_model(),
+        'cpus_online': os.cpu_count(),
+        'affinity': len(os.sched_getaffinity(0))
+                    if hasattr(os, 'sched_getaffinity') else None,
+        'kernel': f'{platform.system()} {platform.release()}',
+        'wsl2': _is_wsl(),
+        'python': sys.version.split()[0],
+        'python_build': platform.python_compiler(),
+        'blackbull': version,
+        'commit': commit,
+        'dirty': dirty,
+        'uvloop': os.environ.get('BB_UVLOOP', '0') == '1',
+    }
+
+
+def stamp(prefix: str = '  ') -> str:
+    d = as_dict()
+    tree = f"{d['blackbull']} @ {d['commit']}"
+    if d['dirty']:
+        tree += ' + UNCOMMITTED CHANGES'
+    lines = [
+        f"{d['cpu']}  ({d['cpus_online']} logical"
+        + (f", {d['affinity']} in affinity mask" if d['affinity'] else '')
+        + ')',
+        f"{d['kernel']}" + ('  [WSL2 — not an isolated bench host]'
+                            if d['wsl2'] else ''),
+        f"Python {d['python']}  ({d['python_build']})",
+        f"BlackBull {tree}",
+        f"loop: {'uvloop' if d['uvloop'] else 'stock asyncio'}   "
+        f"{d['timestamp']}",
+    ]
+    return '\n'.join(prefix + ln for ln in lines)
+
+
+if __name__ == '__main__':
+    print(stamp(''))

--- a/blackbull/event.py
+++ b/blackbull/event.py
@@ -73,6 +73,11 @@ class EventDispatcher:
         # listeners are almost always registered before serving, so the
         # per-request cost collapses to one int read + compare.
         self.generation: int = 0
+        # Names with at least one handler of any kind.  ``has_listeners`` is
+        # called several times per request — once per lifecycle emit site — so
+        # it answers from this set rather than probing three dicts.  Handlers
+        # are only ever added, so the set never needs to shrink.
+        self._registered: set[str] = set()
 
     def on(self, event_name: str, handler: EventHandler,
            blocking: bool = False) -> None:
@@ -89,23 +94,26 @@ class EventDispatcher:
             self._blocking_observers[event_name].append(handler)
         else:
             self._observers[event_name].append(handler)
+        self._registered.add(event_name)
         self.generation += 1
 
     def intercept(self, event_name: str, handler: EventHandler) -> None:
         """Register an interception handler for ``event_name``."""
         self._interceptors[event_name].append(handler)
+        self._registered.add(event_name)
         self.generation += 1
 
     def has_listeners(self, event_name: str) -> bool:
         """Return True if any interceptor or observer is registered for ``event_name``.
 
         Hot path: callers use this to skip detail-dict / ``Event`` construction
-        when no one will receive the event.  ``defaultdict.get`` returns ``None``
-        for missing keys without inserting an empty list.
+        when no one will receive the event, and there is one such call site per
+        lifecycle event per request.  Answered from the registration index, so
+        the common "nobody is listening" verdict costs one set lookup instead
+        of three dict probes — and, like the ``defaultdict.get`` form it
+        replaces, it never inserts an empty list for an unknown name.
         """
-        return (bool(self._interceptors.get(event_name))
-                or bool(self._blocking_observers.get(event_name))
-                or bool(self._observers.get(event_name)))
+        return event_name in self._registered
 
     async def emit(self, event: Event) -> None:
         """Dispatch ``event`` to all registered handlers.

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -119,6 +119,139 @@ def _block_values_are_clean(data: bytes) -> bool:
     residue = data.translate(None, _BLOCK_ALLOWED_OCTETS)
     return residue.count(b'\r\n') * 2 == len(residue)
 
+
+# Bounds on one connection's validated header-line cache.  A keep-alive peer
+# resends byte-identical lines (``User-Agent``, ``Accept``, ``Cookie`` — real
+# browsers do this), so the split/lower/validate work for each is done once per
+# connection instead of once per request.
+#
+# All three bounds exist because **the cache key is attacker-controlled**, and
+# the resource a peer can force us to spend is *bytes*, not entries.  A captured
+# Chromium page load needs 26 distinct lines totalling 988 B, longest 145 B —
+# so these leave real traffic entirely uncapped while denying the adversarial
+# shape (7 x 8 KiB never-repeating lines per request, which an entry-count-only
+# bound would let grow to ~1 MiB per connection, held for as long as the peer
+# keeps the connection alive).
+
+#: Entries.  Bounds the dict itself.
+_LINE_CACHE_MAX = 64
+
+#: Longest line admitted.  A line above this skips the cache **entirely** — no
+#: lookup either, so a huge line never pays a hash it cannot benefit from.
+#: 1 KiB clears the largest thing a browser really repeats (a ~145 B
+#: ``User-Agent``, a session ``Cookie``) by a wide margin.
+_LINE_CACHE_MAX_LINE = 1024
+
+#: Total key bytes admitted per connection.  The binding constraint, and the
+#: one that multiplies by concurrent connections: ~8 KiB/conn worst case
+#: (~16 KiB counting the retained name/value slices) against 988 B of real
+#: need.
+_LINE_CACHE_MAX_BYTES = 8192
+
+
+# ---------------------------------------------------------------------------
+# Shared default line table
+# ---------------------------------------------------------------------------
+# The per-connection cache cannot help the *first* request on a connection —
+# there is nothing in it yet — which is the whole of the interaction for a
+# ``Connection: close`` client.  This table closes that gap: header lines whose
+# value set is fixed by a specification are the same bytes for every client on
+# every deployment, so they can be validated once at import and shared.
+#
+# **The admission rule is what keeps this honest**: a line belongs here only if
+# its value set is enumerated by a spec — Fetch Metadata's ``Sec-Fetch-*``,
+# the UA client hints' boolean/platform forms, and the fixed tokens of RFC 9110
+# — plus a handful of genuinely universal idioms.  Values *observed in a packet
+# capture* do not qualify, however frequent: seeding the table from a capture
+# would be tuning the server to the browser that happened to be measured.
+# That is why no ``User-Agent``, ``Accept-Language``, ``sec-ch-ua``, ``Host``,
+# ``Referer`` or ``Cookie`` line appears below, though all are frequent.
+#
+# Framing-relevant names (``Content-Length``, ``Transfer-Encoding``, ``Host``,
+# ``Connection`` values that change framing semantics beyond the two tokens
+# below) are deliberately absent: a shared table is the last place a framing
+# decision should come from.  ``tests/unit/test_default_line_table.py`` pins
+# both rules.
+_SPEC_ENUMERATED_LINES: tuple[bytes, ...] = (
+    # Fetch Metadata Request Headers (W3C) — closed value sets.
+    *(b'Sec-Fetch-Site: ' + v for v in
+      (b'cross-site', b'same-origin', b'same-site', b'none')),
+    *(b'Sec-Fetch-Mode: ' + v for v in
+      (b'cors', b'navigate', b'no-cors', b'same-origin', b'websocket')),
+    *(b'Sec-Fetch-Dest: ' + v for v in
+      (b'audio', b'audioworklet', b'document', b'embed', b'empty', b'font',
+       b'frame', b'iframe', b'image', b'manifest', b'object', b'paintworklet',
+       b'report', b'script', b'serviceworker', b'sharedworker', b'style',
+       b'track', b'video', b'worker', b'xslt')),
+    b'Sec-Fetch-User: ?1',
+    # UA client hints (RFC 8942 / W3C) — booleans and the platform enum.
+    b'sec-ch-ua-mobile: ?0',
+    b'sec-ch-ua-mobile: ?1',
+    *(b'sec-ch-ua-platform: "' + v + b'"' for v in
+      (b'Android', b'Chrome OS', b'Chromium OS', b'iOS', b'Linux', b'macOS',
+       b'Windows', b'Unknown')),
+    # Fixed tokens (RFC 9110 / RFC 9112 / RFC 6797 / DNT).
+    b'Upgrade-Insecure-Requests: 1',
+    b'DNT: 0',
+    b'DNT: 1',
+    b'TE: trailers',
+    b'Pragma: no-cache',
+    b'Connection: keep-alive',
+    b'Connection: Keep-Alive',
+    b'Connection: close',
+    *(b'Cache-Control: ' + v for v in
+      (b'no-cache', b'no-store', b'max-age=0')),
+    # Universal idioms rather than spec enums, and few on purpose: ``*/*`` is
+    # what every non-browser client sends, and the gzip/deflate/br/zstd
+    # progression is the content-coding registry in the order it grew.
+    b'Accept: */*',
+    b'Accept-Encoding: gzip',
+    b'Accept-Encoding: gzip, deflate',
+    b'Accept-Encoding: gzip, deflate, br',
+    b'Accept-Encoding: gzip, deflate, br, zstd',
+    b'Accept-Encoding: identity',
+)
+
+
+def _build_default_lines() -> dict[bytes, tuple[bytes, bytes]]:
+    """Validate every default line and map it to the pair ``_parse`` produces.
+
+    The pair is derived with the *same* expressions the parse loop uses and
+    checked with the *same* rules, so a hand-written entry cannot disagree with
+    what parsing that line would have yielded.  A violation raises at import
+    rather than serving a wrong pair at runtime.
+    """
+    table: dict[bytes, tuple[bytes, bytes]] = {}
+    for line in _SPEC_ENUMERATED_LINES:
+        colon = line.find(b':')
+        if colon < 1 or line[0] in (0x20, 0x09):
+            raise ValueError(f'malformed default header line: {line!r}')
+        key = line[:colon]
+        if key.translate(None, _TCHAR_OCTETS):
+            raise ValueError(f'invalid name in default header line: {line!r}')
+        lkey = key.lower()
+        if lkey in _UNDERSCORE_FRAMING_NAMES or lkey in _FRAMING_NAMES:
+            raise ValueError(
+                f'framing header must not be pre-seeded: {line!r}')
+        value = line[colon + 1:].strip(b' \t')
+        if _FIELD_VALUE_INVALID_RE.search(value):
+            raise ValueError(f'CTL in default header value: {line!r}')
+        if len(line) > _LINE_CACHE_MAX_LINE:
+            raise ValueError(f'default header line too long: {line!r}')
+        table[line] = (lkey, value)
+    return table
+
+
+#: Names a shared table must never carry, because they decide message framing
+#: or routing and must be read from the request every time.
+_FRAMING_NAMES = frozenset({
+    b'content-length', b'transfer-encoding', b'host', b'expect', b'upgrade',
+    b'trailer', b'te-framing',
+})
+
+# Built at the bottom of this constant block: ``_build_default_lines`` runs the
+# real validation rules, and ``_UNDERSCORE_FRAMING_NAMES`` is defined below.
+
 # RFC 9110 §8.6 — strict Content-Length: at most one canonical leading SP
 # (the byte after the colon), then ``0`` or a no-leading-zero decimal.
 # Matched against the *raw* post-colon bytes, before the generic OWS strip
@@ -134,6 +267,12 @@ _CL_STRICT_RE = re.compile(rb'\A ?(?:0|[1-9][0-9]*)\Z')
 # (CGI-style); nginx drops them by default, we reject.
 _UNDERSCORE_FRAMING_NAMES = frozenset((
     b'content_length', b'transfer_encoding'))
+
+#: Built here rather than beside its literals because validating an entry needs
+#: every rule above, ``_UNDERSCORE_FRAMING_NAMES`` included.  An invalid or
+#: framing-relevant entry raises at import — the table can never be wrong at
+#: runtime, only absent.
+_DEFAULT_LINES = _build_default_lines()
 
 
 class BadRequestError(Exception):
@@ -405,6 +544,16 @@ class HTTP1Actor(Actor):
     # exercise ``_parse`` in isolation) see a cleartext scope by default.
     _ssl: bool = False
 
+    # Both are per-connection state that ``_parse`` memoises on first use.
+    # They are declared here as immutable ``None`` rather than initialised in
+    # ``__init__`` for two reasons: the ``__new__`` test doubles above never
+    # run ``__init__``, and a mutable class-level default would be *shared by
+    # every connection* — which for the line cache is precisely the
+    # cross-connection bleed its design forbids.
+    _line_cache: 'dict[bytes, tuple[bytes, bytes]] | None' = None
+    _line_cache_bytes: int = 0
+    _max_line: int | None = None
+
     def __init__(
         self,
         reader: AbstractReader,
@@ -591,11 +740,6 @@ class HTTP1Actor(Actor):
                 # ``app(scope, …)`` is used *iff* the flag is set. The actor's own
                 # plumbing (RecipientFactory, access log, keep-alive) always reads
                 # ``conn``.
-                if cfg.force_asgi_scope:
-                    app_arg = conn.to_asgi_scope(force_asgi=True)  # pure scope
-                else:
-                    app_arg = conn                                     # native Connection
-
                 if conn.type == 'websocket':
                     # WebSocket is native too: the upgrade path
                     # threads the typed Connection — the WS-only extras
@@ -668,6 +812,18 @@ class HTTP1Actor(Actor):
                     # ``method`` back from ``conn`` (now 'GET'), so no separate
                     # ``scope['method']`` write (which would force materialization).
                     conn.method = 'GET'
+
+                # The app's argument is built *here*, after every pre-dispatch
+                # mutation of ``conn`` — the HEAD→GET rewrite above being the one
+                # that matters.  The native lane passes the Connection itself and
+                # so would tolerate an earlier binding, but the compat lane emits
+                # a *snapshot*: taken any earlier it freezes ``method='HEAD'``,
+                # the router finds no HEAD route, and the dual-path lane answers
+                # 405 where the native lane answers 200 (COMP-HEAD-NO-BODY).
+                if cfg.force_asgi_scope:
+                    app_arg = conn.to_asgi_scope(force_asgi=True)  # pure scope
+                else:
+                    app_arg = conn                                     # native Connection
                 # One recipient per connection, rebound per request — the same
                 # trade as ``send.reset_per_request_state()`` above, and for the
                 # same reason: the reader, body timeout, and deadline are
@@ -828,8 +984,14 @@ class HTTP1Actor(Actor):
         ``run()`` because it sees the accumulating buffer; per-line is
         cheaper to check here, post-split.
         """
-        from ..env import get_settings as _get_settings  # noqa: PLC0415
-        max_line = _get_settings().header_max_line
+        # Connection-scoped, so it is read once per connection rather than
+        # once per request.  The cost being removed is not ``get_settings()``
+        # itself (it is ``functools.cache``d) but the ``from ..env import``
+        # statement that has to run ahead of it on every single parse.
+        max_line = self._max_line
+        if max_line is None:
+            from ..env import get_settings as _get_settings  # noqa: PLC0415
+            max_line = self._max_line = _get_settings().header_max_line
         lines = data.split(b'\r\n')
         # No line can be longer than the block that contains it, so the
         # per-line walk is only reachable for a block that is itself over the
@@ -946,12 +1108,52 @@ class HTTP1Actor(Actor):
         # and still raises, so the diagnostic never changes.
         values_need_checking = not _block_values_are_clean(data)
 
+        # Per-connection cache of lines that have already passed every check
+        # below.  The key is the *exact* line bytes, so any changed byte is a
+        # miss and gets validated from scratch; only a line that reached the
+        # bottom of the loop without raising is ever admitted.  Both facts
+        # together are what make this a replay of validated work rather than a
+        # way to skip validation.  Created per instance on first use — see the
+        # class-level ``None`` for why it is not a class attribute.
+        cache = self._line_cache
+        if cache is None:
+            cache = self._line_cache = {}
+        # Hashing a line to probe a cache that is known to be empty buys
+        # nothing, and on the first request of a connection that is every
+        # probe.  Skipping them is what keeps the connection-per-request shape
+        # (``Connection: close``, HTTP/1.0, health checks) close to the cost of
+        # not having a cache at all: that client pays for admissions it never
+        # reads, but not for lookups that cannot hit.  Decided once per
+        # request, not once per line.
+        do_lookup = len(cache) > 0
+
         raw: list[tuple[bytes, bytes]] = []
         for line in lines[idx + 1:]:
             if not line:
                 # Empty line = end of headers; anything after is body (already
                 # split off upstream because we read until CRLFCRLF).
                 continue
+            # A line too long to ever be admitted skips the cache completely —
+            # including the lookup, because hashing 8 KiB to answer a question
+            # whose answer is always "no" is the adversary's cheapest way to
+            # spend our CPU.  ``len`` on bytes is O(1).
+            cacheable = len(line) <= _LINE_CACHE_MAX_LINE
+            if cacheable:
+                # The per-connection cache first — it holds this peer's long,
+                # expensive lines — then the shared spec table, which is the
+                # only thing that can help the *first* request on a connection.
+                hit = cache.get(line) if do_lookup else None
+                if hit is None:
+                    hit = _DEFAULT_LINES.get(line)
+                if hit is not None:
+                    # Identical bytes, already validated — on this connection
+                    # when it came from ``cache``, at import when it came from
+                    # ``_DEFAULT_LINES``.  Safe even when
+                    # ``values_need_checking`` is True for *this* block: the
+                    # hit was proved clean when it was admitted and its bytes
+                    # have not changed since.
+                    raw.append(hit)
+                    continue
             # RFC 9112 §5.2 — obs-fold (leading SP/HTAB on a header line)
             # MUST be rejected in requests.  Indexing yields an int and skips
             # the one-byte slice a `line[:1]` comparison would allocate; the
@@ -993,7 +1195,18 @@ class HTTP1Actor(Actor):
                 raise BadRequestError(
                     f'CTL in header value (smuggling / log-injection): '
                     f'{key!r}: {value!r}')
-            raw.append((lkey, value))
+            pair = (lkey, value)
+            raw.append(pair)
+            # Admission is the last statement in the loop body on purpose:
+            # every ``raise`` above is a line that never enters the cache.
+            # Bytes are the bound that matters — see the constants above.
+            # Tested against the *resulting* size, not the current one, so the
+            # budget is a real ceiling rather than one a final line can step over.
+            if (cacheable
+                    and len(cache) < _LINE_CACHE_MAX
+                    and self._line_cache_bytes + len(line) <= _LINE_CACHE_MAX_BYTES):
+                cache[line] = pair
+                self._line_cache_bytes += len(line)
 
         # RFC 9112 §3.2.2 — for an absolute-form target the request's own
         # authority is definitive; replace any client Host so a mismatched or

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -38,6 +38,49 @@ _PATHSEND_FALLBACK_CHUNK = 64 * 1024
 _VECTORED_JOIN_THRESHOLD = 32 * 1024
 
 
+# Status line and Content-Length are the two per-response values that are
+# rebuilt from scratch on every single request and drawn from a small, known
+# domain.  Both tables are built once at import; both fall back to the original
+# expression for an input outside the domain, so an unregistered status code or
+# a large body renders exactly as before rather than raising.
+
+#: ``status -> b'HTTP/1.1 <code> <phrase>\r\n'``, the full first line.  The CRLF
+#: is baked in so the renderer appends one list item instead of two.
+_STATUS_LINES: dict[HTTPStatus, bytes] = {
+    s: f'HTTP/1.1 {s} {s.phrase}'.encode() + _CRLF for s in HTTPStatus
+}
+
+
+def _status_line(status) -> bytes:
+    """The full ``HTTP/1.1 <code> <phrase>\\r\\n`` line for *status*."""
+    line = _STATUS_LINES.get(status)
+    if line is None:
+        # Not an ``HTTPStatus`` member — an application answering with a code
+        # IANA has not registered.  Render it the long way; ``phrase`` is only
+        # available on the enum, so an unknown code has an empty reason phrase
+        # (legal: RFC 9112 §4 makes the reason phrase optional).
+        phrase = getattr(status, 'phrase', '')
+        return f'HTTP/1.1 {int(status)} {phrase}'.encode() + _CRLF
+    return line
+
+
+#: Content-Length values below this are answered from a table.  Covers every
+#: response whose body fits in a few pages — the ``/ping``-shaped traffic that
+#: dominates request *count* — while keeping the table itself small.
+_CONTENT_LENGTH_CACHE_MAX = 8192
+
+_CONTENT_LENGTHS: tuple[bytes, ...] = tuple(
+    str(n).encode() for n in range(_CONTENT_LENGTH_CACHE_MAX + 1)
+)
+
+
+def _content_length_bytes(n: int) -> bytes:
+    """Decimal ASCII for *n*, from the table when it is small enough."""
+    if 0 <= n <= _CONTENT_LENGTH_CACHE_MAX:
+        return _CONTENT_LENGTHS[n]
+    return str(n).encode()
+
+
 # RFC 7231 Date header is whole-second resolution, so re-formatting it
 # per response is wasted work — email.utils.formatdate shows ~2.6% of
 # CPU on a B2r profile.  Cache for the current integer second.
@@ -612,7 +655,7 @@ class HTTP1Sender(BaseSender):
                 headers.append(b'transfer-encoding', b'chunked')
             self._chunked = True
         elif b'content-length' not in headers:
-            headers.append(b'content-length', str(body_len).encode())
+            headers.append(b'content-length', _content_length_bytes(body_len))
 
     @staticmethod
     def _ensure_date_header(headers: Headers) -> None:
@@ -663,7 +706,7 @@ class HTTP1Sender(BaseSender):
 
     def _render_start(self, status: HTTPStatus, headers: HeaderList) -> bytes:
         """Build the status line + headers + blank-line as a single bytes blob."""
-        parts: list[bytes] = [f'HTTP/1.1 {status} {status.phrase}'.encode(), _CRLF]
+        parts: list[bytes] = [_status_line(status)]
         for k, v in headers:
             parts.append(k)
             parts.append(b': ')

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -274,6 +274,25 @@ Callers must never call `transport.writelines` directly with
 small parts.  The gate is the single decision point, and the
 invariant keeps performance predictable across payload sizes.
 
+### Response values that come from tables
+
+Two values are rebuilt on every single response and drawn from a
+small, known domain, so both are precomputed once at import:
+
+- **The status line.**  `_STATUS_LINES` maps every `HTTPStatus` member
+  to the complete `HTTP/1.1 <code> <phrase>\r\n` line, CRLF included.
+- **Small Content-Length values.**  `_CONTENT_LENGTHS` holds the
+  decimal ASCII for `0…8192`, which covers the body sizes that
+  dominate request *count*.
+
+Both fall back to the original expression for an input outside the
+table's domain — a status code IANA has not registered renders with an
+empty reason phrase (legal: RFC 9112 §4 makes it optional) rather than
+raising `KeyError`, and a large body formats with `str(n).encode()`.
+Tests assert the tables agree with the expressions they replaced across
+the whole domain, because a table that disagrees anywhere is a wire
+bug that no amount of speed pays for.
+
 ## Parse-path invariant
 
 The HTTP/1.1 parser validates bytes with **C-level bulk operations**,
@@ -319,6 +338,213 @@ do not reintroduce them without new numbers:
 The through-line: an optimisation that replaces a C bulk operation
 with Python bytecode pays ~30 ns per byte instead of ~2 ns, and no
 reduction in pass count or allocation count makes that back.
+
+### Validated header-line cache
+
+The cheapest validation is the one already done.  A keep-alive peer
+resends byte-identical header lines on every request — `User-Agent`,
+`Accept`, `Accept-Language`, `Cookie` — so each connection keeps a
+bounded dict mapping **the exact raw line bytes** to the
+`(lowercased-name, stripped-value)` pair that line produced the first
+time it was seen and fully validated.  A hit replaces the colon split,
+the token check, the lowercase, the OWS strip and the value scan with
+one dict lookup.
+
+Four properties are what make this a replay of validated work rather
+than a way to skip validation, and none of them is optional:
+
+- **The key is the exact line bytes.** One changed byte is a miss, and
+  a miss is validated from scratch.  There is no normalisation, no
+  case-folding and no prefix matching on the lookup path.
+- **Only a line that reached the bottom of the loop is admitted.**
+  Admission is the last statement in the body, after every `raise`, so
+  a rejected line can never enter.
+- **The cache is per connection.**  It lives on the `HTTP1Actor`
+  instance, so validated lines never cross a connection — and
+  therefore never cross a tenant.
+- **It is bounded** (64 entries).  The key can be attacker-controlled, so a
+  peer cycling unique header names must not be able to grow it;
+  admission simply stops at the limit rather than evicting.
+
+The precedent is HPACK's dynamic table, which is this same idea blessed
+at protocol level — HTTP/1.1 merely lacks the wire form for it.
+
+### The shared spec table
+
+A per-connection cache cannot help the **first** request on a
+connection — there is nothing in it yet — and for a
+`Connection: close` client that first request is the entire
+interaction.  Populating a cache it will never read made that shape
+**21 % slower** than having no cache at all.
+
+So the cache has a second tier that needs no warming: a process-wide
+table of header lines whose value set is *fixed by a specification*,
+validated once at import and shared by every connection.  Fetch
+Metadata's `Sec-Fetch-Site` / `-Mode` / `-Dest` / `-User`, the client
+hints' boolean and platform forms, and the fixed tokens of RFC 9110
+(`Connection`, `TE`, `Pragma`, `Upgrade-Insecure-Requests`, `DNT`)
+are the same bytes for every client on every deployment.  On captured
+browser traffic they are **56 % of all header lines**, and that share
+does not decay with connection churn.
+
+HPACK's *static* table is the same idea, again — and again HTTP/1.1
+lacks the wire form, so the table lives in the parser instead.
+
+Three rules keep it from being an over-fit:
+
+- **Specification, not observation.**  A line qualifies because a spec
+  enumerates its values, not because it was frequent in a capture.
+  That is why no `User-Agent`, `sec-ch-ua`, `Accept-Language`,
+  `Cookie`, `Referer` or `Host` line is seeded, though every one of
+  them is more frequent than most entries that *are*.
+- **No framing header, ever.**  `Content-Length`,
+  `Transfer-Encoding`, `Host`, `Expect` and `Upgrade` are excluded by
+  an explicit check that raises at import.  A shared table is the last
+  place a framing decision should come from.
+- **Built through the real rules.**  Each entry is validated at import
+  with the same octet checks the parse loop applies, and a test
+  asserts every entry equals what parsing that line actually produces
+  — so a hand-written pair cannot drift from the parser.
+
+The table is immutable and never written to at runtime; learning goes
+to the per-connection dict alone, so nothing a peer sends can affect
+another connection.
+
+**Why it is not a benchmark artefact.**  A load generator resends one
+byte-identical request, which is the cache's best case and not what a
+real client does.  The numbers below therefore come from **captured
+traffic**, not from a model of it: a real Chromium loading a real page
+(document, 2 stylesheets, 3 scripts, 12 images, 2 XHRs), with every
+request head recorded exactly as it arrived
+(`bench/hotpath/capture_browser_headers.py`).
+
+That capture is what makes the mechanism legible.  21 requests carried
+**275 header lines drawn from only 26 distinct ones** — 8 of which
+(`Host`, `Connection`, `User-Agent`, `Accept-Encoding`,
+`Accept-Language`, three client hints) appeared on every single
+request, while `Accept`, `Referer` and the `Sec-Fetch-*` family varied
+by destination.  Because the cache is keyed per **line**, a request
+that changes four of its thirteen lines still hits on the other nine;
+what governs the hit rate is the *variety* of distinct lines on a
+connection, not whether requests are identical.  Chromium also emits
+its headers **in different orders** for navigations and subresources —
+which a whole-block cache would be defeated by and a per-line one does
+not notice.
+
+A cache that can only *learn* has a ceiling of
+`(lines − distinct) / lines` — every distinct line must miss once —
+which is **90.5 %** on this capture.  The shared table exceeds it,
+because a pre-seeded line never misses at all.
+
+The one thing a single capture cannot settle is how far a page spreads
+across connections: Chromium opens up to six per origin, and the
+learned tier sees fewer repeats the wider the spread.  The seeded tier
+does not care.  Re-dealing the same requests across N connections
+shows which half is which:
+
+| connections | hit rate | seeded | learned | parse cost |
+|---:|---:|---:|---:|---:|
+| 1 (as captured, no latency) | 96.7 % | 56.0 % | 40.7 % | 8.96 → 5.85 µs (**−35 %**) |
+| 2 | 94.2 % | 56.0 % | 38.2 % | 8.93 → 6.17 µs (−31 %) |
+| 4 | 89.8 % | 56.0 % | 33.8 % | 8.95 → 6.28 µs (−30 %) |
+| 6 (Chromium's per-origin max) | 85.5 % | 56.0 % | 29.5 % | 8.90 → 6.51 µs (**−27 %**) |
+| 12 | 72.7 % | 56.0 % | 16.7 % | 9.00 → 7.27 µs (−19 %) |
+
+Read the two middle columns rather than the total.  That the seeded
+column is *flat* is structural — the table does not depend on
+connections, so churn cannot erode it.  That it sits at *56 %* is a
+property of this client's header mix, and another client's would put
+it somewhere else.  The shape generalises; the level does not.
+
+!!! note "Where these numbers come from"
+
+    AMD Ryzen 5 7600X (6C/12T, Zen 4), Ubuntu 24.04 on **WSL2** — a
+    desktop VM, not an isolated benchmark host.  CPython **3.14.6**,
+    stock `asyncio` (`BB_UVLOOP=0`).  Both arms in one session: the
+    "before" column is `v0.66.0` (`450df4a`) in a `git worktree`,
+    the "after" column the same commit plus this work.  `min` of 7
+    for the µs-scale parser figures, medians of 5–7 interleaved
+    sweeps for anything driven by `wrk` (whose run-to-run spread on
+    this host is ~10 %).  Browser capture: Edge/Chromium 150 headless.
+
+    Two caveats that bound how far these generalise. The capture is
+    **n = 1** — one page load in one browser, whose requests are
+    intra-correlated by construction, so it is a point estimate with
+    no variance estimate. And **localhost has no latency**, which is
+    why Chromium used a single connection; over a real RTT it opens
+    up to six per origin, so **−17 % is the figure to quote for WAN
+    traffic**, not −30 %.
+
+    Full record, including how to size a proper multi-site sample from
+    the HTTP Archive corpus:
+    `bench/results/sprint87-frontend-spike-20260730/ENVIRONMENT.md`.
+    Every harness under `bench/hotpath/` prints its own environment
+    stamp (`bench/hotpath/provenance.py`) as its first output.
+
+So on traffic shaped like this capture, **−27 % to −35 %** is what one
+can expect — the lower figure over a real network.  Not a guarantee:
+the hit rate follows how much of a client's header set has
+spec-enumerated values and how many requests share a connection, and
+both vary by client and by deployment.  A client sending mostly
+bespoke headers on connections it closes immediately gets close to
+nothing; it does not get less than nothing, which is the part that is
+guaranteed.
+
+**Short-lived connections.**  The seeded tier needs no warming, so
+reconnection costs only the learned half.  Replaying the same capture while
+closing the connection every K requests — HttpArena's `limited-conn`
+profile is K = 10, and `Connection: close` is K = 1:
+
+| requests per connection | parse cost |
+|---:|---:|
+| 1 (`Connection: close`) | 8.75 → 8.21 µs (**−6 %**) |
+| 2 | 8.96 → 7.23 µs (−19 %) |
+| 10 (`limited-conn`) | 8.90 → 6.21 µs (**−30 %**) |
+| keep-alive | 8.77 → 6.27 µs (−29 %) |
+
+Without the seeded tier the K = 1 row was **+21 %** — a real regression
+on connection-churn traffic, and the reason the tier exists.
+
+On ordinary traffic that merely fails to repeat — every header value
+unique, or the cache already full — the path is still **5 % faster**
+than not having the cache, because the same change hoisted the
+per-request settings read out of `_parse` to connection setup.  A
+connection whose headers carry a per-request unique value (a request
+id, a timestamp, a rotating token) misses on those lines and still hits
+on the rest.
+
+### The worst case, stated
+
+The cache key is attacker-controlled, so the bounds above are not
+tuning — they are the security argument, and the resource that needs
+bounding is **bytes, not entries**.  With an entry-count bound alone,
+64 entries × `BB_HEADER_MAX_LINE` (8 KiB) retains **~1 MiB per
+connection**, which a peer pins by sending each line once and then
+idling on keep-alive — 9.6 GiB across 10k connections, against 988 B
+of real need.
+
+Hence the per-line cap and the byte budget.  A peer choosing the line
+length to maximise damage (`bench/hotpath/line_cache_worst_case.py`
+sweeps it, because a per-line cap moves the worst case *down* to just
+under itself rather than up to the limit):
+
+| | worst case | at |
+|---|---:|---|
+| CPU | **+19.2 %** vs no cache | 64 never-repeating 128 B lines/request |
+| memory | **16 KiB/connection** (153 MiB at 10k) | same |
+
+(Same host and toolchain as above; the memory figure is accounted
+bytes — key plus the retained name/value slices — which is what
+multiplies by concurrent connections.)
+
+Both are bounded, and the CPU figure sits on top of a request the peer
+chose to make expensive — 40.7 µs against ~6 µs for an ordinary one.
+Above the per-line cap the cache is skipped entirely, lookup included,
+so a peer sending 8 KiB lines makes the parse *faster* than the
+no-cache build rather than slower.
+
+None of this applies to HTTP/2: HPACK already does it on the wire, and
+better.  This is the HTTP/1.1 path recovering what H/2 gets for free.
 
 ## The pieces around the actor core
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.66.0"
+version = "0.67.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conformance/http1/test_dual_path_identity.py
+++ b/tests/conformance/http1/test_dual_path_identity.py
@@ -1,0 +1,158 @@
+"""The two dispatch lanes must be indistinguishable on the wire.
+
+BlackBull threads a native :class:`Connection` end to end.  ``BB_FORCE_ASGI_SCOPE=1``
+takes the compat lane instead: the server converts ``Connection -> scope`` and the
+app converts it back with ``from_scope`` at dispatch, so both directions of the ASGI
+conversion are exercised on every request.  The lane exists to keep that conversion
+from bitrotting, and it only does its job if the conversion is *invisible*.
+
+So the invariant is not "the compat lane works" but **"the compat lane produces
+byte-identical output"** — for every request shape, including the ones that are
+rejected before routing.  The `HEAD` regression this file was written after
+passed every HEAD test on the native lane and answered 405 on the compat lane,
+because the scope snapshot was taken before the HEAD->GET rewrite.  Anything
+that mutates the Connection between parse and dispatch can reintroduce that
+class of divergence; this asserts the whole corpus rather than one method.
+"""
+import asyncio
+import re
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.env import reset_settings_cache
+from blackbull.server.http1_actor import HTTP1Actor
+
+from .test_http1_dispatch import _FakeReader, _FakeWriter
+
+# The Date header is whole-second wall clock, so it may legitimately differ
+# between two runs of the same request.  Nothing else may.
+_DATE_RE = re.compile(rb'^date:.*$', re.IGNORECASE | re.MULTILINE)
+
+
+def _normalise(raw: bytes) -> bytes:
+    return _DATE_RE.sub(b'date: <normalised>', raw)
+
+
+def _req(line: bytes, *headers: bytes, body: bytes = b'') -> bytes:
+    parts = [line, b'Host: localhost', *headers]
+    if body:
+        parts.append(b'Content-Length: %d' % len(body))
+    return b'\r\n'.join(parts) + b'\r\n\r\n' + body
+
+
+CORPUS = {
+    # --- ordinary routing ------------------------------------------------
+    'get': _req(b'GET / HTTP/1.1'),
+    'get-query': _req(b'GET /?a=1&b=2 HTTP/1.1'),
+    'get-encoded-path': _req(b'GET /caf%C3%A9 HTTP/1.1'),
+    'get-1.0': _req(b'GET / HTTP/1.0'),
+    'post-body': _req(b'POST /echo HTTP/1.1', body=b'hello'),
+    'post-empty-body': _req(b'POST /echo HTTP/1.1', body=b''),
+    # --- the method rewrite that broke ------------------------------------
+    'head': _req(b'HEAD / HTTP/1.1'),
+    'head-with-headers': _req(b'HEAD / HTTP/1.1', b'Accept: */*',
+                              b'User-Agent: probe'),
+    # --- server-level answers, not routed ---------------------------------
+    'options-asterisk': _req(b'OPTIONS * HTTP/1.1'),
+    'absolute-form': _req(b'GET http://real.example/ HTTP/1.1'),
+    # --- misses and rejections --------------------------------------------
+    'not-found': _req(b'GET /nope HTTP/1.1'),
+    'method-not-allowed': _req(b'DELETE / HTTP/1.1'),
+    'bad-header-name': _req(b'GET / HTTP/1.1', b'Bad Name: v'),
+    'obs-fold': _req(b'GET / HTTP/1.1', b' folded: v'),
+    'bad-content-length': _req(b'POST /echo HTTP/1.1', b'Content-Length: 007'),
+    'unsupported-version': _req(b'GET / HTTP/9.9'),
+    # --- header shapes ----------------------------------------------------
+    'many-headers': _req(
+        b'GET / HTTP/1.1',
+        b'User-Agent: Mozilla/5.0 (X11; Linux x86_64)',
+        b'Accept: text/html,application/xhtml+xml',
+        b'Accept-Encoding: gzip, deflate, br',
+        b'Accept-Language: en-US,en;q=0.9',
+        b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543',
+        b'Referer: http://localhost/index.html'),
+    'repeated-header': _req(b'GET / HTTP/1.1', b'Accept: a', b'Accept: b'),
+    'ows-padded-value': _req(b'GET / HTTP/1.1', b'Accept:    */*   '),
+}
+
+
+@pytest.fixture
+def app():
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    @a.route(path='/echo', methods=['POST'])
+    async def _echo(conn, receive, send):
+        event = await receive()
+        await send(event.get('body', b'') or b'(empty)', 200)
+
+    @a.route(path='/café')
+    async def _unicode_path():
+        return 'cafe'
+
+    return a
+
+
+async def _drive(app, request: bytes) -> bytes:
+    # The head is handed over via ``request=``; the reader carries only the
+    # body, so the keep-alive loop sees EOF and serves exactly one response.
+    head, _, body = request.partition(b'\r\n\r\n')
+    reader, writer = _FakeReader(body), _FakeWriter()
+    actor = HTTP1Actor(reader, writer, app, None, request=head + b'\r\n\r\n')
+    await asyncio.wait_for(actor.run(), timeout=5.0)
+    return bytes(writer.written)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('name', sorted(CORPUS))
+async def test_both_lanes_produce_identical_bytes(app, name, monkeypatch):
+    """Native and BB_FORCE_ASGI_SCOPE=1 must agree byte for byte."""
+    request = CORPUS[name]
+
+    reset_settings_cache()
+    native = await _drive(app, request)
+
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    try:
+        forced = await _drive(app, request)
+    finally:
+        monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+        reset_settings_cache()
+
+    assert _normalise(forced) == _normalise(native), (
+        f'{name}: the compat lane diverged from the native lane.\n'
+        f'  native: {native[:200]!r}\n'
+        f'  forced: {forced[:200]!r}')
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('name', sorted(CORPUS))
+async def test_both_lanes_agree_on_status(app, name, monkeypatch):
+    """A narrower assertion that survives intentional body changes.
+
+    ``test_both_lanes_produce_identical_bytes`` is the real invariant, but it
+    fails wholesale if a response body is ever deliberately changed.  This one
+    keeps the status-code half of the guarantee legible on its own.
+    """
+    request = CORPUS[name]
+
+    def status_of(raw: bytes) -> bytes:
+        return raw.split(b'\r\n', 1)[0] if raw else b'<no response>'
+
+    reset_settings_cache()
+    native = status_of(await _drive(app, request))
+
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    try:
+        forced = status_of(await _drive(app, request))
+    finally:
+        monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+        reset_settings_cache()
+
+    assert native == forced, f'{name}: {native!r} (native) != {forced!r} (compat)'

--- a/tests/conformance/http1/test_head_dual_path.py
+++ b/tests/conformance/http1/test_head_dual_path.py
@@ -1,0 +1,97 @@
+"""HEAD must reach the GET handler on *both* dispatch lanes (RFC 9110 §9.3.2).
+
+BlackBull synthesises a HEAD response by rewriting the request's method to
+``GET`` and stripping body bytes on the way out.  The native lane threads the
+live :class:`Connection`, so the rewrite is visible to the router by reference.
+The ``BB_FORCE_ASGI_SCOPE=1`` lane hands the app a *snapshot* dict instead —
+so the snapshot has to be taken after the rewrite, not before, or the router
+sees ``HEAD``, finds no HEAD route, and answers 405.
+
+Both lanes must produce the same status.  That identity is the whole point of
+the dual-path lane: the compat conversion is only faithful if it is invisible.
+"""
+import asyncio
+from http import HTTPStatus
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.env import reset_settings_cache
+from blackbull.server.http1_actor import HTTP1Actor
+
+from .test_http1_dispatch import _FakeReader, _FakeWriter
+
+
+HEAD_REQUEST = b'HEAD / HTTP/1.1\r\nHost: localhost\r\n\r\n'
+GET_REQUEST = b'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n'
+
+
+@pytest.fixture
+def app():
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    return a
+
+
+async def _drive(app, request: bytes) -> bytes:
+    # The head is handed over via ``request=``; the reader is left empty so the
+    # keep-alive loop sees EOF and serves exactly one response.  Seeding the
+    # reader with the same bytes would serve the request twice.
+    reader, writer = _FakeReader(b''), _FakeWriter()
+    actor = HTTP1Actor(reader, writer, app, None, request=request)
+    await asyncio.wait_for(actor.run(), timeout=5.0)
+    return bytes(writer.written)
+
+
+def _status(raw: bytes) -> int:
+    return int(raw.split(b' ', 2)[1])
+
+
+@pytest.fixture
+def forced_asgi(monkeypatch):
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    yield
+    monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+    reset_settings_cache()
+
+
+@pytest.mark.asyncio
+async def test_head_reaches_the_get_handler_natively(app):
+    raw = await _drive(app, HEAD_REQUEST)
+    assert _status(raw) == HTTPStatus.OK
+
+
+@pytest.mark.asyncio
+async def test_head_reaches_the_get_handler_under_forced_asgi_scope(app, forced_asgi):
+    raw = await _drive(app, HEAD_REQUEST)
+    assert _status(raw) == HTTPStatus.OK, (
+        'HEAD was routed as HEAD on the forced-ASGI lane — the scope snapshot '
+        'was taken before the HEAD->GET rewrite')
+
+
+@pytest.mark.asyncio
+async def test_both_lanes_agree_on_the_head_status(app, monkeypatch):
+    native = await _drive(app, HEAD_REQUEST)
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    try:
+        forced = await _drive(app, HEAD_REQUEST)
+    finally:
+        monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+        reset_settings_cache()
+    assert _status(native) == _status(forced)
+
+
+@pytest.mark.asyncio
+async def test_head_response_carries_no_body_under_forced_asgi_scope(app, forced_asgi):
+    """§9.3.2 — headers identical to the GET response, body absent."""
+    raw = await _drive(app, HEAD_REQUEST)
+    head, _, body = raw.partition(b'\r\n\r\n')
+    assert body == b''
+    # The Content-Length still describes what a GET would have returned.
+    assert b'content-length: 5' in head.lower()

--- a/tests/unit/test_default_line_table.py
+++ b/tests/unit/test_default_line_table.py
@@ -1,0 +1,111 @@
+"""The shared default line table must be indistinguishable from parsing.
+
+The per-connection cache cannot help the first request on a connection.  A
+small table of header lines whose value set is fixed by a specification can,
+because those bytes are the same for every client on every deployment — so
+they are validated once at import and shared process-wide.
+
+Shared state on the parse path is exactly where a wrong entry would be most
+damaging, so the table is held to two rules, and both are asserted here:
+
+1. **Every entry maps to what parsing that line actually produces.**  Not to
+   what a human wrote next to it.
+2. **No framing-relevant name may appear.**  Framing must be read from the
+   request every time, never from a shared table.
+
+A third rule is about honesty rather than safety: entries must be justified by
+a specification's value set, not by their frequency in a packet capture.  That
+one cannot be asserted mechanically — the closest proxy is rule 2 plus the
+exclusion of client-, user- and deployment-specific names, which is checked.
+"""
+import pytest
+
+from blackbull.server.http1_actor import (
+    _DEFAULT_LINES,
+    _FRAMING_NAMES,
+    _LINE_CACHE_MAX_LINE,
+    HTTP1Actor,
+)
+
+
+def _actor() -> HTTP1Actor:
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def test_table_is_not_empty():
+    assert len(_DEFAULT_LINES) > 20
+
+
+@pytest.mark.parametrize('line', sorted(_DEFAULT_LINES),
+                         ids=lambda ln: ln.decode('latin-1'))
+def test_entry_matches_what_parsing_that_line_produces(line):
+    """Rule 1 — differential against the parser itself, on a cold actor."""
+    raw = (b'GET /x HTTP/1.1\r\nHost: example.com\r\n' + line + b'\r\n\r\n')
+    conn = _actor()._parse(raw)
+    pairs = list(iter(conn.headers))
+    assert _DEFAULT_LINES[line] in pairs, (
+        f'{line!r} maps to {_DEFAULT_LINES[line]!r} but parsing it yields '
+        f'{[p for p in pairs if p[0] != b"host"]!r}')
+
+
+@pytest.mark.parametrize('line', sorted(_DEFAULT_LINES),
+                         ids=lambda ln: ln.decode('latin-1'))
+def test_no_framing_header_is_pre_seeded(line):
+    """Rule 2 — a shared table is the last place framing should come from."""
+    name = _DEFAULT_LINES[line][0]
+    assert name not in _FRAMING_NAMES
+
+
+def test_no_client_or_deployment_specific_names():
+    """Values that differ per browser build, per user or per deployment must
+    not be seeded — seeding those would be tuning to whatever was captured."""
+    forbidden = {
+        b'user-agent', b'accept-language', b'sec-ch-ua', b'cookie', b'referer',
+        b'origin', b'authorization', b'if-none-match', b'if-modified-since',
+        b'host',
+    }
+    seeded = {pair[0] for pair in _DEFAULT_LINES.values()}
+    assert not (seeded & forbidden)
+
+
+def test_every_entry_respects_the_per_line_cap():
+    assert all(len(line) <= _LINE_CACHE_MAX_LINE for line in _DEFAULT_LINES)
+
+
+def test_table_is_small_enough_to_be_shared():
+    """It is process-wide, so it should stay a table, not a database."""
+    total = sum(len(k) + len(v[0]) + len(v[1]) for k, v in _DEFAULT_LINES.items())
+    assert total < 8192, f'{total} B of shared table is more than intended'
+
+
+def test_first_request_on_a_connection_hits_the_table():
+    """The point of the whole thing: no warm-up needed for a spec line."""
+    cold = _actor()
+    conn = cold._parse(
+        b'GET /x HTTP/1.1\r\nHost: example.com\r\n'
+        b'Sec-Fetch-Dest: image\r\nConnection: keep-alive\r\n\r\n')
+    pairs = list(iter(conn.headers))
+    assert (b'sec-fetch-dest', b'image') in pairs
+    # Served from the shared table, so the per-connection cache stayed empty
+    # of them — they would be found there on every later request anyway.
+    assert b'Sec-Fetch-Dest: image' not in (cold._line_cache or {})
+
+
+def test_a_near_miss_on_a_seeded_line_is_validated_normally():
+    """One changed byte must miss the table and go through the full checks."""
+    cold = _actor()
+    with pytest.raises(Exception):
+        cold._parse(b'GET /x HTTP/1.1\r\nHost: example.com\r\n'
+                    b'Sec-Fetch-Dest: ima\x01ge\r\n\r\n')
+
+
+def test_table_is_never_mutated_by_serving_traffic():
+    """It is shared across connections; a write would be cross-connection bleed."""
+    before = dict(_DEFAULT_LINES)
+    actor = _actor()
+    for i in range(20):
+        actor._parse(b'GET /x HTTP/1.1\r\nHost: example.com\r\n'
+                     b'Sec-Fetch-Mode: cors\r\nX-Learn-%d: v\r\n\r\n' % i)
+    assert _DEFAULT_LINES == before

--- a/tests/unit/test_event.py
+++ b/tests/unit/test_event.py
@@ -273,3 +273,58 @@ async def test_blocking_observer_counts_as_a_listener():
     assert d.has_listeners('test') is False
     d.on('test', cleanup, blocking=True)
     assert d.has_listeners('test') is True
+
+# ---------------------------------------------------------------------------
+# has_listeners — the per-request guard on every lifecycle emit site
+# ---------------------------------------------------------------------------
+
+def _has_listeners_reference(d: EventDispatcher, name: str) -> bool:
+    """The predicate as it stood before the registration index."""
+    return (bool(d._interceptors.get(name))
+            or bool(d._blocking_observers.get(name))
+            or bool(d._observers.get(name)))
+
+
+@pytest.mark.parametrize('kind', ['intercept', 'observe', 'blocking'])
+def test_has_listeners_agrees_with_the_three_dict_predicate(kind):
+    """The index must answer exactly what scanning the three dicts answers."""
+    d = EventDispatcher()
+
+    async def handler(event):
+        pass
+
+    assert d.has_listeners('e') is _has_listeners_reference(d, 'e')
+    if kind == 'intercept':
+        d.intercept('e', handler)
+    elif kind == 'observe':
+        d.on('e', handler)
+    else:
+        d.on('e', handler, blocking=True)
+    assert d.has_listeners('e') is _has_listeners_reference(d, 'e') is True
+    # A name nobody registered stays False.
+    assert d.has_listeners('other') is _has_listeners_reference(d, 'other')
+
+
+def test_has_listeners_does_not_create_empty_entries():
+    """Asking about an unknown event must not grow the defaultdicts."""
+    d = EventDispatcher()
+    for _ in range(3):
+        assert d.has_listeners('never-registered') is False
+    assert 'never-registered' not in d._observers
+    assert 'never-registered' not in d._interceptors
+    assert 'never-registered' not in d._blocking_observers
+
+
+def test_registration_bumps_generation_so_cached_guards_invalidate():
+    """EventAggregator caches derived booleans against this counter."""
+    d = EventDispatcher()
+
+    async def handler(event):
+        pass
+
+    before = d.generation
+    d.on('e', handler)
+    assert d.generation > before
+    mid = d.generation
+    d.intercept('e', handler)
+    assert d.generation > mid

--- a/tests/unit/test_header_line_cache.py
+++ b/tests/unit/test_header_line_cache.py
@@ -1,0 +1,305 @@
+"""The per-connection validated header-line cache must not change meaning.
+
+Keep-alive peers resend byte-identical header lines every request, so a line
+that passed full validation once can be replayed from a per-connection dict
+instead of being re-split, re-lowercased and re-checked.  The cache is only
+legitimate if it is invisible: every request must parse to exactly what it
+would have parsed to with the cache disabled, and every request that would
+have been rejected must still be rejected.
+
+That is what these tests assert — a *differential* against a cache-free actor,
+not a restatement of the cache's own logic.  The safety terms from the design
+(exact-bytes key, nothing unvalidated admitted, bounded, per-connection) each
+get a test, because each is what stops this from being a smuggling vector.
+"""
+import pytest
+
+from blackbull.server.http1_actor import (
+    _LINE_CACHE_MAX,
+    _LINE_CACHE_MAX_BYTES,
+    _LINE_CACHE_MAX_LINE,
+    BadRequestError,
+    HTTP1Actor,
+)
+
+
+def _actor() -> HTTP1Actor:
+    """An actor with just enough state for ``_parse``, as test_parser does."""
+    a = HTTP1Actor.__new__(HTTP1Actor)
+    a._ssl = False
+    return a
+
+
+def _req(*headers: bytes, target: bytes = b'/x', method: bytes = b'GET') -> bytes:
+    lines = [method + b' ' + target + b' HTTP/1.1', b'Host: example.com', *headers]
+    return b'\r\n'.join(lines) + b'\r\n\r\n'
+
+
+def _pairs(conn) -> list[tuple[bytes, bytes]]:
+    return list(iter(conn.headers))
+
+
+# --------------------------------------------------------------------------
+# Equivalence — the cache is invisible
+# --------------------------------------------------------------------------
+
+VALID_VECTORS = [
+    _req(b'Accept: */*'),
+    _req(b'User-Agent: Mozilla/5.0 (X11; Linux x86_64)'),
+    _req(b'Accept:    spaced-out   '),
+    _req(b'Accept:\tHTAB-wrapped\t'),
+    _req(b'X-Empty:'),
+    _req(b'Content-Length: 0', method=b'POST'),
+    _req(b'Content-Length: 42', method=b'POST'),
+    _req(b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543'),
+    _req(b'Accept: a', b'Accept: b'),                 # repeated name, one request
+    _req(b'X-Odd-Case-NAME: Value'),
+    _req(b'Connection: keep-alive', b'Cache-Control: max-age=0'),
+]
+
+
+@pytest.mark.parametrize('raw', VALID_VECTORS, ids=range(len(VALID_VECTORS)))
+def test_second_parse_on_same_connection_matches_the_first(raw):
+    """A cache hit must reproduce the cold parse byte-for-byte."""
+    warm = _actor()
+    first = _pairs(warm._parse(raw))
+    second = _pairs(warm._parse(raw))
+    assert second == first
+    # And it must match an actor that has never seen the line at all.
+    assert first == _pairs(_actor()._parse(raw))
+
+
+@pytest.mark.parametrize('raw', VALID_VECTORS, ids=range(len(VALID_VECTORS)))
+def test_ows_stripping_survives_a_cache_hit(raw):
+    """The stripped value is what is cached — not the raw post-colon bytes."""
+    warm = _actor()
+    warm._parse(raw)
+    for _name, value in _pairs(warm._parse(raw)):
+        assert value == value.strip(b' \t')
+
+
+REJECTED_VECTORS = [
+    _req(b'Bad Name: value'),                     # SP before colon (§5.1)
+    _req(b'Bad\x00Name: value'),                  # NUL in name — not tchar
+    _req(b' Folded: value'),                      # obs-fold (§5.2)
+    _req(b'\tFolded: value'),                     # obs-fold, HTAB
+    _req(b'NoColon'),
+    _req(b':empty-name'),
+    _req(b'X-Ctl: has\x01ctl'),                   # CTL in value
+    _req(b'Content_Length: 5'),                   # NORM-UNDERSCORE
+    _req(b'Content-Length: 007', method=b'POST'),  # leading zeros (§8.6)
+    _req(b'Content-Length:  5', method=b'POST'),   # doubled OWS
+]
+
+
+@pytest.mark.parametrize('raw', REJECTED_VECTORS, ids=range(len(REJECTED_VECTORS)))
+def test_rejection_is_stable_across_repeats(raw):
+    """A rejected request stays rejected — nothing bad reaches the cache."""
+    warm = _actor()
+    with pytest.raises(Exception) as first:
+        warm._parse(raw)
+    with pytest.raises(Exception) as second:
+        warm._parse(raw)
+    assert type(first.value) is type(second.value)
+
+
+@pytest.mark.parametrize('raw', REJECTED_VECTORS, ids=range(len(REJECTED_VECTORS)))
+def test_a_valid_request_first_does_not_launder_a_bad_one(raw):
+    """Warming the cache with good lines must not admit a bad line after it."""
+    warm = _actor()
+    for good in VALID_VECTORS:
+        warm._parse(good)
+    with pytest.raises(Exception):
+        warm._parse(raw)
+
+
+# --------------------------------------------------------------------------
+# The safety terms
+# --------------------------------------------------------------------------
+
+def test_key_is_exact_bytes_so_one_changed_byte_misses():
+    """A near-miss line must be validated from scratch, not served from a hit."""
+    warm = _actor()
+    warm._parse(_req(b'X-Ctl: clean'))
+    # Same name, same length, one byte changed into a CTL.
+    with pytest.raises(BadRequestError):
+        warm._parse(_req(b'X-Ctl: clea\x01'))
+
+
+def test_case_variant_of_a_cached_name_is_not_served_from_the_hit():
+    """``Accept`` and ``ACCEPT`` are different bytes; both must lowercase."""
+    warm = _actor()
+    first = _pairs(warm._parse(_req(b'Accept: */*')))
+    second = _pairs(warm._parse(_req(b'ACCEPT: */*')))
+    assert first == second        # both lowercase to b'accept'
+    assert (b'accept', b'*/*') in second
+
+
+def test_content_length_strictness_is_not_bypassed_by_a_warm_cache():
+    """A cached ``Content-Length: 5`` must not admit ``005`` on the next request."""
+    warm = _actor()
+    warm._parse(_req(b'Content-Length: 5', method=b'POST'))
+    with pytest.raises(BadRequestError):
+        warm._parse(_req(b'Content-Length: 005', method=b'POST'))
+
+
+def test_cache_is_per_connection():
+    """Two actors must not share validated lines — no cross-connection bleed."""
+    a, b = _actor(), _actor()
+    a._parse(_req(b'Accept: */*'))
+    a._parse(_req(b'Accept: */*'))   # admission is deferred to the 2nd request
+    assert a._line_cache
+    assert not b._line_cache      # untouched by a's traffic
+    b._parse(_req(b'Accept: */*'))
+    assert a._line_cache is not b._line_cache
+
+
+def test_cache_is_bounded():
+    """A peer sending endless unique lines must not grow the dict without limit."""
+    warm = _actor()
+    for i in range(_LINE_CACHE_MAX * 3):
+        warm._parse(_req(b'X-Unique-%d: v' % i))
+    assert len(warm._line_cache) <= _LINE_CACHE_MAX
+
+
+def test_cache_actually_holds_the_repeated_line():
+    """Pin the mechanism: the second parse must be served from the dict."""
+    warm = _actor()
+    raw = _req(b'User-Agent: probe')
+    warm._parse(raw)
+    warm._parse(raw)                 # admission is deferred to the 2nd request
+    assert b'User-Agent: probe' in warm._line_cache
+    assert warm._line_cache[b'User-Agent: probe'] == (b'user-agent', b'probe')
+
+
+def test_absolute_form_host_override_still_wins_with_a_warm_cache():
+    """§3.2.2 — the target's authority replaces a cached Host line."""
+    warm = _actor()
+    warm._parse(_req(b'Accept: */*'))
+    conn = warm._parse(
+        b'GET http://real.example/x HTTP/1.1\r\n'
+        b'Host: spoofed.example\r\n\r\n')
+    assert conn.headers.get(b'host') == b'real.example'
+    assert conn.server[0] == 'real.example'
+
+
+# --------------------------------------------------------------------------
+# Resource bounds — the key is attacker-controlled, so entry count is not
+# the resource that needs bounding.  Bytes are.
+# --------------------------------------------------------------------------
+
+def test_an_oversized_line_is_never_cached():
+    """A line past the per-line cap must not be retained at all.
+
+    Without this, 64 entries x BB_HEADER_MAX_LINE (8 KiB) is ~1 MiB retained
+    per connection against ~1 KiB of real need — memory an attacker pins by
+    sending each line once and then idling on keep-alive.
+    """
+    warm = _actor()
+    big = b'X-Big: ' + b'a' * (_LINE_CACHE_MAX_LINE + 1)
+    conn = warm._parse(_req(big))
+    # It still parses correctly ...
+    assert (b'x-big', b'a' * (_LINE_CACHE_MAX_LINE + 1)) in _pairs(conn)
+    # ... it is simply never admitted.
+    assert all(len(k) <= _LINE_CACHE_MAX_LINE for k in warm._line_cache)
+
+
+def test_oversized_lines_cannot_grow_the_cache_at_all():
+    warm = _actor()
+    for i in range(50):
+        warm._parse(_req(b'X-Big%d: %s' % (i, b'a' * _LINE_CACHE_MAX_LINE)))
+    assert all(len(k) <= _LINE_CACHE_MAX_LINE for k in warm._line_cache)
+    assert not any(k.startswith(b'X-Big') for k in warm._line_cache)
+
+
+def test_cache_respects_a_byte_budget():
+    """Admission stops at the byte budget, not merely at the entry count."""
+    warm = _actor()
+    # Lines well under the per-line cap, but many of them.
+    for i in range(_LINE_CACHE_MAX * 4):
+        warm._parse(_req(b'X-Pad-%03d: %s' % (i, b'v' * 200)))
+    assert warm._line_cache_bytes <= _LINE_CACHE_MAX_BYTES
+    assert len(warm._line_cache) <= _LINE_CACHE_MAX
+
+
+def test_worst_case_retention_is_bounded_and_small():
+    """State the guarantee as a number, so a future tuning change trips here.
+
+    The accounted retention is key + name + value per entry; this is the figure
+    that multiplies by concurrent connections.
+    """
+    warm = _actor()
+    for i in range(500):
+        warm._parse(_req(b'X-Q-%04d: %s' % (i, b'v' * 900)))
+    accounted = sum(len(k) + len(v[0]) + len(v[1])
+                    for k, v in warm._line_cache.items())
+    # Two budgets' worth is the ceiling: the byte counter tracks the key, and
+    # the value slices add at most as much again.
+    assert accounted <= 2 * _LINE_CACHE_MAX_BYTES
+    assert accounted < 64 * 1024, f'{accounted} B/connection is too much'
+
+
+def test_real_world_header_set_still_fits_entirely():
+    """The bounds must not cost anything on traffic a browser actually sends.
+
+    Sizes taken from a captured Chromium page load: 26 distinct lines, 988 B
+    in total, longest 145 B.  If a future tuning makes real traffic miss, this
+    is where it shows up.
+    """
+    warm = _actor()
+    captured = [
+        # ``_req`` supplies the Host line; a second one is a smuggling reject.
+        b'Connection: keep-alive',
+        b'sec-ch-ua: "Not;A=Brand";v="8", "Chromium";v="150", "Microsoft Edge";v="150"',
+        b'sec-ch-ua-mobile: ?0',
+        b'sec-ch-ua-platform: "Windows"',
+        b'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+        b'(KHTML, like Gecko) HeadlessChrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0',
+        b'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,'
+        b'image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+        b'Accept-Encoding: gzip, deflate, br, zstd',
+        b'Accept-Language: ja,en;q=0.9,en-GB;q=0.8,en-US;q=0.7',
+        b'Sec-Fetch-Site: same-origin',
+        b'Sec-Fetch-Mode: no-cors',
+        b'Sec-Fetch-Dest: style',
+        b'Referer: http://localhost:8788/',
+    ]
+    warm._parse(_req(*captured))
+    assert warm._line_cache_bytes <= _LINE_CACHE_MAX_BYTES
+    # Every captured line is served without re-validation — from the shared
+    # spec table where the value set is fixed, from this connection's cache
+    # otherwise.  The split between the two is an implementation detail; that
+    # nothing falls through both is not.
+    from blackbull.server.http1_actor import _DEFAULT_LINES
+    for line in captured:
+        assert line in warm._line_cache or line in _DEFAULT_LINES, line
+
+
+def test_admission_happens_on_the_first_request():
+    """Populate immediately — deferring it was measured and rejected.
+
+    Deferring admission to the second request makes a connection-per-request
+    client cheaper (+6.9 % rather than +21 % against a no-cache build) but
+    costs every longer-lived connection, which is the dominant shape: at ten
+    requests per connection — HttpArena's ``limited-conn`` profile — deferral
+    gave -16.6 % where immediate admission gives -23.2 %, and at two requests
+    it turned a break-even into +13.9 %.  Parse is ~11 % of server CPU, so the
+    connection-per-request cost is ~+2 % CPU on a shape that is a minority of
+    real traffic.  Numbers: bench/hotpath/line_cache_churn.py.
+    """
+    warm = _actor()
+    warm._parse(_req(b'User-Agent: probe'))
+    assert b'User-Agent: probe' in warm._line_cache
+
+
+def test_an_empty_cache_is_not_probed():
+    """The first request must not hash lines against a cache that cannot hit.
+
+    Observable via the byte counter: a single-request connection admits, but
+    a lookup that could never succeed is not paid for.  (CPython caches a
+    bytes hash on the object, so the saving is the dict probe, not the hash —
+    which is why this alone does not make the first request free.)
+    """
+    warm = _actor()
+    warm._parse(_req(b'Accept: */*'))
+    assert warm._line_cache_bytes > 0

--- a/tests/unit/test_response_precompute.py
+++ b/tests/unit/test_response_precompute.py
@@ -1,0 +1,74 @@
+"""Response-side precomputation must be byte-identical to what it replaces.
+
+Two per-response allocations are answered from tables built once at import:
+the status line (`f'HTTP/1.1 {status} {status.phrase}'.encode()`) and small
+Content-Length values (`str(n).encode()`).  A table is only safe if it agrees
+with the expression it replaced on *every* input, including the ones that fall
+off the end of it — so these tests check the tables against the original
+expressions rather than against a restatement of the table.
+"""
+from http import HTTPStatus
+
+import pytest
+
+from blackbull.server.sender import (
+    _CONTENT_LENGTH_CACHE_MAX,
+    _content_length_bytes,
+    _status_line,
+)
+
+
+# --------------------------------------------------------------------------
+# Status line
+# --------------------------------------------------------------------------
+
+def _status_line_reference(status: HTTPStatus) -> bytes:
+    """The expression as it stood before the table."""
+    return f'HTTP/1.1 {status} {status.phrase}'.encode() + b'\r\n'
+
+
+@pytest.mark.parametrize('status', list(HTTPStatus), ids=lambda s: s.name)
+def test_status_line_matches_the_fstring_for_every_member(status):
+    assert _status_line(status) == _status_line_reference(status)
+
+
+def test_status_line_covers_the_whole_enum():
+    """No member may fall through to the slow path unnoticed."""
+    from blackbull.server.sender import _STATUS_LINES
+    assert set(_STATUS_LINES) == set(HTTPStatus)
+
+
+def test_status_line_falls_back_for_a_status_outside_the_enum():
+    """An unregistered code must still render, not raise a KeyError."""
+    assert _status_line(599) == b'HTTP/1.1 599 \r\n'
+
+
+def test_status_line_ends_with_crlf():
+    assert _status_line(HTTPStatus.OK) == b'HTTP/1.1 200 OK\r\n'
+
+
+# --------------------------------------------------------------------------
+# Content-Length
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('n', [0, 1, 2, 9, 10, 99, 100, 1023, 1024, 4096,
+                               _CONTENT_LENGTH_CACHE_MAX - 1,
+                               _CONTENT_LENGTH_CACHE_MAX,
+                               _CONTENT_LENGTH_CACHE_MAX + 1,
+                               65536, 1 << 30])
+def test_content_length_matches_str_encode(n):
+    assert _content_length_bytes(n) == str(n).encode()
+
+
+def test_content_length_agrees_across_the_whole_cached_range():
+    mismatched = [n for n in range(_CONTENT_LENGTH_CACHE_MAX + 2)
+                  if _content_length_bytes(n) != str(n).encode()]
+    assert mismatched == []
+
+
+def test_content_length_has_no_leading_zeros():
+    """RFC 9110 §8.6 — a leading zero is a smuggling vector we reject inbound;
+    never emit one outbound either."""
+    for n in (0, 1, 10, 100, 1000):
+        rendered = _content_length_bytes(n)
+        assert rendered == b'0' or not rendered.startswith(b'0')


### PR DESCRIPTION
Closes Sprint 87. Phase D of `reduce-loop-exposure.md`.

## Why not Phase C

The sprint opened as Phase C — replace the asyncio streams layer with
`asyncio.Protocol` — against a **+57 %** forecast and a gate of "loop touches
must fall from 2.06 toward 0.04". A pre-flight measurement disproved both
before any code was written:

| shape | transport | execution model | touches/req |
|---|---|---|---:|
| `streams` (today) | `start_server` | parked coroutine | 2.07 |
| `proto-coro` (Phase C as scoped) | `asyncio.Protocol` | parked coroutine | **2.06** |
| `proto-sync` (the "0.04" row) | `asyncio.Protocol` | inline, no coroutine | 0.04 |

The two rows the forecast came from differ in **two** variables. Phase C
changes only the transport, and the loop-touch count belongs to the execution
model — 2.0 of it is what waking a parked coroutine costs, which the actor
model requires. Corrected forecast **+1.7 %**, confirmed independently by
py-spy: `asyncio.streams` is 4.83 % of self-time, `blackbull`'s own Python is
55.11 %. Phase C is re-forecast and re-queued; the sprint moved to Phase D.

## What ships

**Shared spec table** — header lines whose value set a *specification*
enumerates (Fetch Metadata `Sec-Fetch-*`, UA client-hint boolean/platform
forms, RFC 9110 fixed tokens) are validated once at import into a
process-wide immutable table. 56 % of header lines on captured browser
traffic, and that share does not decay with connection churn. It is HPACK's
static table, which HTTP/1.1 has no wire form for.

**Per-connection cache** — lines that pass every check are memoised per
connection, keyed on exact bytes. Bounded by **bytes, not entries**: the key
is attacker-controlled, and an entry-count bound alone retained ~1 MiB per
connection (9.6 GiB across 10k) against 988 B of real need.

Plus: `BB_HEADER_MAX_LINE` read once per connection; status line and
Content-Length `0…8192` from import-time tables; `has_listeners` from a
registration index.

**Fix** — `HEAD` was answered `405` under `BB_FORCE_ASGI_SCOPE=1`: the compat
lane took its scope snapshot before the HEAD→GET rewrite (`COMP-HEAD-NO-BODY`,
RFC 9110 §9.3.2). Pre-existing, reproduced on unmodified v0.66.0.

## Measured

Captured Chromium traffic, one box one session, against a worktree at v0.66.0:

| requests per connection | parse cost |
|---:|---:|
| 1 (`Connection: close`) | 8.75 → 8.21 µs (−6 %) |
| 10 (HttpArena `limited-conn`) | 8.90 → 6.21 µs (**−30 %**) |
| keep-alive | 8.77 → 6.27 µs (−29 %) |

No input shape regresses: unique-value and cache-full arms are both ~5 %
faster than no cache; the adversarial worst case over a line-length sweep is
+19.2 % CPU and 16 KiB/connection.

## Gates

- 5826 tests pass, 261 skipped, 1 xfailed
- `just typecheck` (beartype) clean
- `mkdocs build --strict` clean
- Http11Probe **159/159** on both the native and `BB_FORCE_ASGI_SCOPE=1` lanes,
  **empty** per-test verdict diff against the Sprint 86 baseline
- h2spec 146 tests, 0 failed
- Loop touches under budget on all three protocols

Measurement environment and its limitations (WSL2 desktop VM, n=1 browser
capture, no `cpufreq` control) are recorded alongside the harnesses; every
`bench/hotpath/` harness now prints its own provenance stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)