### PR TITLE
docs: wire ab-verify into agent docs; add EC2 calibration + wait-rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,6 +67,15 @@ priority order:
 Never use regex to match language syntax (function signatures, class defs,
 call expressions). Use `ast-grep` for those.
 
+### 9. Questions end the turn — never auto-continue past a decision gate
+
+When a question or decision gate is presented (go/revise/abort, a choice
+between options, a gate awaiting approval) and the answer is not an explicit
+user choice, **END the turn**: restate the pending question and stop.  Do not
+treat a "user unavailable / work autonomously" response as approval.  Pause
+any background step that depends on the decision.  This applies in Autopilot
+mode too — the agent must explicitly stop and wait; resume only on an
+explicit user answer.
 
 ## Task-to-skill mapping
 
@@ -75,6 +84,7 @@ Before acting on a request, read the corresponding skill file first.
 | Request type | Read first |
 |---|---|
 | Benchmark / performance comparison | `.github/skills/bench-compare/SKILL.md` |
+| A/B regression check / rule out regression / equivalence within ±Δ% | `.claude/skills/ab-verify/SKILL.md` [private] + `bench/peers/AB-HIGH-PRECISION.md` |
 | HttpArena (EC2 / local) | `.github/skills/httparena-bench/SKILL.md` |
 | HttpArena local run details | `/memories/repo/httparena-local-run.md` |
 | Type checking | `.github/skills/type-check/SKILL.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ A personal learning project — wire correctness over API stability (ZeroVer).
   to capture non-obvious intent, design trade-offs, or invariants the next
   reader would otherwise have to reverse-engineer from the code.
 
+- **Questions end the turn.** A pending decision gate is a stop, not a
+  licence to continue.  If the answer to a gate question is not an explicit
+  user choice, end the turn with the question restated — do not treat a
+  "user unavailable / work autonomously" response as approval, and pause
+  background steps that depend on the decision.  Resume only on explicit
+  user input.  (Applies in Autopilot mode too; the agent must explicitly
+  stop and wait.)
+
 ---
 
 ## Architecture principles
@@ -143,6 +151,7 @@ fallback where one exists.
 | Writing/adjusting tests | `.claude/patterns/testing.md` + `.claude/skills/create-test/SKILL.md` [both private] |
 | Running benchmarks or profiling | `.claude/patterns/benchmarking.md` + `.claude/skills/bench-compare/SKILL.md` [both private] |
 | Running peer server comparisons (FastAPI / Sanic / etc.) locally | `.claude/skills/peer-compare/SKILL.md` [private] |
+| High-precision A/B check (rule out regression / equivalence within ±Δ%) | `bench/peers/AB-HIGH-PRECISION.md` + `.claude/skills/ab-verify/SKILL.md` [skill private] — read the null phase before trusting a real verdict; pooled TOST on EC2 |
 | Tracing a regression across sprints | `.claude/sprint-logs/` [private] — per-sprint bottleneck-attribution logs.  `bench/CHARACTERIZATION.md` is the public summary; sprint-logs hold the raw diagnostic numbers |
 | Cutting a release / sprint close | `.claude/patterns/release.md` + `.claude/skills/sprint-close/SKILL.md` [both private] |
 | Reasoning about actors / events | `.claude/design/actor-model.md` + `.claude/design/event-catalogue.md` [both private] |
@@ -152,9 +161,9 @@ fallback where one exists.
 
 **Skills** (invocable, harness-surfaced; they live in `.claude/skills/` [private] —
 `.github/skills` is an optional local symlink, see `.gitignore`):
-`sprint-close`, `bench-compare`, `peer-compare`, `pre-release-docs`, `update-roadmap`,
-`create-test`, `type-check`, `add-event`, `new-http2-frame`, `protocol-handler`,
-`httparena-bench`, `run-http11probe`.
+`ab-verify`, `refactor`, `sprint-close`, `bench-compare`, `peer-compare`, `pre-release-docs`,
+`update-roadmap`, `create-test`, `type-check`, `add-event`, `new-http2-frame`,
+`protocol-handler`, `httparena-bench`, `run-http11probe`.
 
 ### Doc lifecycle (so docs don't rot)
 

--- a/bench/peers/AB-HIGH-PRECISION.md
+++ b/bench/peers/AB-HIGH-PRECISION.md
@@ -160,6 +160,26 @@ Instance lifecycle via `bench/aws/up.sh` / `install.sh` / `down.sh`, but
   the strongest evidence a benchmark could never beat: a strict no-op on the
   measured path.
 
+### 6.1 Calibration — non-no-op refactor (2026-08-01, HTTP1Actor.run extraction)
+
+Contrast to §6: this refactor DID change the measured path, and the A/B
+caught it before merge.
+
+- **Change:** extracted two `async def` methods out of `HTTP1Actor.run`
+  (`_read_and_parse`, `_dispatch_one_request`) — +1 coroutine hop per request
+  each, everything else byte-identical.
+- **EC2 m7a.2xlarge, 8 rounds ABBA, 16 runs/arm:** null (A/A) Δ = −0.24 %,
+  CI [−0.62 %, +0.15 %] → **±1 % equivalent (box resolvable)**.  Real Δ =
+  **−3.03 % ± 0.31** — consistent in every round, zero overlap (base min
+  30481 > treat max 30272), 3× the null floor.  Per-request 32.37 → 33.38 µs
+  (+1.01 µs).
+- **Interpretation:** on the ~30k req/s request-ingest loop each added
+  `await` hop costs **~1.5 %** throughput.  A two-hop async extraction is a
+  measurable regression against BlackBull's "no call, no allocation" bar
+  (commit 88038e0 removed a per-event coroutine wrapper worth 7 % CPU).
+- **Outcome:** reverted (verdict rule 4).  The null phase passing is exactly
+  what made the real −3 % trustworthy instead of box noise.
+
 ## 7. Verdict rules
 
 A regression (the change being *slower*) is essentially ruled out when:
@@ -174,3 +194,12 @@ A ±0.5 % equivalence claim specifically needs the real-phase 95 % CI inside
 ±0.5 % **and** the null phase to also pass (after outlier trim).  If the CI
 upper bound sits at +0.57–0.69 % because the point estimate is +0.3 %, more
 rounds (not outlier removal) are the only path.
+
+4. **Regression vs. no-resolve — read the null phase first.**  When the
+   null (A/A) phase passes equivalence but the real CI **exceeds** the
+   bound, the change is a real regression: revert or fix, do not re-measure
+   (2026-08-01 §6.1: real −3.03 % with a passing null → reverted).  When
+   the null phase *fails* equivalence, the box cannot resolve ±Δ that
+   session — escalate or add rounds before trusting any real-phase verdict
+   (2026-08-01 local WSL2: null combined CI ±2.4 % at 4 rounds made the
+   real reading uninterpretable; EC2 resolved it).

--- a/bench/peers/ab_equiv_report.py
+++ b/bench/peers/ab_equiv_report.py
@@ -8,9 +8,18 @@ that lets you *claim* no meaningful difference on a specific box.
 
 Method
 ------
-The box is bimodal: each server restart lands the process in a fast or a
-slow state (~15 % apart) and holds it.  Comparing base vs treat *across*
-modes therefore measures the coin toss, not the commits.  So:
+The LOCAL desktop box is bimodal: each server restart lands the process in
+a fast or a slow state (~15 % apart) and holds it.  Comparing base vs
+treat *across* modes therefore measures the coin toss, not the commits.
+So:
+
+0. **Monomodal boxes (EC2) — use a POOLED two-sample TOST instead.**  This
+   script's split/combined estimator is only valid when `hi-mode` (from
+   `ab_report.py`) shows true ~15 % separated clusters.  On EC2 it misleads:
+   the 2026-08-01 keep-alive verification had it shift the real Δ to +0.11 %
+   and falsely claim ±0.5 % equivalence (correct pooled verdict: ±1 % only).
+   Pooled: Δ = mean(base) − mean(treat) over ALL samples per arm, Welch SE.
+   See `bench/peers/AB-HIGH-PRECISION.md` §2.2 / §6.1.
 
 1. Per phase, split samples into slow/fast using the midpoint of the
    observed range (the same diagnostic ab_report.py uses for `hi-mode`).


### PR DESCRIPTION
## What & why

Wire the `ab-verify` skill (high-precision A/B regression checking) into the
auto-loaded agent surfaces so future agents can find it, add the EC2
calibration from the 2026-08-01 non-no-op verification, and codify the
"questions end the turn" rule that was violated during that run.

### 1. A/B knowledge sharing (EC2 failure prevention)
- **`bench/peers/AB-HIGH-PRECISION.md`**
  - §6.1: new calibration — a two-`async def` extraction out of
    `HTTP1Actor.run` measured **−3.03 % ± 0.31** on EC2 (~1.5 %/coroutine hop,
    +1.01 µs/req), with a passing null phase; reverted. Contrasts with the
    existing no-op §6 calibration.
  - §7 rule 4: read the null phase first — null passes + real CI exceeds the
    bound ⇒ real regression (revert); null fails ⇒ box can't resolve ±Δ
    (escalate to EC2 or add rounds).
- **`AGENTS.md`**: add the A/B check row to the working docs map; add
  `ab-verify` (and the previously-omitted `refactor`) to the skills list.
- **`.github/copilot-instructions.md`**: add the "A/B regression check" row to
  the task-to-skill mapping table.
- **`bench/peers/ab_equiv_report.py`**: correct the docstring's blanket
  bimodality assumption — the split/combined estimator is LOCAL-box only; on
  monomodal EC2 use a POOLED two-sample TOST (documented failure case: shifted
  a real Δ to +0.11 % and falsely claimed ±0.5 %).

### 2. Response-waiting rule (Autopilot safety)
- **`.github/copilot-instructions.md`**: new operating principle #9 —
  "Questions end the turn". A pending decision is a stop; "user unavailable /
  work autonomously" is NOT approval; pause decision-dependent background
  steps; resume only on an explicit user answer.
- **`AGENTS.md`**: mirrored operating principle.

Docs-only, no code behaviour change. Not included: the unrelated pre-existing
working-tree changes (`bench/aws/httparena_compare.sh`, `fastapi_gzip_app.py`).
