### PR TITLE
chore(bench): add ab-verify EC2 launcher + install.sh uv/.git provisioning

### DIFF
--- a/bench/aws/ab.sh
+++ b/bench/aws/ab.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# bench/aws/ab.sh — launch and finish an A/B commit comparison on EC2.
+#
+# The ab-verify counterpart to run.sh (which only drives compare_servers.sh).
+# `launch` starts bench/peers/ab_commit.sh detached on the server instance —
+# PATH-safe, stdin/stdout detached so the ssh session returns immediately —
+# and `finish` polls the raw.tsv results back, scp's them, and tears the
+# instance down.  install.sh (run with DEPLOY_GIT=1) provisions uv + .git so
+# ab_commit.sh works out of the box.
+#
+# Usage:
+#   REF_BASE=b165880 REF_TREAT=fe83e4c URL_PATH=/conn ROUNDS=8 \
+#     bash bench/aws/ab.sh launch
+#   URL_PATHS=/conn,/plaintext REF_BASE=.. REF_TREAT=.. bash bench/aws/ab.sh launch
+#   bash bench/aws/ab.sh finish          # poll + scp + teardown (run nohup'd locally)
+#
+# Env (defaults mirror ab_commit.sh; EC2-friendly defaults differ where noted):
+#   REF_BASE(=HEAD~1) REF_TREAT(=HEAD) PATHSPEC(=blackbull/)
+#   ROUNDS(=8) DURATION(=15) WARMUP(=5) THREADS(=4) CONNS(=32)
+#   PORT(=8443) BB_UVLOOP(=0) PIPELINE(=1) PHASES(=null real)
+#   SERVER_CPUS(=0-1) LOAD_CPUS(=2-5)
+#   URL_PATH(=/plaintext) or URL_PATHS (comma-separated — multiple sessions)
+#   EXPECT_LINES (raw.tsv completeness per session; default 1+ROUNDS*8)
+#   AB_FINISH_LOG (finish progress log; default bench/results/ab-finish.log)
+#   AB_POLLS(=300) AB_POLL_INTERVAL(=10) — finish polling budget (~50 min)
+set -uo pipefail
+
+source "$(dirname "$0")/config.sh"
+_bench_aws_check_env
+_bench_aws_load_state
+
+SERVER_REMOTE="$SSH_USER@$SERVER_PUBLIC_IP"
+REMOTE_REPO="/home/$SSH_USER/BlackBull"
+
+REF_BASE="${REF_BASE:-HEAD~1}"
+REF_TREAT="${REF_TREAT:-HEAD}"
+PATHSPEC="${PATHSPEC:-blackbull/}"
+ROUNDS="${ROUNDS:-8}"
+DURATION="${DURATION:-15}"
+WARMUP="${WARMUP:-5}"
+THREADS="${THREADS:-4}"
+CONNS="${CONNS:-32}"
+PORT="${PORT:-8443}"
+BB_UVLOOP="${BB_UVLOOP:-0}"
+PIPELINE="${PIPELINE:-1}"
+PHASES="${PHASES:-null real}"
+SERVER_CPUS="${SERVER_CPUS:-0-1}"
+LOAD_CPUS="${LOAD_CPUS:-2-5}"
+URL_PATH="${URL_PATH:-/plaintext}"
+URL_PATHS="${URL_PATHS:-}"
+EXPECT_LINES="${EXPECT_LINES:-$((1 + ROUNDS * 8))}"
+AB_FINISH_LOG="${AB_FINISH_LOG:-$REPO_ROOT/bench/results/ab-finish.log}"
+AB_POLLS="${AB_POLLS:-300}"
+AB_POLL_INTERVAL="${AB_POLL_INTERVAL:-10}"
+
+MODE="${1:-launch}"
+
+# --- build the env prefix for one ab_commit.sh invocation ------------------
+ab_env() {  # $1 = url
+    printf "REF_BASE='%s' REF_TREAT='%s' PATHSPEC='%s' URL_PATH='%s' ROUNDS='%s' " \
+        "$REF_BASE" "$REF_TREAT" "$PATHSPEC" "$1" "$ROUNDS"
+    printf "DURATION='%s' WARMUP='%s' THREADS='%s' CONNS='%s' PORT='%s' BB_UVLOOP='%s' " \
+        "$DURATION" "$WARMUP" "$THREADS" "$CONNS" "$PORT" "$BB_UVLOOP"
+    printf "PIPELINE='%s' PHASES='%s' SERVER_CPUS='%s' LOAD_CPUS='%s' " \
+        "$PIPELINE" "$PHASES" "$SERVER_CPUS" "$LOAD_CPUS"
+}
+
+case "$MODE" in
+launch)
+    if [ -n "$URL_PATHS" ]; then
+        IFS=',' read -r -a URLS <<< "$URL_PATHS"
+    else
+        URLS=("$URL_PATH")
+    fi
+
+    # Preflight: uv on PATH (install.sh symlinks it) and both refs present,
+    # so ab_commit.sh's git-checkout swap can actually run.
+    if ! ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "command -v uv >/dev/null 2>&1 && cd $REMOTE_REPO && \
+         git cat-file -e $REF_BASE^{commit} && git cat-file -e $REF_TREAT^{commit}" 2>/dev/null; then
+        echo "bench/aws/ab.sh: preflight failed — uv or git refs missing." >&2
+        echo "  run: DEPLOY_GIT=1 bash bench/aws/install.sh   (installs uv, deploys .git)" >&2
+        exit 1
+    fi
+
+    # Build the runner script locally (avoids nested-quote hell through ssh),
+    # scp it up, then launch it fully detached so the ssh call returns.
+    RUNNER="$(mktemp)"
+    trap 'rm -f "$RUNNER"' EXIT
+    {
+        echo '#!/usr/bin/env bash'
+        echo 'set -uo pipefail'
+        printf 'cd %q\n' "$REMOTE_REPO"
+        for u in "${URLS[@]}"; do
+            log="bench/results/ec2-ab-${u#/}.log"
+            printf 'env %s bash bench/peers/ab_commit.sh > %q 2>&1\n' "$(ab_env "$u")" "$log"
+        done
+    } > "$RUNNER"
+
+    scp "${SSH_OPTS[@]}" "$RUNNER" "$SERVER_REMOTE:$REMOTE_REPO/bench/results/ab_runner.sh" \
+        >/dev/null 2>&1
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "cd $REMOTE_REPO && rm -rf bench/results/ab-commit-* && \
+         chmod +x bench/results/ab_runner.sh && \
+         nohup bash bench/results/ab_runner.sh </dev/null >/dev/null 2>&1 & echo launched"
+    echo "ab_commit.sh launched on $SERVER_REMOTE"
+    echo "  profiles : ${URLS[*]}"
+    echo "  base     : $REF_BASE   treat: $REF_TREAT"
+    echo "  rounds   : $ROUNDS   duration: ${DURATION}s   phases: $PHASES"
+    echo "  runner log per profile: bench/results/ec2-ab-*.log (on instance)"
+    echo "  finish later with: bash bench/aws/ab.sh finish"
+    ;;
+
+finish)
+    {
+        echo "ab.sh finish start: $(date -u)"
+        runner=-1; complete=0
+        for i in $(seq 1 "$AB_POLLS"); do
+            state=$(ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+                "cd $REMOTE_REPO && n=\$(pgrep -f 'bench/results/ab_runner.sh' | wc -l); \
+                 c=0; for f in bench/results/ab-commit-*/raw.tsv; do [ -f \"\$f\" ] && \
+                 [ \"\$(wc -l < \"\$f\")\" -ge $EXPECT_LINES ] && c=\$((c+1)); done; echo \"\$n \$c\"" \
+                2>/dev/null)
+            runner="${state%% *}"
+            complete="${state##* }"
+            [ "$runner" = "0" ] && [ "$complete" -ge 1 ] && break
+            sleep "$AB_POLL_INTERVAL"
+        done
+        echo "poll done: runner_procs=${runner:-?} complete_rawtsv=${complete:-?} at $(date -u)"
+
+        echo "pulling results ..."
+        for d in $(ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+            "cd $REMOTE_REPO && ls -d bench/results/ab-commit-* 2>/dev/null"); do
+            scp "${SSH_OPTS[@]}" -r "$SERVER_REMOTE:$REMOTE_REPO/$d" "$REPO_ROOT/bench/results/" \
+                && echo "scp OK: $d" || echo "SCP FAILED: $d"
+        done
+        for f in "$REPO_ROOT"/bench/results/ab-commit-*/raw.tsv; do
+            [ -f "$f" ] && echo "raw.tsv lines: $f -> $(wc -l < "$f")"
+        done
+
+        echo "tearing down: $(date -u)"
+        bash "$(dirname "$0")/down.sh" 2>&1 | tail -4
+        echo "AB FINISH COMPLETE: $(date -u)"
+    } >> "$AB_FINISH_LOG" 2>&1
+    echo "finish running in background; progress -> $AB_FINISH_LOG"
+    ;;
+
+*)
+    echo "usage: bash bench/aws/ab.sh [launch|finish]" >&2
+    exit 1
+    ;;
+esac

