### PR TITLE
Sprint 92 — Send-side native-ization: native app-server seam, ASGI opt-in

### DIFF
--- a/bench/peers/ab_commit.sh
+++ b/bench/peers/ab_commit.sh
@@ -96,8 +96,36 @@ for f in "${FILES[@]}"; do
     fi
 done
 
+# A file may exist in only one of the two refs (added or deleted between
+# them).  `git checkout <ref> -- <path>` cannot handle a path absent from
+# the target ref, so each file is checked out when it exists at the target
+# and REMOVED when it does not.  `$PROOF_FILE` is the first swapped file
+# that exists in BOTH refs — the import-hash proof below needs a module
+# that is importable under either arm.
+PROOF_FILE=""
+for f in "${FILES[@]}"; do
+    if git cat-file -e "$REF_BASE:$f" 2>/dev/null \
+            && git cat-file -e "$REF_TREAT:$f" 2>/dev/null; then
+        PROOF_FILE="$f"
+        break
+    fi
+done
+
+_swap_file_set() {  # $1 = ref (or HEAD_REF for restore)
+    local ref="$1" f
+    for f in "${FILES[@]}"; do
+        if git cat-file -e "$ref:$f" 2>/dev/null; then
+            git checkout "$ref" -- "$f" || return 1
+        else
+            rm -f "$f"
+        fi
+    done
+    find blackbull -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+    return 0
+}
+
 restore_tree() {
-    git checkout "$HEAD_REF" -- "${FILES[@]}" 2>/dev/null || true
+    _swap_file_set "$HEAD_REF" 2>/dev/null || true
 }
 kill_server() {
     if command -v fuser >/dev/null 2>&1; then
@@ -120,9 +148,9 @@ trap cleanup EXIT INT TERM HUP
 # and hashing that, not hashing the path we think it will use.
 swap_to() {
     local ref="$1"
-    git checkout "$ref" -- "${FILES[@]}" || return 1
-    find blackbull -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
-    uv run python - "${FILES[0]}" <<'PY'
+    _swap_file_set "$ref" || return 1
+    if [ -n "$PROOF_FILE" ]; then
+        uv run python - "$PROOF_FILE" <<'PY'
 import hashlib, importlib, pathlib, sys
 rel = sys.argv[1]
 mod = importlib.import_module(
@@ -134,6 +162,7 @@ if p != want:
     raise SystemExit(1)
 print(f'{p} {hashlib.sha1(p.read_bytes()).hexdigest()[:12]}')
 PY
+    fi
 }
 
 start_server() {

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -84,27 +84,92 @@ def _wrap_send(raw_send: ASGISendCallable):
     return _send
 
 
+def _wrap_send_native(raw_send: ASGISendCallable):
+    """Handler-boundary adapter for the native H1 path: all shapes → native.
+
+    Thin wrapper over :func:`blackbull.response.wrap_native_send` — the
+    shared conversion (with ``as_middleware``) so global and per-route
+    middleware observe the same native contract.  Installed at the same
+    altitude as :func:`_wrap_send` (the handler boundary, innermost), so on
+    H1 everything above the route handler sees only
+    :class:`~blackbull.native.NativeResponse`.  See ``wrap_native_send`` for
+    the accepted shapes (full-form ``send(dict)`` compat held until
+    2027-07-29).
+    """
+    from .response import wrap_native_send  # noqa: PLC0415
+    return wrap_native_send(raw_send)
+
+
+def _to_asgi_boundary(send: ASGISendCallable):
+    """Wrap an external ASGI host's ``send`` with native→ASGI conversion.
+
+    The app is native internally in **both** modes (decision 7): the router
+    converts handler sends to ``NativeResponse`` on the H1 path.  At the
+    external-host edge (scope-dict entry / ``asgi=True``), this wrapper
+    converts ``NativeResponse`` emissions back to ASGI dicts via
+    :meth:`~blackbull.native.NativeResponse.to_asgi` so uvicorn / httpx /
+    TestClient receive standard ``http.response.*`` events.  Everything else
+    (lifespan, websocket, and already-ASGI events) passes straight through.
+    """
+    from .native import NativeResponse  # noqa: PLC0415
+
+    async def _send(event):
+        if isinstance(event, NativeResponse):
+            for ev in event.to_asgi():
+                await send(ev)
+        else:
+            await send(event)
+
+    return _send
+
+
 def _inject_response_headers(raw_send: ASGISendCallable, extra_headers):
     """Wrap *raw_send* to append *extra_headers* to the response.
 
     A route may declare headers (via the ``_bb_response_headers`` hook) that
     must appear on all of its responses — success and the centrally-rendered
-    error alike.  Installed **below** :func:`_wrap_send`, so it only ever
-    observes plain ASGI dicts: convenience shapes (``Response``, 3-arg) have
-    already been normalised by the time an event reaches here.  The headers
-    are appended to the ``http.response.start`` event; every other event
-    passes straight through.
+    error alike.  Installed **below** the handler-boundary adapter, so on the
+    H1 native path it observes ``NativeResponse`` (appends to the header arm)
+    and on the H2 / ASGI path it observes plain ASGI dicts (appends to the
+    ``http.response.start`` event).  Every other event passes straight
+    through.
     """
+    from .native import NativeResponse  # noqa: PLC0415
+
     # Unannotated for the same per-request-closure reason as _wrap_send;
-    # ``event`` is an ASGISendEvent.
+    # ``event`` is a NativeResponse or an ASGISendEvent.
     async def _send(event):
-        if isinstance(event, dict) and event.get('type') == 'http.response.start':
+        if isinstance(event, NativeResponse):
+            # Native header arm — presence is `is not None`, never truthiness
+            # (an empty header list is a real header).
+            if event.header is not None:
+                event.header.append(extra_headers)
+        elif isinstance(event, dict) and event.get('type') == 'http.response.start':
             headers: list = list(event.get('headers') or [])
             headers.extend(extra_headers)
             event = {**event, 'headers': headers}
         await raw_send(event)
 
     return _send
+
+
+def _boundary_wrap(mw):
+    """Wrap a global middleware so its input send is native-converting on H1.
+
+    Middleware-generated events (short-circuit responses, the static
+    middleware's ``_respond`` / pathsend dicts) bypass the handler-boundary
+    adapter; wrapping the middleware's input send converts those to
+    ``NativeResponse`` too, so the pipeline below the middleware is uniformly
+    native.  On H2 the ASGI-dict path stays (no native sender arm yet — next
+    sprint), so the conversion is gated per request and disappears with the
+    H2 native-ization.
+    """
+    async def wrapped(conn, receive, send, call_next):
+        if conn.http_version == '1.1':
+            send = _wrap_send_native(send)
+        return await mw(conn, receive, send, call_next)
+
+    return wrapped
 
 
 def _wants_html(conn) -> bool:
@@ -249,7 +314,15 @@ class BlackBull:
                  trusted_proxies: list[str] | str | None = None,
                  config: AppConfig | None = None,
                  cache_max: int | None = None,
+                 asgi: bool = False,
                  ):
+        # ``asgi`` marks the app as external-host-oriented (decision 2026-08-03):
+        # the app is native internally in BOTH modes, and the native→ASGI
+        # boundary conversion applies at the external edge.  asgi=True applies
+        # it unconditionally in ``__call__``; the flag-less app still gets it
+        # automatically when entered with an ASGI scope dict (uvicorn / httpx /
+        # TestClient).  ``to_asgi()`` requires the flag.
+        self._asgi = asgi
         self._config = config
         # ``cache_max`` bounds the per-worker route lookup cache (0 disables
         # it); ``None`` keeps the Router default (2048).  See the routing guide.
@@ -668,15 +741,19 @@ class BlackBull:
                 await serve_grpc(self._grpc_registry, conn, receive, send)
                 return
 
-        # Normalise send for the HTTP path: handlers may emit Response objects
-        # or the (bytes, status, headers) 3-arg form.  Apply _wrap_send here —
-        # at the handler boundary, after the WebSocket branch — so middleware
-        # (which sees send before _dispatch is entered) always receives plain
-        # ASGI dicts.  See _wrap_send for why outward placement is a bug.
-        # ``raw_send`` is retained so an RFC 10008 ``Accept-Query`` route can
-        # re-wrap with the header injector *below* _wrap_send (dict-only).
+        # Normalise send for the HTTP path.  On H1 (Sprint 92 native seam)
+        # the handler-boundary adapter converts every accepted shape —
+        # Response, the (bytes, status, headers) 3-arg form, ASGI dicts
+        # (full-form compat), NativeResponse — to NativeResponse, so
+        # middleware and the sender observe a single native representation.
+        # On H2 the ASGI-dict path stays until its native arm (next sprint) —
+        # this gate exists only to keep the H2 tests passing and disappears
+        # with the H2 native-ization.  ``raw_send`` is retained so an RFC
+        # 10008 ``Accept-Query`` route can re-wrap with the header injector
+        # *below* the adapter.
+        adapter = _wrap_send_native if conn.http_version == '1.1' else _wrap_send
         raw_send = send
-        send = _wrap_send(send)
+        send = adapter(send)
 
         try:
             # RFC 9110 §9.1 — methods are case-sensitive tokens.  Prefer the
@@ -723,10 +800,10 @@ class BlackBull:
         # the guard, not here.
         resp_headers = getattr(function, '_bb_response_headers', None)
         if resp_headers is not None:
-            # Installed below _wrap_send so it sees only ASGI dicts, and around
-            # raw_send so the header also lands on the centrally-rendered error
-            # response (e.g. a guard's 415).
-            send = _wrap_send(_inject_response_headers(raw_send, resp_headers))
+            # Installed below the adapter (sees native on H1, dicts on H2),
+            # and around raw_send so the header also lands on the
+            # centrally-rendered error response (e.g. a guard's 415).
+            send = adapter(_inject_response_headers(raw_send, resp_headers))
         guard = getattr(function, '_bb_request_guard', None)
         if guard is not None:
             try:
@@ -802,7 +879,14 @@ class BlackBull:
     def _build_chain(self):
         chain = self._dispatch
         for mw in reversed(self._global_middlewares):
-            chain = functools.partial(mw, call_next=chain)
+            # Middleware-boundary adapter (decision 2026-08-03): wrap each
+            # global middleware's input send with the native conversion on H1
+            # so middleware-generated events (short-circuit responses, the
+            # static middleware's pathsend / _respond dicts) are also native
+            # — the pipeline below a global middleware is uniformly native.
+            # On H2 the dict path stays (no native sender arm yet), so the
+            # conversion is gated per request.
+            chain = functools.partial(_boundary_wrap(mw), call_next=chain)
         self._chain = chain
 
     async def __call__(self, conn, receive: ASGIReceiveCallable | None,
@@ -824,9 +908,19 @@ class BlackBull:
         # thread the Connection from then on. (Lifespan is the one scope that is
         # not a request and never becomes a Connection.)
         #
+        # External edge (decision 2026-08-03): the app is native internally in
+        # BOTH modes, so when entered with an ASGI scope dict (uvicorn / httpx /
+        # TestClient) — or when built with ``asgi=True`` — the host's ``send``
+        # is wrapped with the native→ASGI boundary conversion: the router emits
+        # NativeResponse, this wrapper converts them back to ``http.response.*``
+        # dicts for the host.  BlackBull's own server (native Connection entry,
+        # asgi=False) passes a native-capable send through untouched.
+        #
         # ``target`` is the object the actor's disconnect-detecting receive wrapper
         # shares with us (the Connection natively, the scope dict in the compat
         # lanes); ``disconnected(target)`` reads the flag off whichever it is.
+        if self._asgi or not isinstance(conn, Connection):
+            send = _to_asgi_boundary(send)
         target = conn
         if isinstance(conn, Connection):
             request = conn                        # HTTP/WebSocket native
@@ -928,6 +1022,22 @@ class BlackBull:
                     'path':      rpath,
                     'exception': err,
                 }))
