### PR TITLE
Native construction costs: three regressions from #222, and what wasn't one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,7 +208,14 @@ so the editable install's metadata catches up.
   its framing helpers with the dict arm, and a native accept arm on
   `WebSocketActor`.  `websocket.*` dicts now appear only at the enumerated
   boundaries: the external ASGI edge, the raw compat form, and the Tier-2 test
-  client.  A test asserts the two arms put **identical bytes on the wire**, so
+  client.  The sender tests the **dict** shape first: a dict is the one arm
+  here that nothing cheaper than `isinstance` recognises, so ordering it first
+  costs the native arm nothing and saves the compat path — every raw-form
+  handler and every external ASGI host — the second check it would otherwise
+  pay as a type guard.  Worth 61 ns on a ~800 ns send (ABBA, in-process,
+  n=16/arm); a test asserts the dict arm is reached without the native type
+  being consulted at all, so the ordering cannot regress silently.
+  A test asserts the two arms put **identical bytes on the wire**, so
   the compat surface cannot drift.
 
 - **The gRPC bridge emits native (proposal §7).**  `serve_grpc` is dispatched

--- a/bench/httparena/app.py
+++ b/bench/httparena/app.py
@@ -58,6 +58,14 @@ if os.path.isdir(_repo_root) and _repo_root not in sys.path:
     sys.path.insert(0, _repo_root)
 
 from blackbull import BlackBull, Connection, Depends, JSONResponse, Response
+
+# The object-form WebSocket, for the /ws-object lane.  Guarded like the gRPC
+# import below: versions old enough to predate it still serve every other
+# profile, they just don't offer the native-channel endpoint.
+try:
+    from blackbull.websocket import WebSocket
+except ImportError:                                   # pragma: no cover
+    WebSocket = None
 from blackbull.middleware.compression import Compression
 
 import db
@@ -232,6 +240,21 @@ async def ws_echo(scope, receive, send):
         else:
             await send({'type': 'websocket.send',
                         'bytes': event.get('bytes') or b''})
+
+
+# The same echo in object form.  `/ws` above is the raw ASGI form — it mints a
+# `websocket.receive` dict per message and sends dicts back — so the echo-ws
+# profiles measure the compat boundary and say nothing about the native
+# channel.  This endpoint takes `next_message()` / `NativeWSMessage` instead;
+# point a run at it (HttpArena's echo-ws URL, or WS_PATH in ab_commit_ws.sh)
+# to measure the two channels against each other on one build.
+if WebSocket is not None:
+    @app.route(path='/ws-object', methods=[HTTPMethod.GET],
+               scheme=Scheme.websocket)
+    async def ws_echo_object(ws: WebSocket):
+        await ws.accept()
+        async for message in ws:
+            await ws.send(message)
 
 
 # ---------------------------------------------------------------------------

--- a/bench/peers/ab_commit_ws.sh
+++ b/bench/peers/ab_commit_ws.sh
@@ -32,6 +32,11 @@
 #   WS_TICK_MS    message burst period        (default 1)
 #   WS_BURST      messages per tick           (default 8)
 #   WS_LIFETIME_MS socket lifetime            (default 8000)
+#   WS_PATH       echo endpoint               (default /ws)
+#                 /ws        = raw (conn, receive, send) form, ASGI dicts
+#                 /ws-object = object form, the native channel
+#                 Both are served by the same app, so switching this changes
+#                 the code path under test and nothing else.
 #
 # Output: bench/results/ab-ws-<UTC>/report.md + raw.tsv + k6 summaries.
 
@@ -54,6 +59,7 @@ WS_DURATION="${WS_DURATION:-10s}"
 WS_TICK_MS="${WS_TICK_MS:-1}"
 WS_BURST="${WS_BURST:-8}"
 WS_LIFETIME_MS="${WS_LIFETIME_MS:-8000}"
