### PR TITLE
Sprint 95 — request bodies on paths that answer before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,49 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+### Security
+
+Two instances of one defect class — a path that answers a request without
+reading its body, leaving those octets to be re-read as something else.  Both
+are keep-alive framing desyncs of the shape request smuggling exploits; neither
+has been demonstrated cross-client, and the measured cases are self-inflicted.
+The remedies differ because the RFC treats the two methods differently.
+
+- **A WebSocket handshake that declares content is now refused with `400`.**
+  ⚠️ **Behaviour change** — an upgrade request with `Content-Length` above zero
+  or any `Transfer-Encoding` draws a 400 and a close; nothing switches
+  protocols.  `Content-Length: 0` declares no content and still upgrades.
+  This closes the
+  sibling of the `OPTIONS *` defect below, found while fixing it: the upgrade
+  path leaves the keep-alive loop before the drain, so those bytes were read
+  back after the 101 as WebSocket frames and **delivered to the application as
+  a message** — an HTTP request body arriving in a handler as something no
+  client sent.  Reaching the same drain is not the remedy here, because after
+  a protocol switch the octets carry two contradictory framings and an
+  intermediary may resolve them the other way; refusing removes the
+  disagreement instead of picking a side.  RFC 9110 §9.3.1 gives content on a
+  `GET` no defined semantics, so no real client sends one — verified against
+  `websockets` 16.1.1 (handshake, text/binary/70 KB echo, ping-pong, clean
+  close, all unaffected).
+
+- **`OPTIONS *` carrying a request body desynchronised the connection.**  The
+  server-wide answer (RFC 9112 §3.2.4) replies without routing and without
+  reading the body, and it was the one answered path that skipped the
+  keep-alive drain, so the leftover bytes were parsed as the start of the next
+  request: `OPTIONS *` with `Content-Length: 4`, pipelined with `GET /`,
+  answered `204` then **`405`** — the method had parsed as `bodyGET`.  RFC 9110
+  §9.3.7 explicitly permits content on `OPTIONS`, so this is a conforming
+  request shape, and behind a reverse proxy that pools upstream connections the
+  desync is the standard request-smuggling shape (not demonstrated
+  cross-client here — the measured case is self-inflicted).  The drain
+  predicate now lives in the loop tail with no per-path exemption, so every
+  request that stays on the connection reaches it, and the 64 KiB bound applies
+  uniformly: a body past it closes the connection instead of draining
+  unboundedly.
+  Http11Probe covers bodyless `OPTIONS *` and origin-form `OPTIONS /` with a
+  body, but never the product and never with a pipelined follow-up, so its
+  159/159 was clean on both sides of the defect.
+
 ## [0.71.0] — 2026-08-07
 
 ### Fixed

--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -259,6 +259,26 @@ Handlers that must answer keepalives during long work should set
 `BB_WS_QUEUE_DEPTH` positive (read-ahead answers immediately), or keep
 their own `ping`/`pong` cadence.
 
+### WebSocket: a handshake carrying content is refused
+
+An upgrade request that declares a body — `Content-Length` above zero,
+or any `Transfer-Encoding` — is answered `400 Bad Request` and the
+connection closes.  `Content-Length: 0` declares no content and still
+upgrades.
+
+The fence is about framing, not policy.  After the `101` the connection
+belongs to WebSocket, so those octets are request content by the
+handshake's own headers *and* the first frames by the switch; a reverse
+proxy in front may resolve that the other way, and the bytes then arrive
+in a handler as a message no client sent.  Refusing removes the
+disagreement rather than picking a side of it — and RFC 9110 §9.3.1
+gives content on a `GET` no defined semantics, so nothing a real client
+sends is affected (verified against `websockets`, browsers, and the
+usual proxies).
+
+If you have a client that genuinely needs to post data alongside the
+handshake, send it as a first message after `accept()` instead.
+
 ### gRPC: reflection is v1alpha-only
 
 All four gRPC RPC shapes — unary, server-streaming, client-streaming, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ critical vulnerabilities.
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.72.x  | :white_check_mark: |
 | 0.71.x  | :white_check_mark: |
