### PR TITLE
refactor: extract wrapper factory, Enum param kinds, match-case dispatch

### DIFF
--- a/blackbull/openapi.py
+++ b/blackbull/openapi.py
@@ -112,7 +112,7 @@ def _query_parameters(handler, param_specs: dict[str, str]) -> list[dict]:
     resolves; ``Depends`` params are not request inputs and carry no entry.
     Full-ASGI handlers (and anything the classifier rejects) emit nothing.
     """
-    from .router import _handler_param_plan, _is_simplified_handler
+    from .router import _ParamKind, _handler_param_plan, _is_simplified_handler
 
     if not _is_simplified_handler(handler):
         return []
@@ -122,7 +122,7 @@ def _query_parameters(handler, param_specs: dict[str, str]) -> list[dict]:
         return []
     out = []
     for name, (kind, payload) in categories.items():
-        if kind != 'query':
+        if kind is not _ParamKind.QUERY:
             continue
         out.append({
             'name': name,

--- a/blackbull/openapi.py
+++ b/blackbull/openapi.py
@@ -112,7 +112,7 @@ def _query_parameters(handler, param_specs: dict[str, str]) -> list[dict]:
     resolves; ``Depends`` params are not request inputs and carry no entry.
     Full-ASGI handlers (and anything the classifier rejects) emit nothing.
     """
-    from .router import _ParamKind, _handler_param_plan, _is_simplified_handler
+    from .router import _handler_param_plan, _is_simplified_handler, _ParamKind
 
     if not _is_simplified_handler(handler):
         return []

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1184,6 +1184,91 @@ async def _ws_reject(ws, detail: str) -> None:
     await ws.close(code=_WS_POLICY_VIOLATION, reason=_truncate_close_reason(detail))
 
 