--- a/bench/aws/install.sh
+++ b/bench/aws/install.sh
@@ -122,6 +122,22 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -e '.[testing,speed,compression,profiling]'
 
+echo "=== uv (required by bench/peers/ab_commit.sh) ==="
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+# The installer drops uv in ~/.local/bin; non-login ssh command shells
+# source neither ~/.bashrc nor /etc/profile, so symlink it onto the
+# system PATH for ab_commit.sh's `uv run` invocations.
+sudo ln -sf "$HOME/.local/bin/uv" /usr/local/bin/uv
+export PATH="$HOME/.local/bin:$PATH"
+export UV_PYTHON="$(command -v python3)"
+# The uv-managed venv must carry the blackbull console script: `uv run
+# python` first (creates/opens the venv), then `uv pip install -e .`
+# adds the CLI that `uv run` would otherwise drop.
+uv run python -c 'import blackbull'
+uv pip install -e .
+
 echo "=== Bench toolchain (h2load, wrk, wrk2, oha, k6, peer ASGI servers) ==="
 bash bench/install.sh
 
@@ -195,8 +211,24 @@ mkdir -p bench/results
 echo "=== Versions ==="
 .venv/bin/python --version
 .venv/bin/python -c 'import blackbull; print("blackbull module OK")'
+uv run blackbull --help >/dev/null 2>&1 && echo "uv run blackbull CLI OK"
 echo "blackbull HEAD (from local rsync source): ${LOCAL_HEAD:-unknown}"
 REMOTE_EOF