-| 0.70.x  | :white_check_mark: |
-| < 0.70  | :x:                |
+| < 0.71  | :x:                |
 
 This table updates with each minor release.
 

--- a/blackbull/server/http1_actor.py
+++ b/blackbull/server/http1_actor.py
@@ -302,6 +302,26 @@ class UnsupportedVersionError(Exception):
     :class:`BadRequestError`: the request *grammar* was valid."""
 
 
+def _declares_content(headers: 'Headers') -> bool:
+    """True if the request's framing headers announce a non-empty body.
+
+    Answers "are there body octets on this connection?", which is a different
+    question from ``HTTP1Recipient.needs_drain()`` ("are unread body octets
+    still buffered?"): this one is asked *before* a recipient exists, on the
+    upgrade path, where the answer decides whether to switch protocols at all.
+
+    Assumes :func:`_validate_message_framing` has already run, so CL/TE
+    conflicts and malformed values cannot reach here — a bare ``chunked`` or a
+    single well-formed ``Content-Length`` is all that is left to classify.
+    """
+    if headers.getlist(b'transfer-encoding'):
+        return True
+    cl = headers.get(b'content-length', b'').strip()
+    # ``Content-Length: 0`` declares an empty body: no octets, nothing to
+    # frame two ways.  ``lstrip(b'0')`` because "000" is also zero.
+    return bool(cl) and bool(cl.lstrip(b'0'))
+
+
 def _validate_message_framing(headers: 'Headers') -> None:
     """RFC 9112 §6 — reject framing-header combinations that are unsafe.
 
@@ -781,14 +801,21 @@ class HTTP1Actor(Actor):
                 if not ok:
                     break  # unhandled error — close connection
 
-                # Drain any request body the handler left unread (e.g. a POST
-                # that 404s, or any handler that ignores ``receive``).  Without
-                # this the leftover body bytes are parsed as the next pipelined
-                # request line — a classic keep-alive framing desync.  A body
-                # larger than the drain bound closes the connection instead.
-                # The server-wide ``OPTIONS *`` path never reads a body, so the
-                # asterisk form skips the drain and falls straight to keep-alive.
-                if not conn._asterisk_form and inner_receive.needs_drain():
+                # Drain any request body left unread — by a handler that
+                # ignores ``receive`` (a POST that 404s), or by a path that
+                # answers before routing at all (the server-wide ``OPTIONS *``).
+                # Without this the leftover body bytes are parsed as the next
+                # pipelined request line — a classic keep-alive framing desync,
+                # and behind a connection-pooling reverse proxy the standard
+                # request-smuggling shape.  The predicate belongs to the loop
+                # tail, not to any one answer path: a per-path exemption is how
+                # the ``OPTIONS *`` gap existed, and the next path added would
+                # reintroduce it.  A body larger than the drain bound closes the
+                # connection instead, so an unbounded read is never the price of
+                # keep-alive.  The WebSocket upgrade leaves ``run()`` above and
+                # never arrives here, which is why it refuses a bodied handshake
+                # outright instead — see ``_do_ws_handshake``.
+                if inner_receive.needs_drain():
                     if not await inner_receive.drain(_MAX_KEEPALIVE_DRAIN):
                         break
 
@@ -1215,7 +1242,8 @@ class HTTP1Actor(Actor):
         """Validate the WebSocket upgrade and store a deferred 101 callback.
 
         Returns True if the handshake is valid and ready to proceed, False if
-        a 400 Bad Request was already sent (bad Sec-WebSocket-Version).
+        a 400 Bad Request was already sent (declared content, bad
+        Sec-WebSocket-Key, or bad Sec-WebSocket-Version).
 
         The actual HTTP 101 response is deferred: it is sent by
         WebSocketActor._send when the ASGI app calls websocket.accept, so that
@@ -1224,6 +1252,27 @@ class HTTP1Actor(Actor):
         """
         send = SenderFactory.http1(self._writer)
         headers = conn.headers
+        # Content on the handshake is refused before anything switches.  Those
+        # octets are request content per ``Content-Length``/``Transfer-Encoding``
+        # *and* the first frames per the 101 — two framings over the same bytes,
+        # which is what a front end and this server would disagree about.  The
+        # upgrade leaves ``run()`` before the keep-alive drain, so left alone
+        # they are read back as frames and handed to the application as a
+        # message.  Refusing beats draining here: RFC 9110 §9.3.1 gives content
+        # on GET no defined semantics (unlike §9.3.7 for OPTIONS, where the
+        # drain is the only correct answer), so nothing legitimate is lost, and
+        # a refusal resolves the ambiguity instead of picking a side of it.
+        # ``Content-Length: 0`` declares no content and so is not ambiguous —
+        # clients and proxies do attach it to GET requests.  CL/TE conflicts and
+        # malformed values are already 400/501 at parse, so a well-formed single
+        # value is all that can reach here.
+        if _declares_content(headers):
+            logger.warning(
+                '400 Bad Request — WebSocket handshake declares content; '
+                'refusing to switch protocols. peer=%r', self._peername)
+            await send(b'', HTTPStatus.BAD_REQUEST,
+                       [(b'content-type', b'text/plain')])
+            return False
         key = headers.get(b'sec-websocket-key', b'').strip()
         # RFC 6455 §4.2.1 — the client MUST send a Sec-WebSocket-Key whose
         # base64-decoded value is 16 bytes.  An absent or malformed key is a

--- a/docs/about/internals.md
+++ b/docs/about/internals.md
@@ -303,6 +303,56 @@ mean ± SE over 5 runs:
 267 ns/chunk, or **4.27 µs saved on a 64 KiB upload** — and the dict count
 for that upload goes from 16 to 0.
 
+## Keep-alive drain invariant
+
+On HTTP/1.1 the connection is a byte stream with no framing of its own:
+the only thing separating request *N* from request *N+1* is that
+exactly as many body bytes were consumed as the headers declared.  So
+every request that stays on the connection passes through the drain in
+`HTTP1Actor`'s loop tail before the connection is reused — not just the
+ones a handler answered:
+
+```python
+if inner_receive.needs_drain():          # loop tail — one site, no exceptions
+    if not await inner_receive.drain(_MAX_KEEPALIVE_DRAIN):
+        break                            # over the bound → close instead
+```
+
+The predicate belongs to the loop, not to any one answer path.  A
+handler that ignores `receive` (a POST that 404s) is the obvious case,
+but a request can also be answered *before* routing — `OPTIONS *` is
+answered server-wide per RFC 9112 §3.2.4, and RFC 9110 §9.3.7 permits
+content on it.  Any such path that skipped the drain would leave the
+body in the reader, where the next `readuntil` parses it as a
+request-line: `body` followed by `GET / HTTP/1.1` becomes the method
+`bodyGET`.  The client's *next* request is then destroyed by the
+framing of the previous one, and behind a reverse proxy that pools
+upstream connections the leftover bytes prefix **another client's**
+request — the standard request-smuggling shape.
+
+Draining is bounded (`_MAX_KEEPALIVE_DRAIN`, 64 KiB) so an unbounded
+read is never the price of keeping a connection alive; past the bound
+the connection closes, which is safe because any desync dies with it.
+A recipient that has already seen a chunked-framing violation reports
+`needs_drain()` as `False` for the same reason — that stream is
+desynced, so draining it would be reading smuggled bytes rather than
+discarding them.
+
+A **WebSocket upgrade** leaves the loop before the tail is reached, so
+it cannot rely on the drain — and it must not.  After a 101 the same
+octets are request content (per `Content-Length`) *and* the first
+frames (per the switch); left alone they were read back as frames and
+delivered to the application as a message.  That contradiction is what
+a front end and this server would disagree about, so
+`_do_ws_handshake` **refuses** a handshake that declares content —
+400, before anything switches — instead of resolving it in one
+direction.  RFC 9110 §9.3.1 gives content on `GET` no defined
+semantics, so nothing legitimate is refused; `Content-Length: 0` is
+not content and still upgrades.  This is the one place where the
+drain's logic and the framing decision differ, and it differs because
+`OPTIONS` is the opposite case: §9.3.7 *permits* content there, which
+is exactly why that path drains rather than refusing.
+
 ## Send-path invariant
 
 Protocol senders never choose between joining and vectored I/O

--- a/docs/guide/websockets.md
+++ b/docs/guide/websockets.md
@@ -311,6 +311,25 @@ connection).
 | Per-message-deflate strategy | Both `server_no_context_takeover` and `client_no_context_takeover` always advertised. |
 | RSV1 bit | Set on compressed data frames per §7 of the RFC; clients without the negotiated extension that send RSV1 are rejected as protocol violations. |
 