+def _make_extended_wrapper(fn, annotations: dict, plan: tuple, depends_plan: tuple,
+                           converters: dict | None):
+    """Build the per-request closure for handlers that use query params and/or Depends.
+
+    Registration-time only (called once per route from ``_adapt_handler``), so
+    this factory adds zero per-request calls; the closure it returns runs per
+    request and is intentionally NOT extracted further (hot-path policy).
+    """
+    has_query = any(kind == 'query' for _, kind, _ in plan)
+    fn_name = fn.__name__
+    is_async = inspect.iscoroutinefunction(fn)
+
+    @wraps(fn)
+    async def _extended_wrapper(conn, receive, send):
+        conn = _conn_of(conn, receive)
+        kwargs: dict = {}
+        if has_query:
+            raw_qs = conn.query_string or b''
+            query_values = (
+                dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
+                if raw_qs else {})
+        for name, kind, payload in plan:
+            if kind == 'query':
+                raw = query_values.get(name, _QUERY_MISSING)
+                if raw is _QUERY_MISSING:
+                    if payload.required:
+                        raise HTTPException(
+                            HTTPStatus.BAD_REQUEST,
+                            f'missing required query parameter {name!r} '
+                            f'for handler {fn_name!r}')
+                    kwargs[name] = payload.default
+                else:
+                    try:
+                        kwargs[name] = payload.coercer(raw)
+                    except (ValueError, TypeError) as exc:
+                        raise HTTPException(
+                            HTTPStatus.BAD_REQUEST,
+                            f'query parameter {name!r}: cannot coerce {raw!r} '
+                            f'to {payload.type.__name__}',
+                        ) from exc
+            elif kind == 'conn':
+                kwargs[name] = conn
+            elif kind == 'body':
+                raw = await conn.body()
+                ann = annotations.get(name, inspect.Parameter.empty)
+                if _is_body_dataclass_annotation(ann):
+                    kwargs[name] = _decode_json_body(ann, raw, fn_name)
+                else:
+                    kwargs[name] = raw
+            elif kind == 'request':
+                kwargs[name] = conn
+            elif kind == 'dataclass':
+                raw = await conn.body()
+                kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
+            else:  # 'path'
+                raw = conn.path_params.get(name, '')
+                ann = annotations.get(name, inspect.Parameter.empty)
+                if (ann is not inspect.Parameter.empty and isinstance(ann, type)
+                        and not isinstance(raw, ann)):
+                    try:
+                        kwargs[name] = ann(raw)
+                    except (ValueError, TypeError) as exc:
+                        raise TypeError(
+                            f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
+                        ) from exc
+                else:
+                    kwargs[name] = raw
+
+        if not depends_plan:
+            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
+            await _finish_result(result, conn, receive, send, converters, fn_name)
+            return
+
+        async with AsyncExitStack() as stack:
+            cache: dict = {}
+            for name, dep in depends_plan:
+                kwargs[name] = await _resolve_depends(dep, stack, cache)
+            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
+            # Send inside the stack's scope so provider teardown runs after
+            # the client has the response (LIFO on the stack).
+            await _finish_result(result, conn, receive, send, converters, fn_name)
+
+    return _extended_wrapper
+
+
 def _adapt_handler(fn, path: str, converters: dict | None = None):
     """Wrap a simplified handler in an ASGI (scope, receive, send) coroutine.
 
@@ -1309,79 +1394,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     # declared parameters require.
     plan = tuple((n, kind, payload) for n, (kind, payload) in categories.items()
                  if kind != 'depends')
-    fn_name = fn.__name__
-
-    @wraps(fn)
-    async def _extended_wrapper(conn, receive, send):
-        conn = _conn_of(conn, receive)
-        kwargs: dict = {}
-        if has_query:
-            raw_qs = conn.query_string or b''
-            query_values = (
-                dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
-                if raw_qs else {})
-        for name, kind, payload in plan:
-            if kind == 'query':
-                raw = query_values.get(name, _QUERY_MISSING)
-                if raw is _QUERY_MISSING:
-                    if payload.required:
-                        raise HTTPException(
-                            HTTPStatus.BAD_REQUEST,
-                            f'missing required query parameter {name!r} '
-                            f'for handler {fn_name!r}')
-                    kwargs[name] = payload.default
-                else:
-                    try:
-                        kwargs[name] = payload.coercer(raw)
-                    except (ValueError, TypeError) as exc:
-                        raise HTTPException(
-                            HTTPStatus.BAD_REQUEST,
-                            f'query parameter {name!r}: cannot coerce {raw!r} '
-                            f'to {payload.type.__name__}',
-                        ) from exc
-            elif kind == 'conn':
-                kwargs[name] = conn
-            elif kind == 'body':
-                raw = await conn.body()
-                ann = annotations.get(name, inspect.Parameter.empty)
-                if _is_body_dataclass_annotation(ann):
-                    kwargs[name] = _decode_json_body(ann, raw, fn_name)
-                else:
-                    kwargs[name] = raw
-            elif kind == 'request':
-                kwargs[name] = conn
-            elif kind == 'dataclass':
-                raw = await conn.body()
-                kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
-            else:  # 'path'
-                raw = conn.path_params.get(name, '')
-                ann = annotations.get(name, inspect.Parameter.empty)
-                if (ann is not inspect.Parameter.empty and isinstance(ann, type)
-                        and not isinstance(raw, ann)):
-                    try:
-                        kwargs[name] = ann(raw)
-                    except (ValueError, TypeError) as exc:
-                        raise TypeError(
-                            f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
-                        ) from exc
-                else:
-                    kwargs[name] = raw
-
-        if not depends_plan:
-            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
-            await _finish_result(result, conn, receive, send, converters, fn_name)
-            return
-
-        async with AsyncExitStack() as stack:
-            cache: dict = {}
-            for name, dep in depends_plan:
-                kwargs[name] = await _resolve_depends(dep, stack, cache)
-            result = (await fn(**kwargs)) if is_async else fn(**kwargs)
-            # Send inside the stack's scope so provider teardown runs after
-            # the client has the response (LIFO on the stack).
-            await _finish_result(result, conn, receive, send, converters, fn_name)
-
-    return _extended_wrapper
+    return _make_extended_wrapper(fn, annotations, plan, depends_plan, converters)
 
 
 # RFC 9110 §5.6.2: token = 1*tchar (visible US-ASCII, no separators)

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1310,9 +1310,6 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     path_param_names: set[str] = _path_param_names(path)
     params, annotations, categories = _handler_param_plan(fn, path_param_names)
 
-    request_param_names: frozenset[str] = frozenset(
-        n for n, (kind, _) in categories.items() if kind == 'request')
-
     # A path param always resolves from the path, so a declared default can
     # never apply — and any same-named query-string key is shadowed.  The
     # default is the one registration-time signal that the author may have
@@ -1337,20 +1334,21 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
         kwargs: dict = {}
         for name in params:
             ann = annotations.get(name, inspect.Parameter.empty)
-            if categories[name][0] == 'conn':
+            kind = categories[name][0]
+            if kind == 'conn':
                 kwargs[name] = conn
-            elif name == 'body':
+            elif kind == 'body':
                 raw = await conn.body()
                 if _is_body_dataclass_annotation(ann):
                     kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
                 else:
                     kwargs[name] = raw
-            elif name in request_param_names:
+            elif kind == 'request':
                 kwargs[name] = conn
-            elif _is_body_dataclass_annotation(ann) and name not in path_param_names:
+            elif kind == 'dataclass':
                 raw = await conn.body()
                 kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
-            else:
+            else:  # 'path'
                 raw = conn.path_params.get(name, '')
                 if (ann is not inspect.Parameter.empty and isinstance(ann, type)
                         and not isinstance(raw, ann)):

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -1134,45 +1134,48 @@ def _adapt_websocket_handler(fn, path: str = ''):
         # Bind everything that cannot fail on a resource *before* resolving any
         # Depends: a connection we are about to reject should never acquire one.
         for name, kind, payload in bind_plan:
-            if kind is _ParamKind.WS:
-                if ws is None:
-                    ws = _WS(conn, receive, send)
-                kwargs[name] = ws
-            elif kind is _ParamKind.CONN:
-                kwargs[name] = conn
-            elif kind is _ParamKind.PATH:
-                raw = conn.path_params.get(name, '')
-                if (payload is not None and isinstance(payload, type)
-                        and not isinstance(raw, payload)):
-                    try:
-                        kwargs[name] = payload(raw)
-                    except (ValueError, TypeError):
-                        await _ws_reject(
-                            _WS(conn, receive, send) if ws is None else ws,
-                            f'path param {name!r}: cannot coerce {raw!r} to '
-                            f'{payload.__name__}')
-                        return
-                else:
-                    kwargs[name] = raw
-            else:  # 'query'
-                raw = query_values.get(name, _QUERY_MISSING)
-                if raw is _QUERY_MISSING:
-                    if payload.required:
-                        await _ws_reject(
-                            _WS(conn, receive, send) if ws is None else ws,
-                            f'missing required query parameter {name!r} for '
-                            f'handler {fn_name!r}')
-                        return
-                    kwargs[name] = payload.default
-                else:
-                    try:
-                        kwargs[name] = payload.coercer(raw)
-                    except (ValueError, TypeError):
-                        await _ws_reject(
-                            _WS(conn, receive, send) if ws is None else ws,
-                            f'query parameter {name!r}: cannot coerce {raw!r} '
-                            f'to {payload.type.__name__}')
-                        return
+            match kind:
+                case _ParamKind.WS:
+                    if ws is None:
+                        ws = _WS(conn, receive, send)
+                    kwargs[name] = ws
+                case _ParamKind.CONN:
+                    kwargs[name] = conn
+                case _ParamKind.PATH:
+                    raw = conn.path_params.get(name, '')
+                    if (payload is not None and isinstance(payload, type)
+                            and not isinstance(raw, payload)):
+                        try:
+                            kwargs[name] = payload(raw)
+                        except (ValueError, TypeError):
+                            await _ws_reject(
+                                _WS(conn, receive, send) if ws is None else ws,
+                                f'path param {name!r}: cannot coerce {raw!r} to '
+                                f'{payload.__name__}')
+                            return
+                    else:
+                        kwargs[name] = raw
+                case _ParamKind.QUERY:
+                    raw = query_values.get(name, _QUERY_MISSING)
+                    if raw is _QUERY_MISSING:
+                        if payload.required:
+                            await _ws_reject(
+                                _WS(conn, receive, send) if ws is None else ws,
+                                f'missing required query parameter {name!r} for '
+                                f'handler {fn_name!r}')
+                            return
+                        kwargs[name] = payload.default
+                    else:
+                        try:
+                            kwargs[name] = payload.coercer(raw)
+                        except (ValueError, TypeError):
+                            await _ws_reject(
+                                _WS(conn, receive, send) if ws is None else ws,
+                                f'query parameter {name!r}: cannot coerce {raw!r} '
+                                f'to {payload.type.__name__}')
+                            return
+                case _:  # unreachable: bind_plan excludes DEPENDS
+                    raise AssertionError(f'unexpected param kind {kind!r} for {name!r}')
 
         if not depends_plan:
             await fn(**kwargs)
@@ -1226,51 +1229,52 @@ def _make_extended_wrapper(fn, annotations: dict, plan: tuple, depends_plan: tup
                 dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
                 if raw_qs else {})
         for name, kind, payload in plan:
-            if kind is _ParamKind.QUERY:
-                raw = query_values.get(name, _QUERY_MISSING)
-                if raw is _QUERY_MISSING:
-                    if payload.required:
-                        raise HTTPException(
-                            HTTPStatus.BAD_REQUEST,
-                            f'missing required query parameter {name!r} '
-                            f'for handler {fn_name!r}')
-                    kwargs[name] = payload.default
-                else:
-                    try:
-                        kwargs[name] = payload.coercer(raw)
-                    except (ValueError, TypeError) as exc:
-                        raise HTTPException(
-                            HTTPStatus.BAD_REQUEST,
-                            f'query parameter {name!r}: cannot coerce {raw!r} '
-                            f'to {payload.type.__name__}',
-                        ) from exc
-            elif kind is _ParamKind.CONN:
-                kwargs[name] = conn
-            elif kind is _ParamKind.BODY:
-                raw = await conn.body()
-                ann = annotations.get(name, inspect.Parameter.empty)
-                if _is_body_dataclass_annotation(ann):
-                    kwargs[name] = _decode_json_body(ann, raw, fn_name)
-                else:
-                    kwargs[name] = raw
-            elif kind is _ParamKind.REQUEST:
-                kwargs[name] = conn
-            elif kind is _ParamKind.DATACLASS:
-                raw = await conn.body()
-                kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
-            else:  # 'path'
-                raw = conn.path_params.get(name, '')
-                ann = annotations.get(name, inspect.Parameter.empty)
-                if (ann is not inspect.Parameter.empty and isinstance(ann, type)
-                        and not isinstance(raw, ann)):
-                    try:
-                        kwargs[name] = ann(raw)
-                    except (ValueError, TypeError) as exc:
-                        raise TypeError(
-                            f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
-                        ) from exc
-                else:
-                    kwargs[name] = raw
+            match kind:
+                case _ParamKind.QUERY:
+                    raw = query_values.get(name, _QUERY_MISSING)
+                    if raw is _QUERY_MISSING:
+                        if payload.required:
+                            raise HTTPException(
+                                HTTPStatus.BAD_REQUEST,
+                                f'missing required query parameter {name!r} '
+                                f'for handler {fn_name!r}')
+                        kwargs[name] = payload.default
+                    else:
+                        try:
+                            kwargs[name] = payload.coercer(raw)
+                        except (ValueError, TypeError) as exc:
+                            raise HTTPException(
+                                HTTPStatus.BAD_REQUEST,
+                                f'query parameter {name!r}: cannot coerce {raw!r} '
+                                f'to {payload.type.__name__}',
+                            ) from exc
+                case _ParamKind.CONN | _ParamKind.REQUEST:
+                    kwargs[name] = conn
+                case _ParamKind.BODY:
+                    raw = await conn.body()
+                    ann = annotations.get(name, inspect.Parameter.empty)
+                    if _is_body_dataclass_annotation(ann):
+                        kwargs[name] = _decode_json_body(ann, raw, fn_name)
+                    else:
+                        kwargs[name] = raw
+                case _ParamKind.DATACLASS:
+                    raw = await conn.body()
+                    kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
+                case _ParamKind.PATH:
+                    raw = conn.path_params.get(name, '')
+                    ann = annotations.get(name, inspect.Parameter.empty)
+                    if (ann is not inspect.Parameter.empty and isinstance(ann, type)
+                            and not isinstance(raw, ann)):
+                        try:
+                            kwargs[name] = ann(raw)
+                        except (ValueError, TypeError) as exc:
+                            raise TypeError(
+                                f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
+                            ) from exc
+                    else:
+                        kwargs[name] = raw
+                case _:  # unreachable: plan excludes DEPENDS; only the 6 kinds above occur
+                    raise AssertionError(f'unexpected param kind {kind!r} for {name!r}')
 
         if not depends_plan:
             result = (await fn(**kwargs)) if is_async else fn(**kwargs)
@@ -1355,31 +1359,32 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
         for name in params:
             ann = annotations.get(name, inspect.Parameter.empty)
             kind = categories[name][0]
-            if kind is _ParamKind.CONN:
-                kwargs[name] = conn
-            elif kind is _ParamKind.BODY:
-                raw = await conn.body()
-                if _is_body_dataclass_annotation(ann):
+            match kind:
+                case _ParamKind.CONN | _ParamKind.REQUEST:
+                    kwargs[name] = conn
+                case _ParamKind.BODY:
+                    raw = await conn.body()
+                    if _is_body_dataclass_annotation(ann):
+                        kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
+                    else:
+                        kwargs[name] = raw
+                case _ParamKind.DATACLASS:
+                    raw = await conn.body()
                     kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
-                else:
-                    kwargs[name] = raw
-            elif kind is _ParamKind.REQUEST:
-                kwargs[name] = conn
-            elif kind is _ParamKind.DATACLASS:
-                raw = await conn.body()
-                kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
-            else:  # 'path'
-                raw = conn.path_params.get(name, '')
-                if (ann is not inspect.Parameter.empty and isinstance(ann, type)
-                        and not isinstance(raw, ann)):
-                    try:
-                        kwargs[name] = ann(raw)
-                    except (ValueError, TypeError) as exc:
-                        raise TypeError(
-                            f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
-                        ) from exc
-                else:
-                    kwargs[name] = raw
+                case _ParamKind.PATH:
+                    raw = conn.path_params.get(name, '')
+                    if (ann is not inspect.Parameter.empty and isinstance(ann, type)
+                            and not isinstance(raw, ann)):
+                        try:
+                            kwargs[name] = ann(raw)
+                        except (ValueError, TypeError) as exc:
+                            raise TypeError(
+                                f"Path param {name!r}: cannot coerce {raw!r} to {ann.__name__}"
+                            ) from exc
+                    else:
+                        kwargs[name] = raw
+                case _:  # unreachable in _wrapper: no query/depends reach the plain pin
+                    raise AssertionError(f'unexpected param kind {kind!r} for {name!r}')
 
         result = (await fn(**kwargs)) if is_async else fn(**kwargs)
 

--- a/blackbull/router.py
+++ b/blackbull/router.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable
 from contextlib import AsyncExitStack
 import dataclasses
 from dataclasses import dataclass, field
+from enum import Enum
 import typing
 from typing import Any, Callable, NamedTuple, Tuple, Type, Optional, Union, get_args, get_origin
 from functools import wraps, partial
@@ -746,6 +747,25 @@ class _QuerySpec(NamedTuple):
 _QUERY_MISSING = object()
 
 
+class _ParamKind(Enum):
+    """Classification of one simplified-handler parameter (registration-time).
+
+    Emitted by :func:`_handler_param_plan` (HTTP) and
+    :func:`_websocket_param_plan` (WS).  Purely internal — derived from the
+    handler's signature, never from request data — so a plain ``Enum`` (not
+    StrEnum) is used: string comparisons like ``kind == 'query'`` must fail
+    loudly rather than silently pass.
+    """
+    PATH = 'path'
+    CONN = 'conn'
+    BODY = 'body'
+    REQUEST = 'request'
+    DATACLASS = 'dataclass'
+    DEPENDS = 'depends'
+    QUERY = 'query'
+    WS = 'ws'
+
+
 def _handler_param_plan(fn, path_param_names: set) -> tuple:
     """Classify every parameter of simplified handler *fn* — once, at
     registration time.