+
+# --- Deploy .git when an A/B commit comparison will run -------------------
+# bench/peers/ab_commit.sh swaps files via `git checkout` between two refs,
+# which requires the repo's .git history on the instance.  The main rsync
+# above excludes .git/ (~113 MB) to keep ordinary bench deploys lean; opt
+# in with DEPLOY_GIT=1 when the run is an A/B commit comparison.
+if [ "${DEPLOY_GIT:-0}" = "1" ]; then
+    echo "=== Deploying .git (DEPLOY_GIT=1) for ab_commit.sh ==="
+    rsync -az -e "ssh ${SSH_OPTS[*]}" \
+        "$REPO_ROOT/.git/" "$SERVER_REMOTE:$REMOTE_REPO/.git/"
+    ssh "${SSH_OPTS[@]}" "$SERVER_REMOTE" \
+        "cd $REMOTE_REPO && git rev-parse --short HEAD && \
+         git cat-file -e ${LOCAL_HEAD}^{commit} && echo 'git refs OK (ab_commit.sh ready)'" \
+        2>&1 | tail -3
+fi
 
 # --- TOPO=single ends here ------------------------------------------------
 if [ "$TOPO" = "single" ]; then

--- a/bench/peers/AB-HIGH-PRECISION.md
+++ b/bench/peers/AB-HIGH-PRECISION.md
@@ -134,8 +134,8 @@ phase's own |bias| + SE (or its CI sits outside the null CI).
 
 ## 4. EC2 workflow (reproducible + fail-safe)
 
