### PR TITLE
release: v0.68.0 — Sprint 88: native test client, two tiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.68.0] — 2026-08-01
+
 ### Added
 
 - **A test client that drives the path a request actually takes.**  BlackBull

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,72 @@ so the editable install's metadata catches up.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- **A test client that drives the path a request actually takes.**  BlackBull
+  threads a typed `Connection` end to end, but the only test client drove the
+  app through `httpx.ASGITransport` → ASGI scope → `from_scope()` — so the
+  `isinstance(conn, Connection)` branch of `BlackBull.__call__`, the branch
+  every production request takes, was never exercised by a `TestClient` test.
+  A defect could live on the native path with the whole suite green, and one
+  did: Sprint 87's `HEAD`-answers-405.  Two tiers close it.
+  **`blackbull.testing.native`** builds a `Connection` and calls
+  `app(conn, receive, send)` directly — everything from `Connection` inward
+  (dispatcher, middleware chain, router, dependency injection, events,
+  response serialisation), no socket and no protocol actor.
+  **`NativeTestServer`** binds a loopback socket and runs BlackBull's own
+  server, so a request travels accept → `HTTP1Actor` parse → `Connection` →
+  dispatch → wire bytes, which is the only place framing headers, keep-alive
+  reuse, and the RFC 9110 §9.3.2 `HEAD` body strip are observable.
+- **Both tiers are async-first with synchronous façades.**  The core is
+  coroutines — the app entry point *is* a coroutine, and a handler runs on the
+  caller's event loop exactly as it does in production.  `NativeClient` and
+  `NativeTestServer`'s `with` form wrap them for tests written as plain `def`,
+  each owning one background event loop for the whole session rather than one
+  per request.
+- **`NativeTestServer.connections_served`** — a TCP *accept* counter, so a
+  test can assert keep-alive reuse as a fact (`== 1` after ten requests)
+  instead of inferring it from the absence of a `Connection: close` header
+  that a server is never obliged to send.
+
+### Changed
+
+- **`TestClient`'s documented role is narrowed to what it uniquely covers.**
+  Its behaviour and API are unchanged; what changed is the recommendation.  It
+  is the **ASGI compatibility boundary** instrument — the `as_scope()` /
+  `from_scope()` round-trip driven the way an external ASGI host drives it —
+  and it stays precisely because a missing `_CONNECTION_FIELDS` entry or a
+  coercion bug in `from_scope()` surfaces there and nowhere else.  For
+  application-logic tests, `blackbull.testing.native` is now the default.
+- `blackbull/testing.py` is now the package `blackbull/testing/`.  Every
+  existing import (`from blackbull.testing import TestClient`,
+  `WebSocketTestSession`, `WebSocketDisconnect`) resolves unchanged.
+
+### Docs
+
+- `docs/guide/testing.md` rewritten around which instrument answers which
+  question, with the two dispatch paths shown side by side so the choice
+  between `native` and `TestClient` is a structural one rather than taste.
+- `KNOWN_LIMITATIONS.md` records Tier 2's scope: HTTP/1.1 and WebSocket,
+  cleartext only — TLS, ALPN, and HTTP/2 stay with the BlackBull clients +
+  ephemeral-port pattern.
+
+### Internal
+
+- The dual-path corpus moved to `tests/conformance/http1/_dual_path_corpus.py`
+  as a single definition of the request shapes the compat lane must be
+  invisible for.  For the vectors a conformant client can issue, the client
+  spec is the definition and the raw bytes are derived from it, so the two
+  drives cannot drift; the malformed and raw-form vectors (`OPTIONS *`,
+  obs-fold, HTTP/9.9, …) stay raw-drive-only.  Byte identity is still asserted
+  over all 19; the client-expressible subset is now also replayed through a
+  real socket on both lanes.
+- Http11Probe re-scored at **159/159 scored, 0 failed, 0 errors**, with a
+  per-test verdict diff **empty** against the v0.67.0 baseline on both the
+  native and `BB_FORCE_ASGI_SCOPE=1` lanes.
+
 ## [0.67.0] — 2026-07-31
 
 ### Changed

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -250,6 +250,24 @@ on **all** interfaces, so `--bind 127.0.0.1:8000` still listens on
 every interface.  Use a `unix:` bind, `fd://` socket activation, or a
 fronting proxy when interface filtering matters.
 
+### `NativeTestServer` is HTTP/1.1 and WebSocket, cleartext only
+
+[`blackbull/testing/native.py`](blackbull/testing/native.py)'s Tier 2
+runs BlackBull's own server on a loopback port and exercises the whole
+request path — accept, parse, dispatch, wire bytes.  It does **not**
+serve TLS or HTTP/2: both need a certificate and ALPN negotiation
+(plus the `h2c` upgrade path), which is disproportionate to the tier's
+job and would make every test that uses it depend on cert fixtures.
+
+Tests that need TLS, ALPN, HTTP/2 framing, or fragmented WebSocket
+messages use the BlackBull clients against an ephemeral-port
+`ASGIServer`, which is the pattern the conformance suites already
+follow — see `docs/guide/testing.md`.  Tier 1
+(`blackbull.testing.native`) is transport-free by design and sits
+*below* the protocol actor, so it cannot observe framing headers or
+the RFC 9110 §9.3.2 `HEAD` body strip either; those are Tier 2
+questions.
+
 ---
 
 ## Deliberate non-goals — not limitations

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Hello, world!
   real traffic can drive a programmable misbehaving client or
   server.  Test your own HTTP/2 client against half-closed streams,
   exhausted windows, and illegal SETTINGS — in CI.
