### PR TITLE
release: v0.72.0 — Sprint 95: request bodies on paths that answer before routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ so the editable install's metadata catches up.
 
 ## [Unreleased]
 
+## [0.72.0] — 2026-08-08
+
 ### Security
 
 Two instances of one defect class — a path that answers a request without

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "blackbull"
 # minor per closed sprint); PATCH covers bug fixes / harness work
 # between sprints.  No 1.0 commitment until the framework's identity
 # and surface have stabilised across several sprints.  See CHANGELOG.md.
-version = "0.71.0"
+version = "0.72.0"
 description = "Async native-Connection web framework with ASGI 3.0 interop, a from-scratch HTTP/1.1 parser, HTTP/2 frame layer, and WebSocket codec. HPACK delegates to the hpack library."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Two-file release commit for **v0.72.0** — `pyproject.toml` version bump + `CHANGELOG.md` heading rename. All code, tests, and docs landed in #225.

## Summary

Sprint 95 closed two instances of one defect class: **a path that answers a request without reading its body**, leaving those octets to be re-read as something else.

- **`OPTIONS *` carrying a body desynchronised the connection.** It was the one answered path exempted from the keep-alive drain, so `OPTIONS *` + `Content-Length: 4` pipelined with `GET /` returned 204 then **405** (`bodyGET`). RFC 9110 §9.3.7 permits content on `OPTIONS`, so draining is the only correct answer; the predicate now sits in the loop tail with no per-path exemption.
- **A WebSocket handshake declaring content is refused with 400.** ⚠️ **Behaviour change.** Found by review while fixing the above. Undrained, those bytes were read back after the 101 as frames and delivered to the application as a message. After a protocol switch the octets carry two contradictory framings, so the handshake is refused rather than resolved in one direction. `Content-Length: 0` still upgrades.

Both are keep-alive framing desyncs of the shape request smuggling exploits. Neither is a demonstrated cross-client exploit — the measured cases are self-inflicted.

## Test plan

- [x] Version bump smoke-tested: `uv pip install -e .` → `blackbull.__version__ == 0.72.0`
- [x] Pre-commit gate on the release commit: full beartype-instrumented suite + `mkdocs build --strict`, all passed
- [x] Full CI green on #225 (16/16, including Autobahn, CodeQL, dual-path lane)
- [x] `SECURITY.md` supported-versions table already shifted to 0.72.x / 0.71.x in #225
- [x] `CHANGELOG.md` `[0.72.0]` block is the curated `[Unreleased]` content — heading rename only, nothing moved

## Note

The `## [Unreleased]` heading is retained empty above `## [0.72.0] — 2026-08-08`, per the release pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)