+WS_PATH="${WS_PATH:-/ws}"
 # Server and load generator on disjoint cores — same bimodality argument as
 # ab_commit.sh: unpinned, the two fight for the same cores and the
 # distribution goes bimodal, swamping a refactor-scale delta.
@@ -89,7 +95,7 @@ mkdir -p "$OUTDIR"
 REPORT="$OUTDIR/report.md"
 RAW="$OUTDIR/raw.tsv"
 BASE_URL="http://127.0.0.1:${PORT}"
-WS_URL="ws://127.0.0.1:${PORT}/ws"
+WS_URL="ws://127.0.0.1:${PORT}${WS_PATH}"
 
 SHA_BASE="$(git rev-parse --short "$REF_BASE")"
 SHA_TREAT="$(git rev-parse --short "$REF_TREAT")"
@@ -246,7 +252,7 @@ printf 'phase\tround\tarm\trps\tproof\n' >"$RAW"
 
 echo "ab_commit_ws.sh: $SHA_BASE (base) vs $SHA_TREAT (treat)"
 echo "  files: ${FILES[*]}"
-echo "  lane : WebSocket echo, k6 -$WS_VUS conns -d$WS_DURATION (tick ${WS_TICK_MS}ms x${WS_BURST}) -> msg/s"
+echo "  lane : WebSocket echo $WS_PATH, k6 -$WS_VUS conns -d$WS_DURATION (tick ${WS_TICK_MS}ms x${WS_BURST}) -> msg/s"
 echo "  uvloop=$BB_UVLOOP  rounds=$ROUNDS (ABBA)"
 echo "  pin  : server=${SERVER_CPUS:-none} load=${LOAD_CPUS:-none}"
 echo "  phases: $PHASES"

--- a/bench/peers/native_app.py
+++ b/bench/peers/native_app.py
@@ -12,6 +12,7 @@ from urllib.parse import parse_qs
 
 from blackbull import BlackBull, Connection, Response
 from blackbull.utils import Scheme
+from blackbull.websocket import WebSocket
 
 app = BlackBull()
 
@@ -144,6 +145,21 @@ async def ws_echo(conn, receive, send):
         else:
             await send({"type": "websocket.send",
                         "bytes": event.get("bytes") or b""})
+
+
+@app.route(path="/ws-object", methods=[HTTPMethod.GET], scheme=Scheme.websocket)
+async def ws_echo_object(ws: WebSocket):
+    """The same echo, object form — the native send/receive channel.
+
+    Registered alongside /ws so the two channels can be compared in one
+    process, on one build, with the load generator the only thing that
+    changes.  /ws is the raw form: it mints a `websocket.receive` dict per
+    message and sends dicts back, which is the ASGI compat boundary.  This
+    one takes `next_message()` / `NativeWSMessage` and pays neither.
+    """
+    await ws.accept()
+    async for message in ws:
+        await ws.send(message)
 
 
 # Registered LAST on purpose.  Paired with /ping — the first route — this

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -459,10 +459,15 @@ def _validate_response_message(response) -> bytes:
     return bytes(response)
 
 
-def _response_start(content_type: bytes,
-                    response_encoding: bytes | None = None,
-                    initial_metadata: list[tuple[bytes, bytes]] | None = None
-                    ) -> NativeResponse:
+def _response_headers(content_type: bytes,
+                      response_encoding: bytes | None = None,
+                      initial_metadata: list[tuple[bytes, bytes]] | None = None
+                      ) -> list[tuple[bytes, bytes]]:
+    """The response header list, without deciding what object carries it.
+
+    Split from :func:`_response_start` so the unary path can fold these
+    headers into the same object as its body and trailers.
+    """
     headers = [(b'content-type', content_type),
                (b'grpc-accept-encoding', _GRPC_ACCEPT_ENCODING)]
     # Advertise the encoding used for any compressed response messages.  Present