+- **Test the path your requests actually take.** `blackbull.testing.native`
+  calls your app the way the server does — a typed `Connection`, no ASGI
+  scope round-trip — and `NativeTestServer` runs the whole stack on a
+  loopback port when the answer depends on the wire (keep-alive, `HEAD`,
+  chunked framing).  Neither needs a subprocess.  See
+  [`docs/guide/testing.md`](https://github.com/TOKUJI/BlackBull/blob/master/docs/guide/testing.md).
 - **Multi-protocol, one process.** A pure-Python MQTT 5 broker and
   gRPC ride beside HTTP/2 and WebSocket on the same runtime;
   extensions add new protocols without touching the core — still no

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.68.x  | :white_check_mark: |
 | 0.67.x  | :white_check_mark: |
-| 0.66.x  | :white_check_mark: |
-| < 0.66  | :x:                |
+| < 0.67  | :x:                |
 
 This table updates with each minor release.
 
@@ -87,6 +87,11 @@ The following are in scope for security reports:
   those locks are by design; a bypass that lets the module run in a
   production process or bind to a non-loopback interface without
   `allow_remote=True` is a security report.
+- The loopback-only bind on `NativeTestServer`
+  (`blackbull/testing/native.py`).  It exists so a test never publishes
+  the application under test to the network; a defect that lets it
+  listen on a non-loopback interface is a security report, on the same
+  reasoning as the `H2FaultServer` guard above.
 
 The following are typically **out of scope**:
 

--- a/blackbull/testing/__init__.py
+++ b/blackbull/testing/__init__.py
@@ -1,12 +1,37 @@
-"""In-memory test client for ASGI 3.0 applications.
+"""Test clients for BlackBull applications — three instruments, three layers.
 
-Lets you exercise a BlackBull (or any ASGI 3.0) app from a synchronous
-pytest test without binding a TCP socket.  Built on
-``httpx.ASGITransport`` for HTTP; uses a background-thread event loop
-to bridge sync calls to the (async-only) ASGI transport, to drive the
-``lifespan`` protocol, and to host WebSocket sessions.
+BlackBull threads a typed :class:`~blackbull.connection.Connection` end to
+end and keeps the ASGI ``scope`` dict at two boundaries only.  That is why
+there is more than one test client here, and why picking the right one
+matters: each drives a different layer, and a defect on one is invisible to
+the others.
 
-Typical usage::
+============================  =============================================
+Instrument                    What it exercises
+============================  =============================================
+:mod:`blackbull.testing.native`   Application logic — routing, middleware,
+                              handlers, DI, events — through the *native*
+                              ``app(conn, receive, send)`` entry point that
+                              every production request takes.  The default
+                              choice for everyday tests.
+:class:`~blackbull.testing.native.NativeTestServer`
+                              The full stack on a real loopback socket:
+                              protocol parsing, framing, keep-alive,
+                              connection lifecycle, wire bytes.
+:class:`TestClient`           The **ASGI compatibility boundary** — the
+                              ``as_scope()`` / ``from_scope()`` round-trip,
+                              driven the way an external ASGI host
+                              (uvicorn, ``httpx.ASGITransport``) drives it.
+============================  =============================================
+
+:class:`TestClient` is deliberately *not* the default.  It reaches the app
+through ``httpx.ASGITransport`` → ASGI scope dict → ``from_scope()``, so the
+``isinstance(conn, Connection)`` branch of ``BlackBull.__call__`` is never
+taken by it.  What it uniquely covers is the conversion chain itself: a
+missing ``_CONNECTION_FIELDS`` entry or a ``from_scope`` coercion bug shows
+up here and nowhere else in the suite, which is exactly why it stays.
+
+``TestClient`` usage — a boundary-conformance instrument::
 
     from blackbull import BlackBull
     from blackbull.testing import TestClient
@@ -17,7 +42,7 @@ Typical usage::
     async def hello():
         return "hi"
 
-    def test_hello():
+    def test_asgi_boundary():
         with TestClient(app) as client:
             response = client.get('/')
             assert response.status_code == 200
@@ -26,6 +51,8 @@ Typical usage::
 The client is a context manager so that ASGI ``lifespan.startup`` runs
 before any request and ``lifespan.shutdown`` runs on exit.  Apps that
 don't implement the lifespan protocol are tolerated silently.
+
+For everything else, start from ``docs/guide/testing.md``.
 """
 
 from __future__ import annotations
@@ -36,8 +63,8 @@ import threading
 from typing import Any
 from urllib.parse import unquote
 
-from .asgi import ASGIReceiveEvent
-from .websocket import WebSocketDisconnect
+from ..asgi import ASGIReceiveEvent
+from ..websocket import WebSocketDisconnect
 
 import httpx
 
@@ -47,6 +74,9 @@ import httpx
 # written against one silently missing the other.  One class, both sides:
 # ``from blackbull.testing import WebSocketDisconnect`` keeps working, and it
 # is the same object as ``blackbull.WebSocketDisconnect``.
+#
+# The native-tier names are appended at the bottom of this module, after
+# ``_LoopThread`` and ``_LifespanManager`` exist — ``native`` builds on both.
 __all__ = ['TestClient', 'WebSocketTestSession', 'WebSocketDisconnect']
 
 
@@ -243,8 +273,8 @@ class WebSocketTestSession:
         # ASGI boundary's job, exercised by the HTTP TestClient's httpx transport).
         # ``subprotocols`` are derived from the request header (added above),
         # matching how a real client offers them over the wire.
-        from .connection import Connection  # noqa: PLC0415
-        from .headers import Headers  # noqa: PLC0415
+        from ..connection import Connection  # noqa: PLC0415
+        from ..headers import Headers  # noqa: PLC0415
         self._conn = Connection(
             method='GET',
             # Parity with the real server: ``conn.path`` is the
@@ -569,4 +599,16 @@ class TestClient:
         )
 
 
-__all__ = ['TestClient', 'WebSocketTestSession', 'WebSocketDisconnect']
+# Imported last: ``native`` reaches back for ``_LoopThread`` /
+# ``_LifespanManager`` (lazily, inside its own methods), so both must already
+# be defined.  ``native`` stays importable as a submodule too — the
+# ``from blackbull.testing import native`` form is the documented one, because
+# ``native.get(app, '/')`` reads better at a call site than a bare ``get``.
+from . import native                                        # noqa: E402
+from .native import (                                        # noqa: E402
+    NativeClient, NativeResponse, NativeTestServer, build_connection,
+)
+
+__all__ = ['TestClient', 'WebSocketTestSession', 'WebSocketDisconnect',
+           'native', 'NativeClient', 'NativeResponse', 'NativeTestServer',
+           'build_connection']

--- a/blackbull/testing/native.py
+++ b/blackbull/testing/native.py
@@ -434,6 +434,10 @@ class NativeTestServer:
         self.app = app
         self.host = host
         self.port = port
+        #: TCP connections accepted since this server started — an *accept*
+        #: count, not a request count, so four keep-alive requests on one
+        #: connection leave it at 1.  Both context-manager forms maintain it.
+        self.connections_served = 0
         self._backlog = backlog
         self._timeout = timeout
         self._server_kwargs = server_kwargs
@@ -453,13 +457,22 @@ class NativeTestServer:
         from ..server.server import LifespanManager, Server  # noqa: PLC0415
 
         self._bb_server = Server(self.app, **self._server_kwargs)
+
+        async def _accept(reader, writer):
+            # The only thing layered over the production callback: count the
+            # accept.  A test asserting keep-alive reuse needs to know how many
+            # TCP connections its requests actually opened, and the honest
+            # place to learn that is the accept path — not a response header
+            # the server merely *may* send, and not httpx's private pool.
+            self.connections_served += 1
+            await self._bb_server.client_connected_cb(reader, writer)
+
         # ``asyncio.start_server`` rather than ``Server.open_socket``: the
         # latter binds 0.0.0.0 + :: (right for a real deployment, wrong for a
-        # test that should never leave the loopback).  The accept callback is
-        # the production one, so everything below accept is identical.
+        # test that should never leave the loopback).  The callback below
+        # accept is the production one, so everything after it is identical.
         self._asyncio_server = await asyncio.start_server(
-            self._bb_server.client_connected_cb, self.host, self.port,
-            backlog=self._backlog)
+            _accept, self.host, self.port, backlog=self._backlog)
         sockets = self._asyncio_server.sockets or ()
         if not sockets:
             raise RuntimeError('NativeTestServer failed to bind a socket.')

--- a/blackbull/testing/native.py
+++ b/blackbull/testing/native.py
@@ -1,0 +1,593 @@
+"""Native-path test client — the two tiers that drive BlackBull's *own*
+request path rather than the ASGI compatibility boundary.
+
+BlackBull threads a typed :class:`~blackbull.connection.Connection` end to
+end; the ASGI ``scope`` dict survives only at two boundaries.  The
+compatibility client in :mod:`blackbull.testing` reaches the app through
+``httpx.ASGITransport`` → scope dict → ``Connection.from_scope()``, so the
+``isinstance(conn, Connection)`` branch of ``BlackBull.__call__`` — the branch
+every production request takes — is never exercised by it.  A defect can
+therefore live on the native path while the whole compat-driven suite passes.
+
+Two tiers close that, mirroring what every framework that owns its protocol
+stack provides:
+
+**Tier 1** — :func:`request` and the verb helpers build a ``Connection`` and
+call ``app(conn, receive, send)`` directly.  No socket, no protocol actor:
+everything from ``Connection`` inward (dispatcher, middleware chain, router,
+handlers, DI, events, response serialisation).  The equivalent of actix-web's
+``init_service`` or Fastify's ``.inject()``::
+
+    resp = await native.get(app, '/hello')
+    assert resp.status == 200
+
+**Tier 2** — :class:`NativeTestServer` binds a real loopback socket and runs
+BlackBull's own :class:`~blackbull.server.server.Server`, so a request
+travels accept → ``HTTP1Actor`` parse → ``Connection`` → native dispatch →
+wire bytes.  The equivalent of aiohttp's ``TestServer`` or Go's
+``httptest.NewServer``::
+
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/hello')
+
+Both tiers are async-first because the app entry point is a coroutine and a
+handler runs on the caller's event loop — which is also what production does.
+:class:`NativeClient` and the synchronous form of :class:`NativeTestServer`
+wrap them for tests written as plain ``def``, each owning one background
+event loop for its whole lifetime rather than per request.
+
+Which instrument to reach for is documented in ``docs/guide/testing.md``:
+Tier 1 for application logic, Tier 2 for anything whose answer depends on the
+wire, and :class:`~blackbull.testing.TestClient` for the ASGI boundary itself.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from typing import Any, Iterable, Mapping
+from urllib.parse import unquote
+
+import httpx
+
+from ..connection import Connection, bind_receive_channel
+from ..headers import Headers
+
+__all__ = [
+    'NativeResponse', 'NativeClient', 'NativeTestServer',
+    'build_connection', 'request',
+    'get', 'head', 'options', 'post', 'put', 'patch', 'delete',
+]
+
+
+#: Client/server addresses stamped onto a synthesised Connection.  The same
+#: pair ``WebSocketTestSession`` uses, so a handler that logs or authorises on
+#: ``conn.client`` sees one consistent identity across both test instruments.
+_TEST_CLIENT_ADDR = ('testclient', 50000)
+_TEST_SERVER_ADDR = ('testserver', 80)
+
+_HeaderInput = Mapping[Any, Any] | Iterable[tuple[Any, Any]] | Headers | None
+
+
+def _encode_header(value: Any) -> bytes:
+    """Coerce a header name or value to the bytes the wire would carry."""
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    return str(value).encode('latin-1')
+
+
+def _header_pairs(headers: _HeaderInput) -> list[tuple[bytes, bytes]]:
+    """Normalise caller-supplied headers to lowercase byte pairs.
+
+    Accepts what a test naturally writes — a ``dict`` of ``str`` or ``bytes``,
+    a list of pairs, or a :class:`Headers` — because the alternative is every
+    call site spelling ``{b'x-probe': b'seen'}`` by hand.  Names are
+    lowercased to match the parser's index (``headers.get(b'content-type')``).
+    """
+    if headers is None:
+        return []
+    items = headers.items() if isinstance(headers, Mapping) else headers
+    return [(_encode_header(k).lower(), _encode_header(v)) for k, v in items]
+
+
+@dataclass
+class NativeResponse:
+    """What Tier 1 collected from the app's ``send`` channel.
+
+    ``body`` is the concatenation of every ``http.response.body`` chunk, so a
+    streaming handler and a single-shot one are compared the same way.
+    ``events`` keeps the raw ASGI events for tests that assert on the emission
+    sequence itself (chunk boundaries, ``more_body`` flags, trailers).
+    """
+
+    status: int
+    headers: Headers
+    body: bytes = b''
+    events: list[dict] = field(default_factory=list, repr=False)
+
+    def json(self) -> Any:
+        """Parse the body as JSON."""
+        return _json.loads(self.body)
+
+    def text(self, encoding: str = 'utf-8') -> str:
+        """Decode the body as text (``errors='replace'``)."""
+        return self.body.decode(encoding, errors='replace')
+
+
+def build_connection(
+    method: str,
+    path: str,
+    *,
+    headers: _HeaderInput = None,
+    body: bytes | str = b'',
+    http_version: str = '1.1',
+    scheme: str = 'http',
+    root_path: str = '',
+    client: tuple[str, int | None] | None = _TEST_CLIENT_ADDR,
+    server: tuple[str, int | None] | None = _TEST_SERVER_ADDR,
+) -> Connection:
+    """Build the :class:`Connection` an H/1.1 request line would have produced.
+
+    The field derivations mirror :meth:`HTTP1Actor._parse` so a Tier 1 test and
+    a real request agree on what the handler sees:
+
+    - the query string is split off ``path`` and carried in ``query_string``,
+      never in ``raw_path``;
+    - ``path`` is percent-decoded, ``raw_path`` keeps the undecoded bytes;
+    - a ``host`` header is supplied when the caller gave none, because every
+      HTTP/1.1 request carries one (RFC 9112 §3.2) and code that reads it
+      would otherwise behave differently under test than on the wire;
+    - a ``content-length`` is derived from *body* for the same reason — an
+      explicit one from the caller wins, so a test can still synthesise a
+      mismatched framing header on purpose.
+    """
+    raw_path, _, query = path.partition('?')
+    pairs = _header_pairs(headers)
+    names = {name for name, _ in pairs}
+    if b'host' not in names:
+        pairs.append((b'host', _TEST_SERVER_ADDR[0].encode('latin-1')))
+    if body and b'content-length' not in names:
+        pairs.append((b'content-length', str(len(_encode_body(body))).encode('ascii')))
+    return Connection(
+        type='http',
+        http_version=http_version,
+        method=method.upper(),
+        scheme=scheme,
+        # UTF-8 (not latin-1) for parity with the parser: a non-ASCII path
+        # such as '/café' must round-trip as the server would have received it.
+        path=(unquote(raw_path, encoding='utf-8', errors='replace')
+              if '%' in raw_path else raw_path),
+        raw_path=raw_path.encode('utf-8'),
+        query_string=query.encode('utf-8'),
+        root_path=root_path,
+        headers=Headers(pairs),
+        client=client,
+        server=server,
+    )
+
+
+def _encode_body(body: bytes | str) -> bytes:
+    if isinstance(body, str):
+        return body.encode('utf-8')
+    return bytes(body)
+
+
+async def request(
+    app: Any,
+    conn: Connection,
+    *,
+    body: bytes | str = b'',
+) -> NativeResponse:
+    """Call ``app(conn, receive, send)`` and collect the response.
+
+    The full-control form: build (or mutate) a :class:`Connection` yourself and
+    drive the app with it.  The verb helpers below are thin wrappers over this.
+
+    The receive channel delivers *body* as one ``http.request`` event and then
+    reports ``http.disconnect`` — the same terminal signal a real recipient
+    gives once the body is drained, so a handler that over-reads gets the
+    production answer rather than hanging.
+    """
+    payload = _encode_body(body)
+    delivered = False
+
+    async def receive() -> dict:
+        nonlocal delivered
+        if not delivered:
+            delivered = True
+            return {'type': 'http.request', 'body': payload, 'more_body': False}
+        return {'type': 'http.disconnect'}
+
+    events: list[dict] = []
+    chunks: list[bytes] = []
+    status: int | None = None
+    response_headers: list = []
+
+    # Same dual-form signature as the protocol senders: a handler may emit ASGI
+    # dicts, or the ``send(body, status, headers)`` convenience form that the
+    # actor's sender also accepts.  Tier 1 has to accept both or it would
+    # reject code the real server runs.
+    async def send(event: Any, status_arg: HTTPStatus = HTTPStatus.OK,
+                   headers_arg: Any = ()) -> None:
+        nonlocal status, response_headers
+        if not isinstance(event, dict):
+            body_bytes = bytes(event) if not isinstance(event, bytes) else event
+            status = int(status_arg)
+            response_headers = list(headers_arg)
+            chunks.append(body_bytes)
+            events.append({'type': 'http.response.start', 'status': status,
+                           'headers': response_headers})
+            events.append({'type': 'http.response.body', 'body': body_bytes,
+                           'more_body': False})
+            return
+        events.append(event)
+        etype = event.get('type')
+        if etype == 'http.response.start':
+            status = int(event.get('status', 200))
+            response_headers = list(event.get('headers') or [])
+        elif etype == 'http.response.body':
+            chunks.append(event.get('body', b'') or b'')
+        elif etype == 'http.response.pathsend':
+            # The ``http.response.pathsend`` extension hands the server a file
+            # path instead of bytes so it can sendfile(2).  Tier 1 has no
+            # transport to hand it to, so it does what the kernel would: read
+            # the file.  The observable response is then the same either way.
+            with open(event['path'], 'rb') as fp:
+                chunks.append(fp.read())
+
+    # Bind the body channel the way the protocol actor does, so ``conn.body()``
+    # / ``conn.stream()`` drain this request's payload rather than nothing.
+    bind_receive_channel(conn, receive)
+    await app(conn, receive, send)
+
+    if status is None:
+        raise AssertionError(
+            'The app produced no http.response.start event — the handler '
+            'returned without sending a response.')
+    return NativeResponse(status=status, headers=Headers(response_headers),
+                          body=b''.join(chunks), events=events)
+
+
+async def _verb(app: Any, method: str, path: str, *,
+                body: bytes | str = b'',
+                json: Any = None,
+                headers: _HeaderInput = None,
+                **kwargs: Any) -> NativeResponse:
+    if json is not None:
+        if body:
+            raise TypeError("pass either 'body' or 'json', not both")
+        body = _json.dumps(json).encode('utf-8')
+        pairs = _header_pairs(headers)
+        if not any(name == b'content-type' for name, _ in pairs):
+            pairs.append((b'content-type', b'application/json'))
+        headers = pairs
+    conn = build_connection(method, path, headers=headers, body=body, **kwargs)
+    return await request(app, conn, body=body)
+
+
+async def get(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a GET through the native dispatch path."""
+    return await _verb(app, 'GET', path, **kwargs)
+
+
+async def head(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a HEAD through the native dispatch path.
+
+    The handler sees ``HEAD``: rewriting it to ``GET`` and stripping the body
+    is the H/1.1 actor's job (RFC 9110 §9.3.2), which is below this tier.  Use
+    :class:`NativeTestServer` to assert HEAD's *wire* behaviour.
+    """
+    return await _verb(app, 'HEAD', path, **kwargs)
+
+
+async def options(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with an OPTIONS through the native dispatch path."""
+    return await _verb(app, 'OPTIONS', path, **kwargs)
+
+
+async def post(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a POST through the native dispatch path."""
+    return await _verb(app, 'POST', path, **kwargs)
+
+
+async def put(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a PUT through the native dispatch path."""
+    return await _verb(app, 'PUT', path, **kwargs)
+
+
+async def patch(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a PATCH through the native dispatch path."""
+    return await _verb(app, 'PATCH', path, **kwargs)
+
+
+async def delete(app: Any, path: str, **kwargs: Any) -> NativeResponse:
+    """Drive ``app`` with a DELETE through the native dispatch path."""
+    return await _verb(app, 'DELETE', path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Synchronous façade over Tier 1
+# ---------------------------------------------------------------------------
+
+class NativeClient:
+    """Synchronous Tier 1 client, for tests written as plain ``def``.
+
+    Owns one background event loop for the whole session — not one per
+    request — and drives the ASGI ``lifespan`` protocol around it, so startup
+    hooks have run before the first request the way they have in production::
+
+        with NativeClient(app) as client:
+            resp = client.get('/hello')
+            assert resp.status == 200
+
+    Prefer the module-level coroutines from an ``async def`` test: they call
+    the app on the test's own loop with no thread hand-off at all.
+    """
+
+    __test__ = False        # not a pytest container despite the name shape
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        # Imported here rather than at module scope: ``blackbull.testing``
+        # imports this module, so a top-level import would be circular.
+        from . import _LifespanManager, _LoopThread  # noqa: PLC0415
+        self._loop_thread = _LoopThread()
+        self._lifespan_cls = _LifespanManager
+        self._lifespan: Any = None
+        self._entered = False
+
+    def __enter__(self) -> 'NativeClient':
+        self._loop_thread.start()
+        self._lifespan = self._lifespan_cls(self.app, self._loop_thread)
+        try:
+            self._lifespan.startup()
+        except Exception:
+            self._loop_thread.stop()
+            raise
+        self._entered = True
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        self._entered = False
+        try:
+            if self._lifespan is not None:
+                self._lifespan.shutdown()
+        finally:
+            self._loop_thread.stop()
+
+    def _run(self, fn, *args: Any, **kwargs: Any) -> NativeResponse:
+        # The guard runs *before* the coroutine is constructed: building one
+        # and then raising leaves a "coroutine was never awaited" warning
+        # attached to the caller's test, pointing at the wrong problem.
+        if not self._entered:
+            raise RuntimeError(
+                'NativeClient must be used as a context manager: '
+                '`with NativeClient(app) as client: ...`')
+        return self._loop_thread.run_coro(fn(self.app, *args, **kwargs))
+
+    def request(self, conn: Connection, *, body: bytes | str = b'') -> NativeResponse:
+        """Full-control form — see :func:`request`."""
+        return self._run(request, conn, body=body)
+
+    def get(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(get, path, **kwargs)
+
+    def head(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(head, path, **kwargs)
+
+    def options(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(options, path, **kwargs)
+
+    def post(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(post, path, **kwargs)
+
+    def put(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(put, path, **kwargs)
+
+    def patch(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(patch, path, **kwargs)
+
+    def delete(self, path: str, **kwargs: Any) -> NativeResponse:
+        return self._run(delete, path, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — real socket, full stack
+# ---------------------------------------------------------------------------
+
+class NativeTestServer:
+    """BlackBull's own server on a loopback port, for full-stack tests.
+
+    Every layer runs: TCP accept, ``ConnectionActor``, ``HTTP1Actor`` parsing,
+    the native ``Connection``, dispatch, and the bytes the sender puts on the
+    wire.  Anything whose answer depends on the wire — keep-alive reuse, the
+    HEAD body strip, chunked framing, connection close semantics — is only
+    observable here.
+
+    Async form (preferred: the server shares the test's event loop, as it
+    shares the process loop in production)::
+
+        async with NativeTestServer(app) as server:
+            resp = await server.client.get('/hello')
+
+    Synchronous form, for plain ``def`` tests — the server runs on one
+    background loop for the session::
+
+        with NativeTestServer(app) as server:
+            resp = server.client.get('/hello')
+
+    The listener binds ``127.0.0.1`` only, so a test never exposes a port
+    beyond the machine.  Plaintext HTTP/1.1 and WebSocket; TLS and HTTP/2 are
+    out of scope for this tier — reach for ``blackbull.fault_injection`` or the
+    conformance suites there.
+    """
+
+    __test__ = False        # not a pytest container despite the name shape
+
+    def __init__(self, app: Any, *, host: str = '127.0.0.1',
+                 port: int = 0, backlog: int = 128,
+                 timeout: float = 10.0, **server_kwargs: Any) -> None:
+        self.app = app
+        self.host = host
+        self.port = port
+        self._backlog = backlog
+        self._timeout = timeout
+        self._server_kwargs = server_kwargs
+        self._bb_server: Any = None
+        self._asyncio_server: asyncio.AbstractServer | None = None
+        self._lifespan: Any = None
+        self._async_client: httpx.AsyncClient | None = None
+        self._loop_thread: Any = None
+        # ``Any``, not ``'_SyncServerClient | None'``: the class is defined
+        # below this one, and beartype rejects a *relative* forward reference
+        # in a local annotation (it can only resolve absolute ones there).
+        self._sync_client: Any = None
+
+    # -- async form ---------------------------------------------------------
+
+    async def __aenter__(self) -> 'NativeTestServer':
+        from ..server.server import LifespanManager, Server  # noqa: PLC0415
+
+        self._bb_server = Server(self.app, **self._server_kwargs)
+        # ``asyncio.start_server`` rather than ``Server.open_socket``: the
+        # latter binds 0.0.0.0 + :: (right for a real deployment, wrong for a
+        # test that should never leave the loopback).  The accept callback is
+        # the production one, so everything below accept is identical.
+        self._asyncio_server = await asyncio.start_server(
+            self._bb_server.client_connected_cb, self.host, self.port,
+            backlog=self._backlog)
+        sockets = self._asyncio_server.sockets or ()
+        if not sockets:
+            raise RuntimeError('NativeTestServer failed to bind a socket.')
+        self.port = sockets[0].getsockname()[1]
+
+        self._lifespan = LifespanManager(self.app)
+        try:
+            await self._lifespan.__aenter__()
+        except BaseException:
+            await self._close_socket()
+            raise
+        self._async_client = httpx.AsyncClient(base_url=self.url,
+                                               timeout=self._timeout)
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        try:
+            if self._async_client is not None:
+                # Close the client first: its keep-alive connections are the
+                # ones ``wait_closed()`` would otherwise wait on.
+                await self._async_client.aclose()
+                self._async_client = None
+        finally:
+            try:
+                if self._lifespan is not None:
+                    await self._lifespan.__aexit__(*exc_info)
+                    self._lifespan = None
+            finally:
+                await self._close_socket()
+
+    async def _close_socket(self) -> None:
+        if self._asyncio_server is None:
+            return
+        self._asyncio_server.close()
+        try:
+            await asyncio.wait_for(self._asyncio_server.wait_closed(),
+                                   timeout=self._timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            # A wedged connection handler must not turn a passing test into a
+            # hang; the socket is closed either way.
+            pass
+        self._asyncio_server = None
+
+    # -- sync form ----------------------------------------------------------
+
+    def __enter__(self) -> 'NativeTestServer':
+        from . import _LoopThread  # noqa: PLC0415
+        self._loop_thread = _LoopThread()
+        self._loop_thread.start()
+        try:
+            self._loop_thread.run_coro(self.__aenter__(), timeout=self._timeout)
+        except BaseException:
+            self._loop_thread.stop()
+            raise
+        self._sync_client = _SyncServerClient(self._loop_thread, self)
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        try:
+            self._loop_thread.run_coro(self.__aexit__(*exc_info),
+                                       timeout=self._timeout + 5.0)
+        finally:
+            self._sync_client = None
+            self._loop_thread.stop()
+            self._loop_thread = None
+
+    # -- accessors ----------------------------------------------------------
+
+    @property
+    def url(self) -> str:
+        """Base URL of the running server, e.g. ``http://127.0.0.1:54321``."""
+        return f'http://{self.host}:{self.port}'
+
+    @property
+    def client(self):
+        """An HTTP client bound to this server.
+
+        ``httpx.AsyncClient`` under ``async with``; a synchronous façade over
+        the same client under plain ``with``.
+        """
+        if self._sync_client is not None:
+            return self._sync_client
+        if self._async_client is None:
+            raise RuntimeError(
+                'NativeTestServer must be used as a context manager: '
+                '`async with NativeTestServer(app) as server: ...`')
+        return self._async_client
+
+
+class _SyncServerClient:
+    """Blocking façade over :class:`NativeTestServer`'s ``httpx.AsyncClient``.
+
+    Each call is scheduled on the server's own loop thread, so the request and
+    the server it talks to share one loop — the same arrangement the async form
+    gets for free.
+    """
+
+    def __init__(self, loop_thread: Any, server: NativeTestServer) -> None:
+        self._loop_thread = loop_thread
+        self._server = server
+
+    def _client(self) -> httpx.AsyncClient:
+        client = self._server._async_client
+        if client is None:
+            raise RuntimeError('NativeTestServer is not running.')
+        return client
+
+    def request(self, method: str, url: str, **kwargs: Any) -> httpx.Response:
+        return self._loop_thread.run_coro(
+            self._client().request(method, url, **kwargs))
+
+    def get(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('GET', url, **kwargs)
+
+    def head(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('HEAD', url, **kwargs)
+
+    def options(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('OPTIONS', url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('POST', url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('PUT', url, **kwargs)
+
+    def patch(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('PATCH', url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> httpx.Response:
+        return self.request('DELETE', url, **kwargs)

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,22 +1,23 @@
 # Testing
 
-BlackBull's `app` is a plain ASGI 3.0 callable, so most application
-tests can drive it in-memory through a synchronous client and never
-touch a TCP socket.  Four useful shapes exist:
+BlackBull threads a typed `Connection` end to end and keeps the ASGI
+`scope` dict at two boundaries only.  That shapes the test tooling:
+there is more than one client here, each drives a different layer,
+and **a defect on one layer is invisible to the others**.
 
-- **`blackbull.testing.TestClient`** — synchronous, in-memory,
-  lifespan-aware.  The default starting point: ordinary
-  `pytest` style, no `async def`, no fixture overhead.
-- **End-to-end with BlackBull's own clients** — start the server
-  on an ephemeral port, drive it through real sockets via
-  `HTTP1Client` / `HTTP2Client` / `Client` / `WebSocketClient`.
-  Best fidelity: exercises the wire, ALPN, TLS, framing.
-- **In-process integration via `httpx.ASGITransport`** — async
-  variant of `TestClient` for tests that want full control over
-  the loop or the underlying `httpx.AsyncClient`.
-- **Direct handler / middleware unit tests** — hand-rolled
-  scope dict + stub callables.  For asserting a single
-  function's behaviour without involving routing or transport.
+Start from what you are asserting:
+
+| You are asserting… | Reach for | Why |
+|---|---|---|
+| Routing, middleware, handlers, DI, events | `blackbull.testing.native` | Calls `app(conn, receive, send)` — the entry point every production request takes.  No socket, no protocol actor. |
+| Anything the wire decides — framing, keep-alive, `HEAD`, chunking, connection close | `NativeTestServer` | BlackBull's own server on a loopback port.  Accept → parse → `Connection` → dispatch → bytes. |
+| That ASGI compatibility still works | `blackbull.testing.TestClient` | The `as_scope()` / `from_scope()` round-trip, driven the way uvicorn drives it. |
+| Cross-protocol behaviour — TLS, ALPN, HTTP/2 framing, WebSocket fragments | BlackBull's own clients + an ephemeral port | Full protocol negotiation against a real server. |
+| One function, no framework | Direct handler / middleware calls | Stub `receive` / `send`, no routing, no transport. |
+
+`TestClient` used to be the default recommendation.  It is now the
+**ASGI-boundary instrument**, not the everyday one — the reasoning is in
+[Choosing between `native` and `TestClient`](#choosing-between-native-and-testclient).
 
 ## Setup
 
@@ -37,10 +38,195 @@ asyncio_mode = strict
 Strict mode requires every async test to carry
 `@pytest.mark.asyncio` explicitly — matching BlackBull's own
 suite — so tests don't accidentally run in the wrong loop
-shape.  Tests written against `TestClient` are synchronous and
-don't need this mark.
+shape.  Tests written against the synchronous clients
+(`TestClient`, `NativeClient`) don't need this mark.
 
-## Quick start with `TestClient`
+## Quick start with `native`
+
+`blackbull.testing.native` builds a `Connection` and calls
+`app(conn, receive, send)` — the same call BlackBull's protocol
+actors make.  Everything from `Connection` inward runs for real:
+the dispatcher, the middleware chain, the router, dependency
+injection, events, and response serialisation.
+
+```python
+import pytest
+from blackbull import BlackBull
+from blackbull.testing import native
+
+app = BlackBull()
+
+
+@app.route(path='/hello')
+async def hello():
+    return 'hi'
+
+
+@pytest.mark.asyncio
+async def test_hello():
+    resp = await native.get(app, '/hello')
+    assert resp.status == 200
+    assert resp.body == b'hi'
+```
+
+The helpers are `get` / `head` / `options` / `post` / `put` /
+`patch` / `delete`, plus `request` for full control.  A response is
+a `NativeResponse` — `status`, `headers` (a `Headers`), `body`, and
+`.json()` / `.text()` convenience readers:
+
+```python
+resp = await native.post(app, '/tasks', json={'name': 'write tests'})
+assert resp.status == 201
+assert resp.json()['id']
+
+resp = await native.post(app, '/upload', body=b'\x00\x01',
+                         headers={b'content-type': b'application/octet-stream'})
+```
+
+Headers accept `str` or `bytes` in either position and are lowercased
+for you.  A `host` header is supplied when you give none, and
+`content-length` is derived from the body — both because a real
+request carries them, and code that branches on them should behave
+the same under test as on the wire.
+
+For a request the helpers can't express, build the `Connection`
+yourself:
+
+```python
+from blackbull import Connection
+from blackbull.headers import Headers
+
+conn = Connection(
+    method='POST', path='/tasks', raw_path=b'/tasks',
+    headers=Headers([(b'content-type', b'application/json')]),
+)
+conn.state['tenant'] = 'acme'          # pre-seed what a middleware would set
+resp = await native.request(app, conn, body=b'{"name":"x"}')
+```
+
+`build_connection()` is the same constructor the helpers use, if you
+want the parser-faithful defaults and then a tweak.
+
+### Synchronous tests
+
+`NativeClient` wraps the same functions for tests written as plain
+`def`.  It owns one background event loop for the whole session — not
+one per request — and runs the ASGI `lifespan` protocol around the
+block:
+
+```python
+from blackbull.testing import NativeClient
+
+
+def test_hello_sync():
+    with NativeClient(app) as client:
+        resp = client.get('/hello')
+        assert resp.status == 200
+```
+
+Prefer the coroutines from an `async def` test: they call the app on
+the test's own loop, with no thread hand-off at all.
+
+### What `native` does not see
+
+Tier 1 collects the events the **application** emitted, not the bytes
+a server would write.  Framing headers (`Content-Length`,
+`Transfer-Encoding`) are injected by the protocol sender, below this
+tier, so they are absent here.  `HEAD` reaches your handler as `HEAD`
+— the rewrite to `GET` (RFC 9110 §9.3.2) is the HTTP/1.1 actor's job.
+
+Those are `NativeTestServer` questions.
+
+## Full stack with `NativeTestServer`
+
+`NativeTestServer` binds a real loopback socket and runs BlackBull's
+own server, so a request travels the entire production path: TCP
+accept → `ConnectionActor` → `HTTP1Actor` parsing → `Connection` →
+native dispatch → the bytes the sender writes.
+
+```python
+import pytest
+from blackbull.testing import NativeTestServer
+
+
+@pytest.mark.asyncio
+async def test_head_has_get_headers_and_no_body():
+    async with NativeTestServer(app) as server:
+        get_resp = await server.client.get('/hello')
+        head_resp = await server.client.head('/hello')
+
+    assert head_resp.content == b''
+    assert head_resp.headers['content-length'] == get_resp.headers['content-length']
+```
+
+`server.client` is an `httpx.AsyncClient` bound to `server.url`, so
+the full httpx API is available — cookies, redirects, streaming,
+custom timeouts.  `server.port` is the OS-assigned port.
+
+The server starts once per context manager and serves as many requests
+as you make, so keep-alive reuse, connection close semantics, and
+pipelining are all observable:
+
+```python
+@pytest.mark.asyncio
+async def test_keep_alive():
+    async with NativeTestServer(app) as server:
+        for _ in range(10):
+            assert (await server.client.get('/hello')).status_code == 200
+```
+
+The synchronous form runs the server on one background loop for the
+session:
+
+```python
+def test_full_stack_sync():
+    with NativeTestServer(app) as server:
+        assert server.client.get('/hello').status_code == 200
+```
+
+Scope and limits:
+
+- **Loopback only.** The listener binds `127.0.0.1`, so a test never
+  publishes a port beyond the machine.
+- **Plaintext HTTP/1.1 and WebSocket.** TLS and HTTP/2 are out of
+  scope for this tier — use the BlackBull clients + ephemeral port
+  pattern below, which negotiates ALPN against a real certificate.
+- **Startup cost is a single `asyncio.start_server`** — no subprocess,
+  no fork.  Per-request cost is loopback TCP, well under a
+  millisecond.
+
+## Choosing between `native` and `TestClient`
+
+Both run in-process and neither needs a port, so the difference is not
+speed — it is *which code runs*.
+
+```text
+native.get(app, '/x')                TestClient(app).get('/x')
+  → Connection                         → httpx.ASGITransport
+  → app(conn, receive, send)           → builds an ASGI scope dict
+  → isinstance(conn, Connection)       → app(scope, receive, send)
+      → True   ← production branch     → isinstance(conn, Connection)
+  → dispatch                               → False
+                                       → Connection.from_scope(scope)
+                                       → dispatch
+```
+
+`TestClient` therefore never takes the branch every production request
+takes.  What it *uniquely* covers is the conversion chain itself: a
+missing `_CONNECTION_FIELDS` entry, or a coercion bug in
+`from_scope()`, shows up there and nowhere else — which is exactly why
+it stays, and why BlackBull keeps a CI lane that runs the whole suite
+under `BB_FORCE_ASGI_SCOPE=1`.
+
+So:
+
+- **Writing an application test?** Use `native` (or `NativeTestServer`
+  when the wire matters).
+- **Deploying under uvicorn, hypercorn, or another ASGI host?** Keep a
+  handful of `TestClient` tests — they are what proves the boundary
+  still works.
+
+## `TestClient` — the ASGI boundary
 
 `blackbull.testing.TestClient` is a synchronous in-memory client
 modelled on `httpx.Client`: GET / POST / PUT / DELETE all work
@@ -49,6 +235,12 @@ dispatched directly into the ASGI app — no socket, no port.
 The ASGI `lifespan` protocol runs around the `with` block, so
 `@app.on_startup` / `@app.on_shutdown` handlers fire in the
 expected order.
+
+Its job is the **compatibility boundary**: it drives the app the way
+an external ASGI host does, through a scope dict and `from_scope()`.
+Everything below still works as documented — it is the recommendation
+that changed, not the API.  For application-logic tests, reach for
+[`native`](#quick-start-with-native) instead.
 
 ```python
 from blackbull import BlackBull
@@ -487,12 +679,14 @@ path through the same in-process adapter.
 
 When to pick which:
 
-- **BlackBull clients + ephemeral port** when the test cares
-  about the wire — TLS, ALPN, HTTP/2 framing, fragmented WS
-  messages, keep-alive, chunked encoding boundaries.
-- **`httpx.ASGITransport`** when you want fast, hermetic
-  request/response assertions and don't care about transport
-  detail.
+- **`NativeTestServer`** for HTTP/1.1 and WebSocket wire behaviour
+  in-process — framing, keep-alive, `HEAD`, chunking.  No
+  subprocess, no certificate.
+- **BlackBull clients + ephemeral port** when the test needs what
+  `NativeTestServer` leaves out: TLS, ALPN, HTTP/2 framing,
+  fragmented WS messages.
+- **`httpx.ASGITransport`** when you are asserting on the ASGI
+  boundary and want the async equivalent of `TestClient`.
 
 ## Direct handler tests
 
@@ -545,9 +739,10 @@ async def test_ping_handler():
 ```
 
 Useful when you want to assert on the raw ASGI event sequence.
-Prefer the `TestClient` pattern above for anything routing-
-shaped — it costs almost nothing more and exercises more of the
-framework.
+For anything routing-shaped, prefer `native` — it costs almost
+nothing more, exercises the whole dispatch pipeline, and hands the
+handler the same `Connection` the server would.  `NativeResponse.events`
+keeps the raw event list if that is what you were reaching for here.
 
 ## Middleware in isolation
 
@@ -596,9 +791,9 @@ BlackBull's test suite (`tests/`) splits into four layers:
 
 You don't need this much structure for an application suite;
 the layers exist because BlackBull also vets protocol behaviour.
-A typical app project gets by with a `tests/` directory of
-integration tests using either the BlackBull client + ephemeral
-port pattern or the `httpx.ASGITransport` pattern from above.
+A typical app project gets by with a `tests/` directory using
+`native` for application logic and `NativeTestServer` for the
+handful of cases where the wire is the point.
 
 ## Next
 

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -173,7 +173,13 @@ async def test_keep_alive():
     async with NativeTestServer(app) as server:
         for _ in range(10):
             assert (await server.client.get('/hello')).status_code == 200
+        assert server.connections_served == 1
 ```
+
+`server.connections_served` counts TCP **accepts**, not requests, so ten
+keep-alive requests on one connection leave it at `1`.  It is the honest
+way to assert connection reuse: `Connection: close` is a header the
+server *may* send, so its absence proves nothing on its own.
 
 The synchronous form runs the server on one background loop for the
 session:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.67.0"
+version = "0.68.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/conformance/http1/_dual_path_corpus.py
+++ b/tests/conformance/http1/_dual_path_corpus.py
@@ -1,0 +1,128 @@
+"""The shared request corpus for dual-path (native vs compat) assertions.
+
+``BB_FORCE_ASGI_SCOPE=1`` makes the server convert ``Connection -> scope`` and
+the app convert it back with ``from_scope`` at dispatch, so both directions of
+the ASGI conversion run on every request.  The lane only does its job if the
+conversion is *invisible*, which is a claim about a set of request shapes — so
+the set lives here, once, and every test that asserts "the two lanes agree"
+draws from it rather than re-specifying its own vectors.
+
+Two consumers, two depths:
+
+- ``test_dual_path_identity`` drives every vector's raw bytes straight into
+  ``HTTP1Actor`` and asserts the two lanes emit **byte-identical** responses.
+- ``test_native_test_server`` replays the client-expressible subset through
+  ``NativeTestServer`` over a real socket and asserts the lanes agree on what
+  a real HTTP client observes.
+
+Not every vector can be driven by a real client: the corpus deliberately
+includes malformed and raw-form requests (obs-fold, a bad header name, an
+absolute-form target, ``OPTIONS *``) that exist precisely because a
+well-behaved client would never send them.  A vector therefore carries a
+:class:`ClientSpec` only when an HTTP client can express it; ``client is None``
+marks it raw-drive-only.  For the expressible ones the ``ClientSpec`` is the
+definition and the raw bytes are derived from it, so the two drives cannot
+drift apart.
+"""
+import re
+from typing import NamedTuple
+
+# The Date header is whole-second wall clock, so it may legitimately differ
+# between two runs of the same request.  Nothing else may.
+_DATE_RE = re.compile(rb'^date:.*$', re.IGNORECASE | re.MULTILINE)
+
+
+def normalise(raw: bytes) -> bytes:
+    """Blank out the one header that may legitimately differ between runs."""
+    return _DATE_RE.sub(b'date: <normalised>', raw)
+
+
+def _req(line: bytes, *headers: bytes, body: bytes = b'') -> bytes:
+    parts = [line, b'Host: localhost', *headers]
+    if body:
+        parts.append(b'Content-Length: %d' % len(body))
+    return b'\r\n'.join(parts) + b'\r\n\r\n' + body
+
+
+class ClientSpec(NamedTuple):
+    """How a real HTTP client would issue this request.
+
+    ``headers`` are ``str`` pairs because that is what an httpx call takes;
+    repeated names are allowed (the list is not a mapping).
+    """
+    method: str
+    target: str
+    headers: tuple[tuple[str, str], ...] = ()
+    body: bytes = b''
+
+
+class Vector(NamedTuple):
+    """One corpus entry.
+
+    ``raw`` is what goes on the wire for the byte-identity drive.  ``client``
+    is the same request expressed for a real HTTP client, or ``None`` when no
+    conformant client can send it.
+    """
+    raw: bytes
+    client: ClientSpec | None = None
+
+
+def _from_client(spec: ClientSpec, *, version: bytes = b'HTTP/1.1') -> Vector:
+    """Build a vector whose raw bytes are *derived* from the client spec."""
+    header_lines = [f'{name}: {value}'.encode('latin-1')
+                    for name, value in spec.headers]
+    raw = _req(b'%s %s %s' % (spec.method.encode(), spec.target.encode(), version),
+               *header_lines, body=spec.body)
+    return Vector(raw=raw, client=spec)
+
+
+CORPUS: dict[str, Vector] = {
+    # --- ordinary routing -------------------------------------------------
+    'get': _from_client(ClientSpec('GET', '/')),
+    'get-query': _from_client(ClientSpec('GET', '/?a=1&b=2')),
+    'get-encoded-path': _from_client(ClientSpec('GET', '/caf%C3%A9')),
+    'post-body': _from_client(ClientSpec('POST', '/echo', body=b'hello')),
+    'post-empty-body': _from_client(ClientSpec('POST', '/echo', body=b'')),
+
+    # --- the method rewrite that broke ------------------------------------
+    'head': _from_client(ClientSpec('HEAD', '/')),
+    'head-with-headers': _from_client(ClientSpec(
+        'HEAD', '/', headers=(('Accept', '*/*'), ('User-Agent', 'probe')))),
+
+    # --- misses and rejections --------------------------------------------
+    'not-found': _from_client(ClientSpec('GET', '/nope')),
+    'method-not-allowed': _from_client(ClientSpec('DELETE', '/')),
+
+    # --- header shapes ----------------------------------------------------
+    'many-headers': _from_client(ClientSpec('GET', '/', headers=(
+        ('User-Agent', 'Mozilla/5.0 (X11; Linux x86_64)'),
+        ('Accept', 'text/html,application/xhtml+xml'),
+        ('Accept-Encoding', 'gzip, deflate, br'),
+        ('Accept-Language', 'en-US,en;q=0.9'),
+        ('Cookie', 'session=8f14e45fceea167a5a36dedd4bea2543'),
+        ('Referer', 'http://localhost/index.html')))),
+    'repeated-header': _from_client(ClientSpec(
+        'GET', '/', headers=(('Accept', 'a'), ('Accept', 'b')))),
+
+    # --- raw-drive only: no conformant client can send these --------------
+    # HTTP/1.0 (httpx speaks 1.1+), the server-wide ``*`` target and
+    # absolute-form request targets (not expressible through a client API),
+    # and four deliberately malformed shapes a client library rejects or
+    # rewrites before they reach the wire.
+    'get-1.0': Vector(_req(b'GET / HTTP/1.0')),
+    'options-asterisk': Vector(_req(b'OPTIONS * HTTP/1.1')),
+    'absolute-form': Vector(_req(b'GET http://real.example/ HTTP/1.1')),
+    'bad-header-name': Vector(_req(b'GET / HTTP/1.1', b'Bad Name: v')),
+    'obs-fold': Vector(_req(b'GET / HTTP/1.1', b' folded: v')),
+    'bad-content-length': Vector(_req(b'POST /echo HTTP/1.1',
+                                      b'Content-Length: 007')),
+    'unsupported-version': Vector(_req(b'GET / HTTP/9.9')),
+    'ows-padded-value': Vector(_req(b'GET / HTTP/1.1', b'Accept:    */*   ')),
+}
+
+#: Vectors a real HTTP client can issue — the subset the socket-level lane
+#: agreement test replays.  The byte-identity guarantee still covers all of
+#: ``CORPUS``; this is about what an external client can *observe*.
+CLIENT_DRIVABLE: dict[str, ClientSpec] = {
+    name: v.client for name, v in CORPUS.items() if v.client is not None
+}

--- a/tests/conformance/http1/test_dual_path_identity.py
+++ b/tests/conformance/http1/test_dual_path_identity.py
@@ -15,7 +15,6 @@ that mutates the Connection between parse and dispatch can reintroduce that
 class of divergence; this asserts the whole corpus rather than one method.
 """
 import asyncio
-import re
 
 import pytest
 
@@ -23,58 +22,8 @@ from blackbull import BlackBull
 from blackbull.env import reset_settings_cache
 from blackbull.server.http1_actor import HTTP1Actor
 
+from ._dual_path_corpus import CORPUS, normalise as _normalise
 from .test_http1_dispatch import _FakeReader, _FakeWriter
-
-# The Date header is whole-second wall clock, so it may legitimately differ
-# between two runs of the same request.  Nothing else may.
-_DATE_RE = re.compile(rb'^date:.*$', re.IGNORECASE | re.MULTILINE)
-
-
-def _normalise(raw: bytes) -> bytes:
-    return _DATE_RE.sub(b'date: <normalised>', raw)
-
-
-def _req(line: bytes, *headers: bytes, body: bytes = b'') -> bytes:
-    parts = [line, b'Host: localhost', *headers]
-    if body:
-        parts.append(b'Content-Length: %d' % len(body))
-    return b'\r\n'.join(parts) + b'\r\n\r\n' + body
-
-
-CORPUS = {
-    # --- ordinary routing ------------------------------------------------
-    'get': _req(b'GET / HTTP/1.1'),
-    'get-query': _req(b'GET /?a=1&b=2 HTTP/1.1'),
-    'get-encoded-path': _req(b'GET /caf%C3%A9 HTTP/1.1'),
-    'get-1.0': _req(b'GET / HTTP/1.0'),
-    'post-body': _req(b'POST /echo HTTP/1.1', body=b'hello'),
-    'post-empty-body': _req(b'POST /echo HTTP/1.1', body=b''),
-    # --- the method rewrite that broke ------------------------------------
-    'head': _req(b'HEAD / HTTP/1.1'),
-    'head-with-headers': _req(b'HEAD / HTTP/1.1', b'Accept: */*',
-                              b'User-Agent: probe'),
-    # --- server-level answers, not routed ---------------------------------
-    'options-asterisk': _req(b'OPTIONS * HTTP/1.1'),
-    'absolute-form': _req(b'GET http://real.example/ HTTP/1.1'),
-    # --- misses and rejections --------------------------------------------
-    'not-found': _req(b'GET /nope HTTP/1.1'),
-    'method-not-allowed': _req(b'DELETE / HTTP/1.1'),
-    'bad-header-name': _req(b'GET / HTTP/1.1', b'Bad Name: v'),
-    'obs-fold': _req(b'GET / HTTP/1.1', b' folded: v'),
-    'bad-content-length': _req(b'POST /echo HTTP/1.1', b'Content-Length: 007'),
-    'unsupported-version': _req(b'GET / HTTP/9.9'),
-    # --- header shapes ----------------------------------------------------
-    'many-headers': _req(
-        b'GET / HTTP/1.1',
-        b'User-Agent: Mozilla/5.0 (X11; Linux x86_64)',
-        b'Accept: text/html,application/xhtml+xml',
-        b'Accept-Encoding: gzip, deflate, br',
-        b'Accept-Language: en-US,en;q=0.9',
-        b'Cookie: session=8f14e45fceea167a5a36dedd4bea2543',
-        b'Referer: http://localhost/index.html'),
-    'repeated-header': _req(b'GET / HTTP/1.1', b'Accept: a', b'Accept: b'),
-    'ows-padded-value': _req(b'GET / HTTP/1.1', b'Accept:    */*   '),
-}
 
 
 @pytest.fixture
@@ -111,7 +60,7 @@ async def _drive(app, request: bytes) -> bytes:
 @pytest.mark.parametrize('name', sorted(CORPUS))
 async def test_both_lanes_produce_identical_bytes(app, name, monkeypatch):
     """Native and BB_FORCE_ASGI_SCOPE=1 must agree byte for byte."""
-    request = CORPUS[name]
+    request = CORPUS[name].raw
 
     reset_settings_cache()
     native = await _drive(app, request)
@@ -139,7 +88,7 @@ async def test_both_lanes_agree_on_status(app, name, monkeypatch):
     fails wholesale if a response body is ever deliberately changed.  This one
     keeps the status-code half of the guarantee legible on its own.
     """
-    request = CORPUS[name]
+    request = CORPUS[name].raw
 
     def status_of(raw: bytes) -> bytes:
         return raw.split(b'\r\n', 1)[0] if raw else b'<no response>'

--- a/tests/conformance/http1/test_native_client_catches_head_regression.py
+++ b/tests/conformance/http1/test_native_client_catches_head_regression.py
@@ -1,0 +1,186 @@
+"""The native test client, judged against the defect that motivated it.
+
+Sprint 87 found ``HEAD`` answering **405** under ``BB_FORCE_ASGI_SCOPE=1``
+while the native lane answered 200.  The cause was ordering, not logic: the
+compat lane's scope snapshot was taken *before* ``HTTP1Actor.run`` rewrites
+``HEAD`` to ``GET`` (RFC 9110 §9.3.2), so the router looked for a ``HEAD``
+route, found none, and returned 405.  Every existing HEAD test passed.
+
+A test client that could not have caught that has not earned its place.  So
+this file re-injects the defect and asks each instrument what it sees.  The
+injection restores exactly one thing — the method the compat snapshot carries
+— because that single ordering difference *is* the bug; nothing else about
+the actor is touched.
+
+The answer, asserted below, is that **only Tier 2 catches it**: the defect
+lives in the protocol actor, above where Tier 1 starts and on a path
+``TestClient`` never runs at all.  That is the argument for Tier 2 stated as
+an executable claim rather than a design opinion.
+"""
+import pytest
+
+from blackbull import BlackBull
+from blackbull.connection import Connection
+from blackbull.env import reset_settings_cache
+from blackbull.server.http1_actor import HTTP1Actor
+from blackbull.testing import NativeTestServer, TestClient, native
+
+
+@pytest.fixture
+def app():
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    return a
+
+
+@pytest.fixture
+def forced_asgi_lane(monkeypatch):
+    """Run the actor's compat lane, the one the regression appeared on."""
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    yield
+    monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+    reset_settings_cache()
+
+
+@pytest.fixture
+def prefix_ordering(monkeypatch):
+    """Re-inject the Sprint 87 ordering: snapshot before the HEAD→GET rewrite.
+
+    ``_parse`` records the method the request line carried; the compat
+    snapshot then reports *that* method instead of the rewritten one — which
+    is what a scope materialised earlier in ``run()`` would have frozen.
+
+    Keyed by ``id(conn)``: :class:`Connection` is a ``slots=True`` dataclass,
+    so neither an attribute nor a ``WeakKeyDictionary`` entry can be attached
+    to it.  The map is per-test and cleared on teardown.
+    """
+    request_line_method: dict[int, str] = {}
+    real_parse = HTTP1Actor._parse
+    real_to_asgi_scope = Connection.to_asgi_scope
+
+    def _parse(self, data):
+        conn = real_parse(self, data)
+        request_line_method[id(conn)] = conn.method
+        return conn
+
+    def _to_asgi_scope(self, *, force_asgi=False):
+        scope = real_to_asgi_scope(self, force_asgi=force_asgi)
+        if force_asgi and id(self) in request_line_method:
+            scope['method'] = request_line_method[id(self)]
+        return scope
+
+    monkeypatch.setattr(HTTP1Actor, '_parse', _parse)
+    monkeypatch.setattr(Connection, 'to_asgi_scope', _to_asgi_scope)
+    yield
+    request_line_method.clear()
+
+
+# --- the gate ---------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_tier2_catches_the_head_regression(app, forced_asgi_lane, prefix_ordering):
+    """With the pre-fix ordering restored, Tier 2 sees the 405."""
+    async with NativeTestServer(app) as server:
+        resp = await server.client.head('/')
+    assert resp.status_code == 405, (
+        'Tier 2 did not observe the Sprint 87 regression — the instrument '
+        'cannot see the defect class it was built for.')
+
+
+@pytest.mark.asyncio
+async def test_tier2_sees_200_once_the_ordering_is_correct(app, forced_asgi_lane):
+    """Same lane, same request, current code: the fixed behaviour."""
+    async with NativeTestServer(app) as server:
+        resp = await server.client.head('/')
+    assert resp.status_code == 200
+    assert resp.content == b''
+
+
+@pytest.mark.asyncio
+async def test_both_lanes_agree_on_head_through_tier2(app):
+    """The native lane was always 200; the point is that the two now match."""
+    async with NativeTestServer(app) as server:
+        resp = await server.client.head('/')
+    assert resp.status_code == 200
+
+
+# --- why Tier 2 is not redundant with the other two instruments -------------
+#
+# The test is not "the other instruments give the wrong answer" — it is that
+# their answer does not *change* when the defect is injected.  An instrument
+# that reports the same thing whether the code is broken or fixed cannot be
+# the one guarding this behaviour, whatever that thing happens to be.
+#
+# Both return 405 either way, for the same underlying reason: the HEAD→GET
+# rewrite lives in ``HTTP1Actor``, so an instrument that starts below the
+# actor (Tier 1) or replaces it entirely (``TestClient``) cannot express
+# RFC 9110 §9.3.2 HEAD semantics at all.
+
+@pytest.mark.asyncio
+async def test_tier1_is_blind_to_the_regression(app, forced_asgi_lane,
+                                                prefix_ordering, monkeypatch):
+    """Tier 1's answer is identical with and without the defect injected."""
+    with_defect = (await native.head(app, '/')).status
+
+    # ``undo`` drops every patch this test's monkeypatch holds, the lane's
+    # env var included — re-set it so the only variable that changed between
+    # the two measurements is the injected ordering.
+    monkeypatch.undo()
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    without_defect = (await native.head(app, '/')).status
+
+    assert with_defect == without_defect, (
+        'Tier 1 distinguished the two, which would make this argument wrong.')
+
+
+def test_the_asgi_test_client_is_blind_to_the_regression(app, forced_asgi_lane,
+                                                         prefix_ordering,
+                                                         monkeypatch):
+    """``TestClient`` runs no protocol actor — ``httpx.ASGITransport`` builds
+    the scope itself, so the actor's snapshot ordering is not in the picture
+    and its answer cannot move."""
+    with TestClient(app) as client:
+        with_defect = client.head('/').status_code
+
+    monkeypatch.undo()
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    with TestClient(app) as client:
+        without_defect = client.head('/').status_code
+
+    assert with_defect == without_defect
+
+
+# --- the defect class, not just the instance --------------------------------
+
+@pytest.mark.asyncio
+async def test_pre_dispatch_mutations_reach_the_compat_lane(app, forced_asgi_lane):
+    """The general invariant the HEAD bug was one instance of.
+
+    Anything ``HTTP1Actor.run`` mutates on the ``Connection`` before dispatch
+    must be visible to the compat lane's scope.  ``HEAD``→``GET`` is the
+    mutation that exists today; this asserts the property rather than the one
+    case, so a future pre-dispatch mutation cannot reintroduce the class
+    silently.
+    """
+    observed = []
+
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root(conn, receive, send):
+        observed.append(conn.method)
+        await send(b'ok')
+
+    async with NativeTestServer(a) as server:
+        await server.client.head('/')
+
+    # The actor rewrote the method before dispatch; the compat lane's scope
+    # carried the rewrite through ``from_scope``, so the router saw GET.
+    assert observed == ['GET']

--- a/tests/conformance/http1/test_native_client_catches_head_regression.py
+++ b/tests/conformance/http1/test_native_client_catches_head_regression.py
@@ -111,50 +111,51 @@ async def test_both_lanes_agree_on_head_through_tier2(app):
 
 # --- why Tier 2 is not redundant with the other two instruments -------------
 #
-# The test is not "the other instruments give the wrong answer" — it is that
-# their answer does not *change* when the defect is injected.  An instrument
-# that reports the same thing whether the code is broken or fixed cannot be
-# the one guarding this behaviour, whatever that thing happens to be.
+# The claim is not "the other instruments give the wrong answer" — it is that
+# their answer cannot *move*.  An instrument that reports the same thing
+# whether the code is broken or fixed is not the one guarding this behaviour,
+# whatever that thing happens to be.
 #
-# Both return 405 either way, for the same underlying reason: the HEAD→GET
-# rewrite lives in ``HTTP1Actor``, so an instrument that starts below the
-# actor (Tier 1) or replaces it entirely (``TestClient``) cannot express
-# RFC 9110 §9.3.2 HEAD semantics at all.
+# The reason is structural, so the tests below assert it structurally rather
+# than by a with/without contrast: the HEAD→GET rewrite lives in
+# ``HTTP1Actor.run``, and the injection hangs off ``HTTP1Actor._parse``.  An
+# instrument that starts below the actor (Tier 1) or replaces it entirely
+# (``TestClient``) never runs either one.  Both therefore see a bare ``HEAD``
+# against a GET-only route and answer 405 — on both lanes, injected or not.
+#
+# 405 is pinned rather than left as an equality, because equality alone cannot
+# tell the honest reading ("blind, and the blind answer is 405") apart from a
+# future answer that silently changed to something else on both sides.
+
+_TIER1_BLIND_HEAD_STATUS = 405
+
 
 @pytest.mark.asyncio
 async def test_tier1_is_blind_to_the_regression(app, forced_asgi_lane,
-                                                prefix_ordering, monkeypatch):
-    """Tier 1's answer is identical with and without the defect injected."""
-    with_defect = (await native.head(app, '/')).status
+                                                prefix_ordering):
+    """Tier 1 answers 405 with the ordering injected — it cannot see it."""
+    assert (await native.head(app, '/')).status == _TIER1_BLIND_HEAD_STATUS
 
-    # ``undo`` drops every patch this test's monkeypatch holds, the lane's
-    # env var included — re-set it so the only variable that changed between
-    # the two measurements is the injected ordering.
-    monkeypatch.undo()
-    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
-    reset_settings_cache()
-    without_defect = (await native.head(app, '/')).status
 
-    assert with_defect == without_defect, (
-        'Tier 1 distinguished the two, which would make this argument wrong.')
+@pytest.mark.asyncio
+async def test_tier1_answers_the_same_without_the_injection(app, forced_asgi_lane):
+    """…and 405 without it.  Same fixtures minus ``prefix_ordering``, so the
+    two tests differ in exactly the injected variable."""
+    assert (await native.head(app, '/')).status == _TIER1_BLIND_HEAD_STATUS
 
 
 def test_the_asgi_test_client_is_blind_to_the_regression(app, forced_asgi_lane,
-                                                         prefix_ordering,
-                                                         monkeypatch):
+                                                         prefix_ordering):
     """``TestClient`` runs no protocol actor — ``httpx.ASGITransport`` builds
-    the scope itself, so the actor's snapshot ordering is not in the picture
-    and its answer cannot move."""
+    the scope itself, so the actor's snapshot ordering is not in the picture."""
     with TestClient(app) as client:
-        with_defect = client.head('/').status_code
+        assert client.head('/').status_code == _TIER1_BLIND_HEAD_STATUS
 
-    monkeypatch.undo()
-    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
-    reset_settings_cache()
+
+def test_the_asgi_test_client_answers_the_same_without_the_injection(
+        app, forced_asgi_lane):
     with TestClient(app) as client:
-        without_defect = client.head('/').status_code
-
-    assert with_defect == without_defect
+        assert client.head('/').status_code == _TIER1_BLIND_HEAD_STATUS
 
 
 # --- the defect class, not just the instance --------------------------------

--- a/tests/conformance/http1/test_native_test_server.py
+++ b/tests/conformance/http1/test_native_test_server.py
@@ -1,0 +1,226 @@
+"""Tier 2 of the native test client — :class:`NativeTestServer`.
+
+This tier binds a real loopback socket and runs BlackBull's own
+:class:`~blackbull.server.server.Server`, so a request travels the whole
+production path: TCP accept → ``ConnectionActor`` → ``HTTP1Actor`` parse →
+``Connection`` → native dispatch → the bytes the sender writes.
+
+The assertions below are deliberately about things that are *only* observable
+on the wire — framing headers the sender injects, the HEAD body strip,
+keep-alive reuse, chunked encoding.  Every one of them is invisible to Tier 1
+(which stops at the app's ``send`` events) and to ``TestClient`` (which never
+runs a protocol actor at all).
+"""
+import asyncio
+from http import HTTPStatus
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.testing import NativeTestServer
+
+
+@pytest.fixture
+def app():
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    @a.route(path='/echo', methods=['POST'])
+    async def _echo(conn, receive, send):
+        await send(await conn.body(), HTTPStatus.OK)
+
+    @a.route(path='/who')
+    async def _who(conn, receive, send):
+        await send(type(conn).__name__.encode(), HTTPStatus.OK)
+
+    @a.route(path='/peer')
+    async def _peer(conn, receive, send):
+        await send(f'{conn.client[0]}|{conn.http_version}'.encode(), HTTPStatus.OK)
+
+    @a.route(path='/chunks')
+    async def _chunks(conn, receive, send):
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        for chunk in (b'a', b'b', b'c'):
+            await send({'type': 'http.response.body', 'body': chunk, 'more_body': True})
+        await send({'type': 'http.response.body', 'body': b'', 'more_body': False})
+
+    return a
+
+
+# --- the core contract ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_round_trips_over_a_real_socket(app):
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/')
+        assert resp.status_code == 200
+        assert resp.text == 'hello'
+
+
+@pytest.mark.asyncio
+async def test_binds_an_ephemeral_loopback_port(app):
+    async with NativeTestServer(app) as server:
+        assert server.port != 0
+        assert server.url == f'http://127.0.0.1:{server.port}'
+        # Loopback only: a test must never publish a port to the network.
+        assert server.host == '127.0.0.1'
+
+
+@pytest.mark.asyncio
+async def test_the_handler_is_reached_through_the_native_connection(app):
+    """The actor parses bytes into a ``Connection`` and dispatches natively."""
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/who')
+        assert resp.text == 'Connection'
+
+
+@pytest.mark.asyncio
+async def test_transport_fields_come_from_the_real_socket(app):
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/peer')
+        client_ip, version = resp.text.split('|')
+        assert client_ip == '127.0.0.1'
+        assert version == '1.1'
+
+
+@pytest.mark.asyncio
+async def test_two_servers_get_distinct_ports(app):
+    async with NativeTestServer(app) as a, NativeTestServer(app) as b:
+        assert a.port != b.port
+        assert (await a.client.get('/')).text == 'hello'
+        assert (await b.client.get('/')).text == 'hello'
+
+
+# --- what only the wire can tell you ---------------------------------------
+
+@pytest.mark.asyncio
+async def test_the_sender_injects_content_length(app):
+    """Tier 1 cannot see this: the app never emits the framing header."""
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/')
+        assert resp.headers['content-length'] == '5'
+
+
+@pytest.mark.asyncio
+async def test_head_returns_the_get_headers_without_a_body(app):
+    """RFC 9110 §9.3.2 — identical to the GET response minus the body."""
+    async with NativeTestServer(app) as server:
+        get_resp = await server.client.get('/')
+        head_resp = await server.client.head('/')
+
+    assert head_resp.status_code == 200
+    assert head_resp.content == b''
+    assert head_resp.headers['content-length'] == get_resp.headers['content-length']
+
+
+@pytest.mark.asyncio
+async def test_keep_alive_reuses_one_connection(app):
+    """Four requests, one TCP connection — the actor's keep-alive loop."""
+    async with NativeTestServer(app) as server:
+        for _ in range(4):
+            resp = await server.client.get('/')
+            assert resp.status_code == 200
+        # httpx pools by default; a connection-per-request would show up as
+        # a `connection: close` on the responses.
+        assert resp.headers.get('connection', '').lower() != 'close'
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_is_chunked_on_the_wire(app):
+    async with NativeTestServer(app) as server:
+        resp = await server.client.get('/chunks')
+        assert resp.text == 'abc'
+        assert resp.headers.get('transfer-encoding') == 'chunked'
+
+
+@pytest.mark.asyncio
+async def test_request_body_is_parsed_from_the_wire(app):
+    async with NativeTestServer(app) as server:
+        resp = await server.client.post('/echo', content=b'payload')
+        assert resp.content == b'payload'
+
+
+@pytest.mark.asyncio
+async def test_unrouted_path_is_404(app):
+    async with NativeTestServer(app) as server:
+        assert (await server.client.get('/nope')).status_code == 404
+
+
+# --- lifecycle --------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_lifespan_runs_around_the_server():
+    a = BlackBull()
+    order = []
+
+    @a.on_startup
+    async def _up():
+        order.append('up')
+
+    @a.on_shutdown
+    async def _down():
+        order.append('down')
+
+    @a.route(path='/x')
+    async def _x():
+        return 'x'
+
+    async with NativeTestServer(a) as server:
+        assert order == ['up']
+        assert (await server.client.get('/x')).text == 'x'
+    assert order == ['up', 'down']
+
+
+@pytest.mark.asyncio
+async def test_the_port_is_released_on_exit(app):
+    async with NativeTestServer(app) as server:
+        port = server.port
+    # Rebinding the same port proves the listener really closed rather than
+    # lingering until interpreter teardown.
+    async with NativeTestServer(app, port=port) as second:
+        assert second.port == port
+
+
+@pytest.mark.asyncio
+async def test_client_outside_the_context_manager_is_an_error(app):
+    server = NativeTestServer(app)
+    with pytest.raises(RuntimeError, match='context manager'):
+        server.client
+
+
+@pytest.mark.asyncio
+async def test_events_fire_exactly_once_per_request():
+    a = BlackBull()
+    seen = []
+
+    @a.on('scope_completed')
+    async def _done(event):
+        seen.append(event)
+
+    @a.route(path='/e')
+    async def _e():
+        return 'ok'
+
+    async with NativeTestServer(a) as server:
+        await server.client.get('/e')
+        await asyncio.sleep(0.1)   # settle window for a late duplicate
+    assert len(seen) == 1
+
+
+# --- the sync façade --------------------------------------------------------
+
+def test_sync_form_serves_requests(app):
+    with NativeTestServer(app) as server:
+        resp = server.client.get('/')
+        assert resp.status_code == 200
+        assert resp.text == 'hello'
+
+
+def test_sync_form_serves_many_requests(app):
+    with NativeTestServer(app) as server:
+        assert server.client.get('/').text == 'hello'
+        assert server.client.post('/echo', content=b'x').content == b'x'
+        assert server.client.get('/nope').status_code == 404

--- a/tests/conformance/http1/test_native_test_server.py
+++ b/tests/conformance/http1/test_native_test_server.py
@@ -14,10 +14,14 @@ runs a protocol actor at all).
 import asyncio
 from http import HTTPStatus
 
+import httpx
 import pytest
 
 from blackbull import BlackBull
+from blackbull.env import reset_settings_cache
 from blackbull.testing import NativeTestServer
+
+from ._dual_path_corpus import CLIENT_DRIVABLE
 
 
 @pytest.fixture
@@ -118,14 +122,36 @@ async def test_head_returns_the_get_headers_without_a_body(app):
 
 @pytest.mark.asyncio
 async def test_keep_alive_reuses_one_connection(app):
-    """Four requests, one TCP connection — the actor's keep-alive loop."""
+    """Four requests, exactly one TCP connection — the actor's keep-alive loop.
+
+    Counted at accept, because that is the only place the answer is a fact.
+    ``Connection: close`` is a signal the server *may* send, so its absence
+    proves nothing on its own — a server that silently dropped the socket
+    between requests would pass a header-only check.
+    """
     async with NativeTestServer(app) as server:
         for _ in range(4):
             resp = await server.client.get('/')
             assert resp.status_code == 200
-        # httpx pools by default; a connection-per-request would show up as
-        # a `connection: close` on the responses.
-        assert resp.headers.get('connection', '').lower() != 'close'
+            # Secondary: no response may ask the client to tear down, which is
+            # what would have forced a reconnect for the next request.
+            assert resp.headers.get('connection', '').lower() != 'close'
+        assert server.connections_served == 1
+
+
+@pytest.mark.asyncio
+async def test_the_accept_counter_counts_connections_not_requests(app):
+    """Pin the counter's meaning, so the keep-alive proof above can be read.
+
+    Two explicit connections carrying two requests each must read 2, not 4.
+    """
+    async with NativeTestServer(app) as server:
+        for _ in range(2):
+            # A fresh client is a fresh pool, hence a fresh TCP connection.
+            async with httpx.AsyncClient(base_url=server.url) as client:
+                assert (await client.get('/')).status_code == 200
+                assert (await client.get('/')).status_code == 200
+        assert server.connections_served == 2
 
 
 @pytest.mark.asyncio
@@ -195,10 +221,14 @@ async def test_client_outside_the_context_manager_is_an_error(app):
 async def test_events_fire_exactly_once_per_request():
     a = BlackBull()
     seen = []
+    done = asyncio.Event()
 
     @a.on('scope_completed')
     async def _done(event):
+        # Append on *every* delivery, signal only the first: a genuine
+        # duplicate must still reach ``seen`` and fail the count below.
         seen.append(event)
+        done.set()
 
     @a.route(path='/e')
     async def _e():
@@ -206,7 +236,10 @@ async def test_events_fire_exactly_once_per_request():
 
     async with NativeTestServer(a) as server:
         await server.client.get('/e')
-        await asyncio.sleep(0.1)   # settle window for a late duplicate
+        # Wait for delivery rather than guessing at it — a fixed sleep is a
+        # flake on a loaded runner.  The timeout is a safety bound, not a race.
+        await asyncio.wait_for(done.wait(), timeout=2.0)
+        await asyncio.sleep(0.2)   # bounded settle window for a late duplicate
     assert len(seen) == 1
 
 
@@ -224,3 +257,83 @@ def test_sync_form_serves_many_requests(app):
         assert server.client.get('/').text == 'hello'
         assert server.client.post('/echo', content=b'x').content == b'x'
         assert server.client.get('/nope').status_code == 404
+
+
+# --- the two lanes agree, over the shared corpus ----------------------------
+#
+# ``_dual_path_corpus`` is the single definition of "the request shapes the
+# compat lane must be invisible for".  ``test_dual_path_identity`` asserts
+# byte identity over all of it by driving the actor directly; this asserts the
+# same claim one layer out — over a real socket, through a real HTTP client —
+# for the subset a conformant client can actually issue.
+
+@pytest.fixture
+def corpus_app():
+    """The routes the shared corpus addresses (mirrors the identity test's)."""
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    @a.route(path='/echo', methods=['POST'])
+    async def _echo(conn, receive, send):
+        body = await conn.body()
+        await send(body or b'(empty)', HTTPStatus.OK)
+
+    @a.route(path='/café')
+    async def _unicode_path():
+        return 'cafe'
+
+    return a
+
+
+#: Headers that may legitimately differ between two runs of the same request.
+_VOLATILE_HEADERS = frozenset({'date'})
+
+
+def _observable(resp):
+    """What a client sees, minus what is allowed to vary between runs."""
+    return (
+        resp.status_code,
+        sorted((k.lower(), v) for k, v in resp.headers.multi_items()
+               if k.lower() not in _VOLATILE_HEADERS),
+        resp.content,
+    )
+
+
+async def _drive_through_server(app, spec):
+    async with NativeTestServer(app) as server:
+        return _observable(await server.client.request(
+            spec.method, spec.target,
+            headers=list(spec.headers) or None,
+            content=spec.body or None,
+        ))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('name', sorted(CLIENT_DRIVABLE))
+async def test_both_lanes_agree_over_the_shared_corpus(corpus_app, name,
+                                                       monkeypatch):
+    """Native and ``BB_FORCE_ASGI_SCOPE=1`` agree on what a client observes.
+
+    The vectors come from ``_dual_path_corpus.CLIENT_DRIVABLE`` — the same
+    definition ``test_dual_path_identity`` draws from — so the claim is stated
+    once and asserted at two depths, rather than re-specified here.
+    """
+    spec = CLIENT_DRIVABLE[name]
+
+    reset_settings_cache()
+    native = await _drive_through_server(corpus_app, spec)
+
+    monkeypatch.setenv('BB_FORCE_ASGI_SCOPE', '1')
+    reset_settings_cache()
+    try:
+        forced = await _drive_through_server(corpus_app, spec)
+    finally:
+        monkeypatch.delenv('BB_FORCE_ASGI_SCOPE', raising=False)
+        reset_settings_cache()
+
+    assert forced == native, (
+        f'{name}: the compat lane diverged from the native lane over a real '
+        f'socket.\n  native: {native}\n  forced: {forced}')

--- a/tests/unit/test_native_test_client.py
+++ b/tests/unit/test_native_test_client.py
@@ -320,17 +320,24 @@ async def test_middleware_runs():
 async def test_lifecycle_events_fire_exactly_once():
     a = BlackBull()
     seen = []
+    done = asyncio.Event()
 
     @a.on('scope_completed')
     async def _done(event):
+        # Append on *every* delivery, signal only the first: a genuine
+        # duplicate must still reach ``seen`` and fail the count below.
         seen.append(event)
+        done.set()
 
     @a.route(path='/e')
     async def _e():
         return 'ok'
 
     await native.get(a, '/e')
-    await asyncio.sleep(0.05)   # settle window for a late duplicate
+    # Wait for delivery rather than guessing at it — a fixed sleep is a flake
+    # on a loaded runner.  The timeout is a safety bound, not a race.
+    await asyncio.wait_for(done.wait(), timeout=2.0)
+    await asyncio.sleep(0.2)    # bounded settle window for a late duplicate
     assert len(seen) == 1
 
 

--- a/tests/unit/test_native_test_client.py
+++ b/tests/unit/test_native_test_client.py
@@ -1,0 +1,390 @@
+"""Tier 1 of the native test client — ``blackbull.testing.native``.
+
+The instrument under test injects a typed :class:`Connection` and calls
+``app(conn, receive, send)`` directly, which is the entry point BlackBull's
+own protocol actors use.  ``TestClient`` cannot reach that entry point: it
+drives the app through ``httpx.ASGITransport`` → ASGI scope dict →
+``from_scope()``, so the ``isinstance(conn, Connection)`` branch of
+``BlackBull.__call__`` — the production hot path — is never taken.
+
+These tests therefore assert two things at once: that the helpers behave like
+a request client, and that the object the handler receives is the native
+``Connection`` rather than a rebuilt one.
+"""
+import asyncio
+from http import HTTPStatus
+
+import pytest
+
+from blackbull import BlackBull
+from blackbull.connection import Connection
+from blackbull.headers import Headers
+from blackbull.testing import native
+from blackbull.testing.native import NativeClient, NativeResponse
+
+
+@pytest.fixture
+def app():
+    a = BlackBull()
+
+    @a.route(path='/')
+    async def _root():
+        return 'hello'
+
+    @a.route(path='/json')
+    async def _json():
+        return {'ok': True, 'n': 3}
+
+    @a.route(path='/echo', methods=['POST'])
+    async def _echo(conn, receive, send):
+        await send(await conn.body(), HTTPStatus.OK)
+
+    @a.route(path='/who')
+    async def _who(conn, receive, send):
+        # The native branch hands the handler the very object the caller
+        # built; the compat branch would hand it a from_scope() rebuild.
+        await send(type(conn).__name__.encode(), HTTPStatus.OK)
+
+    @a.route(path='/inspect')
+    async def _inspect(conn, receive, send):
+        body = (f'{conn.method}|{conn.path}|{conn.query_string.decode()}|'
+                f'{conn.http_version}|{conn.scheme}').encode()
+        await send(body, HTTPStatus.OK)
+
+    @a.route(path='/hdr')
+    async def _hdr(conn, receive, send):
+        await send(conn.headers.get(b'x-probe', b'<none>'), HTTPStatus.OK)
+
+    @a.route(path='/items/{item_id}')
+    async def _item(item_id):
+        return f'item={item_id}'
+
+    @a.route(path='/café')
+    async def _unicode():
+        return 'cafe'
+
+    return a
+
+
+# --- the core contract ------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_returns_a_native_response(app):
+    resp = await native.get(app, '/')
+    assert isinstance(resp, NativeResponse)
+    assert resp.status == 200
+    assert resp.body == b'hello'
+
+
+@pytest.mark.asyncio
+async def test_handler_receives_the_native_connection(app):
+    """The whole point of Tier 1: ``BlackBull.__call__``'s native branch.
+
+    Under ``TestClient`` this handler would still see a ``Connection``, but
+    a *different* one — rebuilt by ``from_scope()``.  Asserting identity is
+    what distinguishes the two lanes.
+    """
+    conn = Connection(method='GET', path='/who', raw_path=b'/who',
+                      headers=Headers([(b'host', b'testserver')]))
+    resp = await native.request(app, conn)
+    assert resp.body == b'Connection'
+
+
+@pytest.mark.asyncio
+async def test_request_threads_the_caller_s_connection_object(app):
+    """No conversion happens: the handler's ``conn`` *is* the injected one."""
+    seen = []
+
+    a = BlackBull()
+
+    @a.route(path='/id')
+    async def _id(conn, receive, send):
+        seen.append(conn)
+        await send(b'ok', HTTPStatus.OK)
+
+    conn = Connection(method='GET', path='/id', raw_path=b'/id',
+                      headers=Headers([(b'host', b'testserver')]))
+    await native.request(a, conn)
+    assert seen and seen[0] is conn
+
+
+@pytest.mark.asyncio
+async def test_response_headers_are_a_headers_object(app):
+    resp = await native.get(app, '/')
+    assert isinstance(resp.headers, Headers)
+    assert resp.headers.get(b'content-type') == b'text/html; charset=utf-8'
+
+
+@pytest.mark.asyncio
+async def test_framing_headers_are_a_tier_2_observation(app):
+    """Tier 1 reports the events the *app* emitted, not the bytes sent.
+
+    ``Content-Length`` is injected by the protocol sender, below this tier, so
+    its absence here is the boundary working as designed — and the reason a
+    test about framing belongs on :class:`NativeTestServer`.
+    """
+    resp = await native.get(app, '/')
+    assert resp.headers.getlist(b'content-length') == []
+
+
+@pytest.mark.asyncio
+async def test_json_and_text_helpers(app):
+    resp = await native.get(app, '/json')
+    assert resp.json() == {'ok': True, 'n': 3}
+    assert resp.text() == '{"ok": true, "n": 3}'
+
+
+# --- request construction ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_query_string_is_split_from_the_path(app):
+    resp = await native.get(app, '/inspect?a=1&b=2')
+    method, path, query, version, scheme = resp.text().split('|')
+    assert (method, path, query) == ('GET', '/inspect', 'a=1&b=2')
+    assert (version, scheme) == ('1.1', 'http')
+
+
+@pytest.mark.asyncio
+async def test_percent_encoded_path_is_decoded_like_the_parser(app):
+    """``conn.path`` is decoded, ``raw_path`` is not — the H/1.1 parser's rule."""
+    resp = await native.get(app, '/caf%C3%A9')
+    assert resp.status == 200
+    assert resp.body == b'cafe'
+
+
+@pytest.mark.asyncio
+async def test_path_params_are_matched(app):
+    resp = await native.get(app, '/items/42')
+    assert resp.body == b'item=42'
+
+
+@pytest.mark.asyncio
+async def test_headers_reach_the_handler(app):
+    resp = await native.get(app, '/hdr', headers={b'x-probe': b'seen'})
+    assert resp.body == b'seen'
+
+
+@pytest.mark.asyncio
+async def test_headers_accept_str_pairs(app):
+    resp = await native.get(app, '/hdr', headers={'X-Probe': 'STR'})
+    assert resp.body == b'STR'
+
+
+@pytest.mark.asyncio
+async def test_a_host_header_is_supplied_by_default(app):
+    a = BlackBull()
+
+    @a.route(path='/host')
+    async def _host(conn, receive, send):
+        await send(conn.headers.get(b'host', b'<none>'), HTTPStatus.OK)
+
+    resp = await native.get(a, '/host')
+    assert resp.body != b'<none>'
+
+
+# --- bodies -----------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_post_body_reaches_conn_body(app):
+    resp = await native.post(app, '/echo', body=b'payload')
+    assert resp.body == b'payload'
+
+
+@pytest.mark.asyncio
+async def test_body_implies_content_length(app):
+    """A real request carries the framing header; a synthesised one must too,
+    or middleware that branches on ``content-length`` behaves differently
+    under test than on the wire."""
+    a = BlackBull()
+
+    @a.route(path='/len', methods=['POST'])
+    async def _len(conn, receive, send):
+        await send(conn.headers.get(b'content-length', b'<none>'), HTTPStatus.OK)
+
+    resp = await native.post(a, '/len', body=b'12345')
+    assert resp.body == b'5'
+
+
+@pytest.mark.asyncio
+async def test_explicit_content_length_is_not_overwritten():
+    a = BlackBull()
+
+    @a.route(path='/len', methods=['POST'])
+    async def _len(conn, receive, send):
+        await send(conn.headers.get(b'content-length'), HTTPStatus.OK)
+
+    resp = await native.post(a, '/len', body=b'12345',
+                             headers={b'content-length': b'99'})
+    assert resp.body == b'99'
+
+
+@pytest.mark.asyncio
+async def test_str_body_is_utf8_encoded():
+    a = BlackBull()
+
+    @a.route(path='/echo', methods=['POST'])
+    async def _echo(conn, receive, send):
+        await send(await conn.body(), HTTPStatus.OK)
+
+    resp = await native.post(a, '/echo', body='café')
+    assert resp.body == 'café'.encode('utf-8')
+
+
+@pytest.mark.asyncio
+async def test_json_argument_sets_body_and_content_type():
+    a = BlackBull()
+
+    @a.route(path='/j', methods=['POST'])
+    async def _j(conn, receive, send):
+        payload = await conn.json()
+        ct = conn.headers.get(b'content-type', b'')
+        await send(f'{payload["k"]}|{ct.decode()}'.encode(), HTTPStatus.OK)
+
+    resp = await native.post(a, '/j', json={'k': 'v'})
+    assert resp.body == b'v|application/json'
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_is_reassembled():
+    a = BlackBull()
+
+    @a.route(path='/stream')
+    async def _stream(conn, receive, send):
+        await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+        for chunk in (b'a', b'b', b'c'):
+            await send({'type': 'http.response.body', 'body': chunk, 'more_body': True})
+        await send({'type': 'http.response.body', 'body': b'', 'more_body': False})
+
+    resp = await native.get(a, '/stream')
+    assert resp.body == b'abc'
+    assert resp.status == 200
+
+
+# --- verbs ------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_every_verb_helper_exists(app):
+    a = BlackBull()
+
+    @a.route(path='/any', methods=['GET', 'POST', 'PUT', 'PATCH', 'DELETE',
+                                   'HEAD', 'OPTIONS'])
+    async def _any(conn, receive, send):
+        await send(conn.method.encode(), HTTPStatus.OK)
+
+    assert (await native.get(a, '/any')).body == b'GET'
+    assert (await native.post(a, '/any')).body == b'POST'
+    assert (await native.put(a, '/any')).body == b'PUT'
+    assert (await native.patch(a, '/any')).body == b'PATCH'
+    assert (await native.delete(a, '/any')).body == b'DELETE'
+    assert (await native.options(a, '/any')).body == b'OPTIONS'
+    # HEAD reaches the handler as HEAD here: the GET-rewrite is the H/1.1
+    # actor's job (RFC 9110 §9.3.2), and Tier 1 starts below the actor.
+    assert (await native.head(a, '/any')).status == 200
+
+
+# --- misses and rejections --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unrouted_path_is_404(app):
+    resp = await native.get(app, '/nope')
+    assert resp.status == 404
+
+
+@pytest.mark.asyncio
+async def test_wrong_method_is_405(app):
+    resp = await native.delete(app, '/')
+    assert resp.status == 405
+
+
+# --- integration with the rest of the framework -----------------------------
+
+@pytest.mark.asyncio
+async def test_middleware_runs():
+    a = BlackBull()
+
+    async def _mw(conn, receive, send, call_next):
+        conn.state['tag'] = 'mw'
+        await call_next(conn, receive, send)
+
+    a.use(_mw)
+
+    @a.route(path='/m')
+    async def _m(conn, receive, send):
+        await send(conn.state.get('tag', '<none>').encode(), HTTPStatus.OK)
+
+    resp = await native.get(a, '/m')
+    assert resp.body == b'mw'
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_events_fire_exactly_once():
+    a = BlackBull()
+    seen = []
+
+    @a.on('scope_completed')
+    async def _done(event):
+        seen.append(event)
+
+    @a.route(path='/e')
+    async def _e():
+        return 'ok'
+
+    await native.get(a, '/e')
+    await asyncio.sleep(0.05)   # settle window for a late duplicate
+    assert len(seen) == 1
+
+
+@pytest.mark.asyncio
+async def test_handler_exception_becomes_500():
+    a = BlackBull()
+
+    @a.route(path='/boom')
+    async def _boom():
+        raise RuntimeError('kaboom')
+
+    resp = await native.get(a, '/boom')
+    assert resp.status == 500
+
+
+# --- the sync façade --------------------------------------------------------
+
+def test_native_client_is_a_sync_facade(app):
+    with NativeClient(app) as client:
+        resp = client.get('/')
+        assert resp.status == 200
+        assert resp.body == b'hello'
+
+
+def test_native_client_serves_many_requests_on_one_loop(app):
+    with NativeClient(app) as client:
+        assert client.get('/').body == b'hello'
+        assert client.post('/echo', body=b'x').body == b'x'
+        assert client.get('/nope').status == 404
+
+
+def test_native_client_outside_context_manager_is_an_error(app):
+    client = NativeClient(app)
+    with pytest.raises(RuntimeError, match='context manager'):
+        client.get('/')
+
+
+def test_native_client_runs_lifespan(app):
+    a = BlackBull()
+    order = []
+
+    @a.on_startup
+    async def _up():
+        order.append('up')
+
+    @a.on_shutdown
+    async def _down():
+        order.append('down')
+
+    @a.route(path='/x')
+    async def _x():
+        return 'x'
+
+    with NativeClient(a) as client:
+        client.get('/x')
+        assert order == ['up']
+    assert order == ['up', 'down']


### PR DESCRIPTION
## Summary

BlackBull threads a typed `Connection` end to end, but the only test client drove the app through `httpx.ASGITransport` → ASGI scope → `from_scope()`. The `isinstance(conn, Connection)` branch of `BlackBull.__call__` — the branch every production request takes — was never exercised by a `TestClient` test, so a defect could live on the native path with the whole suite green. One did: Sprint 87's HEAD-answers-405 under `BB_FORCE_ASGI_SCOPE=1`.

Two tiers close the gap:

- **`blackbull.testing.native`** builds a `Connection` and calls `app(conn, receive, send)` directly — everything from `Connection` inward (dispatcher, middleware chain, router, DI, events, response serialisation). No socket, no protocol actor.
- **`NativeTestServer`** binds a loopback socket and runs BlackBull's own server, so a request travels accept → `HTTP1Actor` parse → `Connection` → dispatch → wire bytes. The only tier where framing headers, keep-alive reuse, and the RFC 9110 §9.3.2 HEAD body strip are observable.

Both cores are async-first — the app entry point is a coroutine and a handler runs on the caller's loop, as in production — with synchronous façades (`NativeClient`, `NativeTestServer`'s `with` form) that own one background loop per session rather than one per request.

`TestClient` is **unchanged in behaviour**. Its documented role is narrowed to what it uniquely covers: the ASGI compatibility boundary, where a missing `_CONNECTION_FIELDS` entry or a `from_scope()` coercion bug surfaces and nowhere else. `blackbull/testing.py` became the package `blackbull/testing/`; every existing import resolves unchanged.

## The gate that judged the work

The sprint required the new client to reproduce the defect that motivated it. With the Sprint 87 parse ordering re-injected, Tier 2 observes the 405 — while Tier 1 and `TestClient` return the same answer either way. That is asserted directly: the HEAD→GET rewrite lives in `HTTP1Actor`, so no instrument below the actor can express HEAD semantics at all.

The gate falsified the plan's own assumption that Tier 1 would catch it, which is the more useful result.

## Test plan

- [x] Full suite `--run-all`: **6154 passed**, 2 skipped, 1 xfailed
- [x] `just typecheck` (beartype): **5891 passed**
- [x] `mkdocs build --strict`: clean
- [x] Http11Probe native lane: **159/159 scored, 0 failed, 0 errors, 5 warnings**
- [x] Http11Probe `BB_FORCE_ASGI_SCOPE=1`: **159/159, 0 failed, 0 errors**
- [x] Probe per-test verdict diff vs the v0.67.0 baseline: **empty on both lanes**
- [x] CI dual-path lane (unit/architecture/properties under `BB_FORCE_ASGI_SCOPE=1`): 2545 passed
- [x] `test_connection_scope_consistency` green, allowlist unchanged (`connection.py` alone)
- [x] Editable-install smoke test: `blackbull.__version__` → `0.68.0`

No file on the request path changed this sprint — the diff is `blackbull/testing/`, docs, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)