+### Handshakes that carry a body are refused
+
+A handshake request that declares content — `Content-Length` above
+zero, or any `Transfer-Encoding` — is answered `400 Bad Request` and
+the connection closes.  Nothing switches protocols.
+
+The reason is framing, not policy.  After the `101` the connection
+belongs to WebSocket, so those octets would be request content by the
+handshake's own headers and the first frames by the switch — and a
+reverse proxy in front may pick the other reading.  Left unresolved,
+the bytes arrive in your handler as an ordinary message that no client
+ever sent.
+
+RFC 9110 §9.3.1 gives content on a `GET` no defined semantics, so no
+real client is affected: `websockets`, browsers, and the usual proxies
+send no body here.  `Content-Length: 0` declares no content and still
+upgrades normally, which is what matters for the clients and proxies
+that attach it to `GET` requests by habit.
+
 ## Transport: HTTP/1.1 Upgrade vs HTTP/2 Extended CONNECT
 
 WebSocket is always available over the HTTP/1.1 `Upgrade`

--- a/tests/conformance/http1/conftest.py
+++ b/tests/conformance/http1/conftest.py
@@ -14,6 +14,8 @@ differences come from the framework, not the handler:
 * ``QUERY /query`` — replies with the request body verbatim (RFC 10008;
   registered with QUERY only, so any other method on the path draws a 405
   whose Allow header must advertise QUERY)