@@ -792,7 +812,7 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
                     f"Simplified handler {fn.__name__!r}: parameter {name!r} "
                     f"is a path param of {sorted(path_param_names)!r} and "
                     f"cannot carry a Depends default.")
-            categories[name] = ('path', None)
+            categories[name] = (_ParamKind.PATH, None)
         elif name == 'scope':
             # Rejected, not merely unsupported. ``scope`` was once an alias
             # injecting the Connection, which is backwards: the word means a
@@ -820,16 +840,16 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
                     f"is reserved for the request {name} and cannot carry a "
                     f"Depends default — rename the parameter.")
             # ``conn`` / ``connection`` inject the native Connection.
-            categories[name] = ('body' if name == 'body' else 'conn', None)
+            categories[name] = (_ParamKind.BODY if name == 'body' else _ParamKind.CONN, None)
         elif is_dep:
-            categories[name] = ('depends', default)
+            categories[name] = (_ParamKind.DEPENDS, default)
         elif ann is _Conn or (name == 'request' and ann is inspect.Parameter.empty):
             # ``conn: Connection`` (preferred) or the legacy ``request: Request``
             # (``Request`` is a deprecated alias of ``Connection``, so both
             # annotations are the same object here), or the bare name ``request``.
-            categories[name] = ('request', None)
+            categories[name] = (_ParamKind.REQUEST, None)
         elif _is_body_dataclass_annotation(ann):