-Instance lifecycle via `bench/aws/up.sh` / `install.sh` / `down.sh`, but
-`ab_commit.sh` needs extra provisioning:
+Instance lifecycle via `bench/aws/up.sh` / `install.sh` / `down.sh`, with
+`bench/aws/ab.sh` orchestrating the `ab_commit.sh` measurement:
 
 1. **Instance:** `INSTANCE_TYPE=m7a.2xlarge TOPO=single bash bench/aws/up.sh`
    (8 vCPU, **no SMT** — each vCPU is a physical core; 8 cores fits 1 worker
@@ -144,23 +144,18 @@ Instance lifecycle via `bench/aws/up.sh` / `install.sh` / `down.sh`, but
    `terminate`, plus a scheduled `sudo shutdown -h +180` on the instance, so
    it self-terminates even if nothing else runs.  The agent is never the sole
    teardown path.
-3. **`bash bench/aws/install.sh`** — deploys repo + venv + wrk + toolchain.
-   Caveats found:
-   - It rsyncs with `--exclude '.git/'` → `ab_commit.sh`'s `git checkout`
-     swap needs the refs: re-rsync the tree **including `.git`**.
-   - Ubuntu 24.04 is PEP-668-externally-managed → install `uv` via the
-     official installer (`~/.local/bin`), not pip.
-   - `uv run` recreates the venv **without** the `blackbull` console script →
-     fix with `uv pip install -e .`; verify the swap works via
-     `blackbull.__file__` in the source tree + the import-hash proof.
-4. **Run:** on the instance,
-   `nohup env REF_BASE=.. REF_TREAT=.. ROUNDS=12 DURATION=15 THREADS=4
-   CONNS=32 SERVER_CPUS=0-1 LOAD_CPUS=2-5 PHASES="null real"
-   bash bench/peers/ab_commit.sh > bench/results/ec2-ab.log 2>&1 &` — nohup
-   so it survives prompt end.
-5. **Finish:** a local nohup'd script polls the remote `raw.tsv` to its
-   expected line count, `scp`s the results dir back, then runs `down.sh`.
-   (Instance self-termination is the backstop.)
+3. **`DEPLOY_GIT=1 bash bench/aws/install.sh`** — deploys repo + venv + wrk +
+   toolchain, installs `uv` (PATH-symlinked to `/usr/local/bin` so
+   `ssh host "uv run …"` works), and deploys the repo's `.git` (the plain
+   rsync excludes it at ~113 MB, but `ab_commit.sh`'s git-checkout swap needs
+   the refs).  Smoke test verifies `uv run blackbull --help`.
+4. **Run:** `REF_BASE=.. REF_TREAT=.. URL_PATH=/conn ROUNDS=8
+   bash bench/aws/ab.sh launch` — starts one or more profiles
+   (`URL_PATHS=/conn,/plaintext`) detached on the instance; the ssh call
+   returns immediately.
+5. **Finish:** `bash bench/aws/ab.sh finish` (run nohup'd locally) polls the
+   remote `raw.tsv` files to their expected line count, scp's the result dirs
+   back, then runs `down.sh`.  (Instance self-termination is the backstop.)
 
 ## 5. Tools
 

--- a/bench/peers/native_app.py
+++ b/bench/peers/native_app.py
@@ -48,6 +48,16 @@ async def plaintext():
     return Response(_PLAINTEXT, content_type=_PLAIN_CT)
 
 
+@app.route(path="/conn", methods=[HTTPMethod.GET])
+async def conn_route(conn: Connection):
+    # A/B-measurable simplified-handler profile: a ``conn`` parameter makes
+    # the plain pin's per-request dispatch loop execute (the no-arg
+    # /plaintext iterates an empty loop), so ab_commit.sh URL_PATH=/conn
+    # measures the wrapper dispatch itself.  The "Hello" body keeps the
+    # harness's server-ready check passing.
+    return Response(_PLAINTEXT, content_type=_PLAIN_CT)
+
+
 @app.route(path="/json", methods=[HTTPMethod.GET])
 async def json_endpoint():
     return Response(_JSON, content_type=_JSON_CT)


### PR DESCRIPTION
## Summary

Tooling only — unrelated to the Round 3/4 router refactor (kept as a separate
branch/PR so the refactor PR stays refactor-only).

### `bench/aws/ab.sh` (new)
`launch` / `finish` launcher for `bench/peers/ab_commit.sh` on EC2:
- **launch**: preflights (uv on PATH + both git refs present via ssh), builds a
  runner script locally (`ab_env()` + `%q` printf — quoting verified), scp's it
  to `bench/results/ab_runner.sh`, then starts it fully detached
  (`nohup … </dev/null >/dev/null 2>&1 &`) so the ssh call returns immediately.
  Supports `URL_PATH` (single) or `URL_PATHS` (comma-separated chained sessions).
- **finish**: polls the remote runner process + `raw.tsv` completeness
  (`>= 1 + ROUNDS*8` lines), scp's the `ab-commit-*` dirs back, runs `down.sh`.
  Progress is written to `bench/results/ab-finish.log`; the instance's own
  +180 min self-shutdown remains the fail-safe backstop.

### `bench/aws/install.sh`
- Installs `uv` via the official installer and PATH-symlinks it to
  `/usr/local/bin` (non-login ssh shells source neither `~/.bashrc` nor
  `/etc/profile`, so `ssh host "uv run …"` would otherwise miss it).
- Deploys the repo `.git` when `DEPLOY_GIT=1` (excluded by default at ~113 MB)
  so `ab_commit.sh`'s git-checkout swap has the refs.
- Correct venv ordering: `uv run python -c 'import blackbull'` then
  `uv pip install -e .`; `uv run blackbull --help` smoke in the Versions step.

### `bench/peers/native_app.py`
- Adds `GET /conn` (conn-param simplified handler) — the no-arg `/plaintext`
  empty-loop profile cannot observe `_wrapper` per-request dispatch changes.

### `bench/peers/AB-HIGH-PRECISION.md`
- §4 EC2 workflow updated to the `DEPLOY_GIT=1 install.sh` + `ab.sh
  launch/finish` flow (replaces the manual nohup caveats).