+
+    def to_asgi(self):
+        """Return the ASGI 3.0 callable to hand to an external host (uvicorn …).
+
+        The app is native internally in both modes; ``BlackBull(asgi=True)``
+        applies the native→ASGI boundary conversion in ``__call__`` whenever
+        the app is driven (scope entry included), so the app instance itself
+        is the callable — ``uvicorn.run(app.to_asgi())`` or ``uvicorn.run(app)``
+        are equivalent.  Requires the ``asgi=True`` constructor flag: without
+        it the app is wired for BlackBull's own native server.
+        """
+        if not self._asgi:
+            raise RuntimeError(
+                'to_asgi() requires BlackBull(asgi=True); an asgi=False app '
+                'is wired for BlackBull\u2019s own native server')
+        return self.__call__
 
     def route(self, methods: str | HTTPMethod | Iterable[str | HTTPMethod] = [HTTPMethod.GET],
               path: str | re.Pattern = '/', scheme: Scheme | Iterable[Scheme] = Scheme.http,

--- a/blackbull/app.py
+++ b/blackbull/app.py
@@ -141,8 +141,10 @@ def _inject_response_headers(raw_send: ASGISendCallable, extra_headers):
     async def _send(event):
         if isinstance(event, NativeResponse):
             # Native header arm — presence is `is not None`, never truthiness
-            # (an empty header list is a real header).
-            if event.header is not None:
+            # (an empty header list is a real header).  Read the raw slot for
+            # the presence check (no discarded _HeaderView on the hot path);
+            # the append still goes through the view's footgun guard.
+            if event._header is not None:
                 event.header.append(extra_headers)
         elif isinstance(event, dict) and event.get('type') == 'http.response.start':
             headers: list = list(event.get('headers') or [])
@@ -165,7 +167,10 @@ def _boundary_wrap(mw):
     H2 native-ization.
     """
     async def wrapped(conn, receive, send, call_next):
-        if conn.http_version == '1.1':
+        # Same defensive gate as middleware.utils.as_middleware: tolerate a
+        # raw scope-dict drive (no http_version attribute) as the H2/dict
+        # lane rather than AttributeErroring.
+        if getattr(conn, 'http_version', '1.1') == '1.1':
             send = _wrap_send_native(send)
         return await mw(conn, receive, send, call_next)
 

--- a/blackbull/middleware/cache.py
+++ b/blackbull/middleware/cache.py
@@ -209,6 +209,10 @@ class Cache:
         streaming = False
         flushed = False
 
+        # Per-request scope: the import must not sit inside the per-event
+        # closure — it would re-bind for every chunk of a streamed response.
+        from ..native import NativeResponse  # noqa: PLC0415
+
         async def cap_send(event):
             nonlocal status, response_headers, streaming, flushed
             # On the H1 native path the handler's emission arrives as a
@@ -219,7 +223,6 @@ class Cache:
             # (Expansion iterates through the sibling ``_cap_dict`` — never a
             # self-referential closure, which would reintroduce the v0.60.0
             # per-request reference cycle.)
-            from ..native import NativeResponse  # noqa: PLC0415
             if isinstance(event, NativeResponse):
                 for ev in event.to_asgi():
                     await _cap_dict(ev)

--- a/blackbull/middleware/cache.py
+++ b/blackbull/middleware/cache.py
@@ -211,6 +211,23 @@ class Cache:
 
         async def cap_send(event):
             nonlocal status, response_headers, streaming, flushed
+            # On the H1 native path the handler's emission arrives as a
+            # NativeResponse (possibly carrying header + body in one object);
+            # expand it to its ASGI event list and process each event through
+            # the dict logic below — the cache is protocol-agnostic and stores
+            # dicts, so the native seam is normalised away at this entry point.
+            # (Expansion iterates through the sibling ``_cap_dict`` — never a
+            # self-referential closure, which would reintroduce the v0.60.0
+            # per-request reference cycle.)
+            from ..native import NativeResponse  # noqa: PLC0415
+            if isinstance(event, NativeResponse):
+                for ev in event.to_asgi():
+                    await _cap_dict(ev)
+                return
+            await _cap_dict(event)
+
+        async def _cap_dict(event):
+            nonlocal status, response_headers, streaming, flushed
             # The ``@as_middleware`` class decorator normalises ``call_next`` so
             # Response/JSONResponse objects from the handler arrive here as
             # plain start+body dict events.

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -209,14 +209,24 @@ class Compression:
         point: compressible Content-Type AND no pre-existing Content-Encoding.
         """
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
-        # app.py).  ``event`` is an ASGISendEvent.
+        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
         async def vary_send(event):
+            # H1 native path: the header arm is a NativeResponse — stamp Vary
+            # directly on its header list (zero-copy; no expansion).  Absence
+            # is ``is not None`` — never truthiness.
+            from ..native import NativeResponse  # noqa: PLC0415
+            if isinstance(event, NativeResponse):
+                if event.header is not None:
+                    headers = Headers(event._header)
+                    if _is_compressible_content_type(headers) and \
+                            not headers.get(b'content-encoding'):
+                        _merge_vary(event._header)
             # Discriminate on the raw type before building anything.  Going
             # through `parse_response_event` allocated a `ResponseBody` copy
             # of every body event just to have the next line's `isinstance`
             # reject it — a per-chunk cost on a streamed response, for a
             # wrapper that only ever cares about the start event.
-            if event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
+            elif event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
                 headers = Headers(event.get('headers', []))
                 if _is_compressible_content_type(headers) and \
                         not headers.get(b'content-encoding'):
@@ -253,8 +263,22 @@ class Compression:
         skip_compression = False
 
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
-        # app.py).  ``event`` is an ASGISendEvent.
+        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
         async def intercepting_send(event):
+            nonlocal streaming, skip_compression, start_forwarded
+            # H1 native path: a NativeResponse may carry header + body in one
+            # object — expand to its ASGI event list and process each event
+            # through the sibling ``_dict_event`` (never a self-referential
+            # closure: the v0.60.0 per-request cycle guard reclaims these
+            # adapters by refcounting alone).
+            from ..native import NativeResponse  # noqa: PLC0415
+            if isinstance(event, NativeResponse):
+                for ev in event.to_asgi():
+                    await _dict_event(ev)
+                return
+            await _dict_event(event)
+
+        async def _dict_event(event):
             nonlocal streaming, skip_compression, start_forwarded
             # Fast path: once the start event has been forwarded under a
             # pass-through decision (already-encoded response, non-

--- a/blackbull/middleware/compression.py
+++ b/blackbull/middleware/compression.py
@@ -209,14 +209,17 @@ class Compression:
         point: compressible Content-Type AND no pre-existing Content-Encoding.
         """
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
-        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
+        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.  The
+        # import lives at per-request scope — inside the per-event closure it
+        # would re-bind for every chunk of a streamed response.
+        from ..native import NativeResponse  # noqa: PLC0415
+
         async def vary_send(event):
             # H1 native path: the header arm is a NativeResponse — stamp Vary
             # directly on its header list (zero-copy; no expansion).  Absence
             # is ``is not None`` — never truthiness.
-            from ..native import NativeResponse  # noqa: PLC0415
             if isinstance(event, NativeResponse):
-                if event.header is not None:
+                if event._header is not None:
                     headers = Headers(event._header)
                     if _is_compressible_content_type(headers) and \
                             not headers.get(b'content-encoding'):
@@ -263,7 +266,11 @@ class Compression:
         skip_compression = False
 
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
-        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
+        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.  The
+        # import lives at per-request scope — inside the per-event closure it
+        # would re-bind for every chunk of a streamed response.
+        from ..native import NativeResponse  # noqa: PLC0415
+
         async def intercepting_send(event):
             nonlocal streaming, skip_compression, start_forwarded
             # H1 native path: a NativeResponse may carry header + body in one
@@ -271,7 +278,6 @@ class Compression:
             # through the sibling ``_dict_event`` (never a self-referential
             # closure: the v0.60.0 per-request cycle guard reclaims these
             # adapters by refcounting alone).
-            from ..native import NativeResponse  # noqa: PLC0415
             if isinstance(event, NativeResponse):
                 for ev in event.to_asgi():
                     await _dict_event(ev)

--- a/blackbull/middleware/cors.py
+++ b/blackbull/middleware/cors.py
@@ -103,8 +103,9 @@ class CORS:
         # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
         async def cors_send(event):
             if isinstance(event, NativeResponse):
-                # Header arm — presence is `is not None` (never truthiness).
-                if event.header is not None:
+                # Header arm — presence is `is not None` (never truthiness);
+                # raw slot for the check, view for the guarded append.
+                if event._header is not None:
                     event.header.append(cors_hdrs)
             elif event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
                 existing = list(event.get('headers', []))

--- a/blackbull/middleware/cors.py
+++ b/blackbull/middleware/cors.py
@@ -88,15 +88,25 @@ class CORS:
 
     @staticmethod
     def _injecting_send(send, cors_hdrs):
-        """Wrap *send* so the ``ResponseStart`` event gains *cors_hdrs*.
+        """Wrap *send* so the response's header arm gains *cors_hdrs*.
 
-        The headers are appended to a copy of the event's own list — the
-        downstream handler's headers are never mutated in place.
+        On the H1 native path the event is a
+        :class:`~blackbull.native.NativeResponse` whose header arm gets the
+        CORS headers appended (a zero-copy mutation visible to the sender);
+        on the H2 / ASGI path it is a ``http.response.start`` dict, appended
+        to a copy of the event's own list — the downstream handler's headers
+        are never mutated in place.
         """
+        from ..native import NativeResponse  # noqa: PLC0415
+
         # Unannotated on purpose: rebuilt per request (see _wrap_send in
-        # app.py).  ``event`` is an ASGISendEvent.
+        # app.py).  ``event`` is a NativeResponse or an ASGISendEvent.
         async def cors_send(event):
-            if event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
+            if isinstance(event, NativeResponse):
+                # Header arm — presence is `is not None` (never truthiness).
+                if event.header is not None:
+                    event.header.append(cors_hdrs)
+            elif event.get('type') == ASGIEvent.HTTP_RESPONSE_START:
                 existing = list(event.get('headers', []))
                 existing.extend(cors_hdrs)
                 event = {**event, 'headers': existing}

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -10,32 +10,57 @@ Public API:
 from functools import wraps
 
 from ..asgi import ASGISendCallable
-from ..response import wrap_native_send
+from ..response import Response, wrap_native_send
 
 
-def _normalize_send(inner_send: ASGISendCallable | None):
-    """Return a wrapper around *inner_send* that normalises to native.
+def _normalize_dict_send(inner_send: ASGISendCallable | None):
+    """Return a wrapper around *inner_send* that expands Response objects.
 
-    On the H1 native path the handler boundary already converts every shape
-    to :class:`~blackbull.native.NativeResponse`, so the middleware's inner
-    send wrapper observes native objects.  This wrapper guarantees the same
-    contract regardless of the seam: ``Response`` / ``StreamingResponse`` /
-    3-arg / ASGI dict shapes from the handler are all converted to
-    ``NativeResponse`` before reaching ``inner_send`` — the exact conversion
-    the app applies at its handler boundary (shared via
-    :func:`blackbull.response.wrap_native_send`), so global and per-route
-    middleware see one representation.
-
-    ASGI ``send`` is always called with a single positional event — no
-    ``*args/**kwargs`` form needs to be preserved here, and dropping it
-    shaves a per-event call-frame setup that shows in py-spy profiles of
-    the static path.
+    The v0.69 ASGI-lane normalisation: handlers that use the simplified
+    return-value form call ``send`` with a ``Response`` object; this wrapper
+    expands it to the two ASGI events (``http.response.start`` +
+    ``http.response.body``) that ``inner_send`` expects, and forwards every
+    other event dict unchanged.  Used on the H2 / external ASGI lanes where
+    the wire contract stays dict — never converts to ``NativeResponse``.
     """
     # ``inner_send`` is Optional because a middleware may be driven with no
     # send channel at all on pass-through paths (a websocket or lifespan
     # scope a middleware declines to touch).  The wrapper is built either
     # way; it is simply never invoked in that case.
-    return wrap_native_send(inner_send)
+    # Unannotated on purpose: rebuilt per request (see _wrap_send in app.py).
+    # ``event`` is an ASGISendEvent or a Response.
+    async def normalized(event):
+        if isinstance(event, Response):
+            # Response is ASGI-callable and ignores conn/receive (it is a pure
+            # serialiser wearing the ASGI-app signature), so drive it with the
+            # inner send to reuse the one Response→ASGI path.
+            await event(None, None, inner_send)
+        else:
+            await inner_send(event)
+
+    return normalized
+
+
+def _normalize_send(inner_send: ASGISendCallable | None, *, native: bool = True):
+    """Return a wrapper around *inner_send* normalising to the lane's contract.
+
+    * ``native=True`` (the H1 native path) — every shape (``Response`` /
+      ``StreamingResponse`` / 3-arg / ASGI dict) is converted to
+      :class:`~blackbull.native.NativeResponse` before reaching
+      ``inner_send`` (shared with the app's handler-boundary adapter via
+      :func:`blackbull.response.wrap_native_send`), so middleware sees one
+      native representation.
+    * ``native=False`` (the H2 / external ASGI lanes) — the v0.69 contract:
+      ``Response`` objects are expanded to ASGI events, everything else
+      passes through as dicts.  **Never** converts to ``NativeResponse`` on
+      these lanes — the H2 sender has no native arm yet (the H2 gate), so a
+      leaked ``NativeResponse`` would ``TypeError`` it.
+
+    ``as_middleware`` picks the flag from ``conn.http_version``.
+    """
+    if native:
+        return wrap_native_send(inner_send)
+    return _normalize_dict_send(inner_send)
 
 
 def as_middleware(target):
@@ -77,7 +102,13 @@ def as_middleware(target):
         @wraps(original_call)
         async def wrapped_call(self, conn, receive, send, call_next):
             async def normalizing_call_next(conn, receive, inner_send):
-                return await call_next(conn, receive, _normalize_send(inner_send))
+                # Protocol-aware: native by default (the H1 / Sprint 92
+                # contract), v0.69 dict normalisation on the H2 lane (the
+                # H2 sender has no native arm yet — a leaked NativeResponse
+                # would TypeError it; the gate drops with the H2 sprint).
+                native = getattr(conn, 'http_version', '1.1') == '1.1'
+                return await call_next(
+                    conn, receive, _normalize_send(inner_send, native=native))
             return await original_call(self, conn, receive, send, normalizing_call_next)
 
         target.__call__ = wrapped_call
@@ -87,7 +118,9 @@ def as_middleware(target):
     @wraps(target)
     async def wrapper(conn, receive, send, call_next):
         async def normalizing_call_next(conn, receive, inner_send):
-            return await call_next(conn, receive, _normalize_send(inner_send))
+            native = getattr(conn, 'http_version', '1.1') == '1.1'
+            return await call_next(
+                conn, receive, _normalize_send(inner_send, native=native))
         return await target(conn, receive, send, normalizing_call_next)
 
     wrapper.__blackbull_middleware__ = True

--- a/blackbull/middleware/utils.py
+++ b/blackbull/middleware/utils.py
@@ -2,51 +2,40 @@
 
 Public API:
 - ``as_middleware``: decorator that normalises the ``send`` callable so inner
-  send wrappers defined by the middleware always receive plain ASGI event
-  dicts, never ``Response`` objects.  Works on both async middleware functions
-  and middleware classes (decorates ``__call__``).
+  send wrappers defined by the middleware always receive a single native
+  representation — ``NativeResponse`` on the H1 native path, plain ASGI event
+  dicts elsewhere — never raw ``Response`` objects.  Works on both async
+  middleware functions and middleware classes (decorates ``__call__``).
 """
 from functools import wraps
 
 from ..asgi import ASGISendCallable
-from ..response import Response
+from ..response import wrap_native_send
 
 
 def _normalize_send(inner_send: ASGISendCallable | None):
-    """Return a wrapper around *inner_send* that expands Response objects.
+    """Return a wrapper around *inner_send* that normalises to native.
 
-    Handlers that use the simplified return-value form call ``send`` with a
-    ``Response`` (or ``JSONResponse``) object.  Middleware that wraps ``send``
-    would otherwise need an ``isinstance`` guard for every response type.
-    This wrapper intercepts ``Response`` objects and emits the two ASGI events
-    (``http.response.start`` + ``http.response.body``) that ``inner_send``
-    expects, forwarding all other event dicts unchanged.
+    On the H1 native path the handler boundary already converts every shape
+    to :class:`~blackbull.native.NativeResponse`, so the middleware's inner
+    send wrapper observes native objects.  This wrapper guarantees the same
+    contract regardless of the seam: ``Response`` / ``StreamingResponse`` /
+    3-arg / ASGI dict shapes from the handler are all converted to
+    ``NativeResponse`` before reaching ``inner_send`` — the exact conversion
+    the app applies at its handler boundary (shared via
+    :func:`blackbull.response.wrap_native_send`), so global and per-route
+    middleware see one representation.
 
     ASGI ``send`` is always called with a single positional event — no
     ``*args/**kwargs`` form needs to be preserved here, and dropping it
     shaves a per-event call-frame setup that shows in py-spy profiles of
     the static path.
-
-    The Response→ASGI expansion is delegated to :meth:`Response.__call__` so
-    there is a single source of truth for the start/body event shape (shared
-    with ``app._wrap_send`` and the simplified-handler dispatch).
     """
     # ``inner_send`` is Optional because a middleware may be driven with no
     # send channel at all on pass-through paths (a websocket or lifespan
     # scope a middleware declines to touch).  The wrapper is built either
     # way; it is simply never invoked in that case.
-    # Unannotated on purpose: rebuilt per request (see _wrap_send in app.py).
-    # ``event`` is an ASGISendEvent or a Response.
-    async def normalized(event):
-        if isinstance(event, Response):
-            # Response is ASGI-callable and ignores conn/receive (it is a pure
-            # serialiser wearing the ASGI-app signature), so drive it with the
-            # inner send to reuse the one Response→ASGI path.
-            await event(None, None, inner_send)
-        else:
-            await inner_send(event)
-
-    return normalized
+    return wrap_native_send(inner_send)
 
 
 def as_middleware(target):

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -59,7 +59,15 @@ class _HeaderView:
 
     def append(self, name_or_pairs, value: bytes | None = None) -> None:
         if value is None:
-            self._items.extend(name_or_pairs)
+            # One-arg form: a *list* of pairs to extend with.  A bare
+            # (name, value) 2-tuple is a footgun — ``extend`` would walk its
+            # elements (two bytes) as separate entries and corrupt the list —
+            # so a 2-tuple of (bytes, bytes) is treated as one pair.
+            if (isinstance(name_or_pairs, tuple) and len(name_or_pairs) == 2
+                    and isinstance(name_or_pairs[0], (bytes, str))):
+                self._items.append(name_or_pairs)
+            else:
+                self._items.extend(name_or_pairs)
         else:
             self._items.append((name_or_pairs, value))
 

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -70,20 +70,33 @@ class NativeResponse:
     ``header`` is ``None`` when absent (never ``[]`` — presence is decided by
     ``is not None``).  ``body`` is ``None`` when absent; ``b''`` is a real
     empty body.  ``more_body`` marks a non-terminal body chunk (streaming).
+    ``expects_trailers`` preserves the ASGI ``http.response.start``
+    ``trailers: True`` flag so the sender withholds the terminal chunk until
+    the trailers event (lossless full-form compat — a terminal body before
+    trailers would otherwise corrupt chunked framing).
     """
 
-    __slots__ = ('status', '_header', '_body', 'more_body', 'trailers')
+    __slots__ = (
+        '_body',
+        '_header',
+        'expects_trailers',
+        'more_body',
+        'status',
+        'trailers',
+    )
 
     def __init__(self, *, status: int = 200,
                  header: list[tuple[bytes, bytes]] | None = None,
                  body: bytes | None = None,
                  more_body: bool = False,
-                 trailers: list[tuple[bytes, bytes]] | None = None) -> None:
+                 trailers: list[tuple[bytes, bytes]] | None = None,
+                 expects_trailers: bool = False) -> None:
         self.status = status
         self.header = header          # setter stores into _header
         self._body = body
         self.more_body = more_body
         self.trailers = trailers
+        self.expects_trailers = expects_trailers
 
     # --- header: DX view, or None when absent -----------------------------
     @property
@@ -133,9 +146,12 @@ class NativeResponse:
         """
         events: list[dict] = []
         if self._header is not None:
-            events.append({'type': 'http.response.start',
+            start: dict = {'type': 'http.response.start',
                            'status': self.status,
-                           'headers': self._header})
+                           'headers': self._header}
+            if self.expects_trailers:
+                start['trailers'] = True
+            events.append(start)
         if self._body is not None:
             events.append({'type': 'http.response.body',
                            'body': self._body,

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -20,7 +20,8 @@ Design invariants (validated in ``scratch/send-model-c.py``):
   the property+view overhead; the properties exist for middleware and
   handler-facing DX.
 - **``to_asgi()`` is the boundary conversion** — 1 object → ASGI event list,
-  used only on the ``asgi=True`` path (symmetric with
+  used only at conversion boundaries: the external ASGI edge (``asgi=True``
+  / external hosts) and the middleware native-read arms (symmetric with
   :meth:`Connection.as_scope`).
 """
 from __future__ import annotations
@@ -31,7 +32,8 @@ class _HeaderView:
 
     Mutations (``append``) are visible to anything reading the response
     afterwards (the sender, ``to_asgi``).  Models the DX of
-    :class:`blackbull.headers.Headers` without a copy.
+    :class:`blackbull.headers.Headers` without a copy — lookups are
+    case-insensitive (RFC 9110 §5.1), matching ``Headers``.
     """
 
     __slots__ = ('_items',)
@@ -46,16 +48,20 @@ class _HeaderView:
         return len(self._items)
 
     def __contains__(self, name: bytes) -> bool:
-        return any(k == name for k, _ in self._items)
+        lowered = name.lower()
+        return any(k == name or k.lower() == lowered for k, _ in self._items)
 
     def get(self, name: bytes, default: bytes = b'') -> bytes:
+        lowered = name.lower()
         for k, v in self._items:
-            if k == name:
+            if k == name or k.lower() == lowered:
                 return v
         return default
 
     def getlist(self, name: bytes) -> list[tuple[bytes, bytes]]:
-        return [(k, v) for k, v in self._items if k == name]
+        lowered = name.lower()
+        return [(k, v) for k, v in self._items
+                if k == name or k.lower() == lowered]
 
     def append(self, name_or_pairs, value: bytes | None = None) -> None:
         if value is None:
@@ -149,14 +155,20 @@ class NativeResponse:
         """Convert to the ASGI event list (``http.response.*`` dicts).
 
         One object → one or more ASGI events, in wire order.  Used only at
-        the ASGI boundary (external hosts / ``asgi=True``); the native path
-        never materialises these dicts.
+        conversion boundaries — the external ASGI edge (external hosts /
+        ``asgi=True``) and the middleware native-read arms (cache,
+        compression); the native H1 sender path never materialises these
+        dicts.
         """
         events: list[dict] = []
         if self._header is not None:
             start: dict = {'type': 'http.response.start',
                            'status': self.status,
-                           'headers': self._header}
+                           # Copy: the cache middleware stores these events,
+                           # and an in-place append on the live response
+                           # (CORS / header injection) must not leak into a
+                           # stored entry via list aliasing.
+                           'headers': list(self._header)}
             if self.expects_trailers:
                 start['trailers'] = True
             events.append(start)
@@ -166,5 +178,5 @@ class NativeResponse:
                            'more_body': self.more_body})
         if self.trailers is not None:
             events.append({'type': 'http.response.trailers',
-                           'headers': self.trailers})
+                           'headers': list(self.trailers)})
         return events

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -1,0 +1,146 @@
+"""Native response message for the H1 send path (native-ization, Sprint 92).
+
+The unified response message BlackBull's own server carries on the native
+path.  One class replaces the ASGI start/body/trailers dicts: a response
+object may carry any combination of ``header`` (status line + headers),
+``body`` (chunks), and ``trailers``, so a complete response is **one object
+and one ``send``**, while streaming is header-object then body-chunk objects.
+
+Design invariants (validated in ``scratch/send-model-c.py``):
+
+- **Presence is ``is not None``, never truthiness** — an empty body is a real
+  body (204-style).  Middleware must preserve ``None`` when transforming
+  (``header or []`` turns ``None`` into ``[]`` and the sender mis-detects a
+  header — a real bug caught in the scratch model).
+- **DX via properties, not the wire shape** — ``resp.header`` is a zero-copy
+  view with ``get``/``append``/``getlist``/``__contains__``/``__len__``/
+  ``__iter__`` (BlackBull ``Headers``-like); ``body`` is a plain ``bytes``
+  with ``content_length``/``is_empty``/``content_type`` helpers.
+- **Server hot path may read the raw slots** (``_header``/``_body``) to skip
+  the property+view overhead; the properties exist for middleware and
+  handler-facing DX.
+- **``to_asgi()`` is the boundary conversion** — 1 object → ASGI event list,
+  used only on the ``asgi=True`` path (symmetric with
+  :meth:`Connection.as_scope`).
+"""
+from __future__ import annotations
+
+
+class _HeaderView:
+    """Zero-copy view over a :class:`NativeResponse` header list.
+
+    Mutations (``append``) are visible to anything reading the response
+    afterwards (the sender, ``to_asgi``).  Models the DX of
+    :class:`blackbull.headers.Headers` without a copy.
+    """
+
+    __slots__ = ('_items',)
+
+    def __init__(self, items: list[tuple[bytes, bytes]]) -> None:
+        self._items = items
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __contains__(self, name: bytes) -> bool:
+        return any(k == name for k, _ in self._items)
+
+    def get(self, name: bytes, default: bytes = b'') -> bytes:
+        for k, v in self._items:
+            if k == name:
+                return v
+        return default
+
+    def getlist(self, name: bytes) -> list[tuple[bytes, bytes]]:
+        return [(k, v) for k, v in self._items if k == name]
+
+    def append(self, name_or_pairs, value: bytes | None = None) -> None:
+        if value is None:
+            self._items.extend(name_or_pairs)
+        else:
+            self._items.append((name_or_pairs, value))
+
+
+class NativeResponse:
+    """A response on the native send path: header and/or body and/or trailers.
+
+    ``header`` is ``None`` when absent (never ``[]`` — presence is decided by
+    ``is not None``).  ``body`` is ``None`` when absent; ``b''`` is a real
+    empty body.  ``more_body`` marks a non-terminal body chunk (streaming).
+    """
+
+    __slots__ = ('status', '_header', '_body', 'more_body', 'trailers')
+
+    def __init__(self, *, status: int = 200,
+                 header: list[tuple[bytes, bytes]] | None = None,
+                 body: bytes | None = None,
+                 more_body: bool = False,
+                 trailers: list[tuple[bytes, bytes]] | None = None) -> None:
+        self.status = status
+        self.header = header          # setter stores into _header
+        self._body = body
+        self.more_body = more_body
+        self.trailers = trailers
+
+    # --- header: DX view, or None when absent -----------------------------
+    @property
+    def header(self) -> _HeaderView | None:
+        if self._header is None:
+            return None
+        return _HeaderView(self._header)
+
+    @header.setter
+    def header(self, value) -> None:
+        if value is None:
+            self._header = None
+        elif isinstance(value, _HeaderView):
+            self._header = value._items
+        else:
+            self._header = value
+
+    # --- body: plain bytes; DX via helper properties -----------------------
+    @property
+    def body(self) -> bytes | None:
+        return self._body
+
+    @body.setter
+    def body(self, value: bytes | None) -> None:
+        self._body = value
+
+    @property
+    def content_length(self) -> int:
+        return len(self._body) if self._body is not None else 0
+
+    @property
+    def is_empty(self) -> bool:
+        return self._body is None or self._body == b''
+
+    @property
+    def content_type(self) -> bytes:
+        hv = self.header
+        return hv.get(b'content-type') if hv is not None else b''
+
+    # --- boundary conversion (asgi=True path only) -------------------------
+    def to_asgi(self) -> list[dict]:
+        """Convert to the ASGI event list (``http.response.*`` dicts).
+
+        One object → one or more ASGI events, in wire order.  Used only at
+        the ASGI boundary (external hosts / ``asgi=True``); the native path
+        never materialises these dicts.
+        """
+        events: list[dict] = []
+        if self._header is not None:
+            events.append({'type': 'http.response.start',
+                           'status': self.status,
+                           'headers': self._header})
+        if self._body is not None:
+            events.append({'type': 'http.response.body',
+                           'body': self._body,
+                           'more_body': self.more_body})
+        if self.trailers is not None:
+            events.append({'type': 'http.response.trailers',
+                           'headers': self.trailers})
+        return events

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -394,8 +394,12 @@ def wrap_native_send(raw_send):
                     header=list(event.get('headers') or []),
                     expects_trailers=bool(event.get('trailers', False))))
             elif ev_type == 'http.response.body':
+                # ``body=None`` (spec violation) falls back to an empty body:
+                # the native sender skips a ``None`` body and a buffered
+                # header would never flush → silent hang.  Empty body keeps
+                # the response completing.
                 await raw_send(NativeResponse(
-                    body=event.get('body', b''),
+                    body=event.get('body') or b'',
                     more_body=event.get('more_body', False)))
             elif ev_type == 'http.response.trailers':
                 await raw_send(NativeResponse(
@@ -422,12 +426,18 @@ async def _stream_and_convert(stream, raw_send) -> None:
         if isinstance(event, dict):
             ev_type = event.get('type')
             if ev_type == 'http.response.start':
+                # Preserve the ASGI `trailers: True` flag losslessly (same
+                # as wrap_native_send — a custom StreamingResponse subclass
+                # may set it).
                 await raw_send(NativeResponse(
                     status=int(event.get('status', HTTPStatus.OK)),
-                    header=list(event.get('headers') or [])))
+                    header=list(event.get('headers') or []),
+                    expects_trailers=bool(event.get('trailers', False))))
             elif ev_type == 'http.response.body':
+                # ``body=None`` (spec violation) falls back to empty — avoids
+                # the native sender skipping a None body (silent hang).
                 await raw_send(NativeResponse(
-                    body=event.get('body', b''),
+                    body=event.get('body') or b'',
                     more_body=event.get('more_body', False)))
             else:
                 await raw_send(event)

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -11,11 +11,12 @@ Provides:
 - `cookie_header`: builds a ``(b'set-cookie', ...)`` header tuple with secure defaults.
 """
 import json
+import logging
 from collections.abc import AsyncIterator, Mapping
 from http import HTTPStatus
-from typing import Union
 
-import logging
+from .native import NativeResponse
+
 logger = logging.getLogger(__name__)
 
 
@@ -91,7 +92,7 @@ class Response:
         await send(Response(b'data', status=HTTPStatus.NOT_FOUND))
     """
 
-    def __init__(self, content: Union[str, bytes],
+    def __init__(self, content: str | bytes,
                  status: HTTPStatus = HTTPStatus.OK,
                  content_type: str = 'text/html; charset=utf-8',
                  headers: Mapping | list | None = None):
@@ -119,6 +120,19 @@ class Response:
         for turning a Response into ASGI events.
         """
         await _emit_response(send, self.body, self.status, self.headers)
+
+    def to_native(self) -> NativeResponse:
+        """Convert this response to the unified native message (one send).
+
+        The native-path serialiser: a complete ``Response`` becomes a single
+        :class:`~blackbull.native.NativeResponse` carrying status, headers,
+        and body — one object, one ``send``.  Symmetric with
+        :meth:`NativeResponse.to_asgi` (the boundary conversion); streaming
+        response types drive themselves and are not converted here.
+        """
+        return NativeResponse(status=int(self.status),
+                              header=list(self.headers),
+                              body=self.body)
 
 
 class JSONResponse(Response):
@@ -324,3 +338,100 @@ def WebSocketResponse(content) -> dict:
     if isinstance(content, bytes):
         return {'type': 'websocket.send', 'bytes': content}
     return {'type': 'websocket.send', 'text': json.dumps(content)}
+
+
+def wrap_native_send(raw_send):
+    """Handler-facing send adapter: every accepted shape → NativeResponse.
+
+    The native-ization flip of ``app._wrap_send``: instead of normalising
+    convenience shapes (``Response``, 3-arg) into ASGI dicts so downstream
+    sees plain dicts, **every** accepted shape becomes a
+    :class:`~blackbull.native.NativeResponse` here, so everything above the
+    route handler (route-header injection, middleware, access log, sender)
+    observes a single native representation on the H1 path.
+
+    Shared by ``app._wrap_send_native`` (the handler boundary) and
+    ``middleware.utils._normalize_send`` (``as_middleware``'s ``call_next``),
+    so global and per-route middleware see the same native contract.
+
+    Accepted shapes (full-form ``send`` — the compat contract, held until
+    2027-07-29):
+
+    * ``Response`` (incl. subclasses) — one NativeResponse (``to_native()``);
+    * ``StreamingResponse`` / ``EventSourceResponse`` — driven; their own
+      start/body dict sequence converts per-event below;
+    * ``(bytes, status, headers)`` 3-arg form — one NativeResponse;
+    * ASGI dicts — per-event: ``http.response.start`` → header arm (the
+      ``trailers`` flag → ``expects_trailers``), ``http.response.body`` →
+      body chunk, ``http.response.trailers`` → trailers arm; push / pathsend /
+      disconnect / unknown pass through (the bilingual sender decides — push
+      is H2-only, pathsend is the static middleware's deferred form);
+    * ``NativeResponse`` — pass through;
+    * anything else — pass through so the sender's type check decides.
+    """
+    # Deliberately unannotated: rebuilt per request (see _wrap_send in app.py).
+    async def _send(event, status=HTTPStatus.OK, headers=()):
+        if isinstance(event, StreamingResponse):
+            # Streaming owns its start/body sequence; drive it through a
+            # cycle-free converter (no self-referential closure — the v0.60.0
+            # per-request cycle guard must keep reclaiming these adapters by
+            # refcounting alone).
+            await _stream_and_convert(event, raw_send)
+        elif isinstance(event, Response):
+            await raw_send(event.to_native())
+        elif isinstance(event, (bytes, bytearray, memoryview)):
+            body = bytes(event) if not isinstance(event, bytes) else event
+            await raw_send(NativeResponse(status=int(status),
+                                          header=list(headers),
+                                          body=body))
+        elif isinstance(event, NativeResponse):
+            await raw_send(event)
+        elif isinstance(event, dict):
+            ev_type = event.get('type')
+            if ev_type == 'http.response.start':
+                await raw_send(NativeResponse(
+                    status=int(event.get('status', HTTPStatus.OK)),
+                    header=list(event.get('headers') or []),
+                    expects_trailers=bool(event.get('trailers', False))))
+            elif ev_type == 'http.response.body':
+                await raw_send(NativeResponse(
+                    body=event.get('body', b''),
+                    more_body=event.get('more_body', False)))
+            elif ev_type == 'http.response.trailers':
+                await raw_send(NativeResponse(
+                    trailers=list(event.get('headers') or [])))
+            else:
+                # push / pathsend / disconnect / unknown — pass through.
+                await raw_send(event)
+        else:
+            await raw_send(event)
+
+    return _send
+
+
+async def _stream_and_convert(stream, raw_send) -> None:
+    """Drive a :class:`StreamingResponse` through the native conversion.
+
+    Streaming emits only ``http.response.start`` / ``http.response.body``
+    dicts; each is converted to a ``NativeResponse`` before reaching
+    *raw_send*.  Kept as a module function so the per-request send adapter
+    holds no self-referential closure (the v0.60.0 per-request cycle guard).
+    """
+    # Deliberately unannotated: rebuilt per request (see _wrap_send in app.py).
+    async def convert(event, status=HTTPStatus.OK, headers=()):
+        if isinstance(event, dict):
+            ev_type = event.get('type')
+            if ev_type == 'http.response.start':
+                await raw_send(NativeResponse(
+                    status=int(event.get('status', HTTPStatus.OK)),
+                    header=list(event.get('headers') or [])))
+            elif ev_type == 'http.response.body':
+                await raw_send(NativeResponse(
+                    body=event.get('body', b''),
+                    more_body=event.get('more_body', False)))
+            else:
+                await raw_send(event)
+        else:
+            await raw_send(event)
+
+    await stream(None, None, convert)

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -559,7 +559,10 @@ class HTTP1Sender(BaseSender):
                 if body.header is not None:
                     self._buffered_status = HTTPStatus(body.status)
                     self._buffered_headers = Headers(list(body._header))
-                    self._expect_trailers = False
+                    # Preserve the ASGI start `trailers: True` flag so a
+                    # terminal body before the trailers event withholds the
+                    # terminal chunk (lossless full-form compat).
+                    self._expect_trailers = body.expects_trailers
                     if self._log_record is not None:
                         self._log_record.status = body.status
                         self._log_record.mark('start_arm_in')

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -18,6 +18,7 @@ import logging
 from ..asgi import (ASGIEvent, ASGISendEvent, HTTPDisconnectEvent,
                     WebSocketAcceptEvent, WebSocketCloseEvent, WebSocketSendEvent)
 from ..headers import Headers, HeaderList
+from ..native import NativeResponse
 
 logger = logging.getLogger(__name__)
 
@@ -365,7 +366,7 @@ class AsyncioWriter(AbstractWriter):
 # sending a disconnect or a bare byte string is legal, because through the
 # app-facing channel it is not.
 _SenderEvent = ASGISendEvent | HTTPDisconnectEvent
-_SenderBody = _SenderEvent | bytes
+_SenderBody = _SenderEvent | bytes | NativeResponse
 _WSSenderEvent = WebSocketSendEvent | WebSocketCloseEvent | WebSocketAcceptEvent
 
 
@@ -547,6 +548,34 @@ class HTTP1Sender(BaseSender):
                 await self._flush(status, h, body)
                 self._completed = True
 
+            case NativeResponse():
+                # Unified native response (native-ization, Sprint 92): one
+                # object may carry header, body, and/or trailers; presence is
+                # `is not None`.  A complete response is one object, one
+                # dispatch; streaming is header-object then body-chunk
+                # objects.  Header is buffered exactly like the dict start
+                # arm (body completes the flush); body/trailers delegate to
+                # the shared helpers the dict arms use.
+                if body.header is not None:
+                    self._buffered_status = HTTPStatus(body.status)
+                    self._buffered_headers = Headers(list(body._header))
+                    self._expect_trailers = False
+                    if self._log_record is not None:
+                        self._log_record.status = body.status
+                        self._log_record.mark('start_arm_in')
+                        for hk, hv in body._header:
+                            if isinstance(hk, bytes):
+                                hkl = hk.lower()
+                                if hkl == b'content-type':
+                                    self._log_record.resp_content_type = hv
+                                elif hkl == b'content-encoding':
+                                    self._log_record.resp_content_encoding = hv
+                        self._log_record.mark('start_arm_out')
+                if body.body is not None:
+                    await self._handle_body_content(body._body, body.more_body)
+                if body.trailers is not None:
+                    await self._handle_trailers(body.trailers)
+
             case {'type': ASGIEvent.HTTP_RESPONSE_START}:
                 self._buffered_status = HTTPStatus(body.get('status', HTTPStatus.OK))
                 self._buffered_headers = Headers(list(body.get('headers', [])))
@@ -571,51 +600,11 @@ class HTTP1Sender(BaseSender):
                     self._log_record.mark('start_arm_out')
 
             case {'type': ASGIEvent.HTTP_RESPONSE_BODY}:
-                content = body.get('body', b'')
-                more_body = body.get('more_body', False)
-                if self._log_record is not None and content:
-                    self._log_record.response_bytes += len(content)
-                # Bracket the actual transport
-                # write for the last body event so we can see whether the
-                # 30-60 ms woff2 tail lives in middleware/handler work
-                # before the write (``start_arm_out → body_arm_in``) or
-                # inside the write + drain (``body_arm_in → body_arm_out``).
-                if self._log_record is not None and not more_body:
-                    self._log_record.mark('body_arm_in')
-                if self._buffered_status is not None:
-                    assert self._buffered_headers is not None
-                    await self._flush(self._buffered_status, self._buffered_headers, content, more_body)
-                    self._buffered_status = None
-                    self._buffered_headers = None
-                else:
-                    if self._head_mode:
-                        # already wrote headers; HEAD response carries no body
-                        if self._log_record is not None and not more_body:
-                            self._log_record.mark('body_arm_out')
-                        if not more_body:
-                            self._completed = True
-                        return
-                    if self._chunked:
-                        if content:
-                            chunk = f'{len(content):x}\r\n'.encode() + content + b'\r\n'
-                            if not more_body and not self._expect_trailers:
-                                chunk += b'0\r\n\r\n'
-                            await self._write(chunk)
-                        elif not more_body and not self._expect_trailers:
-                            await self._write(b'0\r\n\r\n')
-                    elif content:
-                        await self._write(content)
-                if self._log_record is not None and not more_body:
-                    self._log_record.mark('body_arm_out')
-                if not more_body:
-                    self._completed = True
+                await self._handle_body_content(body.get('body', b''),
+                                                body.get('more_body', False))
 
             case {'type': ASGIEvent.HTTP_RESPONSE_TRAILERS}:
-                await self._write(b'0\r\n')
-                for name, value in body.get('headers', []):
-                    await self._write(name + b': ' + value + b'\r\n')
-                await self._write(b'\r\n')
-                self._completed = True
+                await self._handle_trailers(body.get('headers', []))
 
             case {'type': ASGIEvent.HTTP_RESPONSE_PATHSEND}:
                 await self._pathsend(body['path'])
@@ -634,6 +623,53 @@ class HTTP1Sender(BaseSender):
 
             case _:
                 raise TypeError(f'HTTP1Sender expected bytes or dict, got {type(body)!r}')
+
+    async def _handle_body_content(self, content: bytes, more_body: bool) -> None:
+        """Write one body chunk — shared by the dict and native paths."""
+        if self._log_record is not None and content:
+            self._log_record.response_bytes += len(content)
+        # Bracket the actual transport
+        # write for the last body event so we can see whether the
+        # 30-60 ms woff2 tail lives in middleware/handler work
+        # before the write (``start_arm_out → body_arm_in``) or
+        # inside the write + drain (``body_arm_in → body_arm_out``).
+        if self._log_record is not None and not more_body:
+            self._log_record.mark('body_arm_in')
+        if self._buffered_status is not None:
+            assert self._buffered_headers is not None
+            await self._flush(self._buffered_status, self._buffered_headers, content, more_body)
+            self._buffered_status = None
+            self._buffered_headers = None
+        else:
+            if self._head_mode:
+                # already wrote headers; HEAD response carries no body
+                if self._log_record is not None and not more_body:
+                    self._log_record.mark('body_arm_out')
+                if not more_body:
+                    self._completed = True
+                return
+            if self._chunked:
+                if content:
+                    chunk = f'{len(content):x}\r\n'.encode() + content + b'\r\n'
+                    if not more_body and not self._expect_trailers:
+                        chunk += b'0\r\n\r\n'
+                    await self._write(chunk)
+                elif not more_body and not self._expect_trailers:
+                    await self._write(b'0\r\n\r\n')
+            elif content:
+                await self._write(content)
+        if self._log_record is not None and not more_body:
+            self._log_record.mark('body_arm_out')
+        if not more_body:
+            self._completed = True
+
+    async def _handle_trailers(self, headers: HeaderList) -> None:
+        """Write trailing headers — shared by the dict and native paths."""
+        await self._write(b'0\r\n')
+        for name, value in headers:
+            await self._write(name + b': ' + value + b'\r\n')
+        await self._write(b'\r\n')
+        self._completed = True
 
     def reset_per_request_state(self) -> None:
         # HTTP1Sender is shared across keep-alive requests;

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -556,7 +556,7 @@ class HTTP1Sender(BaseSender):
                 # objects.  Header is buffered exactly like the dict start
                 # arm (body completes the flush); body/trailers delegate to
                 # the shared helpers the dict arms use.
-                if body.header is not None:
+                if body._header is not None:
                     self._buffered_status = HTTPStatus(body.status)
                     self._buffered_headers = Headers(list(body._header))
                     # Preserve the ASGI start `trailers: True` flag so a
@@ -576,7 +576,16 @@ class HTTP1Sender(BaseSender):
                         self._log_record.mark('start_arm_out')
                 if body.body is not None:
                     await self._handle_body_content(body._body, body.more_body)
-                if body.trailers is not None:
+                if body.trailers is not None and not self._completed:
+                    # Single-object header + terminal body + trailers: the
+                    # terminal body already completed the response on the
+                    # wire (content-length framing); writing the trailers
+                    # block now would splice chunked framing after it.  Drop
+                    # them — the dict lane's entry guard already drops
+                    # post-terminal trailers.  A non-terminal body
+                    # (``more_body=True``) keeps ``_completed`` False, so the
+                    # trailers block legitimately terminates the chunked
+                    # framing.
                     await self._handle_trailers(body.trailers)
 
             case {'type': ASGIEvent.HTTP_RESPONSE_START}:

--- a/blackbull/testing/native.py
+++ b/blackbull/testing/native.py
@@ -208,11 +208,13 @@ async def request(
     response_headers: list = []
 
     # Same dual-form signature as the protocol senders: a handler may emit ASGI
-    # dicts, or the ``send(body, status, headers)`` convenience form that the
-    # actor's sender also accepts.  Tier 1 has to accept both or it would
-    # reject code the real server runs.
-    async def send(event: Any, status_arg: HTTPStatus = HTTPStatus.OK,
-                   headers_arg: Any = ()) -> None:
+    # dicts, the ``send(body, status, headers)`` convenience form that the
+    # actor's sender also accepts, or — on the H1 native seam (Sprint 92) — a
+    # NativeResponse.  Tier 1 has to accept all of them or it would reject code
+    # the real server runs.  The NativeResponse expansion iterates through the
+    # sibling ``_record`` — never a self-referential closure.
+    def _record(event: Any, status_arg: HTTPStatus = HTTPStatus.OK,
+                headers_arg: Any = ()) -> None:
         nonlocal status, response_headers
         if not isinstance(event, dict):
             body_bytes = bytes(event) if not isinstance(event, bytes) else event
@@ -238,6 +240,17 @@ async def request(
             # the file.  The observable response is then the same either way.
             with open(event['path'], 'rb') as fp:
                 chunks.append(fp.read())
+
+    async def send(event: Any, status_arg: HTTPStatus = HTTPStatus.OK,
+                   headers_arg: Any = ()) -> None:
+        from ..native import NativeResponse  # noqa: PLC0415
+        if isinstance(event, NativeResponse):
+            # one native object may carry header + body + trailers — expand to
+            # its ASGI event list and fold each event into the same capture.
+            for ev in event.to_asgi():
+                _record(ev)
+            return
+        _record(event, status_arg, headers_arg)
 
     # Bind the body channel the way the protocol actor does, so ``conn.body()``
     # / ``conn.stream()`` drain this request's payload rather than nothing.

--- a/docs/guide/middleware.md
+++ b/docs/guide/middleware.md
@@ -32,10 +32,16 @@ shape; the simplified handler form does **not** apply to them.
 
 ## Typing the message channel
 
-The events crossing `receive` and `send` are ASGI 3.0 dicts — that wire
-contract is unchanged and always will be.  What BlackBull adds is a set of
-`TypedDict` *declarations* for them, so a type checker can tell which keys
-are legal on which event:
+The events crossing `receive` and `send` follow the ASGI 3.0 wire contract
+on the **ASGI lanes** — HTTP/2, WebSocket, and the external-host edge
+(`BlackBull(asgi=True)` under uvicorn) — as plain ASGI dicts.  On
+BlackBull's own **HTTP/1.1 native path** the response side carries
+`NativeResponse` objects instead: one message may hold any combination of a
+header arm, body chunks, and trailers, and its *presence* semantics are
+`is not None` (never truthiness — an empty body is a real body).
+
+BlackBull also ships a set of `TypedDict` *declarations* for the ASGI event
+shapes, so a type checker can tell which keys are legal on which event:
 
 ```python
 from blackbull import ASGIReceiveCallable, ASGISendCallable, ASGISendEvent
@@ -63,27 +69,50 @@ are importable from `blackbull.asgi` if you want to name one directly.
 Everything here is annotation-only: nothing is validated or converted at
 runtime, and unannotated middleware keeps working exactly as before.
 
+!!! note "Native path: the send channel carries `NativeResponse`"
+    On BlackBull's own HTTP/1.1 path, the response events a middleware's
+    inner `send` wrapper observes are `NativeResponse` objects — not dicts.
+    A middleware that subscripts `event['type']` must instead branch on the
+    object's arms: `event.header is not None` (header arm, with
+    `event.status` / `event.header.get(b'name')`), `event.body is not None`
+    (body chunk, with `event.more_body`), and `event.trailers is not None`.
+    The `@as_middleware` decorator guarantees this single native
+    representation for the wrappers it normalises; on the ASGI lanes the
+    same wrappers see plain dicts.  Use
+    [`blackbull.testing.native`](testing.md) to exercise the native path.
+
 ## The `@as_middleware` decorator
 
 Route handlers can return `Response` / `JSONResponse` objects
 instead of calling `send(...)` with raw ASGI events.  A middleware
 that wraps `send` would otherwise have to handle both forms.
 Decorate the middleware with `@as_middleware` and the inner
-wrapper sees only plain dict events — `Response` objects are
-expanded into `http.response.start` + `http.response.body` for you:
+wrapper sees a single native representation: `NativeResponse` on
+the HTTP/1.1 native path, plain ASGI dicts on the ASGI lanes —
+`Response` objects are converted for you, never leaking through:
 
 ```python
 from blackbull import as_middleware
+from blackbull.native import NativeResponse
 
 @as_middleware
 async def add_header_mw(scope, receive, send, call_next):
     async def wrapped(event):
-        if event['type'] == 'http.response.start':
+        if isinstance(event, NativeResponse):
+            if event.header is not None:
+                # header arm — append zero-copy; visible to the sender
+                event.header.append(b'x-custom', b'1')
+        elif event['type'] == 'http.response.start':
             event = {**event,
                      'headers': list(event.get('headers', [])) + [(b'x-custom', b'1')]}
         await send(event)
     await call_next(scope, receive, wrapped)
 ```
+
+On the native path a complete response is **one object, one `send`**
+(header + body together), while a streamed response is a header object
+followed by body-chunk objects.  Remember the presence contract: test
+`event.header is not None` / `event.body is not None`, never truthiness.
 
 `@as_middleware` also works on classes (it wraps `__call__`).  All
 of BlackBull's built-in middleware uses the class form:

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -327,6 +327,13 @@ package to parse the body manually.
     plain ASGI dicts on the wire.  The `http.response.start` `trailers`
     flag is preserved losslessly via `NativeResponse.expects_trailers`.
 
+    On the native path a `Response` (or subclass) is serialised via
+    `Response.to_native()`.  A subclass that overrides `__call__` to emit a
+    custom event sequence is honoured on the ASGI lanes (H2 / external
+    host) but not on the native H1 path — keep the wire behaviour in
+    `__call__` (shared by both lanes via the normalisers) or override
+    `to_native()` to control the native serialisation.
+
 ### `Response`
 
 ```python
@@ -519,12 +526,28 @@ For function-based middleware, the safest approach is to pass
 body events through immediately rather than accumulating them:
 
 ```python
+from blackbull.native import NativeResponse
+
 async def prefix_mw(scope, receive, send, call_next):
     captured_start = None
 
     async def capturing_send(event):
         nonlocal captured_start
-        if event.get('type') == 'http.response.start':
+        if isinstance(event, NativeResponse):
+            # BlackBull's own HTTP/1.1 server threads native response
+            # objects — see the middleware guide for the contract.  A single
+            # object may carry header + body together.
+            if event.body is not None and not event.more_body:
+                # Non-streaming — transform the terminal body
+                await send(NativeResponse(status=event.status,
+                                          header=(list(event.header)
+                                                  if event.header is not None
+                                                  else None),
+                                          body=b'[prefix] ' + event.body))
+            else:
+                # Streaming (or header-only) — pass through without buffering
+                await send(event)
+        elif event.get('type') == 'http.response.start':
             captured_start = event
         elif event.get('type') == 'http.response.body':
             if event.get('more_body'):
@@ -542,6 +565,11 @@ async def prefix_mw(scope, receive, send, call_next):
 
     await call_next(scope, receive, capturing_send)
 ```
+
+The two branches are the same policy on two wire shapes: the native object
+arm transforms only terminal bodies (so `more_body=True` chunks stream
+through untouched), and the dict arm keeps the original start/body
+sequencing for the ASGI lanes.
 
 For most use cases (header injection, logging) the middleware
 does not touch the body at all and streaming safety is not a

--- a/docs/guide/requests-and-responses.md
+++ b/docs/guide/requests-and-responses.md
@@ -315,6 +315,18 @@ package to parse the body manually.
 
 ## Responses
 
+!!! note "Native send path"
+    On BlackBull's own HTTP/1.1 server, `send` accepts **`Response` /
+    `JSONResponse` objects, `(bytes, status, headers)`, `NativeResponse`,
+    and ASGI `http.response.*` dicts** — the full-form ASGI dict forms are
+    a compatibility contract held until **2027-07-29**, converted to the
+    native message at the handler boundary.  A complete `Response` becomes
+    one `NativeResponse` object (one `send`); streaming is a header object
+    then body-chunk objects.  Under an external ASGI host
+    (`BlackBull(asgi=True)` + `to_asgi()`) the same handler code runs with
+    plain ASGI dicts on the wire.  The `http.response.start` `trailers`
+    flag is preserved losslessly via `NativeResponse.expects_trailers`.
+
 ### `Response`
 
 ```python

--- a/tests/architecture/test_connection_scope_consistency.py
+++ b/tests/architecture/test_connection_scope_consistency.py
@@ -17,7 +17,6 @@ import pathlib
 
 import blackbull
 
-
 _PKG_ROOT = pathlib.Path(blackbull.__file__).parent
 
 # Files still allowed to construct a raw ``{'type': 'http'|'websocket', ...}``
@@ -88,9 +87,11 @@ def test_native_baseline_request_never_materializes_scope_dict():
     framework-internal hot-path code starts deriving a scope from the
     Connection, one of those methods fires and this fails."""
     import asyncio
+
     from blackbull import BlackBull
-    from blackbull.headers import Headers
     from blackbull.connection import Connection
+    from blackbull.headers import Headers
+    from blackbull.native import NativeResponse
 
     app = BlackBull()
 
@@ -123,7 +124,12 @@ def test_native_baseline_request_never_materializes_scope_dict():
             return {'type': 'http.request', 'body': b'', 'more_body': False}
 
         async def send(ev):
-            sent.append(ev)
+            # H1 native seam (Sprint 92): the app emits NativeResponse on the
+            # native path — expand to its ASGI events for the assertions.
+            if isinstance(ev, NativeResponse):
+                sent.extend(ev.to_asgi())
+            else:
+                sent.append(ev)
 
         # Native entry: hand the Connection straight to the app (as the actor does).
         asyncio.run(app(conn, receive, send))

--- a/tests/unit/test_compression_vary.py
+++ b/tests/unit/test_compression_vary.py
@@ -27,11 +27,26 @@ def _scope(accept: bytes = b'gzip'):
     })
 
 
+def _collecting_send(events):
+    """Send wrapper that expands NativeResponse to its ASGI event list.
+
+    The middleware under test is ``@as_middleware``-decorated, so its sends
+    are normalised to the H1 native contract (NativeResponse); the tests
+    inspect the ASGI event shape, so the seam is normalised away here.
+    """
+    from blackbull.native import NativeResponse
+
+    async def send(event):
+        if isinstance(event, NativeResponse):
+            events.extend(event.to_asgi())
+        else:
+            events.append(event)
+    return send
+
+
 async def _run(mw, body: bytes, resp_headers, accept: bytes = b'gzip') -> dict:
     events: list[dict] = []
-
-    async def send(event: dict) -> None:
-        events.append(event)
+    send = _collecting_send(events)
 
     async def call_next(scope, receive, send):
         await send({'type': 'http.response.start', 'status': 200,
@@ -181,9 +196,7 @@ class TestNoCodecPathForwardsBodiesUntouched:
     @pytest.mark.asyncio
     async def test_streamed_body_chunks_are_forwarded_verbatim(self):
         events: list[dict] = []
-
-        async def send(event):
-            events.append(event)
+        send = _collecting_send(events)
 
         chunks = [b'alpha', b'beta', b'gamma']
 
@@ -207,9 +220,7 @@ class TestNoCodecPathForwardsBodiesUntouched:
     @pytest.mark.asyncio
     async def test_unknown_event_types_pass_through(self):
         events: list[dict] = []
-
-        async def send(event):
-            events.append(event)
+        send = _collecting_send(events)
 
         async def call_next(scope, receive, send):
             await send({'type': 'http.response.start', 'status': 200,

--- a/tests/unit/test_cors.py
+++ b/tests/unit/test_cors.py
@@ -41,11 +41,19 @@ async def _call(mw, scope):
 
 
 def _header(events, name: bytes) -> bytes | None:
+    # The middleware is @as_middleware-decorated → its sends are normalised
+    # to the H1 native contract; expand NativeResponse to its ASGI events.
+    from blackbull.native import NativeResponse
     for event in events:
-        if event.get('type') == 'http.response.start':
-            for k, v in event.get('headers', []):
-                if k.lower() == name:
-                    return v
+        if isinstance(event, NativeResponse):
+            evs = event.to_asgi()
+        else:
+            evs = [event]
+        for ev in evs:
+            if ev.get('type') == 'http.response.start':
+                for k, v in ev.get('headers', []):
+                    if k.lower() == name:
+                        return v
     return None
 
 

--- a/tests/unit/test_error_routing.py
+++ b/tests/unit/test_error_routing.py
@@ -134,17 +134,22 @@ def _make_scope(path='/', method='GET', type_='http'):
 
 
 class _CaptureSend:
-    """Collects all ASGI send() calls.
+    """Collects all send() calls.
 
-    Accepts both forms:
-    - ASGI event dict: ``await send({'type': 'http.response.start', ...})``
-    - High-level bytes: ``await send(body_bytes, status, headers)``
+    Accepts the shapes the app emits on the H1 native path (Sprint 92):
+    - native response message: ``await send(NativeResponse(...))`` — expanded
+      to its ASGI event list via ``to_asgi()``;
+    - ASGI event dict: ``await send({'type': 'http.response.start', ...})``;
+    - high-level bytes: ``await send(body_bytes, status, headers)``.
     """
     def __init__(self):
         self.events = []
 
     async def __call__(self, body_or_event, status: HTTPStatus=None, headers=None):
-        if isinstance(body_or_event, dict):
+        from blackbull.native import NativeResponse
+        if isinstance(body_or_event, NativeResponse):
+            self.events.extend(body_or_event.to_asgi())
+        elif isinstance(body_or_event, dict):
             self.events.append(body_or_event)
         elif isinstance(body_or_event, bytes):
             if status is not None:

--- a/tests/unit/test_middleware_decorator.py
+++ b/tests/unit/test_middleware_decorator.py
@@ -221,6 +221,88 @@ async def test_startup_accepts_undecorated_valid_middleware():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
+async def test_h2_lane_normalization_stays_dict_with_as_middleware():
+    """Clean-subagent BLOCKER guard: on an http_version='2' request,
+    @as_middleware's normalisation must keep the ASGI-dict contract.  A
+    leaked NativeResponse would TypeError the H2 sender (no native arm yet —
+    the H2 gate)."""
+    from blackbull import BlackBull
+    from blackbull.headers import Headers
+    from blackbull.connection import Connection
+
+    app = BlackBull()
+
+    @as_middleware
+    async def forward_mw(scope, receive, send, call_next):
+        async def inner_send(event):
+            await send(event)
+        await call_next(scope, receive, inner_send)
+
+    app.use(forward_mw)
+
+    @app.route(path='/h2')
+    async def h2():
+        return b'ok'
+
+    conn = Connection(type='http', http_version='2', method='GET', scheme='http',
+                      path='/h2', raw_path=b'/h2', query_string=b'', root_path='',
+                      headers=Headers([(b'host', b'localhost')]),
+                      client=('127.0.0.1', 5), server=('localhost', 80), extensions={})
+    sent = []
+
+    async def receive():
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    async def send(ev):
+        sent.append(ev)
+
+    await app(conn, receive, send)
+
+    assert sent, 'no response emitted'
+    assert all(isinstance(e, dict) for e in sent), (
+        f'NativeResponse leaked onto the H2 lane: {sent!r}')
+    assert any(e.get('type') == 'http.response.start' for e in sent)
+
+
+@pytest.mark.asyncio
+async def test_h2_with_cors_global_middleware_stays_dict():
+    """Clean-subagent BLOCKER: H2 + global CORS must not leak NativeResponse
+    to the H2 sender (would TypeError — HTTP2Sender has no native arm)."""
+    from blackbull import BlackBull
+    from blackbull.headers import Headers
+    from blackbull.connection import Connection
+    from blackbull.middleware.cors import CORS
+
+    app = BlackBull()
+    app.use(CORS(allow_origins=['https://example.com']))
+
+    @app.route(path='/h2c')
+    async def h2c():
+        return {'ok': True}
+
+    conn = Connection(type='http', http_version='2', method='GET', scheme='http',
+                      path='/h2c', raw_path=b'/h2c', query_string=b'', root_path='',
+                      headers=Headers([(b'host', b'localhost'),
+                                       (b'origin', b'https://example.com')]),
+                      client=('127.0.0.1', 5), server=('localhost', 80), extensions={})
+    sent = []
+
+    async def receive():
+        return {'type': 'http.request', 'body': b'', 'more_body': False}
+
+    async def send(ev):
+        sent.append(ev)
+
+    await app(conn, receive, send)
+
+    assert all(isinstance(e, dict) for e in sent), (
+        f'NativeResponse leaked to the H2 lane via CORS: {sent!r}')
+    start = next(e for e in sent if e.get('type') == 'http.response.start')
+    hdrs = dict(start.get('headers', []))
+    assert hdrs.get(b'access-control-allow-origin') == b'https://example.com'
+
+
+@pytest.mark.asyncio
 async def test_plain_middleware_send_wrapper_sees_native():
     """An undecorated middleware that wraps ``send`` must receive
     NativeResponse on the H1 native path — never raw ``Response`` objects.

--- a/tests/unit/test_middleware_decorator.py
+++ b/tests/unit/test_middleware_decorator.py
@@ -1,16 +1,19 @@
 """Tests for the @as_middleware decorator and _normalize_send utility."""
+import json
+
 import pytest
 
 from blackbull.middleware.utils import _normalize_send, as_middleware
+from blackbull.native import NativeResponse
 from blackbull.response import JSONResponse, Response
 
-
 # ---------------------------------------------------------------------------
-# _normalize_send
+# _normalize_send — native contract (Sprint 92): the middleware's inner send
+# wrapper observes NativeResponse, never raw Response objects.
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_normalize_response_expands_to_start_and_body():
+async def test_normalize_response_to_single_native_response():
     sent = []
 
     async def inner(event, *a, **kw):
@@ -18,19 +21,16 @@ async def test_normalize_response_expands_to_start_and_body():
 
     await _normalize_send(inner)(Response('hello'))
 
-    assert sent[0] == {
-        'type': 'http.response.start',
-        'status': 200,
-        'headers': [(b'content-type', b'text/html; charset=utf-8')],
-    }
-    assert sent[1]['type'] == 'http.response.body'
-    assert sent[1]['body'] == b'hello'
-    assert sent[1]['more_body'] is False
+    assert len(sent) == 1
+    n = sent[0]
+    assert isinstance(n, NativeResponse)
+    assert n.status == 200
+    assert (b'content-type', b'text/html; charset=utf-8') in list(n.header)
+    assert n.body == b'hello'
 
 
 @pytest.mark.asyncio
 async def test_normalize_json_response():
-    import json
     sent = []
 
     async def inner(event, *a, **kw):
@@ -38,12 +38,13 @@ async def test_normalize_json_response():
 
     await _normalize_send(inner)(JSONResponse({'ok': True}))
 
-    assert sent[0]['type'] == 'http.response.start'
-    assert json.loads(sent[1]['body']) == {'ok': True}
+    n = sent[0]
+    assert isinstance(n, NativeResponse)
+    assert json.loads(n.body) == {'ok': True}
 
 
 @pytest.mark.asyncio
-async def test_normalize_dict_passthrough():
+async def test_normalize_dict_converts_to_native():
     sent = []
 
     async def inner(event, *a, **kw):
@@ -52,7 +53,11 @@ async def test_normalize_dict_passthrough():
     event = {'type': 'http.response.start', 'status': 204, 'headers': []}
     await _normalize_send(inner)(event)
 
-    assert sent == [event]
+    assert len(sent) == 1
+    n = sent[0]
+    assert isinstance(n, NativeResponse)
+    assert n.status == 204
+    assert n.header is not None
 
 
 # ---------------------------------------------------------------------------
@@ -60,8 +65,9 @@ async def test_normalize_dict_passthrough():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_decorated_inner_send_receives_dicts_for_response():
-    """Inner send wrapper inside an @as_middleware-decorated function sees only dicts."""
+async def test_decorated_inner_send_receives_native_for_response():
+    """Inner send wrapper inside an @as_middleware-decorated function sees
+    NativeResponse on the native contract (Sprint 92)."""
     received = []
 
     @as_middleware
@@ -81,13 +87,13 @@ async def test_decorated_inner_send_receives_dicts_for_response():
 
     await mw({}, None, outer_send, call_next=handler)
 
-    assert all(isinstance(e, dict) for e in received)
-    assert received[0]['type'] == 'http.response.start'
-    assert received[1]['type'] == 'http.response.body'
+    assert all(isinstance(e, NativeResponse) for e in received)
+    assert received[0].header is not None
+    assert received[0].body == b'hi'
 
 
 @pytest.mark.asyncio
-async def test_decorated_inner_send_receives_dicts_for_json_response():
+async def test_decorated_inner_send_receives_native_for_json_response():
     received = []
 
     @as_middleware
@@ -105,7 +111,8 @@ async def test_decorated_inner_send_receives_dicts_for_json_response():
 
     await mw({}, None, noop_send, call_next=handler)
 
-    assert all(isinstance(e, dict) for e in received)
+    assert all(isinstance(e, NativeResponse) for e in received)
+    assert json.loads(received[0].body) == {'n': 42}
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +151,6 @@ def test_wraps_preserves_name_and_doc():
     @as_middleware
     async def my_middleware(scope, receive, send, call_next):
         """My doc."""
-        pass
 
     assert my_middleware.__name__ == 'my_middleware'
     assert my_middleware.__doc__ == 'My doc.'
@@ -215,25 +221,32 @@ async def test_startup_accepts_undecorated_valid_middleware():
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_plain_middleware_send_wrapper_sees_asgi_dicts():
-    """An undecorated middleware that wraps ``send`` and subscripts
-    ``msg['type']`` must receive ASGI dicts.
+async def test_plain_middleware_send_wrapper_sees_native():
+    """An undecorated middleware that wraps ``send`` must receive
+    NativeResponse on the H1 native path — never raw ``Response`` objects.
 
     Before 0.43.2 ``_wrap_send`` was applied at ``BlackBull.__call__``
     (outermost), so a simplified handler returning a dict (auto-JSONResponse)
     reached the middleware's send wrapper as a ``Response`` object →
     ``TypeError: 'Response' object is not subscriptable``.  The adapter now
-    sits at the handler boundary in ``_dispatch`` so middleware always sees
-    plain dicts.
+    sits at the handler boundary in ``_dispatch`` so middleware sees the
+    native contract (NativeResponse on H1; ASGI dicts on H2 / the ASGI
+    path), never a bare ``Response``.  The drive below enters via a scope
+    dict, so the external edge converts the native emission back to dicts
+    for the host's ``send``.
     """
     from blackbull import BlackBull
+    from blackbull.native import NativeResponse
 
     app = BlackBull()
     seen_status = []
 
     async def stats_mw(scope, receive, send, call_next):
         async def capture(msg):
-            if msg['type'] == 'http.response.start':   # subscripts the dict
+            if isinstance(msg, NativeResponse):
+                if msg.header is not None:        # native header arm
+                    seen_status.append(msg.status)
+            elif msg.get('type') == 'http.response.start':  # H2/ASGI lane
                 seen_status.append(msg['status'])
             await send(msg)
         await call_next(scope, receive, capture)
@@ -257,5 +270,6 @@ async def test_plain_middleware_send_wrapper_sees_asgi_dicts():
     await app(scope, receive, send)
 
     assert seen_status == [200]
+    # scope entry → the external edge converts native → ASGI dicts
     assert all(isinstance(e, dict) for e in sent)
     assert sent[0]['type'] == 'http.response.start'

--- a/tests/unit/test_middlewares.py
+++ b/tests/unit/test_middlewares.py
@@ -19,17 +19,33 @@ carry extra fields such as ``headers`` or ``subprotocols``.  The fix is to check
 """
 
 import gzip
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
+
 from blackbull.middleware import websocket
 from blackbull.middleware.compression import Compression
+from blackbull.native import NativeResponse
+
+
+def _collect(events, event):
+    """Expand a NativeResponse to its ASGI event list when capturing.
+
+    The middleware under test is ``@as_middleware``-decorated, so its sends
+    are normalised to the H1 native contract (NativeResponse); the tests
+    inspect the ASGI event shape, so the seam is normalised away here.
+    """
+    if isinstance(event, NativeResponse):
+        events.extend(event.to_asgi())
+    else:
+        events.append(event)
 
 # The legacy ``compress`` module-level instance was retired with the
 # *Middleware-suffix rename — tests construct a fresh ``Compression``
 # here, which is the same shape (pre-built, no args).
 compress = Compression()
-from blackbull.headers import Headers
 from blackbull.connection import Connection
+from blackbull.headers import Headers
 
 try:
     import brotli as _brotli
@@ -357,7 +373,7 @@ class TestHTTPCompression:
         events = []
 
         async def capture_send(event):
-            events.append(event)
+            _collect(events, event)
 
         await compress(scope, AsyncMock(return_value={'type': 'http.disconnect'}),
                        capture_send, call_next=handler)

--- a/tests/unit/test_native_response.py
+++ b/tests/unit/test_native_response.py
@@ -79,6 +79,24 @@ class TestHeaderView:
         hv.append(b'content-encoding', b'gzip')
         assert (b'content-encoding', b'gzip') in r.to_asgi()[0]['headers']
 
+    def test_append_single_tuple_is_one_pair(self):
+        # A bare (name, value) 2-tuple in the one-arg form must be treated as
+        # one pair, not extended element-wise (extend() would walk the two
+        # bytes as separate malformed entries — the blackbull-session footgun).
+        r = NativeResponse(header=[])
+        hv = r.header
+        assert hv is not None
+        hv.append((b'set-cookie', b'a=b'))
+        assert list(hv) == [(b'set-cookie', b'a=b')]
+        assert hv.get(b'set-cookie') == b'a=b'
+
+    def test_append_list_of_pairs_still_extends(self):
+        r = NativeResponse(header=[])
+        hv = r.header
+        assert hv is not None
+        hv.append([(b'a', b'1'), (b'b', b'2')])
+        assert list(hv) == [(b'a', b'1'), (b'b', b'2')]
+
     def test_header_absent_returns_none(self):
         assert NativeResponse().header is None
         assert NativeResponse(body=b'x').header is None

--- a/tests/unit/test_native_response.py
+++ b/tests/unit/test_native_response.py
@@ -1,0 +1,147 @@
+"""Unit tests for the native response message (native-ization, Sprint 92).
+
+Each test protects the unified NativeResponse contract at the component
+boundary: presence semantics (``is not None``), DX header/body properties,
+and the ``to_asgi()`` boundary conversion.  No sockets, no actor loop.
+"""
+import pytest
+
+from blackbull.native import NativeResponse
+
+
+# ---------------------------------------------------------------------------
+# Construction & presence semantics
+# ---------------------------------------------------------------------------
+
+class TestConstruction:
+    def test_defaults(self):
+        r = NativeResponse()
+        assert r.status == 200
+        assert r.header is None
+        assert r.body is None
+        assert r.more_body is False
+        assert r.trailers is None
+
+    def test_full_response(self):
+        r = NativeResponse(status=201,
+                           header=[(b'content-type', b'text/plain')],
+                           body=b'Hello')
+        assert r.status == 201
+        assert r.header is not None
+        assert r.body == b'Hello'
+
+    def test_presence_is_not_none(self):
+        # presence is decided by `is not None`, never by truthiness: an
+        # empty body is a real body (204-style) and must not be confused
+        # with "absent".
+        r = NativeResponse(body=b'')
+        assert r.body is not None
+        assert r.is_empty
+        assert NativeResponse().body is None
+
+
+class TestHeaderView:
+    def test_get(self):
+        r = NativeResponse(header=[(b'content-type', b'text/plain'),
+                                   (b'x-a', b'1')])
+        hv = r.header
+        assert hv is not None
+        assert hv.get(b'content-type') == b'text/plain'
+        assert hv.get(b'missing', b'def') == b'def'
+
+    def test_getlist(self):
+        r = NativeResponse(header=[(b'x-a', b'1'), (b'x-b', b'2'), (b'x-a', b'3')])
+        hv = r.header
+        assert hv is not None
+        assert hv.getlist(b'x-a') == [(b'x-a', b'1'), (b'x-a', b'3')]
+
+    def test_contains(self):
+        r = NativeResponse(header=[(b'content-type', b'text/plain')])
+        hv = r.header
+        assert hv is not None
+        assert b'content-type' in hv
+        assert b'x-missing' not in hv
+
+    def test_len_and_iter(self):
+        r = NativeResponse(header=[(b'a', b'1'), (b'b', b'2')])
+        hv = r.header
+        assert hv is not None
+        assert len(hv) == 2
+        assert list(hv) == [(b'a', b'1'), (b'b', b'2')]
+
+    def test_append_is_zero_copy(self):
+        # the view wraps the underlying list; a mutation must be visible
+        # to anything reading the response afterwards (e.g. to_asgi).
+        r = NativeResponse(header=[(b'a', b'1')])
+        hv = r.header
+        assert hv is not None
+        hv.append(b'content-encoding', b'gzip')
+        assert (b'content-encoding', b'gzip') in r.to_asgi()[0]['headers']
+
+    def test_header_absent_returns_none(self):
+        assert NativeResponse().header is None
+        assert NativeResponse(body=b'x').header is None
+
+
+class TestBodyDX:
+    def test_content_length(self):
+        assert NativeResponse(body=b'Hello').content_length == 5
+        assert NativeResponse().content_length == 0
+
+    def test_is_empty(self):
+        assert NativeResponse().is_empty
+        assert NativeResponse(body=b'').is_empty
+        assert not NativeResponse(body=b'x').is_empty
+
+    def test_content_type(self):
+        r = NativeResponse(header=[(b'content-type', b'application/json')])
+        assert r.content_type == b'application/json'
+        assert NativeResponse().content_type == b''
+
+
+# ---------------------------------------------------------------------------
+# to_asgi() boundary conversion
+# ---------------------------------------------------------------------------
+
+class TestToASGI:
+    def test_complete_response(self):
+        r = NativeResponse(status=200,
+                           header=[(b'content-type', b'text/plain')],
+                           body=b'Hi')
+        events = r.to_asgi()
+        assert events == [
+            {'type': 'http.response.start',
+             'status': 200, 'headers': [(b'content-type', b'text/plain')]},
+            {'type': 'http.response.body', 'body': b'Hi', 'more_body': False},
+        ]
+
+    def test_header_only(self):
+        r = NativeResponse(status=204, header=[(b'x-a', b'1')])
+        assert r.to_asgi() == [
+            {'type': 'http.response.start', 'status': 204,
+             'headers': [(b'x-a', b'1')]},
+        ]
+
+    def test_body_only(self):
+        r = NativeResponse(body=b'chunk', more_body=True)
+        assert r.to_asgi() == [
+            {'type': 'http.response.body', 'body': b'chunk', 'more_body': True},
+        ]
+
+    def test_trailers(self):
+        r = NativeResponse(trailers=[(b'x-trailer', b'v')])
+        assert r.to_asgi() == [
+            {'type': 'http.response.trailers', 'headers': [(b'x-trailer', b'v')]},
+        ]
+
+
+class TestSlots:
+    def test_no_dict_per_instance(self):
+        # __slots__ — no per-instance __dict__; guards accidental attr drift.
+        r = NativeResponse()
+        assert not hasattr(r, '__dict__')
+
+    def test_unknown_attr_rejected(self):
+        r = NativeResponse()
+        with pytest.raises(AttributeError):
+            r.typo_field = 1

--- a/tests/unit/test_native_response.py
+++ b/tests/unit/test_native_response.py
@@ -63,6 +63,20 @@ class TestHeaderView:
         assert b'content-type' in hv
         assert b'x-missing' not in hv
 
+    def test_lookups_case_insensitive(self):
+        # RFC 9110 §5.1 — header field names are case-insensitive; the view
+        # models the Headers DX (review m2), so mixed-case lookups must hit
+        # even when the stored names are lowercase.
+        r = NativeResponse(header=[(b'content-type', b'text/plain'),
+                                   (b'x-a', b'1'), (b'x-a', b'2')])
+        hv = r.header
+        assert hv is not None
+        assert b'Content-Type' in hv
+        assert hv.get(b'CONTENT-TYPE') == b'text/plain'
+        assert hv.get(b'X-A') == b'1'
+        assert hv.getlist(b'X-A') == [(b'x-a', b'1'), (b'x-a', b'2')]
+        assert hv.get(b'Content-Encoding', b'def') == b'def'
+
     def test_len_and_iter(self):
         r = NativeResponse(header=[(b'a', b'1'), (b'b', b'2')])
         hv = r.header
@@ -162,6 +176,24 @@ class TestToASGI:
         events = r.to_asgi()
         assert events[0]['trailers'] is True
         assert NativeResponse(status=200, header=[]).to_asgi()[0].get('trailers') is None
+
+    def test_to_asgi_copies_header_lists(self):
+        # Review i2: the start/trailers dicts must not alias the live
+        # NativeResponse's lists — the cache middleware stores these events,
+        # and an in-place append on the live response (CORS / header
+        # injection) must not leak into a stored entry.
+        r = NativeResponse(header=[(b'a', b'1')],
+                           trailers=[(b't', b'v')])
+        events = r.to_asgi()
+        events[0]['headers'].append((b'b', b'2'))
+        events[-1]['headers'].append((b't2', b'v2'))
+        # live object untouched
+        assert list(r.header) == [(b'a', b'1')]
+        assert r.trailers == [(b't', b'v')]
+        # a second conversion is unaffected by the first's mutation
+        again = r.to_asgi()
+        assert again[0]['headers'] == [(b'a', b'1')]
+        assert again[-1]['headers'] == [(b't', b'v')]
 
 
 class TestSlots:

--- a/tests/unit/test_native_response.py
+++ b/tests/unit/test_native_response.py
@@ -21,6 +21,7 @@ class TestConstruction:
         assert r.body is None
         assert r.more_body is False
         assert r.trailers is None
+        assert r.expects_trailers is False
 
     def test_full_response(self):
         r = NativeResponse(status=201,
@@ -133,6 +134,16 @@ class TestToASGI:
         assert r.to_asgi() == [
             {'type': 'http.response.trailers', 'headers': [(b'x-trailer', b'v')]},
         ]
+
+    def test_expects_trailers_flag_on_start(self):
+        # the ASGI start `trailers: True` flag is preserved losslessly
+        # through the native form and back at the boundary.
+        r = NativeResponse(status=200,
+                           header=[(b'content-type', b'text/plain')],
+                           expects_trailers=True)
+        events = r.to_asgi()
+        assert events[0]['trailers'] is True
+        assert NativeResponse(status=200, header=[]).to_asgi()[0].get('trailers') is None
 
 
 class TestSlots:

--- a/tests/unit/test_native_sender.py
+++ b/tests/unit/test_native_sender.py
@@ -177,6 +177,37 @@ class TestNativeResponsePath:
         assert b'content-length: 2\r\n' in w2.data
         assert b'x-t: v' not in w2.data      # dropped — existing H1 behaviour
 
+    async def test_single_object_terminal_body_trailers_drop(self):
+        # Review M1: one object carrying header + terminal body + trailers
+        # must NOT splice chunked trailers framing after a content-length
+        # body.  The native arm drops the trailers once the body completed
+        # the response — the same post-terminal drop as the dict lane's
+        # entry guard.
+        s, w = _sender()
+        await s(NativeResponse(status=200,
+                               header=[(b'content-type', b'text/plain')],
+                               body=b'Hi',
+                               trailers=[(b'x-t', b'v')]))
+        assert b'content-length: 2\r\n' in w.data
+        assert w.data.endswith(b'\r\n\r\nHi')
+        assert b'x-t: v' not in w.data
+        assert b'0\r\n' not in w.data
+        assert s._completed is True
+
+    async def test_single_object_nonterminal_body_trailers(self):
+        # Legitimate single-object trailers: a non-terminal body keeps
+        # ``_completed`` False, so the trailers block legitimately terminates
+        # the chunked framing.
+        s, w = _sender()
+        await s(NativeResponse(status=200,
+                               header=[(b'content-type', b'text/plain')],
+                               body=b'Hi', more_body=True,
+                               trailers=[(b'x-t', b'v')]))
+        assert b'transfer-encoding: chunked' in w.data
+        assert b'x-t: v' in w.data
+        assert w.data.endswith(b'2\r\nHi\r\n0\r\nx-t: v\r\n\r\n')
+        assert s._completed is True
+
     async def test_completed_drops_later_sends(self):
         s, w = _sender()
         await s(NativeResponse(status=200, body=b'Hi'))

--- a/tests/unit/test_native_sender.py
+++ b/tests/unit/test_native_sender.py
@@ -1,0 +1,147 @@
+"""Tests for HTTP1Sender consuming the native response message (Sprint 92).
+
+Pins the wire-equivalence invariant: a NativeResponse-driven response
+produces byte-identical output to the existing ASGI-dict path, and the
+unified object's presence semantics (``is not None``) drive a single sender
+path with no consumer detection.
+"""
+import pytest
+
+from blackbull.server.sender import HTTP1Sender, AbstractWriter
+from blackbull.native import NativeResponse
+from blackbull.asgi import ASGIEvent
+
+pytestmark = pytest.mark.asyncio
+
+
+class BytesWriter(AbstractWriter):
+    def __init__(self):
+        self.data = b''
+
+    async def write(self, data: bytes) -> None:
+        self.data += data
+
+
+def _sender():
+    w = BytesWriter()
+    return HTTP1Sender(w), w
+
+
+# ---------------------------------------------------------------------------
+# Wire equivalence: NativeResponse path == dict path
+# ---------------------------------------------------------------------------
+
+class TestWireEquivalence:
+    async def test_complete_response_matches_dict_path(self):
+        # dict path
+        s1, w1 = _sender()
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200,
+                  'headers': [(b'content-type', b'text/plain')]})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'Hello',
+                  'more_body': False})
+        # native path — one object, one send
+        s2, w2 = _sender()
+        await s2(NativeResponse(status=200,
+                                header=[(b'content-type', b'text/plain')],
+                                body=b'Hello'))
+        assert w2.data == w1.data
+
+    async def test_streaming_matches_dict_path(self):
+        s1, w1 = _sender()
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200,
+                  'headers': [(b'content-type', b'text/plain')]})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'chunk1',
+                  'more_body': True})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'chunk2',
+                  'more_body': False})
+
+        s2, w2 = _sender()
+        await s2(NativeResponse(status=200,
+                                header=[(b'content-type', b'text/plain')]))
+        await s2(NativeResponse(body=b'chunk1', more_body=True))
+        await s2(NativeResponse(body=b'chunk2'))
+        assert w2.data == w1.data
+
+    async def test_empty_body_matches_dict_path(self):
+        s1, w1 = _sender()
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 204,
+                  'headers': []})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'',
+                  'more_body': False})
+
+        s2, w2 = _sender()
+        await s2(NativeResponse(status=204, header=[], body=b''))
+        assert w2.data == w1.data
+
+
+# ---------------------------------------------------------------------------
+# Presence-driven single path
+# ---------------------------------------------------------------------------
+
+class TestNativeResponsePath:
+    async def test_complete_single_send(self):
+        s, w = _sender()
+        await s(NativeResponse(status=200,
+                               header=[(b'content-type', b'text/plain')],
+                               body=b'Hi'))
+        # sender auto-emits Date (RFC 9110 §6.6.1), so assert structure,
+        # not exact bytes.
+        assert w.data.startswith(b'HTTP/1.1 200 OK\r\n')
+        assert b'content-type: text/plain\r\n' in w.data
+        assert b'content-length: 2\r\n' in w.data
+        assert w.data.endswith(b'\r\n\r\nHi')
+        assert s._completed is True
+
+    async def test_header_only_is_buffered(self):
+        s, w = _sender()
+        await s(NativeResponse(status=200,
+                               header=[(b'content-type', b'text/plain')]))
+        assert w.data == b''          # buffered, nothing on the wire
+        assert s._buffered_status is not None
+
+    async def test_header_then_body(self):
+        s, w = _sender()
+        await s(NativeResponse(status=200,
+                               header=[(b'content-type', b'text/plain')]))
+        await s(NativeResponse(body=b'Hi'))
+        assert w.data.startswith(b'HTTP/1.1 200 OK\r\n')
+        assert b'content-type: text/plain\r\n' in w.data
+        assert b'content-length: 2\r\n' in w.data
+        assert w.data.endswith(b'\r\n\r\nHi')
+        assert s._completed is True
+
+    async def test_streaming_chunks(self):
+        s, w = _sender()
+        await s(NativeResponse(status=200, header=[(b'content-type', b'text/plain')]))
+        await s(NativeResponse(body=b'c1', more_body=True))
+        await s(NativeResponse(body=b'c2'))
+        # streaming: chunked transfer encoding (headers are lowercase-normalised)
+        assert b'transfer-encoding: chunked' in w.data
+        assert w.data.endswith(b'2\r\nc1\r\n2\r\nc2\r\n0\r\n\r\n')
+
+    async def test_trailers(self):
+        # trailers require chunked framing: the body must be non-terminal
+        s, w = _sender()
+        await s(NativeResponse(status=200, header=[(b'content-type', b'text/plain')]))
+        await s(NativeResponse(body=b'Hi', more_body=True))
+        await s(NativeResponse(trailers=[(b'x-t', b'v')]))
+        assert b'transfer-encoding: chunked' in w.data
+        assert b'x-t: v' in w.data
+        assert w.data.endswith(b'0\r\nx-t: v\r\n\r\n')
+
+    async def test_completed_drops_later_sends(self):
+        s, w = _sender()
+        await s(NativeResponse(status=200, body=b'Hi'))
+        before = w.data
+        await s(NativeResponse(body=b'second'))
+        assert w.data == before      # second response dropped
+
+    async def test_head_mode_no_body(self):
+        s, w = _sender()
+        s._head_mode = True
+        await s(NativeResponse(status=200,
+                               header=[(b'content-length', b'2')]))
+        await s(NativeResponse(body=b'Hi'))
+        # HEAD: headers but no body bytes
+        assert b'HTTP/1.1 200 OK' in w.data
+        assert b'Hi' not in w.data

--- a/tests/unit/test_native_sender.py
+++ b/tests/unit/test_native_sender.py
@@ -129,6 +129,54 @@ class TestNativeResponsePath:
         assert b'x-t: v' in w.data
         assert w.data.endswith(b'0\r\nx-t: v\r\n\r\n')
 
+    async def test_expects_trailers_matches_dict_path(self):
+        # Full-form ASGI start(trailers=True) → chunked body → trailers.  The
+        # native form preserves the start flag (expects_trailers) so the
+        # terminal chunk is withheld until the trailers event — byte-identical
+        # to the dict path (lossless compat).
+        s1, w1 = _sender()
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200,
+                  'headers': [(b'content-type', b'text/plain')], 'trailers': True})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'Hi',
+                  'more_body': True})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_TRAILERS,
+                  'headers': [(b'x-t', b'v')]})
+
+        s2, w2 = _sender()
+        await s2(NativeResponse(status=200,
+                                header=[(b'content-type', b'text/plain')],
+                                expects_trailers=True))
+        await s2(NativeResponse(body=b'Hi', more_body=True))
+        await s2(NativeResponse(trailers=[(b'x-t', b'v')]))
+        assert w2.data == w1.data
+        assert b'transfer-encoding: chunked' in w2.data
+        assert w2.data.endswith(b'2\r\nHi\r\n0\r\nx-t: v\r\n\r\n')
+        assert s2._completed is True
+
+    async def test_terminal_body_then_trailers_matches_dict_path(self):
+        # start(trailers=True) → body(more_body=False) → trailers: on H1 the
+        # completed guard drops a post-terminal trailers event today (both the
+        # content-length framing and the drop are pre-existing H1 behaviour —
+        # the H2 sender's END_STREAM deferral is the next-sprint concern).
+        # The native path mirrors the dict path byte-for-byte (lossless compat).
+        s1, w1 = _sender()
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_START, 'status': 200,
+                  'headers': [(b'content-type', b'text/plain')], 'trailers': True})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_BODY, 'body': b'Hi',
+                  'more_body': False})
+        await s1({'type': ASGIEvent.HTTP_RESPONSE_TRAILERS,
+                  'headers': [(b'x-t', b'v')]})
+
+        s2, w2 = _sender()
+        await s2(NativeResponse(status=200,
+                                header=[(b'content-type', b'text/plain')],
+                                expects_trailers=True))
+        await s2(NativeResponse(body=b'Hi'))
+        await s2(NativeResponse(trailers=[(b'x-t', b'v')]))
+        assert w2.data == w1.data
+        assert b'content-length: 2\r\n' in w2.data
+        assert b'x-t: v' not in w2.data      # dropped — existing H1 behaviour
+
     async def test_completed_drops_later_sends(self):
         s, w = _sender()
         await s(NativeResponse(status=200, body=b'Hi'))

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -5,14 +5,40 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from blackbull import Response, JSONResponse, RedirectResponse, WebSocketResponse
-from blackbull.response import cookie_header
+from blackbull import JSONResponse, RedirectResponse, Response, WebSocketResponse
 from blackbull.app import _wrap_send
-
+from blackbull.native import NativeResponse
+from blackbull.response import cookie_header
 
 # ---------------------------------------------------------------------------
 # Response
 # ---------------------------------------------------------------------------
+
+def test_response_to_native():
+    r = Response(b'Hi', status=HTTPStatus.CREATED,
+                 headers=[(b'x-a', b'1')])
+    n = r.to_native()
+    assert isinstance(n, NativeResponse)
+    assert n.status == 201
+    assert n.header is not None
+    assert (b'x-a', b'1') in list(n.header)
+    assert n.body == b'Hi'
+    assert n.more_body is False
+    assert n.trailers is None
+
+
+def test_json_response_to_native():
+    n = JSONResponse({'ok': True}).to_native()
+    assert n.body == json.dumps({'ok': True}).encode()
+    assert n.content_type == b'application/json'
+
+
+def test_response_to_native_is_single_object():
+    # the native serialiser is one object — the wire-emission equivalent of
+    # `to_asgi()` returning a start+body pair (1 send vs 2).
+    n = Response(b'Hi').to_native()
+    assert len(n.to_asgi()) == 2  # start + body, and back again losslessly
+
 
 def test_response_body_from_bytes():
     assert Response(b'hi').body == b'hi'

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -40,6 +40,28 @@ def test_response_to_native_is_single_object():
     assert len(n.to_asgi()) == 2  # start + body, and back again losslessly
 
 
+@pytest.mark.asyncio
+async def test_wrap_native_send_body_none_falls_back_to_empty():
+    """Clean-subagent MAJOR: a spec-violating full-form body event with
+    body=None must not hang the native sender (it skips a None body and a
+    buffered header would never flush) — it falls back to an empty body."""
+    from blackbull.app import _wrap_send_native
+
+    sent = []
+
+    async def raw_send(event):
+        sent.append(event)
+
+    send = _wrap_send_native(raw_send)
+    await send({'type': 'http.response.start', 'status': 200, 'headers': []})
+    await send({'type': 'http.response.body', 'body': None, 'more_body': False})
+
+    assert len(sent) == 2
+    n = sent[1]
+    assert n.body is not None      # falls back to b'', never None
+    assert n.body == b''
+
+
 def test_response_body_from_bytes():
     assert Response(b'hi').body == b'hi'
 


### PR DESCRIPTION
## Sprint 92 — Send-side native-ization: native app-server seam, ASGI opt-in

**Status**: ready for review — no merge requested yet; release is gated on Sprint 93 (release constraint 2, below).

This PR makes the **send side** mirror the receive side, which is already native. BlackBull's own server already threads a native `Connection`; the send side still forced ASGI dicts on the native path (`_wrap_send` → `_emit_response` → dict → sender `match 'type'`). This removes the ASGI layer from the native HTTP/1.1 path: app↔server carry native response objects, `asgi=True` / `to_asgi()` is the opt-in for external ASGI hosts, and ASGI compatibility costs are explicitly out of the native-path performance requirements.

### What changed

| Area | Change |
|---|---|
| `blackbull/native.py` (new) | `NativeResponse` — `__slots__` unified response message (status / header / body / more_body / trailers / expects_trailers); `_HeaderView` DX (case-insensitive get/getlist/contains/len/iter, guarded append); presence = `is not None` (never truthiness); `to_asgi()` boundary conversion. |
| H1 sender | single native arm (`header is not None` / `body is not None` / `trailers is not None`); a complete response is 1 object + 1 send; wire-equivalent to the dict path (byte-for-byte pinned in `test_native_sender.py`). |
| Router / response | `wrap_native_send` converts every accepted shape (Response / StreamingResponse / 3-arg / ASGI dict / NativeResponse) at the handler boundary on H1; `Response.to_native()`; cycle-free `_stream_and_convert` (v0.60.0 per-request cycle guard). |
| Middleware | `as_middleware` protocol-aware normalisation; CORS / cache / compression native read arms; `_boundary_wrap` converts middleware-generated events on H1 (uniformly native below a global middleware). |
| App boundary | `asgi=True` constructor flag + `to_asgi()`; external edge native→ASGI conversion; the app is native internally in **both** modes (decision 7). |
| H2 gate | H2 keeps the ASGI-dict lane behind a test-passing-only gate (`conn.http_version == '1.1'`) — next sprint removes it. |

### Compatibility

- Full-form `send(dict)` accepted until **2027-07-29** (user decision), converted at the handler boundary (early conversion). The same handler code runs on both the native and ASGI lanes.

### Verification

- **5969 tests passed** + beartype typecheck clean.
- **EC2 A/B (native seam vs ASGI dict)** — m7a.2xlarge, 8 rounds ABBA, `/plaintext` + `/json`: real Δ **+2.15 % ± 0.20** on both profiles, null floors 0.47 %/0.4 %, round-paired 16/16 treat>base → **SHIPS** (no regression). Swap proofs base=f0f1ad922a0a (v0.69) / treat=7a81f0345f36 (sprint-92).
- **Extension impact check** — blackbull-session migrated to the native contract (Connection-primary `__call__`, dual-contract `wrapped_send`; committed separately in the session repo); htcpcp 65 passed + native BREW verified; protobuf 54 passed (gRPC path stays on the dict lane).
- **Independent fresh-eyes review** (close-out, `c93de3b`) — 1 MAJOR + 6 MINORs + 4 INFOs, all resolved: single-object terminal-body+trailers wire splice (MAJOR), case-insensitive `_HeaderView`, per-event import hoist, hot-path presence checks, `to_asgi()` header/trailers list copy, docs (native-path `to_native()` contract + native-aware streaming middleware example).

### Release constraints (user, 2026-08-03)

1. A/B no regression — ✅ **SHIPS (+2.15 % both profiles)**
2. HTTP/2 / WebSocket / gRPC native at every boundary — ⏳ **Sprint 93** (this PR is H1-only by design; the H2 sender has no native arm yet)
3. Extension / middleware native — ✅ (middleware + session / htcpcp / protobuf verified)

v0.70.0 is held until all three constraints hold; constraint 2 is the next sprint's scope.