-            categories[name] = ('dataclass', None)
+            categories[name] = (_ParamKind.DATACLASS, None)
         else:
             # Fallback category: resolve from the query string.
             target = str if ann is inspect.Parameter.empty else _unwrap_optional(ann)
@@ -845,7 +865,7 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
                     f"(optionally `| None`)."
                 )
             required = default is inspect.Parameter.empty
-            categories[name] = ('query', _QuerySpec(
+            categories[name] = (_ParamKind.QUERY, _QuerySpec(
                 name=name, type=target, coercer=coercer, required=required,
                 default=None if required else default))
 
@@ -855,7 +875,7 @@ def _handler_param_plan(fn, path_param_names: set) -> tuple:
     # second ``read_body`` call indefinitely.  A ``Request`` param does not
     # count: it drains lazily through the same cache the wrappers use.
     body_param_count = sum(
-        1 for kind, _ in categories.values() if kind in ('body', 'dataclass'))
+        1 for kind, _ in categories.values() if kind in (_ParamKind.BODY, _ParamKind.DATACLASS))
     if body_param_count > 1:
         raise TypeError(
             f"Simplified handler {fn.__name__!r}: more than one parameter would "
@@ -1013,23 +1033,23 @@ def _websocket_param_plan(fn, path_param_names: set = frozenset()) -> tuple[tupl
                     f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
                     f"reserved for the WebSocket object and cannot carry a "
                     f"Depends default — rename the parameter.")
-            plan.append((name, 'ws', None))
+            plan.append((name, _ParamKind.WS, None))
         elif ann is _Conn or (bare and name in ('conn', 'connection')):
             if is_dep:
                 raise TypeError(
                     f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
                     f"reserved for the Connection and cannot carry a Depends "
                     f"default — rename the parameter.")
-            plan.append((name, 'conn', None))
+            plan.append((name, _ParamKind.CONN, None))
         elif name in path_param_names:
             if is_dep:
                 raise TypeError(
                     f"WebSocket handler {fn.__name__!r}: parameter {name!r} is "
                     f"a path param of {sorted(path_param_names)!r} and cannot "
                     f"carry a Depends default.")
-            plan.append((name, 'path', None if bare else ann))
+            plan.append((name, _ParamKind.PATH, None if bare else ann))
         elif is_dep:
-            plan.append((name, 'depends', default))
+            plan.append((name, _ParamKind.DEPENDS, default))
         else:
             # Unlike the HTTP plan, a *bare* leftover name is not silently taken
             # as a str query param.  On HTTP that fallback is load-bearing
@@ -1055,7 +1075,7 @@ def _websocket_param_plan(fn, path_param_names: set = frozenset()) -> tuple[tupl
                     f"For full control, declare the raw '(conn, receive, send)' "
                     f"signature instead.")
             required = default is inspect.Parameter.empty
-            plan.append((name, 'query', _QuerySpec(
+            plan.append((name, _ParamKind.QUERY, _QuerySpec(
                 name=name, type=target, coercer=coercer, required=required,
                 default=None if required else default)))
     return tuple(plan)
@@ -1090,15 +1110,15 @@ def _adapt_websocket_handler(fn, path: str = ''):
 
     # The overwhelmingly common shape — a lone ``ws`` — gets a wrapper with no
     # per-connection argument assembly at all.
-    if len(plan) == 1 and plan[0][1] == 'ws':
+    if len(plan) == 1 and plan[0][1] is _ParamKind.WS:
         @wraps(fn)
         async def _ws_wrapper(conn, receive, send):
             await fn(_WS(conn, receive, send))
         return _ws_wrapper
 
-    depends_plan = tuple((n, payload) for n, kind, payload in plan if kind == 'depends')
-    bind_plan = tuple((n, kind, payload) for n, kind, payload in plan if kind != 'depends')
-    has_query = any(kind == 'query' for _, kind, _ in bind_plan)
+    depends_plan = tuple((n, payload) for n, kind, payload in plan if kind is _ParamKind.DEPENDS)
+    bind_plan = tuple((n, kind, payload) for n, kind, payload in plan if kind is not _ParamKind.DEPENDS)
+    has_query = any(kind is _ParamKind.QUERY for _, kind, _ in bind_plan)
     fn_name = fn.__name__
 
     @wraps(fn)
@@ -1114,13 +1134,13 @@ def _adapt_websocket_handler(fn, path: str = ''):
         # Bind everything that cannot fail on a resource *before* resolving any
         # Depends: a connection we are about to reject should never acquire one.
         for name, kind, payload in bind_plan:
-            if kind == 'ws':
+            if kind is _ParamKind.WS:
                 if ws is None:
                     ws = _WS(conn, receive, send)
                 kwargs[name] = ws
-            elif kind == 'conn':
+            elif kind is _ParamKind.CONN:
                 kwargs[name] = conn
-            elif kind == 'path':
+            elif kind is _ParamKind.PATH:
                 raw = conn.path_params.get(name, '')
                 if (payload is not None and isinstance(payload, type)
                         and not isinstance(raw, payload)):
@@ -1192,7 +1212,7 @@ def _make_extended_wrapper(fn, annotations: dict, plan: tuple, depends_plan: tup
     this factory adds zero per-request calls; the closure it returns runs per
     request and is intentionally NOT extracted further (hot-path policy).
     """
-    has_query = any(kind == 'query' for _, kind, _ in plan)
+    has_query = any(kind is _ParamKind.QUERY for _, kind, _ in plan)
     fn_name = fn.__name__
     is_async = inspect.iscoroutinefunction(fn)
 
@@ -1206,7 +1226,7 @@ def _make_extended_wrapper(fn, annotations: dict, plan: tuple, depends_plan: tup
                 dict(parse_qsl(raw_qs.decode('latin-1'), keep_blank_values=True))
                 if raw_qs else {})
         for name, kind, payload in plan:
-            if kind == 'query':
+            if kind is _ParamKind.QUERY:
                 raw = query_values.get(name, _QUERY_MISSING)
                 if raw is _QUERY_MISSING:
                     if payload.required:
@@ -1224,18 +1244,18 @@ def _make_extended_wrapper(fn, annotations: dict, plan: tuple, depends_plan: tup
                             f'query parameter {name!r}: cannot coerce {raw!r} '
                             f'to {payload.type.__name__}',
                         ) from exc
-            elif kind == 'conn':
+            elif kind is _ParamKind.CONN:
                 kwargs[name] = conn
-            elif kind == 'body':
+            elif kind is _ParamKind.BODY:
                 raw = await conn.body()
                 ann = annotations.get(name, inspect.Parameter.empty)
                 if _is_body_dataclass_annotation(ann):
                     kwargs[name] = _decode_json_body(ann, raw, fn_name)
                 else:
                     kwargs[name] = raw
-            elif kind == 'request':
+            elif kind is _ParamKind.REQUEST:
                 kwargs[name] = conn
-            elif kind == 'dataclass':
+            elif kind is _ParamKind.DATACLASS:
                 raw = await conn.body()
                 kwargs[name] = _decode_json_body(annotations[name], raw, fn_name)
             else:  # 'path'
@@ -1315,7 +1335,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     # default is the one registration-time signal that the author may have
     # meant a query param, so say so now rather than 404-by-surprise later.
     for name, p in params.items():
-        if categories[name][0] == 'path' and p.default is not inspect.Parameter.empty:
+        if categories[name][0] is _ParamKind.PATH and p.default is not inspect.Parameter.empty:
             warnings.warn(
                 f"Simplified handler {fn.__name__!r}: parameter {name!r} matches "
                 f"a path placeholder in {path!r}; its default is never used and "
@@ -1335,17 +1355,17 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
         for name in params:
             ann = annotations.get(name, inspect.Parameter.empty)
             kind = categories[name][0]
-            if kind == 'conn':
+            if kind is _ParamKind.CONN:
                 kwargs[name] = conn
-            elif kind == 'body':
+            elif kind is _ParamKind.BODY:
                 raw = await conn.body()
                 if _is_body_dataclass_annotation(ann):
                     kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
                 else:
                     kwargs[name] = raw
-            elif kind == 'request':
+            elif kind is _ParamKind.REQUEST:
                 kwargs[name] = conn
-            elif kind == 'dataclass':
+            elif kind is _ParamKind.DATACLASS:
                 raw = await conn.body()
                 kwargs[name] = _decode_json_body(ann, raw, fn.__name__)
             else:  # 'path'
@@ -1378,9 +1398,9 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
             f"app.register_converter({type(result).__name__}, ...)."
         )
 
-    has_query = any(kind == 'query' for kind, _ in categories.values())
+    has_query = any(kind is _ParamKind.QUERY for kind, _ in categories.values())
     depends_plan = tuple(
-        (n, payload) for n, (kind, payload) in categories.items() if kind == 'depends')
+        (n, payload) for n, (kind, payload) in categories.items() if kind is _ParamKind.DEPENDS)
 
     if not has_query and not depends_plan:
         # Zero-overhead pin: neither new parameter category is in play, so
@@ -1391,7 +1411,7 @@ def _adapt_handler(fn, path: str, converters: dict | None = None):
     # fully computed at registration; the per-request work is only what the
     # declared parameters require.
     plan = tuple((n, kind, payload) for n, (kind, payload) in categories.items()
-                 if kind != 'depends')
+                 if kind is not _ParamKind.DEPENDS)
     return _make_extended_wrapper(fn, annotations, plan, depends_plan, converters)
 
 

--- a/tests/unit/test_query_params.py
+++ b/tests/unit/test_query_params.py
@@ -276,3 +276,53 @@ class TestQueryParamsEndToEnd:
         with TestClient(app) as client:
             r = client.get('/search?page=xyz')
             assert r.status_code == 400
+
+
+class TestPathPlaceholderNamedBody:
+    """A ``{body}`` path placeholder wins over the reserved ``body`` name.
+
+    Regression: the plain (zero-overhead-pin) wrapper used to dispatch a
+    parameter literally named ``body`` to the request-body branch even when
+    ``{body}`` was declared as a path placeholder — binding the request body
+    where the extended wrapper (and the path-param classifier, which gives
+    path placeholders top precedence) bound the path value.  The two wrappers
+    must agree: the placeholder wins.
+    """
+
+    def test_body_placeholder_binds_path_value_in_plain_wrapper(self):
+        app = BlackBull()
+
+        @app.route(path='/x/{body}')
+        async def h(body):
+            return f'body={body!r}'
+
+        with TestClient(app) as client:
+            r = client.get('/x/abc', content=b'RAW-BODY')
+            assert r.status_code == 200
+            assert r.text == "body='abc'"
+
+    def test_body_placeholder_binds_path_value_in_extended_wrapper(self):
+        app = BlackBull()
+
+        @app.route(path='/y/{body}')
+        async def h(body, q: str = 'q'):
+            return f'body={body!r} q={q!r}'
+
+        with TestClient(app) as client:
+            r = client.get('/y/abc', params={'q': 'Q'}, content=b'RAW-BODY')
+            assert r.status_code == 200
+            assert r.text == "body='abc' q='Q'"
+
+    def test_bare_body_param_still_binds_request_body(self):
+        """Without a ``{body}`` placeholder the reserved ``body`` name keeps
+        binding the request body — the fix must not disturb the normal case."""
+        app = BlackBull()
+
+        @app.route(path='/normal')
+        async def h(body):
+            return f'body={body!r}'
+
+        with TestClient(app) as client:
+            r = client.get('/normal', content=b'RAW-BODY')
+            assert r.status_code == 200
+            assert r.text == "body=b'RAW-BODY'"

--- a/tests/unit/test_websocket_injection.py
+++ b/tests/unit/test_websocket_injection.py
@@ -14,7 +14,8 @@ import pytest
 
 from blackbull import (BlackBull, Connection, Depends, Headers, WebSocket,
                        WebSocketDisconnect)
-from blackbull.router import _adapt_websocket_handler, _websocket_param_plan
+from blackbull.router import (_ParamKind, _adapt_websocket_handler,
+                              _websocket_param_plan)
 from blackbull.utils import Scheme
 
 
@@ -49,7 +50,7 @@ def _conn(path='/ws', *, query=b'', path_params=None) -> Connection:
     return conn
 
 
-def _kinds(plan) -> tuple[str, ...]:
+def _kinds(plan) -> tuple[_ParamKind, ...]:
     return tuple(kind for _, kind, _ in plan)
 
 
@@ -65,14 +66,14 @@ def test_path_param_is_classified_by_name():
     async def handler(ws: WebSocket, room: str):
         pass
 
-    assert _kinds(_websocket_param_plan(handler, {'room'})) == ('ws', 'path')
+    assert _kinds(_websocket_param_plan(handler, {'room'})) == (_ParamKind.WS, _ParamKind.PATH)
 
 
 def test_annotated_leftover_is_a_query_param():
     async def handler(ws: WebSocket, since: int):
         pass
 
-    assert _kinds(_websocket_param_plan(handler, set())) == ('ws', 'query')
+    assert _kinds(_websocket_param_plan(handler, set())) == (_ParamKind.WS, _ParamKind.QUERY)
 
 
 def test_query_param_must_be_annotated():
@@ -97,7 +98,7 @@ def test_depends_default_is_classified():
     async def handler(ws: WebSocket, db=Depends(provider)):
         pass
 
-    assert _kinds(_websocket_param_plan(handler, set())) == ('ws', 'depends')
+    assert _kinds(_websocket_param_plan(handler, set())) == (_ParamKind.WS, _ParamKind.DEPENDS)
 
 
 @pytest.mark.parametrize('name', ['ws', 'websocket', 'conn', 'connection'])

--- a/tests/unit/test_websocket_object.py
+++ b/tests/unit/test_websocket_object.py
@@ -18,7 +18,8 @@ import pytest
 
 from blackbull import (BlackBull, Connection, Headers, WebSocket,
                        WebSocketDisconnect)
-from blackbull.router import _adapt_websocket_handler, _websocket_param_plan
+from blackbull.router import (_ParamKind, _adapt_websocket_handler,
+                              _websocket_param_plan)
 from blackbull.utils import Scheme
 
 # ``send()`` annotates its parameter, so under the beartype import-hook the
@@ -466,7 +467,7 @@ def test_raw_triplet_handler_is_not_wrapped_at_all():
     assert not hasattr(_registered(app, '/raw2'), '__wrapped__')
 
 
-def _kinds(plan) -> tuple[str, ...]:
+def _kinds(plan) -> tuple[_ParamKind, ...]:
     """Just the categories of a param plan, in signature order."""
     return tuple(kind for _, kind, _ in plan)
 
@@ -474,7 +475,7 @@ def _kinds(plan) -> tuple[str, ...]:
 @pytest.mark.parametrize('name', ['ws', 'websocket'])
 def test_bare_parameter_names_get_the_object(name):
     plan = _websocket_param_plan(eval(f'lambda {name}: None'))
-    assert _kinds(plan) == ('ws',)
+    assert _kinds(plan) == (_ParamKind.WS,)
 
 
 def test_annotation_wins_over_name():
@@ -482,14 +483,14 @@ def test_annotation_wins_over_name():
     async def handler(ws: Connection):
         pass
 
-    assert _kinds(_websocket_param_plan(handler)) == ('conn',)
+    assert _kinds(_websocket_param_plan(handler)) == (_ParamKind.CONN,)
 
 
 def test_object_and_connection_together():
     async def handler(ws: WebSocket, conn: Connection):
         pass
 
-    assert _kinds(_websocket_param_plan(handler)) == ('ws', 'conn')
+    assert _kinds(_websocket_param_plan(handler)) == (_ParamKind.WS, _ParamKind.CONN)
 
 
 def test_unresolvable_parameter_fails_at_registration_not_at_connect_time():
@@ -511,7 +512,7 @@ def test_an_explicit_annotation_works_under_any_parameter_name():
     async def handler(sock: WebSocket):
         pass
 
-    assert _kinds(_websocket_param_plan(handler)) == ('ws',)
+    assert _kinds(_websocket_param_plan(handler)) == (_ParamKind.WS,)
 
 
 def test_http_route_is_unaffected_by_the_websocket_branch():


### PR DESCRIPTION
## Summary

Round 3 + Round 4 of the simplified-handler refactor. Pure behavior-preserving
restructuring (one real fix, see 5cb0cec) — the request-lifecycle events and
byte-on-wire behaviour are unchanged. Full suite identical before/after:
**5894 passed / 265 skipped / 1 xfailed** (identical to the pre-refactor
baseline), 0 new beartype violations.

### Commits
- **4a0cbd5** `refactor: extract extended-wrapper factory at registration time`
  — pull `_extended_wrapper` construction out of the per-route registration
  path into `_make_extended_wrapper(...)`.
- **5cb0cec** `fix: honor {body} path placeholder over the reserved body name`
  — Part A (found by the refactor's critic review): `_wrapper` dispatched on
  parameter *name* (`name == 'body'`), which bound the request body where
  `_extended_wrapper` (kind-based) bound the path value for a route like
  `/x/{body}` + `h(body)`.  Now kind-based in both wrappers; regression tests
  in `tests/unit/test_query_params.py` (`TestPathPlaceholderNamedBody`).
- **6f207bc** `refactor: classify simplified-handler params with _ParamKind
  enum` — internal string kinds → `_ParamKind(Enum)` (PATH/CONN/BODY/REQUEST/
  DATACLASS/DEPENDS/QUERY/WS).  Plain Enum, not StrEnum: string comparisons
  against kinds must fail loudly.
- **c7efe50** `refactor: dispatch param kinds with match-case in wrappers` —
  all three wrapper loops use `match kind:`; `CONN | REQUEST` merged; a
  `case _:` guard replaces the old silent else-fallback.
- **f84d347** `refactor: sort _ParamKind import in openapi (lint I001)`.

### A/B verification (EC2, m7a.2xlarge, 8 rounds ABBA, 16 runs/arm)
Base `5cb0cec` vs treat `c7efe50`, two profiles, pooled + round-paired TOST:

| profile | real Δ (pooled) | 95% CI | verdict |
|---|---|---|---|
| `/conn` (exercises the changed dispatch) | −0.176 % | [−0.713, +0.360] | **equivalent within ±1 %** |
| `/plaintext` (no-op loop) | +0.085 % | [−0.474, +0.645] | **equivalent within ±1 %** |

Null (A/A) phases pass ±1 % in both sessions (box resolvable); swap integrity
confirmed by the import-hash proof column (base `921701e058ae` vs treat
`aa995ccceda4`, consistent all rounds).  ±0.5 % is not claimable at 8 rounds
— consistent with the §6 calibration floor.  Teardown clean.

Note: match-case on Enum members re-fetches the member per arm
(`LOAD_GLOBAL`+`LOAD_ATTR`); measured at ~0.05 % of a 38 µs request — below
the A/B resolution.  Cheaper identity-dispatch forms exist but are not worth
the readability cost; revisit if a Python JIT / constant pattern arrives.