+* ``WS /ws``       — echoes text messages back with an ``echo:`` prefix, so a
+  test can tell an application-delivered message apart from handshake bytes
 """
 from __future__ import annotations
 
@@ -28,6 +30,7 @@ import pytest
 from blackbull import BlackBull, read_body
 from blackbull.response import StreamingResponse
 from blackbull.server import ASGIServer
+from blackbull.utils import Scheme
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +64,20 @@ def _make_app() -> BlackBull:
                accept_query=['application/sql', 'text/plain'])
     async def query_typed(body: bytes):
         return body
+
+    @app.route(path='/ws', scheme=Scheme.websocket)
+    async def ws_echo(conn, receive, send):
+        # Echoes each text message back with an ``echo:`` prefix, so a test
+        # can tell an application-delivered message from handshake bytes.
+        await receive()                       # websocket.connect
+        await send({'type': 'websocket.accept'})
+        while True:
+            event = await receive()
+            if event.get('type') == 'websocket.disconnect':
+                break
+            if event.get('text') is not None:
+                await send({'type': 'websocket.send',
+                            'text': 'echo:' + event['text']})
 
     @app.route(path='/chunked')
     async def chunked(scope, receive, send):

--- a/tests/conformance/http1/test_http1_dispatch.py
+++ b/tests/conformance/http1/test_http1_dispatch.py
@@ -286,9 +286,14 @@ class TestHTTP11KeepAlive:
         req1_first_line, req1_rest = req1.split(b'\r\n', 1)
         paths = []
 
-        async def capturing_app(scope, receive, send):
-            # BlackBull's server threads the native Connection for HTTP.
-            paths.append(scope.path)
+        async def capturing_app(app_arg, receive, send):
+            # BlackBull's server threads the native Connection for HTTP;
+            # ``BB_FORCE_ASGI_SCOPE=1`` hands the app a plain ASGI dict
+            # instead.  The claim under test is that the keep-alive loop
+            # re-derives the target per request, which holds in both lanes —
+            # so the envelope is read the way each lane exposes it.
+            paths.append(app_arg['path'] if isinstance(app_arg, dict)
+                         else app_arg.path)
 
         actor = HTTP1Actor(_FakeReader(req1_rest + req2), _FakeWriter(),
                            capturing_app, None, request=req1_first_line + b'\r\n')

--- a/tests/conformance/http1/test_rfc9112_connection.py
+++ b/tests/conformance/http1/test_rfc9112_connection.py
@@ -12,6 +12,8 @@
 These tests open a single socket and exchange multiple requests on it
 to validate the persistent-connection contract.
 """
