### PR TITLE
refactor: split CORS header assembly out of the dispatch method

### DIFF
--- a/blackbull/middleware/cors.py
+++ b/blackbull/middleware/cors.py
@@ -73,11 +73,11 @@ class CORS:
         return hdrs
 
     def _preflight_headers(self, origin: str) -> list[tuple[bytes, bytes]]:
-        """The base CORS set plus the three headers only a preflight answers.
+        """The base CORS set plus the headers only a preflight answers.
 
-        Extends the fresh list ``_cors_headers`` returns, so the two header
-        sets stay described in one place rather than half here, half at the
-        dispatch site.
+        Extends the fresh list ``_cors_headers`` returns, keeping both header
+        sets described next to each other.  ``max-age`` is emitted only when
+        configured, so a preflight carries two or three extra headers.
         """
         hdrs = self._cors_headers(origin)
         hdrs.append((b'access-control-allow-methods', self._methods.encode()))

--- a/blackbull/middleware/cors.py
+++ b/blackbull/middleware/cors.py
@@ -86,6 +86,24 @@ class CORS:
             hdrs.append((b'access-control-max-age', self._max_age.encode()))
         return hdrs
 
+    @staticmethod
+    def _injecting_send(send, cors_hdrs):
+        """Wrap *send* so the ``ResponseStart`` event gains *cors_hdrs*.
+
+        The headers are appended to a copy of the event's own list — the
+        downstream handler's headers are never mutated in place.
+        """
+        # Unannotated on purpose: rebuilt per request (see _wrap_send in
+        # app.py).  ``event`` is an ASGISendEvent.
+        async def cors_send(event):
+            if event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
+                existing = list(event.get('headers', []))
+                existing.extend(cors_hdrs)
+                event = {**event, 'headers': existing}
+            await send(event)
+
+        return cors_send
+
     async def __call__(self, conn, receive, send, call_next) -> None:
         # BlackBull threads a native ``Connection`` for HTTP and WebSocket; the
         # guard is defensive against a raw ASGI scope dict (only reachable if
@@ -111,12 +129,4 @@ class CORS:
 
         # Actual cross-origin request: inject CORS headers into the response start event
         cors_hdrs = self._cors_headers(origin)
-
-        async def cors_send(event):
-            if event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
-                existing = list(event.get('headers', []))
-                existing.extend(cors_hdrs)
-                event = {**event, 'headers': existing}
-            await send(event)
-
-        await call_next(conn, receive, cors_send)
+        await call_next(conn, receive, self._injecting_send(send, cors_hdrs))

--- a/blackbull/middleware/cors.py
+++ b/blackbull/middleware/cors.py
@@ -72,6 +72,20 @@ class CORS:
             hdrs.append((b'vary', b'Origin'))
         return hdrs
 
+    def _preflight_headers(self, origin: str) -> list[tuple[bytes, bytes]]:
+        """The base CORS set plus the three headers only a preflight answers.
+
+        Extends the fresh list ``_cors_headers`` returns, so the two header
+        sets stay described in one place rather than half here, half at the
+        dispatch site.
+        """
+        hdrs = self._cors_headers(origin)
+        hdrs.append((b'access-control-allow-methods', self._methods.encode()))
+        hdrs.append((b'access-control-allow-headers', self._allow_hdrs.encode()))
+        if self._max_age:
+            hdrs.append((b'access-control-max-age', self._max_age.encode()))
+        return hdrs
+
     async def __call__(self, conn, receive, send, call_next) -> None:
         # BlackBull threads a native ``Connection`` for HTTP and WebSocket; the
         # guard is defensive against a raw ASGI scope dict (only reachable if
@@ -90,11 +104,7 @@ class CORS:
         # Preflight: respond directly, never call call_next
         acr_method = headers.get(b'access-control-request-method', b'')
         if conn.method == 'OPTIONS' and acr_method:
-            cors_hdrs = self._cors_headers(origin)
-            cors_hdrs.append((b'access-control-allow-methods', self._methods.encode()))
-            cors_hdrs.append((b'access-control-allow-headers', self._allow_hdrs.encode()))
-            if self._max_age:
-                cors_hdrs.append((b'access-control-max-age', self._max_age.encode()))
+            cors_hdrs = self._preflight_headers(origin)
             await send({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200, 'headers': cors_hdrs})
             await send({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'', 'more_body': False})
             return


### PR DESCRIPTION
Pure structural change to `blackbull/middleware/cors.py`.  No behaviour
change, no public API change, no doc change.

## Why

`CORS.__call__` was the only function in the file over 30 lines (38), and it
carried four responsibilities: the non-`Connection` guard, the origin
admission gate, preflight header assembly *and* its two-event short-circuit,
and the actual-request header injection.

The costly one was the third.  The preflight header set was built **in the
dispatch method**, by taking the list `_cors_headers()` returns and mutating
it in place with four more `append` calls.  "Which headers does a preflight
get?" was therefore only answerable by reading the dispatcher — the helper
owned half the set, the caller owned the other half.

## What

Two Extract Methods, one commit each:

- **`_preflight_headers(origin)`** — the preflight-only headers move next to
  `_cors_headers`, which they extend.  Append order is moved verbatim, and
  the `if self._max_age` guard travels with them.
- **`_injecting_send(send, cors_hdrs)`** — the per-request `send` wrapper
  becomes a `@staticmethod` factory, the same shape as the existing
  `CompressionMiddleware._vary_ensuring_send`.  The closure is still built
  once per request and still closes over that request's `send` and header
  list.

`__call__` drops 38 → 26 lines and is now four guard clauses plus a dispatch.
Both new members are underscore-prefixed; no doc under `docs/` names a CORS
internal, so `docs/guide/middleware.md` §CORS stays accurate as written.

## Verification

- Full suite **5826 passed, 261 skipped, 1 xfailed** — identical to the
  baseline captured before any edit, and re-confirmed by the pre-commit hook
  on each commit.
- `just typecheck` clean.  `ruff check --no-fix` on the file clean.
- **Byte-identical output, proved rather than asserted.**  Header *order* is
  covered by no test, so a throwaway harness captured the exact ordered ASGI
  events for 12 configurations (all four `_cors_headers` shapes, all four
  preflight shapes including `max_age=None`, both pass-throughs, `OPTIONS`
  without `Access-Control-Request-Method`, and the constructor `ValueError`).
  The pre-refactor class was reloaded from `bf84587` via `importlib` and run
  through the same harness: identical at each of the two commits, not just at
  the tip.
- Six supplementary probes covered what single-request captures cannot —
  sequential and `asyncio.gather`-interleaved requests through **one**
  instance (the per-request-state-leak failure mode a closure→method
  extraction risks), streaming bodies, non-mutation of the handler's own
  header list, raw-scope pass-through, and a handler emitting no events.  All
  matched pre vs post.

`ruff format` was deliberately **not** run: this repo has no ruff config and
the formatter restyles the whole file (quote normalisation plus collapsing the
column-aligned `__init__` block), which would dwarf the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)