### PR TITLE
fix: clear the open CodeQL code-scanning notes

### DIFF
--- a/blackbull/event_aggregator.py
+++ b/blackbull/event_aggregator.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from blackbull.asgi import WebSocketReceiveEvent
 from blackbull.event import Event, EventDispatcher
 

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1127,29 +1127,32 @@ def _adapt_websocket_handler(fn, path: str = ''):
                     try:
                         kwargs[name] = payload(raw)
                     except (ValueError, TypeError):
-                        return await _ws_reject(
+                        await _ws_reject(
                             _WS(conn, receive, send) if ws is None else ws,
                             f'path param {name!r}: cannot coerce {raw!r} to '
                             f'{payload.__name__}')
+                        return
                 else:
                     kwargs[name] = raw
             else:  # 'query'
                 raw = query_values.get(name, _QUERY_MISSING)
                 if raw is _QUERY_MISSING:
                     if payload.required:
-                        return await _ws_reject(
+                        await _ws_reject(
                             _WS(conn, receive, send) if ws is None else ws,
                             f'missing required query parameter {name!r} for '
                             f'handler {fn_name!r}')
+                        return
                     kwargs[name] = payload.default
                 else:
                     try:
                         kwargs[name] = payload.coercer(raw)
                     except (ValueError, TypeError):
-                        return await _ws_reject(
+                        await _ws_reject(
                             _WS(conn, receive, send) if ws is None else ws,
                             f'query parameter {name!r}: cannot coerce {raw!r} '
                             f'to {payload.type.__name__}')
+                        return
 
         if not depends_plan:
             await fn(**kwargs)

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -10,7 +10,6 @@ from binascii import Error as BinasciiError
 from collections.abc import Awaitable, Callable
 from hashlib import sha1
 from http import HTTPStatus
-from typing import Any
 from urllib.parse import unquote
 
 from ..actor import Actor, Message
@@ -61,24 +60,18 @@ _H1_PATHSEND_EXTENSIONS = {'http.response.pathsend': {}}
 # RFC 9110 §5.6.2 — token = 1*tchar
 # RFC 9110 §5.5  — field-value disallows CTLs (0x00-0x1F, 0x7F) except HTAB
 # RFC 9112 §4   — method = token, HTTP-version = "HTTP/" DIGIT "." DIGIT
-_TOKEN_CHARS = (
-    b"!#$%&'*+-.^_`|~"
-    + bytes(range(0x30, 0x3A))   # 0-9
-    + bytes(range(0x41, 0x5B))   # A-Z
-    + bytes(range(0x61, 0x7B))   # a-z
-)
-_TOKEN_SET = frozenset(_TOKEN_CHARS)
 _HTTP_VERSION_RE = re.compile(rb'^HTTP/\d\.\d$')
 
-# Compiled-regex validators replace per-byte
-# `any(c not in _TOKEN_SET for c in …)` and `any((b < 0x20 or
-# b == 0x7F) and b != 0x09 for b in …)` scans in `_parse`.  The
-# character classes below are the exact negation of the RFC 9110
-# §5.6.2 tchar set and the RFC 9110 §5.5 CTL-except-HTAB allow-list
-# respectively; `re.search` returns a Match on the first invalid
-# byte (3–4× faster than the equivalent Python loop per pyperf).
-# `_TOKEN_SET` is retained for any external callers that may rely
-# on it.
+# Compiled-regex validators replace the per-byte membership scans this parser
+# used to run.  The character classes below are the exact negation of the RFC
+# 9110 §5.6.2 tchar set and the RFC 9110 §5.5 CTL-except-HTAB allow-list
+# respectively; `re.search` returns a Match on the first invalid byte (3–4×
+# faster than the equivalent Python loop per pyperf).
+#
+# `_FIELD_NAME_INVALID_RE` has no call site in this module — `_TCHAR_OCTETS`
+# below is what `_parse` uses — but it is **not** dead: it is the reference
+# `tests/unit/test_parse_octet_tables.py` validates that table against, octet
+# for octet, so the fast form cannot drift from the RFC without a test failing.
 _FIELD_NAME_INVALID_RE = re.compile(rb"[^!#$%&'*+\-.^_`|~0-9A-Za-z]")
 _FIELD_VALUE_INVALID_RE = re.compile(rb"[\x00-\x08\x0a-\x1f\x7f]")
 

--- a/blackbull/server/http2_actor.py
+++ b/blackbull/server/http2_actor.py
@@ -8,7 +8,7 @@ import logging
 import time
 from collections.abc import Awaitable, Callable
 from http import HTTPStatus
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from ..actor import Actor, Message
 from ..event_aggregator import EventAggregator


### PR DESCRIPTION
Clears all six open alerts on
[code-scanning](https://github.com/TOKUJI/BlackBull/security/code-scanning).
Five are genuine; the sixth is a false positive and is dismissed on the alert
rather than by contorting the source to satisfy the scanner.

| # | Rule | Verdict |
|---|---|---|
| 436–438 | `py/unused-import` | genuine — `typing.Any` unused in `event_aggregator.py`, `http1_actor.py`, `http2_actor.py` |
| 440 | `py/unused-global-variable` | genuine — `_TOKEN_CHARS` / `_TOKEN_SET` are dead |
| 439 | `py/mixed-returns` | genuine readability wart, not a bug |
| 441 | `py/unused-global-variable` | **false positive** — `_FIELD_NAME_INVALID_RE` is used by tests |

## The genuine ones

**Unused `Any`** — confirmed by inspection, not just by the scanner: the only
other occurrence of the word in `http1_actor.py` is prose inside a comment.

**`_TOKEN_CHARS` / `_TOKEN_SET`** — the pre-regex membership-scan form,
superseded first by `_FIELD_NAME_INVALID_RE` and then by `_TCHAR_OCTETS`.
Neither has a call site anywhere in the package or the test suite. The comment
justifying them ("retained for any external callers that may rely on it") does
not hold for a private name with no importers, so both are removed.

**`py/mixed-returns`** — `_ws_plan_wrapper` mixed `return await
_ws_reject(...)` with a bare `return` and an implicit fall-through. Not a bug:
`_ws_reject` is declared `-> None`, so every path already returned `None`. But
the explicit form would silently leak a value if `_ws_reject` ever returned
one, and it reads as though the return matters. Now uniformly
`await ...; return`.

The three rewritten sites keep their coverage — `test_websocket_injection.py`
asserts `[e['code'] for e in _closes(channel)] == [1008]` at each, which pins
both the close code *and* that the handler does not run on afterwards, which
is exactly what the added `return` guarantees.

## The false positive

`_FIELD_NAME_INVALID_RE` has no call site in `http1_actor.py` — `_TCHAR_OCTETS`
is what `_parse` uses — but it is **not** dead. `tests/unit/test_parse_octet_tables.py`
validates `_TCHAR_OCTETS` against it octet for octet, so it is precisely what
stops the fast table drifting from RFC 9110 §5.6.2 without a test failing.
CodeQL does not follow the test import.

Deleting it to silence the scanner would remove the guard that makes the
optimisation safe, so the alert is dismissed as a false positive instead and
the comment at the definition now states why the name has no local caller.

## Gates

5826 tests pass, beartype clean. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)