+import base64
+import os
 import socket
 
 import pytest
@@ -162,18 +164,17 @@ class TestAsteriskFormKeepAlive:
         assert rest.status == 200, f'GET after OPTIONS * failed: {rest!r}'
         assert rest.body.startswith(b'ok')
 
-    def test_asterisk_with_body_leaves_body_undrained_known_gap(self, h1_app):
-        """KNOWN GAP — 405 here is *not* correct behaviour, it is today's.
+    def test_asterisk_with_body_drains_before_next_request(self, h1_app):
+        """RFC 9110 §9.3.7 permits content on OPTIONS, so the server-wide
+        answer must still consume it.
 
-        The server-wide answer replies without reading the request body, and
-        nothing drains it, so the leftover bytes are parsed as the start of the
-        next request: ``body`` + ``GET / HTTP/1.1`` becomes the method
-        ``bodyGET``, which no route allows.  A drained path would answer 200.
-
-        This asserts the status quo so that the surrounding keep-alive loop can
-        be restructured without silently changing it.  When the drain gap is
-        fixed, this test is *expected* to fail — update it deliberately rather
-        than reading 405 as the contract.
+        Undrained, the body bytes become the start of the next request line:
+        ``body`` + ``GET / HTTP/1.1`` parses as the method ``bodyGET``, which
+        no route allows, and the client's next request is destroyed by the
+        framing of the previous one (405 instead of 200).  Behind a
+        connection-pooling reverse proxy that desync is the request-smuggling
+        shape, so the 200 below is the security-relevant assertion, not just a
+        keep-alive nicety.
         """
         s = open_socket('127.0.0.1', h1_app.port, timeout=5)
         try:
@@ -193,8 +194,136 @@ class TestAsteriskFormKeepAlive:
         first = parse_response(buf[:second])
         rest = parse_response(buf[second:], closed=True)
         assert first.status == 204
-        assert rest.status == 405, (
-            f'undrained-body framing changed (was 405); got {rest.status}')
+        assert rest.status == 200, (
+            f'body was not drained — the next request was parsed out of the '
+            f'leftover bytes; got {rest.status}')
+        assert rest.body.startswith(b'ok')
+
+    def test_asterisk_with_chunked_body_then_pipelined_get(self, h1_app):
+        """The drain must follow chunked framing through the terminal chunk.
+
+        A length-oblivious drain would stop early and leave ``0\\r\\n\\r\\n``
+        (or the chunk-size lines) in the reader — the same desync as the
+        Content-Length case, reached through the other framing.
+        """
+        s = open_socket('127.0.0.1', h1_app.port, timeout=5)
+        try:
+            s.sendall(
+                b'OPTIONS * HTTP/1.1\r\nHost: localhost\r\n'
+                b'Transfer-Encoding: chunked\r\n\r\n'
+                b'4\r\nbody\r\n0\r\n\r\n'
+                b'GET / HTTP/1.1\r\nHost: localhost\r\n'
+                b'Connection: close\r\n\r\n'
+            )
+            buf = read_until_eof(s)
+        finally:
+            s.close()
+
+        second = buf.find(b'HTTP/1.1 ', 8)
+        assert second > 0, f'no second response; got {buf!r}'
+        first = parse_response(buf[:second])
+        rest = parse_response(buf[second:], closed=True)
+        assert first.status == 204
+        assert rest.status == 200, (
+            f'chunked body was not drained through the terminal chunk; '
+            f'got {rest.status}')
+        assert rest.body.startswith(b'ok')
+
+    def test_asterisk_with_large_body_within_bound_drains(self, h1_app):
+        """A body at the drain bound is still fully drained.
+
+        Pairs with the over-bound case below to pin the bound from both
+        sides: at the bound the connection survives and the pipelined request
+        is answered; past it the connection closes.  A body this size also
+        exceeds ``StreamReader``'s own buffer limit, so an undrained
+        connection dies here for a reason unrelated to the drain — the 200
+        is what separates draining from merely surviving.
+        """
+        body = b'x' * (64 * 1024)          # == _MAX_KEEPALIVE_DRAIN
+        s = open_socket('127.0.0.1', h1_app.port, timeout=5)
+        try:
+            s.sendall(
+                b'OPTIONS * HTTP/1.1\r\nHost: localhost\r\n'
+                b'Content-Length: ' + str(len(body)).encode() + b'\r\n\r\n'
+                + body
+                + b'GET / HTTP/1.1\r\nHost: localhost\r\n'
+                  b'Connection: close\r\n\r\n'
+            )
+            buf = read_until_eof(s)
+        finally:
+            s.close()
+
+        second = buf.find(b'HTTP/1.1 ', 8)
+        assert second > 0, f'no second response; got {buf[:200]!r}'
+        assert parse_response(buf[:second]).status == 204
+        rest = parse_response(buf[second:], closed=True)
+        assert rest.status == 200, (
+            f'body at the drain bound was not drained; got {rest.status}')
+        assert rest.body.startswith(b'ok')
+
+    def test_asterisk_with_oversized_body_closes(self, h1_app):
+        """A body past the keep-alive drain bound closes the connection.
+
+        Draining is bounded so an attacker cannot make the server read an
+        arbitrary amount of unwanted body to keep one connection alive; past
+        the bound the routed path closes, and the server-wide answer must not
+        become the cheaper way to buy an unbounded read.  Closing is safe —
+        any desync dies with the connection.
+
+        The exchange is staged rather than sent in one write.  Closing with an
+        unread body still in the receive buffer makes the kernel send RST,
+        which discards data we have not read yet — so the 204 is collected
+        *before* the oversized body goes out, and the close is then observed
+        on its own.  Sent as one blob, this test would race the reset.
+        """
+        body = b'x' * (64 * 1024 + 4096)   # over _MAX_KEEPALIVE_DRAIN
+        s = open_socket('127.0.0.1', h1_app.port, timeout=5)
+        try:
+            # 1. Headers only — the server-wide answer needs nothing else.
+            s.sendall(
+                b'OPTIONS * HTTP/1.1\r\nHost: localhost\r\n'
+                b'Content-Length: ' + str(len(body)).encode() + b'\r\n\r\n'
+            )
+            head = b''
+            while b'\r\n\r\n' not in head:
+                chunk = s.recv(4096)
+                assert chunk, f'connection closed before the answer; got {head!r}'
+                head += chunk
+            assert parse_response(head).status == 204
+
+            # 2. Now the over-bound body, plus a request that must never run.
+            try:
+                s.sendall(
+                    body
+                    + b'GET / HTTP/1.1\r\nHost: localhost\r\n'
+                      b'Connection: close\r\n\r\n'
+                )
+            except OSError:
+                pass          # server may already have closed mid-write
+
+            # 3. The connection must end — by EOF or by RST — with the
+            #    pipelined GET unanswered.  Read to the end ourselves so a
+            #    timeout is distinguishable from a close: a server that simply
+            #    ignored the request would also produce no second response.
+            tail = b''
+            closed = False
+            try:
+                while len(tail) < 65536:
+                    chunk = s.recv(4096)
+                    if not chunk:
+                        closed = True     # clean FIN
+                        break
+                    tail += chunk
+            except ConnectionResetError:
+                closed = True             # RST — a close either way
+            except (socket.timeout, TimeoutError):
+                pass                      # still open: the failure below
+        finally:
+            s.close()
+
+        assert closed, 'connection stayed open past the drain bound'
+        assert b'HTTP/1.1 ' not in tail, (
+            f'pipelined request was answered past the drain bound; got {tail!r}')
 
     def test_asterisk_then_bare_crlf_closes(self, h1_app):
         # A bare CRLF where the next request-line belongs terminates the
@@ -229,3 +358,95 @@ class TestAsteriskFormKeepAlive:
         assert buf.count(b'HTTP/1.1 ') == 1, (
             f'expected exactly one response; got {buf!r}')
         assert parse_response(buf, closed=True).status == 204
+
+
+@pytest.mark.integration
+class TestUpgradeRequestBody:
+    """RFC 9110 §7.8 — content on a request that switches protocols.
+
+    The upgrade path leaves the keep-alive loop before its drain, so the
+    body-framing contract that the loop enforces has to be asserted here
+    separately.
+    """
+
+    def _ws_handshake(self, port, extra_headers=b'', body=b''):
+        key = base64.b64encode(os.urandom(16))
+        s = open_socket('127.0.0.1', port, timeout=5)
+        try:
+            s.sendall(
+                b'GET /ws HTTP/1.1\r\nHost: localhost\r\n'
+                b'Upgrade: websocket\r\nConnection: Upgrade\r\n'
+                b'Sec-WebSocket-Key: ' + key + b'\r\n'
+                b'Sec-WebSocket-Version: 13\r\n'
+                + extra_headers + b'\r\n' + body
+            )
+            return read_until_eof(s)
+        finally:
+            s.close()
+
+    @staticmethod
+    def _masked_text_frame(payload: bytes) -> bytes:
+        mask = b'\xaa\xbb\xcc\xdd'
+        masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+        return b'\x81' + bytes([0x80 | len(payload)]) + mask + masked
+
+    def test_ws_upgrade_with_body_is_rejected(self, h1_app):
+        """A handshake that declares content is refused before the switch.
+
+        Those bytes are HTTP request content per ``Content-Length``, and the
+        first WebSocket frames per the 101 — two framings over the same
+        octets, which is exactly what intermediaries disagree about.  The
+        server refuses rather than picking one: undrained, the body reached
+        the application as a WebSocket message (``echo:'SMUGGLED'``), which is
+        the smuggling shape with the app as the victim.
+
+        RFC 9110 §9.3.1 gives content on GET no defined semantics and tells
+        clients not to send it, so refusing costs nothing real — unlike
+        ``OPTIONS``, where §9.3.7 explicitly permits content and the drain is
+        therefore the only correct answer.
+        """
+        payload = b"'SMUGGLED'"
+        frame = self._masked_text_frame(payload)
+        buf = self._ws_handshake(
+            h1_app.port,
+            extra_headers=b'Content-Length: ' + str(len(frame)).encode() + b'\r\n',
+            body=frame,
+        )
+
+        assert parse_response(buf, closed=True).status == 400, (
+            f'bodied handshake was not refused; got {buf[:120]!r}')
+        assert b'101' not in buf.split(b'\r\n')[0], (
+            f'protocol switch happened anyway; got {buf[:120]!r}')
+        assert payload not in buf, (
+            f'body still reached the application; got {buf!r}')
+
+    def test_ws_upgrade_with_chunked_body_is_rejected(self, h1_app):
+        # The other framing reaches the same refusal — a chunked handshake
+        # declares content just as much as a Content-Length one does.
+        buf = self._ws_handshake(
+            h1_app.port,
+            extra_headers=b'Transfer-Encoding: chunked\r\n',
+            body=b'4\r\nbody\r\n0\r\n\r\n',
+        )
+        assert parse_response(buf, closed=True).status == 400, (
+            f'chunked handshake was not refused; got {buf[:120]!r}')
+
+    def test_ws_upgrade_with_zero_content_length_still_upgrades(self, h1_app):
+        """``Content-Length: 0`` declares *no* content, so it must still work.
+
+        Clients and proxies do attach a zero Content-Length to GET requests.
+        Zero bytes cannot be framed two ways, so there is nothing to disagree
+        about and nothing to refuse — the refusal above is about content, not
+        about the header being present.
+        """
+        buf = self._ws_handshake(
+            h1_app.port, extra_headers=b'Content-Length: 0\r\n')
+        assert buf.split(b'\r\n')[0] == b'HTTP/1.1 101 Switching Protocols', (
+            f'zero-length handshake was refused; got {buf[:120]!r}')
+
+    def test_ws_upgrade_without_body_still_upgrades(self, h1_app):
+        # The plain handshake is the control: the check must not cost the
+        # ordinary path its upgrade.
+        buf = self._ws_handshake(h1_app.port)
+        assert buf.split(b'\r\n')[0] == b'HTTP/1.1 101 Switching Protocols', (
+            f'plain handshake was refused; got {buf[:120]!r}')


### PR DESCRIPTION
Two instances of one defect class: **a path that answers a request without reading its body**, leaving those octets to be re-read as something else. Both are keep-alive framing desyncs of the shape request smuggling exploits. Neither is a demonstrated cross-client exploit — the measured cases are self-inflicted — but the framing is why they were scheduled.

The two remedies deliberately differ, because RFC 9110 treats content on the two methods differently.

## 1. `OPTIONS *` carrying a body desynchronised the connection

The server-wide answer (RFC 9112 §3.2.4) replies without routing and without reading the body, and it was the one answered path exempted from the keep-alive drain:

```
OPTIONS * HTTP/1.1 / Host: localhost / Content-Length: 4
body
GET / HTTP/1.1 / Host: localhost / Connection: close
```
```
HTTP/1.1 204 No Content     (correct)
HTTP/1.1 405 Method Not Allowed
```

The 405 is the tell — `body` + `GET / HTTP/1.1` parsed as the method `bodyGET`, so the client's *next* request was destroyed by the framing of the previous one. Behind a connection-pooling reverse proxy, that is the smuggling shape.

RFC 9110 §9.3.7 explicitly permits content on `OPTIONS`, so **draining is the only correct answer**. The predicate now sits in the loop tail with no per-path exemption.

## 2. A WebSocket handshake declaring content is refused with 400

⚠️ **Behaviour change.** Found by review *while* fixing the above — the upgrade path leaves `run()` before the drain, so it was never covered.

Reproduced end-to-end: a handshake with `Content-Length: 14` carrying a masked text frame came back as `\x81\x0fecho:'SMUGGLED'` — an HTTP request body delivered to the application as a WebSocket message, with no second client and no proxy needed.

Reaching the same drain is **not** the remedy here: after a protocol switch the same octets carry two contradictory framings (request content per `Content-Length`, first frames per the 101), and an intermediary may resolve them the other way. `_do_ws_handshake` refuses instead of picking a side. RFC 9110 §9.3.1 gives content on a `GET` no defined semantics, so nothing real is refused; `Content-Length: 0` still upgrades.

## Test plan

- [x] Full suite `--run-all`: **6374 passed**, 2 skipped, 1 xfailed
- [x] beartype (`--beartype-packages=blackbull`): clean
- [x] Http11Probe **native**: 159/159 scored, 0 failed / 0 errors, 5 warnings
- [x] Http11Probe **`BB_FORCE_ASGI_SCOPE=1`**: identical; lane verdict diff empty (213/213 records)
- [x] Probe re-run after the WS fix: no verdict changed
- [x] Dual-path identity + architecture gates: 53 passed
- [x] `mkdocs build --strict`: clean
- [x] Real third-party client (`websockets` 16.1.1): handshake, text/binary/70 KB echo, ping-pong, clean close — unaffected
- [ ] Autobahn — **could not run locally**: this environment's Docker cannot bind-mount host *files* (a regular file appears inside the container as a directory, so `wstest` dies with `IOError: Is a directory`). Verified independently with `docker run -v "$D:/results" alpine ls -la`. **CI is the gate.**

### Red-before-green

Three of the four new `OPTIONS *` cases fail on the pre-fix tree. The fourth — the over-bound 64 KiB case — is a **fence, not a proof**: verified wire-identical on both sides (pre-fix it closed because the undrained body blew `StreamReader`'s own buffer limit). It is paired with a new at-bound case that *is* red pre-fix, and its docstring says so.

## Note: the probe never covered either vector

Both defects sat in a blind spot of the authoritative corpus. `COMP-OPTIONS-STAR` is bodyless with no follow-up; `SMUG-OPTIONS-CL-BODY` is origin-form (`OPTIONS /`, which routes and therefore always drained) and is unscored; all six `WS-UPGRADE-*` vectors are bodyless. Both halves are present, never the product, and no vector sends a second request that could reveal a desync. A clean 159/159 should not be read as coverage of this class.

## Also in this PR

- `test_keep_alive_paths_differ_between_requests` made lane-portable (pre-existing failure under `BB_FORCE_ASGI_SCOPE=1`: it read the envelope by attribute). 14 more of the same shape remain in HTTP/2 tests — pre-existing, not touched here.
- `SECURITY.md` supported-versions table shifted for the upcoming v0.72.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)