### PR TITLE
ci(codeql): bump all codeql-action steps to v4.37.4 in one change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,13 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # All ``github/codeql-action/*`` steps (init/autobuild/analyze) must be the
+    # SAME version when a ``config-file`` is in play — the config is written by
+    # ``init`` and read by ``analyze``, and a mismatch fails the analysis with
+    # "Loaded a configuration file for version X, but running version Y".
+    # Dependabot updates each ``uses:`` line as its own PR by default, which
+    # would ship exactly that mismatch.  Group them so one PR bumps all steps.
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
@@ -50,9 +50,9 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a   # v4.37.1
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38   # v4.37.4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Why these three dependabot PRs fail

#187 / #188 / #190 each bump exactly **one** of the `github/codeql-action`
steps (`init` / `autobuild` / `analyze`) to v4.37.3.  This workflow uses
`config-file: ./.github/codeql/codeql-config.yml`; under that mode CodeQL
requires **all three steps to run the same version** — `init` writes the
config and `analyze` reads it, so a mismatch aborts the analysis:

```
Loaded a configuration file for version '4.37.1', but running version '4.37.3'
Not all workflow steps that use github/codeql-action actions use the same version
```

Every one of the three PRs failed the `Analyze (python)` job with exactly that
error.  Individually they can never pass.

## This change

- Bumps **all three** steps (`init` / `autobuild` / `analyze`) to
  **v4.37.4** (the current latest) in a single commit, all pinned to
  `f205ea1c3313d32999d8d6a48b4f6530d4437b38`.
- Groups `github/codeql-action/*` in `.github/dependabot.yml` so future
  CodeQL action bumps arrive as **one** PR instead of three incompatible ones.

Supersedes #187, #188, #190.