@@ -474,7 +479,18 @@ def _response_start(content_type: bytes,
     # Handler-supplied leading metadata (context.send_initial_metadata).
     if initial_metadata:
         headers.extend(initial_metadata)
-    return NativeResponse(status=200, header=headers, expects_trailers=True)
+    return headers
+
+
+def _response_start(content_type: bytes,
+                    response_encoding: bytes | None = None,
+                    initial_metadata: list[tuple[bytes, bytes]] | None = None
+                    ) -> NativeResponse:
+    return NativeResponse(
+        status=200,
+        header=_response_headers(content_type, response_encoding,
+                                 initial_metadata),
+        expects_trailers=True)
 
 
 async def _serve_unary(handler, request, context, send, content_type,
@@ -513,13 +529,36 @@ async def _serve_unary(handler, request, context, send, content_type,
             send, context, GrpcStatus.INTERNAL, str(exc), content_type)
         return
 
-    await context._start_response()
-    await send(NativeResponse(
-        body=_frame_response(response, response_encoding is not None),
-        more_body=True))
-    await send(NativeResponse(
-        trailers=_status_trailers(context.code, context.details,
-                                  context._trailing)))
+    body = _frame_response(response, response_encoding is not None)
+    trailers = _status_trailers(context.code, context.details,
+                                context._trailing)
+
+    if context._started:
+        # ``send_initial_metadata`` already put HEADERS on the wire, so only
+        # the body and trailers are left.
+        await send(NativeResponse(body=body, more_body=True))
+        await send(NativeResponse(trailers=trailers))
+        return
+
+    # Nothing sent yet, and a unary response is fully known here — headers,
+    # body and status trailers all at once — so it goes as **one** object.
+    # Three objects cost three constructions and three sender dispatches to
+    # describe a single response.
+    #
+    # ``more_body=True`` is deliberate and load-bearing, not an oversight:
+    # HTTP2Sender only takes its trailers-coalescing path for a *non-terminal*
+    # body chunk, holding HEADERS + DATA so they flush together with the
+    # trailing HEADERS in one write.  END_STREAM belongs on the trailers
+    # either way (RFC 9113 §8.1); marking the body terminal here would split
+    # that single write in two.
+    context._started = True
+    await send(NativeResponse(status=200,
+                              header=_response_headers(
+                                  content_type, response_encoding,
+                                  context._initial_metadata),
+                              expects_trailers=True,
+                              body=body, more_body=True,
+                              trailers=trailers))
 
 
 async def _serve_server_streaming(handler, request, context, send, content_type,

--- a/blackbull/grpc/asgi.py
+++ b/blackbull/grpc/asgi.py
@@ -552,13 +552,11 @@ async def _serve_unary(handler, request, context, send, content_type,
     # either way (RFC 9113 §8.1); marking the body terminal here would split
     # that single write in two.
     context._started = True
-    await send(NativeResponse(status=200,
-                              header=_response_headers(
-                                  content_type, response_encoding,
-                                  context._initial_metadata),
-                              expects_trailers=True,
-                              body=body, more_body=True,
-                              trailers=trailers))
+    await send(NativeResponse.with_trailers(
+        200,
+        _response_headers(content_type, response_encoding,
+                          context._initial_metadata),
+        body, trailers))
 
 
 async def _serve_server_streaming(handler, request, context, send, content_type,

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -221,6 +221,62 @@ class NativeResponse:
         # Mutually exclusive with ``body``: the bytes come from the file.
         self.file_path = file_path
 
+    # --- fast constructors for framework-owned producers -------------------
+    #
+    # `Connection` — the request-side native object — is built once per
+    # request by a generated dataclass ``__init__`` taking positional
+    # arguments.  The response side had no equivalent: every emission went
+    # through the keyword-only ``__init__`` above, and keyword dispatch with
+    # seven defaulted parameters is where the cost is.  Measured on the same
+    # slots: positional 105.9 ns, ``__new__`` + direct writes 102.9 ns,
+    # keyword 245.4 ns.  Bypassing ``__init__`` buys nothing on its own; the
+    # calling convention is the whole difference.
+    #
+    # These are deliberately *shape-specific* rather than one seven-argument
+    # ``_make``.  In slot order ``more_body`` and ``expects_trailers`` are two
+    # bools separated only by ``trailers``, so a positional catch-all would be
+    # a standing misordering trap for a saving of ~140 ns.  Each constructor
+    # below names the shape it builds and takes only what that shape varies.
+    #
+    # The public keyword ``__init__`` is unchanged and remains the form for
+    # application code and for any shape not covered here.
+
+    @classmethod
+    def complete(cls, status: int, header: list[tuple[bytes, bytes]],
+                 body: bytes | None) -> 'NativeResponse':
+        """Header plus terminal body — a whole response in one object."""
+        self = cls.__new__(cls)
+        self.status = status
+        self._header = header
+        self._body = body
+        self.more_body = False
+        self.trailers = None
+        self.expects_trailers = False
+        self.file_path = None
+        return self
+
+    @classmethod
+    def with_trailers(cls, status: int, header: list[tuple[bytes, bytes]],
+                      body: bytes | None,
+                      trailers: list[tuple[bytes, bytes]]) -> 'NativeResponse':
+        """Header, body and trailers together — the gRPC unary shape.
+
+        ``more_body`` is True by construction, and load-bearing:
+        ``HTTP2Sender`` only takes its trailers-coalescing path for a
+        *non-terminal* body chunk, holding HEADERS + DATA so they flush with
+        the trailing HEADERS in one write.  END_STREAM rides the trailers
+        either way (RFC 9113 §8.1).
+        """
+        self = cls.__new__(cls)
+        self.status = status
+        self._header = header
+        self._body = body
+        self.more_body = True
+        self.trailers = trailers
+        self.expects_trailers = True
+        self.file_path = None
+        return self
+
     # --- header: DX view, or None when absent -----------------------------
     @property
     def header(self) -> _HeaderView | None:

--- a/blackbull/native.py
+++ b/blackbull/native.py
@@ -202,7 +202,13 @@ class NativeResponse:
                  expects_trailers: bool = False,
                  file_path: str | None = None) -> None:
         self.status = status
-        self.header = header          # setter stores into _header
+        # Write the slot directly rather than going through the ``header``
+        # property.  The setter is a descriptor call plus an isinstance test,
+        # and this constructor runs for every response the framework emits —
+        # once per HTTP response, three times per gRPC unary call.  The two
+        # branches below are the setter's, inlined; the property remains the
+        # public way to assign a header after construction.
+        self._header = header._items if isinstance(header, _HeaderView) else header
         self._body = body
         self.more_body = more_body
         self.trailers = trailers

--- a/blackbull/response.py
+++ b/blackbull/response.py
@@ -78,8 +78,7 @@ async def _emit_response(send, body: bytes, status, headers) -> None:
     """
     # One object, one send: the complete-response shape the native seam was
     # built for.  The dict form always cost two events for the same response.
-    await send(NativeResponse(status=int(status), header=list(headers),
-                              body=body))
+    await send(NativeResponse.complete(int(status), list(headers), body))
 
 
 class Response:
@@ -129,9 +128,8 @@ class Response:
         :meth:`NativeResponse.to_asgi` (the boundary conversion); streaming
         response types drive themselves and are not converted here.
         """
-        return NativeResponse(status=int(self.status),
-                              header=list(self.headers),
-                              body=self.body)
+        return NativeResponse.complete(int(self.status), list(self.headers),
+                                       self.body)
 
 
 class JSONResponse(Response):

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -1480,9 +1480,37 @@ class WebSocketSender(BaseSender):
     async def __call__(self, body: '_WSSenderEvent | NativeWSMessage',
                        _status: HTTPStatus | None = None,
                        _headers: HeaderList = []):
+        # Dict arm first.  A dict is the one shape here that nothing cheaper
+        # than ``isinstance`` can recognise, and it is what the external-host
+        # edge and the raw (conn, receive, send) compat form emit.  Testing it
+        # first means the compat path pays one check; the native arm below
+        # pays the same one on its way past, where it used to pay one and the
+        # compat path two — the second being a pure type guard.
+        if isinstance(body, dict):
+            event_type = body.get('type', '')
+
+            match event_type:
+
+                case ASGIEvent.WS_SEND:
+                    if 'text' in body and body['text'] is not None:
+                        await self._send_payload(body['text'].encode('utf-8'),
+                                                 WSOpcode.TEXT)
+                    else:
+                        await self._send_payload(body.get('bytes', b''),
+                                                 WSOpcode.BINARY)
+
+                case ASGIEvent.WS_CLOSE:
+                    await self._send_close(body.get('code', WSCloseCode.NORMAL))
+
+                case ASGIEvent.WS_ACCEPT:
+                    pass  # handshake reply sent by HTTP1Actor._do_ws_handshake()
+                case _:
+                    logger.warning('WebSocketSender: unknown event type %r',
+                                   event_type)
+            return
+
         # Native arm (the WS counterpart of the HTTP ``case NativeResponse():``
-        # seam).  BlackBull's own path emits these; the dict arm below is the
-        # external-host edge and the raw (conn, receive, send) compat surface.
+        # seam).  BlackBull's own object path emits these.
         if isinstance(body, NativeWSMessage):
             match body.kind:
                 case NativeWSMessage.SEND:
@@ -1503,30 +1531,9 @@ class WebSocketSender(BaseSender):
                                    body.kind)
             return
 
-        if not isinstance(body, dict):
-            raise TypeError(
-                f'WebSocketSender expected a NativeWSMessage or a dict, '
-                f'got {type(body)!r}')
-
-        event_type = body.get('type', '')
-
-        match event_type:
-
-            case ASGIEvent.WS_SEND:
-                if 'text' in body and body['text'] is not None:
-                    await self._send_payload(body['text'].encode('utf-8'),
-                                             WSOpcode.TEXT)
-                else:
-                    await self._send_payload(body.get('bytes', b''),
-                                             WSOpcode.BINARY)
-
-            case ASGIEvent.WS_CLOSE:
-                await self._send_close(body.get('code', WSCloseCode.NORMAL))
-
-            case ASGIEvent.WS_ACCEPT:
-                pass  # handshake reply is sent by HTTP1Actor._do_ws_handshake()
-            case _:
-                logger.warning('WebSocketSender: unknown event type %r', event_type)
+        raise TypeError(
+            f'WebSocketSender expected a NativeWSMessage or a dict, '
+            f'got {type(body)!r}')
 
 
 

--- a/blackbull/server/sender.py
+++ b/blackbull/server/sender.py
@@ -1459,19 +1459,24 @@ class WebSocketSender(BaseSender):
         # outbound frames are sent verbatim (RSV1=0).
         self._compressor = compressor
 
-    async def _send_payload(self, raw: bytes, opcode: WSOpcode) -> None:
-        """Frame and write one data payload.
+    def _frame_payload(self, raw: bytes,
+                       opcode: WSOpcode) -> tuple[bytes, bytes]:
+        """Frame one data payload into ``(header, payload)``.
 
         Shared by the native and dict arms so the two cannot put different
-        bytes on the wire.  Vectored write: ``(header, payload)`` goes to
-        writelines so the payload is never copied into a concatenated frame
-        buffer (the join ``encode_frame`` would allocate).
+        bytes on the wire.  **Sync on purpose**: nothing here suspends —
+        compressing and building a header are pure computation — and when this
+        was an ``async def`` every send allocated and awaited a coroutine that
+        never yielded, for 67 ns on a ~700 ns send.  The caller awaits
+        :meth:`_write_many`, which is the only part that can block.
+
+        The pair is written vectored, so the payload is never copied into a
+        concatenated frame buffer (the join ``encode_frame`` would allocate).
         """
         rsv1 = self._compressor is not None
         if rsv1:
             raw = self._compressor.compress(raw)
-        header = encode_frame_header(len(raw), opcode, rsv1=rsv1)
-        await self._write_many((header, raw))
+        return encode_frame_header(len(raw), opcode, rsv1=rsv1), raw
 
     async def _send_close(self, code: int) -> None:
         await self._write(encode_frame(code.to_bytes(2, 'big'),
@@ -1493,11 +1498,11 @@ class WebSocketSender(BaseSender):
 
                 case ASGIEvent.WS_SEND:
                     if 'text' in body and body['text'] is not None:
-                        await self._send_payload(body['text'].encode('utf-8'),
-                                                 WSOpcode.TEXT)
+                        await self._write_many(self._frame_payload(
+                            body['text'].encode('utf-8'), WSOpcode.TEXT))
                     else:
-                        await self._send_payload(body.get('bytes', b''),
-                                                 WSOpcode.BINARY)
+                        await self._write_many(self._frame_payload(
+                            body.get('bytes', b''), WSOpcode.BINARY))
 
                 case ASGIEvent.WS_CLOSE:
                     await self._send_close(body.get('code', WSCloseCode.NORMAL))
@@ -1515,11 +1520,11 @@ class WebSocketSender(BaseSender):
             match body.kind:
                 case NativeWSMessage.SEND:
                     if body.text is not None:
-                        await self._send_payload(body.text.encode('utf-8'),
-                                                 WSOpcode.TEXT)
+                        await self._write_many(self._frame_payload(
+                            body.text.encode('utf-8'), WSOpcode.TEXT))
                     else:
-                        await self._send_payload(body.data or b'',
-                                                 WSOpcode.BINARY)
+                        await self._write_many(self._frame_payload(
+                            body.data or b'', WSOpcode.BINARY))
                 case NativeWSMessage.CLOSE:
                     await self._send_close(body.code
                                            if body.code is not None

--- a/tests/unit/test_websocket_native_channel.py
+++ b/tests/unit/test_websocket_native_channel.py
@@ -155,3 +155,45 @@ def test_close_reason_is_omitted_when_empty():
     """ASGI treats a missing reason and an empty one alike; don't invent keys."""
     assert 'reason' not in NativeWSMessage.close(1000).to_asgi()[0]
     assert NativeWSMessage.close(1000, 'bye').to_asgi()[0]['reason'] == 'bye'
+
+
+# ---------------------------------------------------------------------------
+# Dispatch order: the compat path must not pay for the native arm
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dict_send_does_not_consult_the_native_type(monkeypatch):
+    """A dict is dispatched without an ``isinstance(_, NativeWSMessage)``.
+
+    The native arm was added ahead of the dict arm, and the dict arm then
+    still ran ``not isinstance(body, dict)`` as a type guard — so every send
+    from the raw ``(conn, receive, send)`` form and every external ASGI host
+    paid two type checks where it had paid none.  That is +71 ns on a ~734 ns
+    send, on the path every `echo-ws` benchmark and every uvicorn-hosted app
+    takes.
+
+    Ordering is the fix, so ordering is what this asserts: the dict arm is
+    reached without the native type being consulted at all.  A timing test
+    would be flaky; an instance-check counter is exact.
+    """
+    import blackbull.server.sender as sender_mod
+
+    consulted = []
+
+    class _Watched(type):
+        def __instancecheck__(cls, obj):     # noqa: N805 - metaclass protocol
+            consulted.append(type(obj))
+            return isinstance(obj, NativeWSMessage)
+
+    class _WatchedNativeWSMessage(metaclass=_Watched):
+        pass
+
+    monkeypatch.setattr(sender_mod, 'NativeWSMessage', _WatchedNativeWSMessage)
+
+    writer = _CollectingWriter()
+    await WebSocketSender(writer)({'type': 'websocket.send', 'text': 'hi'})
+
+    assert writer.out, 'the dict send produced no bytes'
+    assert consulted == [], (
+        f'the dict path consulted NativeWSMessage {len(consulted)}x — the '
+        f'native arm is being tested before the dict arm again')


### PR DESCRIPTION
Follow-up to #222. Three construction-cost regressions that #222 introduced, found by profiling the gRPC unary path and tracing hot paths against their transports — plus the negative results, which are most of the value here.

## Why these exist

#222 replaced ASGI dicts with `NativeResponse` on the send path. The premise holds for the **sender**: the dict arm really is more expensive to dispatch, and that saving is real and measured. It does **not** hold for the **producer** — a `__slots__` object with keyword construction is not a cheaper dict:

| construction | ns | vs dict |
|---|---:|---:|
| dict literal | 65.4 | 1.00× |
| manual class, *same 7 slots*, positional `__init__` | 90.1 | 1.38× |
| `__new__` + raw slot writes | 96.0 | 1.47× |
| **`NativeResponse` (keyword)** | **258.4** | **3.95×** |

`__slots__` is not the cause. Slot-writing this shape costs ~90 ns; the rest is calling convention plus constructor body.

## What changed

**1. `NativeResponse.__init__` writes `_header` directly.** It was assigning through the `header` *property* — a descriptor call plus an `isinstance` test to store a list, on a path that runs for every response the framework emits. **−39 ns per construction**, everywhere.

**2. Positional fast constructors, symmetric with `Connection`.** `Connection` — the request-side native object — is built once per request by a generated dataclass `__init__` taking positional args. The response side had no equivalent. Adds two *shape-specific* constructors rather than one seven-argument `_make`: in slot order `more_body` and `expects_trailers` are two bools separated only by `trailers`, so a positional catch-all would be a standing misordering trap for ~140 ns.

```
NativeResponse.complete(status, header, body)
NativeResponse.with_trailers(status, header, body, trailers)
```

Applied at the three hottest sites — `_emit_response` and `Response.to_native` (every HTTP response) and the gRPC unary emission. The public keyword `__init__` is unchanged and stays the form for application code.

**3. gRPC unary emits one object, not three.** A unary response is fully known at emission time, so it no longer costs three constructions and three sender dispatches to describe one response. Conditional on `context._started` — a handler that called `send_initial_metadata()` already has HEADERS on the wire and still emits body and trailers separately.

**4. WS framing helper is sync, not async.** #222 extracted the framing into `_send_payload` so the native and dict arms could not put different bytes on the wire. That property is worth keeping; making it `async def` was not — nothing in it suspends, so every send allocated and awaited a coroutine that never yielded. `_frame_payload` now returns `(header, payload)` synchronously and each arm awaits `_write_many`, the only part that can block. One implementation kept, coroutine dropped.

**5. `CORS`/`Compression` no longer crash object-form WebSocket handlers.** Both wrapped `send` with a header injector whose non-native branch called `.get('type')` on every event; once the WS send channel went native, `NativeWSMessage` (a `__slots__` class) has no `.get`. Reachable on `CORS` for any object-form WS handler whose upgrade carries an allowed `Origin`, and on `Compression` via the no-matching-codec path. Both guards mutation-tested.

**6. `/ws-object` bench lane.** Both bench apps' `/ws` handlers are raw `(conn, receive, send)` form, so every `echo-ws` number ever recorded measures the ASGI dict boundary and says nothing about the native channel. Adds the object-form endpoint *alongside* `/ws`, so both channels can be compared in one process on one build. `ab_commit_ws.sh` grows `WS_PATH`.

## Measured

All in-process, ABBA-interleaved. Cross-invocation differencing on this box spans ~10 % on identical code and is useless at this scale — an A/A null over 12 invocations of the same build ranged 725–799 ns.

| path | before | after |
|---|---:|---:|
| gRPC unary construction | 506.5 ns | **216.0 ns** (−57 %) |
| `complete` shape (every HTTP response) | 196.6 ns | **115.8 ns** (−41 %) |
| `with_trailers` shape | 239.6 ns | **132.4 ns** (−45 %) |
| WS dict send vs `2501bee` | +76.4 ns regression | **−2.0 ± 6.5 ns (parity)** |

## Verification

- **Byte-identical wire output** at every changed emission: gRPC unary through a real `HTTP2Sender` (126 bytes, and 100 bytes for the fast-constructor form), WS framing (66 bytes).
- **A real grpcio client completes 4,000 unary calls** — it validates trailers and status strictly, so a malformed frame sequence would fail it. That matters more than the unit tests here, because the `more_body=True` invariant below would show up as a split write, not a test failure.
- `just typecheck`: **6104 passed**, 265 skipped, 1 xfailed. Dual-path lane (`BB_FORCE_ASGI_SCOPE=1`): **2739 passed**.

## One invariant worth knowing about

`with_trailers` sets `more_body=True` by construction, and it is load-bearing rather than an oversight. `HTTP2Sender` only takes its trailers-coalescing path for a **non-terminal** body chunk, holding HEADERS + DATA so they flush with the trailing HEADERS in one write. END_STREAM rides the trailers either way (RFC 9113 §8.1). Marking the body terminal — the obvious "correct" spelling — splits that single write in two. It is commented at both the constructor and the call site.

## Negative results

These cost most of the investigation and are the part worth reading.

**The gRPC "regression" reported from the v0.67.0 → v0.70.0 HttpArena run does not exist as framed.** Profiling (py-spy, 3 ABBA rounds, 100k calls/arm) split the unary path into segments:

| segment | pre | head | delta |
|---|---:|---:|---:|
| shared transport (H2 frames, HPACK, actor, recipient, sender, socket) | 101.52 µs | 101.68 µs | **+0.2 %** |
| gRPC-only | 11.91 µs | 13.87 µs | +16.4 % |

The shared transport is 86 % of the cost and is **flat**. gRPC dispatches at `app.py:671` *before* `_wrap_send_native`, and never touches the router or `Response` — so whatever made baseline-h2 +3.57 % faster is in code gRPC structurally cannot execute. Its expected inherited gain is ≈0, not the +1.73 % a naive throughput-share model predicts. The same reasoning voids the WebSocket comparison: after the handshake, WS shares nothing per-message with the HTTP path.

**The DB-backed deficit does not reproduce in BlackBull's code.** With a zero-cost `Depends` provider and keep-alive pipelined load (23.4 µs/req):

| lane | pre | head | delta |
|---|---:|---:|---:|
| `/plain` (1 param) | 23,982 ± 372 | 23,447 ± 699 | −2.23 % |
| `/fakedb` (2 params, one `Depends`) | 24,976 ± 267 | 24,493 ± 312 | −1.93 % |

Cost of the `Depends` parameter: pre +994 ± 458, head +1046 ± 765 ns — **difference-in-differences +52 ± 892 ns, 0.1σ**. The DB shape inherits normally; the deficit is not in the injection path. Sidecar variance (the arms ran 26 minutes apart with live Postgres/Redis) is the remaining candidate, consistent with `api-16` landing *above* expectation in the same family.

**`echo-ws-pipeline` remains unexplained and unconfirmed**, and the local rig cannot settle it: its k6 lane never saturates the server. Two facts, neither needing a CPU reading — 8× the server cores gave **0.78–0.95×** the throughput at `WS_BURST=8`, and raising in-flight depth *lowered* throughput 0.25–0.87× where HttpArena's gcannon raises it 1.50–2.05×. `WS_BURST` is pacing, not pipelining. Settling it needs HttpArena's own `echo-ws-pipeline` varying only `BB_WS_QUEUE_DEPTH` (which flipped 256 → 0 in v0.69.0, two releases before #222).

## Not claimed

None of this is presented as recovering a measured EC2 regression. The profiled gRPC-only segment delta was +1950 ± 780 ns at n=3 — a 95 % interval of [−1406, +5306], which includes zero. What is established is the construction cost itself, measured in-process with tight SEs, and that is what these changes remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
